### PR TITLE
C++: Speed up `getInstructionOperandDefinition`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/FunctionIR.qll
@@ -56,6 +56,11 @@ class FunctionIR extends TFunctionIR {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
+  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
+    result.getFunctionIR() = this
+  }
+
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -192,10 +192,11 @@ cached private module Cached {
     instruction.getTag() = ChiTag(getOldInstruction(result)) and
     tag instanceof ChiPartialOperandTag
     or
-    instruction instanceof UnmodeledUseInstruction and
-    tag instanceof UnmodeledUseOperandTag and
-    result  instanceof UnmodeledDefinitionInstruction and
-    instruction.getFunction() = result.getFunction()
+    exists(FunctionIR f |
+      tag instanceof UnmodeledUseOperandTag and
+      result = f.getUnmodeledDefinitionInstruction() and
+      instruction = f.getUnmodeledUseInstruction()
+    )
     or
     tag instanceof ChiTotalOperandTag and
     result = getChiInstructionTotalOperand(instruction)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/FunctionIR.qll
@@ -56,6 +56,11 @@ class FunctionIR extends TFunctionIR {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
+  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
+    result.getFunctionIR() = this
+  }
+
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/FunctionIR.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/FunctionIR.qll
@@ -56,6 +56,11 @@ class FunctionIR extends TFunctionIR {
     result.getFunctionIR() = this
   }
 
+  pragma[noinline]
+  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
+    result.getFunctionIR() = this
+  }
+
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -192,10 +192,11 @@ cached private module Cached {
     instruction.getTag() = ChiTag(getOldInstruction(result)) and
     tag instanceof ChiPartialOperandTag
     or
-    instruction instanceof UnmodeledUseInstruction and
-    tag instanceof UnmodeledUseOperandTag and
-    result  instanceof UnmodeledDefinitionInstruction and
-    instruction.getFunction() = result.getFunction()
+    exists(FunctionIR f |
+      tag instanceof UnmodeledUseOperandTag and
+      result = f.getUnmodeledDefinitionInstruction() and
+      instruction = f.getUnmodeledUseInstruction()
+    )
     or
     tag instanceof ChiTotalOperandTag and
     result = getChiInstructionTotalOperand(instruction)


### PR DESCRIPTION
A part of `SSAConstruction.getInstructionOperandDefinition` was more
expensive than it had to be. On a ChakraCore snapshot, this changes the
tuple counts from

    3020569 ~2%       {3} r40 = JOIN OperandTag::TUnmodeledUseOperand#f WITH Instruction::Instruction::getFunction_dispred#ff CARTESIAN PRODUCT OUTPUT FIELDS {Instruction::Instruction::getFunction_dispred#ff.<0>,OperandTag::TUnmodeledUseOperand#f.<0>,Instruction::Instruction::getFunction_dispred#ff.<1>}
    62405   ~0%       {3} r41 = JOIN r40 WITH Instruction::UnmodeledUseInstruction#class#fffffff ON r40.<0>=Instruction::UnmodeledUseInstruction#class#fffffff.<0> OUTPUT FIELDS {r40.<2>,r40.<1>,r40.<0>}
    2868421 ~1%       {3} r42 = JOIN r41 WITH Instruction::Instruction::getFunction_dispred#ff_10#join_rhs ON r41.<0>=Instruction::Instruction::getFunction_dispred#ff_10#join_rhs.<0> OUTPUT FIELDS {Instruction::Instruction::getFunction_dispred#ff_10#join_rhs.<1>,r41.<1>,r41.<2>}
    62405   ~0%       {3} r43 = JOIN r42 WITH Instruction::UnmodeledDefinitionInstruction#class#fffffff ON r42.<0>=Instruction::UnmodeledDefinitionInstruction#class#fffffff.<0> OUTPUT FIELDS {r42.<2>,r42.<1>,r42.<0>}

to

    (0s) Starting to evaluate predicate SSAConstruction::Cached::getUnmodeledUseInstruction#ff
    (0s) Tuple counts:
    62405   ~0%     {2} r1 = JOIN Instruction::UnmodeledUseInstruction#class#fffffff WITH Instruction::Instruction::getFunction_dispred#ff ON Instruction::UnmodeledUseInstruction#class#fffffff.<0>=Instruction::Instruction::getFunction_dispred#ff.<0> OUTPUT FIELDS {Instruction::Instruction::getFunction_dispred#ff.<1>,Instruction::Instruction::getFunction_dispred#ff.<0>}
                                      return r1
    ...
    75716   ~0%       {3} r40 = JOIN OperandTag::TUnmodeledUseOperand#f WITH FunctionIR::FunctionIR::getUnmodeledDefinitionInstruction#ff CARTESIAN PRODUCT OUTPUT FIELDS {FunctionIR::FunctionIR::getUnmodeledDefinitionInstruction#ff.<0>,OperandTag::TUnmodeledUseOperand#f.<0>,FunctionIR::FunctionIR::getUnmodeledDefinitionInstruction#ff.<1>}
    62405   ~0%       {3} r41 = JOIN r40 WITH FunctionIR::FunctionIR::getUnmodeledUseInstruction#ff ON r40.<0>=FunctionIR::FunctionIR::getUnmodeledUseInstruction#ff.<0> OUTPUT FIELDS {FunctionIR::FunctionIR::getUnmodeledUseInstruction#ff.<1>,r40.<1>,r40.<2>}