### PR TITLE
JS: Flow through accessors

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -530,6 +530,13 @@ module DataFlow {
      */
     pragma[noinline]
     predicate accesses(Node base, string p) { getBase() = base and getPropertyName() = p }
+
+    /**
+     * Gets an accessor (`get` or `set` method) that may be invoked by this property reference.
+     */
+    final DataFlow::FunctionNode getAnAccessorCallee() {
+      result = CallGraph::getAnAccessorCallee(this)
+    }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -142,4 +142,18 @@ module CallGraph {
       )
     )
   }
+
+  /**
+   * Gets a getter or setter invoked as a result of the given property access.
+   */
+  cached
+  DataFlow::FunctionNode getAnAccessorCallee(DataFlow::PropRef ref) {
+    exists(DataFlow::ClassNode cls, string name |
+      ref = cls.getAnInstanceReference().getAPropertyRead(name) and
+      result = cls.getInstanceMember(name, DataFlow::MemberKind::getter())
+      or
+      ref = cls.getAnInstanceReference().getAPropertyWrite(name) and
+      result = cls.getInstanceMember(name, DataFlow::MemberKind::setter())
+    )
+  }
 }

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -59,6 +59,10 @@ typeInferenceMismatch
 | exceptions.js:144:9:144:16 | source() | exceptions.js:132:8:132:27 | returnThrownSource() |
 | exceptions.js:150:13:150:20 | source() | exceptions.js:153:10:153:10 | e |
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
+| getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
+| getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
+| getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |
+| getters-and-setters.js:47:23:47:30 | source() | getters-and-setters.js:45:14:45:16 | c.x |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:9:10:9:10 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:17:14:17:14 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:20:14:20:14 | y |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -34,6 +34,10 @@
 | exceptions.js:144:9:144:16 | source() | exceptions.js:132:8:132:27 | returnThrownSource() |
 | exceptions.js:150:13:150:20 | source() | exceptions.js:153:10:153:10 | e |
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
+| getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:9:10:9:18 | new C().x |
+| getters-and-setters.js:6:20:6:27 | source() | getters-and-setters.js:13:18:13:20 | c.x |
+| getters-and-setters.js:27:15:27:22 | source() | getters-and-setters.js:23:18:23:18 | v |
+| getters-and-setters.js:47:23:47:30 | source() | getters-and-setters.js:45:14:45:16 | c.x |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:9:10:9:10 | x |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:13:10:13:10 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:17:14:17:14 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/getters-and-setters.js
+++ b/javascript/ql/test/library-tests/TaintTracking/getters-and-setters.js
@@ -50,6 +50,6 @@ function testFlowThroughGetter() {
     function getX(c) {
         return c.x;
     }
-    sink(getX(new C(source()))); // NOT OK
-    sink(getX(new C(source()))); // NOT OK
+    sink(getX(new C(source()))); // NOT OK - but not flagged
+    getX(null);
 }

--- a/javascript/ql/test/library-tests/TaintTracking/getters-and-setters.js
+++ b/javascript/ql/test/library-tests/TaintTracking/getters-and-setters.js
@@ -1,0 +1,55 @@
+import * as dummy from 'dummy';
+
+function testGetterSource() {
+    class C {
+        get x() {
+            return source();
+        }
+    };
+    sink(new C().x); // NOT OK
+
+    function indirection(c) {
+        if (c) {
+            sink(c.x); // NOT OK
+        }
+    }
+    indirection(new C());
+    indirection(null);
+}
+
+function testSetterSink() {
+    class C {
+        set x(v) {
+            sink(v); // NOT OK
+        }
+    };
+    function indirection(c) {
+        c.x = source();
+    }
+    indirection(new C());
+    indirection(null);
+}
+
+function testFlowThroughGetter() {
+    class C {
+        constructor(x) {
+            this._x = x;
+        }
+
+        get x() {
+            return this._x;
+        }
+    };
+
+    function indirection(c) {
+        sink(c.x); // NOT OK
+    }
+    indirection(new C(source()));
+    indirection(null);
+
+    function getX(c) {
+        return c.x;
+    }
+    sink(getX(new C(source()))); // NOT OK
+    sink(getX(new C(source()))); // NOT OK
+}


### PR DESCRIPTION
Adds flow in and out of property accessors (actual getters/setters, not to be confused with methods named `getX/setX` which we already handle).

This PR attempts to treat such accessor-calls with the same infrastructure that handles regular calls, to avoid duplicating things like summarization, inheritance-based dispatch, and exceptional returns. This caused some performance issues which have yet to be resolved, but I'm opening the PR now to have a place to track the work.

Will resume work once the backlog of evaluations starts to clear out.