### PR TITLE
C#: Fix extraction error when Event accessors are ordinary methods

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
@@ -33,10 +33,10 @@ namespace Semmle.Extraction.CSharp.Entities
             var remover = symbol.RemoveMethod;
 
             if (!(adder is null))
-                EventAccessor.Create(Context, adder);
+                Method.Create(Context, adder);
 
             if (!(remover is null))
-                EventAccessor.Create(Context, remover);
+                Method.Create(Context, remover);
 
             ExtractModifiers();
             BindComments();


### PR DESCRIPTION
Makes the code between Properties and Events consistent, and fixes an extraction error on CoreFx, where for some reason, the event accessor is represented as an ordinary method.