### PR TITLE
Python: Move query suites to public repo.

### DIFF
--- a/python/config/suites/lgtm/python2-alerts-lgtm
+++ b/python/config/suites/lgtm/python2-alerts-lgtm
@@ -1,0 +1,3 @@
+# DO NOT EDIT
+# This is a stub file. The actual suite of queries to run is generated
+# automatically based on query precision and severity.

--- a/python/config/suites/lgtm/python2-lgtm
+++ b/python/config/suites/lgtm/python2-lgtm
@@ -1,0 +1,2 @@
+@import "python2-queries-lgtm"
+@import "python2-metrics-lgtm"

--- a/python/config/suites/lgtm/python2-metrics-lgtm
+++ b/python/config/suites/lgtm/python2-metrics-lgtm
@@ -1,0 +1,17 @@
++ semmlecode-python-queries/Lexical/FCommentedOutCode.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfCode.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfComments.ql: /Metrics/Files
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfDuplicatedCode.ql: /Metrics/Duplication
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FLinesOfSimilarCode.ql: /Metrics/Duplication
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/FNumberOfTests.ql: /Metrics/Functions
+    @_namespace com.lgtm/python-queries
+
++ semmlecode-python-queries/Metrics/Dependencies/ExternalDependencies.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+    @_namespace com.lgtm/python-queries

--- a/python/config/suites/lgtm/python2-queries-lgtm
+++ b/python/config/suites/lgtm/python2-queries-lgtm
@@ -1,0 +1,10 @@
++ semmlecode-python-queries/analysis/Definitions.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/analysis/AlertSuppression.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Filters/ClassifyFiles.ql
+    @_namespace com.lgtm/python-queries
++ semmlecode-python-queries/Filters/ImportAdditionalLibraries.ql
+    @_namespace com.lgtm/python-queries
+
+@import "python2-alerts-lgtm"


### PR DESCRIPTION
Following on the work in #439 and #51, this creates the files needed to move the query suites to the external repo. On its own, this change has no effect, but it must be present before the internal changes are applied.

In addition, I've reorganised the files slightly in order to be more consistent with the query suites for the other languages. This includes creating a `python2-queries-lgtm` file which contains the entries that were previously directly specified in `python2-lgtm`.
