### PR TITLE
C++: Add DataFlow::instructionNode

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -22,10 +22,7 @@ private predicate predictable(Expr expr) {
 
 // TODO: remove when `predictable` has an `Instruction` parameter instead of `Expr`.
 private predicate predictableInstruction(Instruction instr) {
-  exists(DataFlow::Node node |
-    node.asInstruction() = instr and
-    predictable(node.asExpr())
-  )
+  predictable(DataFlow::instructionNode(instr).asExpr())
 }
 
 private class DefaultTaintTrackingCfg extends DataFlow::Configuration {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -157,6 +157,11 @@ abstract class PostUpdateNode extends Node {
 }
 
 /**
+ * Gets the node corresponding to `instr`.
+ */
+Node instructionNode(Instruction instr) { result.asInstruction() = instr }
+
+/**
  * Gets a `Node` corresponding to `e` or any of its conversions. There is no
  * result if `e` is a `Conversion`.
  */


### PR DESCRIPTION
This is for symmetry with `exprNode` etc., and it should be handy for the same reasons. I found one caller of `asInstruction` that got simpler by using the new predicate instead.