### PR TITLE
JS: recognize more conditionals in useless-conditional

### DIFF
--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -120,12 +120,11 @@ predicate whitelist(Expr e) {
  */
 predicate isConditional(ASTNode cond, Expr e) {
   e = cond.(IfStmt).getCondition() or
-  e = cond.(WhileStmt).getExpr() or
-  e = cond.(ForStmt).getTest() or
+  e = cond.(LoopStmt).getTest() or
   e = cond.(ConditionalExpr).getCondition() or
   e = cond.(LogicalBinaryExpr).getLeftOperand() or
   // Include `z` in `if (x && z)`.
-  isConditional(_, cond) and e = cond.(LogicalBinaryExpr).getRightOperand()
+  isConditional(_, cond) and e = cond.(Expr).getUnderlyingValue().(LogicalBinaryExpr).getRightOperand()
 }
 
 from ASTNode cond, DataFlow::AnalyzedNode op, boolean cv, ASTNode sel, string msg

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -19,6 +19,8 @@
 | UselessConditional.js:94:16:94:16 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:100:13:100:24 | true && true | This expression always evaluates to true. |
 | UselessConditional.js:101:18:101:18 | x | This use of variable 'x' always evaluates to false. |
+| UselessConditional.js:102:19:102:19 | x | This use of variable 'x' always evaluates to false. |
+| UselessConditional.js:103:23:103:23 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -99,6 +99,8 @@ async function awaitFlow(){
         }
         if (true && true) {} // NOT OK
         if (y && x) {} // NOT OK
+        if (y && (x)) {} // NOT OK
+        do { } while (x); // NOT OK
     }
 });
 


### PR DESCRIPTION
Reimplements the following two improvements to Useless Conditional from https://github.com/Semmle/ql/pull/380:
- It recognises loop conditions.
- It recognises `z` in `if (x && z)` as a conditional. Previously only `x` and `x && z` were recognised.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/florian.ti.semmle.com_1541112728031).