### PR TITLE
Python: WIP improve py/uninitialized-local-variable

### DIFF
--- a/python/ql/src/Variables/UninitializedLocal.ql
+++ b/python/ql/src/Variables/UninitializedLocal.ql
@@ -25,9 +25,15 @@ predicate uninitialized_local(NameNode use) {
 }
 
 predicate explicitly_guarded(NameNode u) {
-    exists(Try t |
+    exists(Try t, Expr type |
         t.getBody().contains(u.getNode()) and
-        t.getAHandler().getType().pointsTo(ClassValue::nameError())
+        t.getAHandler().getType() = type and
+        exists (ClassValue c |
+            c = ClassValue::nameError().getASuperType() |
+            type.pointsTo(c)
+            or
+            type.(Tuple).getAnElt().pointsTo(c)
+        )
     )
 }
 

--- a/python/ql/test/2/query-tests/Variables/undefined/UninitializedLocal.py
+++ b/python/ql/test/2/query-tests/Variables/undefined/UninitializedLocal.py
@@ -10,3 +10,18 @@ def rec1(a):
 
 def rec2(b):
     [rec2(b - 1) for c in range(b)]
+
+
+def deliberate_name_error4(cond, my_list):
+    if cond:
+        x = 0 # x is uninitialised, but guarded. So don't report it.
+    try:
+        x = my_list[x + 42]
+    # FIXME: With this query, only reports IndexError  (doesn't seem possible to find NameError :O)
+    #
+    # from Try t, ExceptStmt except
+    # where except = t.getAHandler()
+    # select t, except.getType(), t.getLocation()
+    except IndexError, NameError: # ONLY VALID IN PYTHON2
+        x = -1
+    return x

--- a/python/ql/test/query-tests/Variables/undefined/UninitializedLocal.py
+++ b/python/ql/test/query-tests/Variables/undefined/UninitializedLocal.py
@@ -219,6 +219,8 @@ def may_fail(cond, c):
         c.fail()
     return x
 
+from unknown import x
+may_fail(x, C())
 
 def deliberate_name_error(cond):
     if cond:
@@ -230,8 +232,6 @@ def deliberate_name_error(cond):
     return x # x is initialised here, but we would need splitting to know that.
 
 
-from unknown import x
-may_fail(x, C())
 
 
 def with_definition(x):

--- a/python/ql/test/query-tests/Variables/undefined/UninitializedLocal.py
+++ b/python/ql/test/query-tests/Variables/undefined/UninitializedLocal.py
@@ -222,16 +222,34 @@ def may_fail(cond, c):
 from unknown import x
 may_fail(x, C())
 
+# In the following cases, x is uninitialised, but guarded. So don't report it.
+
 def deliberate_name_error(cond):
     if cond:
         x = 0
     try:
-        x # x is uninitialised, but guarded. So don't report it.
+        x
     except NameError:
-        x = 1
+        x = -1
     return x # x is initialised here, but we would need splitting to know that.
 
+def deliberate_name_error2(cond):
+    if cond:
+        x = 0
+    try:
+        x
+    except Exception:
+        x = -1
+    return x
 
+def deliberate_name_error3(cond, my_list):
+    if cond:
+        x = 0
+    try:
+        x = my_list[x + 42]
+    except (NameError, IndexError):
+        x = -1
+    return x
 
 
 def with_definition(x):


### PR DESCRIPTION
Need to fix a few things for this to work:

- [ ] For Python 2 only code, we don't seem to have a way to get to `NameError` in the statement 
```
try:
    ...
except IndexError, NameError:
    ...
````
- [ ] By some reason, we don't have any `pointsTo` or `refersTo` information about `Exception` (which should point to the builtin class)
```
try:
    ...
except Exception:
    ...
```