### PR TITLE
C#: Fix DB inconsistencies with extends/2

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -93,17 +93,12 @@ namespace Semmle.Extraction.CSharp.Entities
 
             // Visit base types
             var baseTypes = new List<Type>();
-            if (symbol.BaseType != null)
+            if (symbol.BaseType != null && symbol.BaseType.SpecialType != SpecialType.System_Object)
             {
                 Type baseKey = Create(Context, symbol.BaseType);
                 trapFile.extend(this, baseKey.TypeRef);
                 if (symbol.TypeKind != TypeKind.Struct)
                     baseTypes.Add(baseKey);
-            }
-
-            if (symbol.TypeKind == TypeKind.Interface)
-            {
-                trapFile.extend(this, Create(Context, Context.Compilation.ObjectType));
             }
 
             if (!(base.symbol is IArrayTypeSymbol))

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -111,7 +111,14 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
   }
 
   /** Gets the immediate base class of this class, if any. */
-  Class getBaseClass() { extend(this, getTypeRef(result)) }
+  Class getBaseClass() {
+    if extend(this, _)
+    then extend(this, getTypeRef(result))
+    else (
+      not this instanceof ObjectType and
+      result instanceof ObjectType
+    )
+  }
 
   /** Gets an immediate base interface of this type, if any. */
   Interface getABaseInterface() { implement(this, getTypeRef(result)) }

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -112,12 +112,11 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
 
   /** Gets the immediate base class of this class, if any. */
   Class getBaseClass() {
-    if extend(this, _)
-    then extend(this, getTypeRef(result))
-    else (
-      not this instanceof ObjectType and
-      result instanceof ObjectType
-    )
+    extend(this, getTypeRef(result))
+    or
+    not extend(this, _) and
+    not this instanceof ObjectType and
+    result instanceof ObjectType
   }
 
   /** Gets an immediate base interface of this type, if any. */


### PR DESCRIPTION
When a base class is unknown (due to a missing reference), Roslyn will incorrectly give a base class  of `Object`, which gets written to the `extends/2` table. This can cause DB inconsistencies. Instead, do not populate `Object` as a base class, and instead deduce it in QL.