### PR TITLE
Python: Limit the number of implicitly defined global variables.

### DIFF
--- a/python/ql/src/semmle/python/essa/Definitions.qll
+++ b/python/ql/src/semmle/python/essa/Definitions.qll
@@ -234,10 +234,15 @@ class ModuleVariable extends SsaSourceVariable {
             exists(ImportStar is | is.getScope() = this.(Variable).getScope())
         )
     }
+    pragma[nomagic]
+    private Scope referenced_multiple_times_with_scope() {
+        count(this.(Variable).getAStore()) > 1 and
+        result = this.(GlobalVariable).getScope()
+    }
 
     pragma [noinline]
     CallNode global_variable_callnode() {
-        result.getScope() = this.(GlobalVariable).getScope()
+        result.getScope() = this.referenced_multiple_times_with_scope()
     }
 
     pragma[noinline]


### PR DESCRIPTION
For `SsaSourceVariables`, especially those with global scope, we keep track of
"implicit uses": places where the variable may be redefined by some operation.

One place where this is problematic is in the handling of implicitly used global
variables. For instance, a global variable may get redefined inside a function
call, and hence each `CallNode` with the same scope as the global variable
counts as an implicit redefinition. (Incidentally, this seems to be a very
coarse approximation, and it may be worth limiting the number of `CallNode`s we
consider.)

Enter this file, which contains a gazillion global variables and lots and lots
of calls:

https://github.com/p3/regal/blob/master/scripts/api/gl.py

This completely overloads the `ModuleVariable::global_variable_callnode`
predicate (which, incidentally, was introduced to fix a bad join order). With
the above file, there is no good join order, as it has to create what amounts to
the cartesian product between the global variable and the call nodes in the
above file.

The fix in this commit is simple: only consider redefinitions of variables that
actually get referenced multiple times. This takes care of the multitude of
global variables that are only referenced a single time.