### PR TITLE
C#: Fix assembly labels

### DIFF
--- a/csharp/extractor/Semmle.Extraction/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction/Entities/Assembly.cs
@@ -69,8 +69,8 @@ namespace Semmle.Extraction.Entities
             get
             {
                 return assemblyPath == null
-                    ? new Key(assembly, ";sourcefile")
-                    : new Key(assembly, "#file:///", assemblyPath.Replace("\\", "/"), ";sourcefile");
+                    ? new Key(assembly, ";assembly")
+                    : new Key(assembly, "#file:///", assemblyPath.Replace("\\", "/"), ";assembly");
             }
         }
     }


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/Semmle/ql/pull/615, whereby the assembly labels were not consistent between CIL and C# extractors.