### PR TITLE
Python: Add false positive test example for issue #2652.

### DIFF
--- a/python/ql/test/query-tests/Variables/unused/UnusedLocalVariable.expected
+++ b/python/ql/test/query-tests/Variables/unused/UnusedLocalVariable.expected
@@ -1,3 +1,4 @@
+| type_annotation_fp.py:5:5:5:7 | foo | The value assigned to local variable 'foo' is never used. |
 | variables_test.py:29:5:29:5 | x | The value assigned to local variable 'x' is never used. |
 | variables_test.py:89:5:89:5 | a | The value assigned to local variable 'a' is never used. |
 | variables_test.py:89:7:89:7 | b | The value assigned to local variable 'b' is never used. |

--- a/python/ql/test/query-tests/Variables/unused/type_annotation_fp.py
+++ b/python/ql/test/query-tests/Variables/unused/type_annotation_fp.py
@@ -1,0 +1,11 @@
+# FP Type annotation counts as redefinition
+# See https://github.com/Semmle/ql/issues/2652
+
+def type_annotation(x):
+    foo = 5
+    if x:
+        foo : int
+        do_stuff_with(foo)
+    else:
+        foo : float
+        do_other_stuff_with(foo)


### PR DESCRIPTION
Fixing this may require an extractor change, and so we should probably hold off on merging it until this has been fixed (to avoid having to synchronise the submodule pointer).