### PR TITLE
JS: Add `cb` as a RouteHandlerCandidate heuristic parameter name

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -37,7 +37,7 @@ module ConnectExpressShared {
       exists(string request, string response, string next, string error |
         (request = "request" or request = "req") and
         (response = "response" or response = "res") and
-        next = "next" and
+        (next = "next" or next = "cb") and
         (error = "error" or error = "err")
       |
         // heuristic: parameter names match the documentation


### PR DESCRIPTION
I stumbled upon this reasonable alias. We may as well support it.