### PR TITLE
Python: Modernise injection libraries.

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -117,6 +117,11 @@ class Value extends TObject {
             my_class.getABaseType+() = other_class
         )
     }
+
+    /** Gets the boolean value of this value. */
+    boolean booleanValue() {
+        result = this.(ObjectInternal).booleanValue()
+    }
 }
 
 /** Class representing modules in the Python program
@@ -594,6 +599,22 @@ class TupleValue extends SequenceValue {
 
 }
 
+/** A class representing strings, either present in the source as a literal, or
+in a builtin as a value. */
+
+class StringValue extends Value {
+    StringValue() {
+        this instanceof BytesObjectInternal or
+        this instanceof UnicodeObjectInternal
+    }
+
+    string getText() {
+        result = this.(BytesObjectInternal).strValue()
+        or
+        result = this.(UnicodeObjectInternal).strValue()
+    }
+}
+
 /** A method-resolution-order sequence of classes */
 class MRO extends TClassList {
 
@@ -682,6 +703,15 @@ module ClassValue {
      * `str` in Python 3 and `unicode` in Python 2. */
     ClassValue unicode() {
         result = TBuiltinClassObject(Builtin::special("unicode"))
+    }
+
+    /** Get the `ClassValue` for the `str` class. This is `bytes` in Python 2,
+    and `unicode` in Python 3. */
+    ClassValue str() {
+        if major_version() = 2 then
+           result = bytes()
+        else
+            result = unicode()
     }
 
     /** Get the `ClassValue` for the `classmethod` class. */

--- a/python/ql/src/semmle/python/security/injection/Exec.qll
+++ b/python/ql/src/semmle/python/security/injection/Exec.qll
@@ -11,10 +11,10 @@ import semmle.python.security.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 
-private FunctionObject exec_or_eval() {
-    result = Object::builtin("exec")
+private FunctionValue exec_or_eval() {
+    result = Value::named("exec")
     or
-    result = Object::builtin("eval")
+    result = Value::named("eval")
 }
 
 /** A taint sink that represents an argument to exec or eval that is vulnerable to malicious input.

--- a/python/ql/src/semmle/python/security/injection/Marshal.qll
+++ b/python/ql/src/semmle/python/security/injection/Marshal.qll
@@ -12,8 +12,8 @@ import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 
 
-private FunctionObject marshalLoads() {
-    result = ModuleObject::named("marshal").attr("loads")
+private FunctionValue marshalLoads() {
+    result = Value::named("marshal.loads")
 }
 
 

--- a/python/ql/src/semmle/python/security/injection/Path.qll
+++ b/python/ql/src/semmle/python/security/injection/Path.qll
@@ -19,9 +19,9 @@ class PathSanitizer extends Sanitizer {
 
 }
 
-private FunctionObject abspath() {
-    exists(ModuleObject os_path |
-        ModuleObject::named("os").attr("path") = os_path
+private FunctionValue abspath() {
+    exists(ModuleValue os_path |
+        Value::named("os.path") = os_path
         |
         os_path.attr("abspath") = result
         or
@@ -43,7 +43,7 @@ class NormalizedPath extends TaintKind {
 }
 
 private predicate abspath_call(CallNode call, ControlFlowNode arg) {
-    call.getFunction().refersTo(abspath()) and
+    call.getFunction().pointsTo(abspath()) and
     arg = call.getArg(0)
 }
 
@@ -84,7 +84,7 @@ class OpenNode extends TaintSink {
 
     OpenNode() {
         exists(CallNode call |
-            call.getFunction().refersTo(Object::builtin("open")) and
+            call.getFunction().pointsTo(Value::named("open")) and
             call.getAnArg() = this
         )
     }

--- a/python/ql/src/semmle/python/security/injection/Pickle.qll
+++ b/python/ql/src/semmle/python/security/injection/Pickle.qll
@@ -12,7 +12,7 @@ import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 
 
-private ModuleObject pickleModule() {
+private ModuleValue pickleModule() {
     result.getName() = "pickle"
     or
     result.getName() = "cPickle"
@@ -20,7 +20,7 @@ private ModuleObject pickleModule() {
     result.getName() = "dill"
 }
 
-private FunctionObject pickleLoads() {
+private FunctionValue pickleLoads() {
     result = pickleModule().attr("loads")
 }
 

--- a/python/ql/src/semmle/python/security/injection/Sql.qll
+++ b/python/ql/src/semmle/python/security/injection/Sql.qll
@@ -12,19 +12,19 @@ import semmle.python.security.strings.Untrusted
 import semmle.python.security.SQL
 
 
-private StringObject first_part(ControlFlowNode command) {
+private StringValue first_part(ControlFlowNode command) {
     command.(BinaryExprNode).getOp() instanceof Add and
-    command.(BinaryExprNode).getLeft().refersTo(result)
+    command.(BinaryExprNode).getLeft().pointsTo(result)
     or
-    exists(CallNode call, SequenceObject seq |
+    exists(CallNode call, SequenceValue seq |
         call = command |
-        call = theStrType().lookupAttribute("join") and
-        call.getArg(0).refersTo(seq) and
-        seq.getInferredElement(0) = result
+        call.getFunction().pointsTo(ClassValue::str().attr("join")) and
+        call.getArg(0).pointsTo(seq) and
+        seq.getItem(0) = result
     )
     or
     command.(BinaryExprNode).getOp() instanceof Mod and 
-    command.getNode().(StrConst).getLiteralObject() = result
+    command.(BinaryExprNode).getLeft().pointsTo(result)
 }
 
 /** Holds if `command` appears to be a SQL command string of which `inject` is a part. */

--- a/python/ql/src/semmle/python/security/injection/Xml.qll
+++ b/python/ql/src/semmle/python/security/injection/Xml.qll
@@ -11,19 +11,19 @@ import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 
 
-private ModuleObject xmlElementTreeModule() {
+private ModuleValue xmlElementTreeModule() {
     result.getName() = "xml.etree.ElementTree"
 }
 
-private ModuleObject xmlMiniDomModule() {
+private ModuleValue xmlMiniDomModule() {
     result.getName() = "xml.dom.minidom"
 }
 
-private ModuleObject xmlPullDomModule() {
+private ModuleValue xmlPullDomModule() {
     result.getName() = "xml.dom.pulldom"
 }
 
-private ModuleObject xmlSaxModule() {
+private ModuleValue xmlSaxModule() {
     result.getName() = "xml.sax"
 }
 
@@ -33,8 +33,8 @@ private class ExpatParser extends TaintKind {
 
 }
 
-private FunctionObject expatCreateParseFunction() {
-    result = ModuleObject::named("xml.parsers.expat").attr("ParserCreate")
+private FunctionValue expatCreateParseFunction() {
+    result = Value::named("xml.parsers.expat.ParserCreate")
 }
 
 private class ExpatCreateParser extends TaintSource {
@@ -47,12 +47,12 @@ private class ExpatCreateParser extends TaintSource {
         kind instanceof ExpatParser
     }
 
-    string toString() {
+    override string toString() {
         result = "expat.create.parser"
     }
 }
 
-private FunctionObject xmlFromString() {
+private FunctionValue xmlFromString() {
     result = xmlElementTreeModule().attr("fromstring")
     or
     result = xmlMiniDomModule().attr("parseString")

--- a/python/ql/src/semmle/python/security/injection/Yaml.qll
+++ b/python/ql/src/semmle/python/security/injection/Yaml.qll
@@ -13,8 +13,8 @@ import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 
 
-private FunctionObject yamlLoad() {
-    result = ModuleObject::named("yaml").attr("load")
+private FunctionValue yamlLoad() {
+    result = Value::named("yaml.load")
 }
 
 /** `yaml.load(untrusted)` vulnerability. */

--- a/python/ql/test/library-tests/web/django/Sinks.expected
+++ b/python/ql/test/library-tests/web/django/Sinks.expected
@@ -1,6 +1,8 @@
 | sql.py:13 | Str | externally controlled string |
 | sql.py:14 | Str | externally controlled string |
 | sql.py:17 | BinaryExpr | externally controlled string |
+| sql.py:17 | Str | externally controlled string |
+| sql.py:17 | username | externally controlled string |
 | sql.py:20 | BinaryExpr | externally controlled string |
 | sql.py:21 | BinaryExpr | externally controlled string |
 | sql.py:22 | BinaryExpr | externally controlled string |

--- a/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
+++ b/python/ql/test/query-tests/Security/CWE-089/SqlInjection.expected
@@ -17,6 +17,7 @@ edges
 | sql_injection.py:24:78:24:85 | externally controlled string | sql_injection.py:24:28:24:85 | externally controlled string |
 #select
 | sql_injection.py:19:24:19:77 | BinaryExpr | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:19:24:19:77 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |
+| sql_injection.py:19:70:19:77 | username | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:19:70:19:77 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |
 | sql_injection.py:22:38:22:95 | BinaryExpr | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:22:38:22:95 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |
 | sql_injection.py:23:26:23:83 | BinaryExpr | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:23:26:23:83 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |
 | sql_injection.py:24:28:24:85 | BinaryExpr | sql_injection.py:12:24:12:31 | externally controlled string | sql_injection.py:24:28:24:85 | externally controlled string | This SQL query depends on $@. | sql_injection.py:12:24:12:31 | username | a user-provided value |


### PR DESCRIPTION
Also adds `StringValue` as a new part of the `Value` API. The alternative would be to use `Value::forString` as seen elsewhere, but this is somewhat arcane and unintuitive to use. 

At a later point, we can go through and change all of the relevant instances of that idiom to use `StringValue` instead.

