### PR TITLE
Divide and conquer broken due to overflow (CWE-190)

### DIFF
--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.java
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.java
@@ -1,0 +1,24 @@
+public static int binarySearchIterative(int[] a, int value) {
+	int low = 0;
+	int high = a.length - 1;
+	while (low <= high) {
+		// BAD: low + high may overflow before division takes place leading to an
+		// ArrayIndexOutOfBoundsException
+		int mid = (low + high) / 2;
+		
+		// GOOD: (high - low) can not overflow
+		int mid = low + (high - low) / 2;
+		
+		// GOOD: (low + high) overflows, but when viewed as an unsigned number, the
+		// value is still the correct sum.
+		// Dividing an unsigned number by 2 is the same as logically right shifting by 1.
+		int mid = (low + high) >>> 1;
+		if (a[mid] > value)
+			high = mid - 1;
+		else if (a[mid] < value)
+			low = mid + 1;
+		else
+			return mid;
+	}
+	return -1; // not found
+}

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -1,0 +1,53 @@
+<!DOCTYPE qhelp PUBLIC
+   "-//Semmle//qhelp//EN"
+   "qhelp.dtd">
+<qhelp>
+   <overview>
+      <p>Calculating the mid-point in a divide and conquer operation (binary
+         search, merge sort, ...)
+         may lead to overflow. The overflowed value
+         can then be negative and if used in an array access, will cause an
+         ArrayIndexOutOfBoundsException.
+      </p>
+      <p>
+         The mid-point may be calculated like this:
+         <code>int mid = (low+high)/2</code>.
+         For very large values of <code>low</code> and <code>high</code>,
+         <code>(low+high)</code> will overflow before division takes place.
+      </p>
+   </overview>
+   <recommendation>
+      <p>Calculate the mid-point in a way that is not susceptible to overflow:
+      </p>
+      <ul>
+         <li>Instead of calculating <code>int mid = (low+high)/2</code>
+            or <code>int mid = (low+high) >> 1</code>, calculate
+            <code>int mid = low + (high - low) / 2</code>
+         </li>
+         or
+         <li>
+            Instead of calculating <code>int mid = (low+high)/2</code>
+            or <code>int mid = (low+high) >> 1</code>, calculate
+            <code>int mid = (low + high) >>> 1</code>
+         </li>
+      </ul>
+   </recommendation>
+   <example>
+      <p>
+         In this example, a buggy binary search and merge sort is shown.
+         Both are divide and conquer algorithms.
+         Both calculate the mid-point in a way that is susceptible to overflow when used for very large
+         arrays (2^30 or more elements).
+         Calculating the mid-point in a way that not overflows, fixes the problem.
+      </p>
+      <sample src="BuggyDivideAndConquer.java" />
+   </example>
+   <references>
+      <li>
+         The CERT Oracle Secure Coding Standard for Java:
+         <a
+            href="https://www.securecoding.cert.org/confluence/display/java/NUM00-J.+Detect+or+prevent+integer+overflow">NUM00-J. Detect or prevent integer overflow</a>
+         .
+      </li>
+   </references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -31,7 +31,6 @@
    <example>
       <p>
          In this example, a buggy binary search and merge sort is shown.
-         Both are divide and conquer algorithms.
          Both algorithms calculate the mid-point in a way that is susceptible to overflow when used for very large
          arrays (2^30 or more elements).
          Calculating the mid-point in a way that doesn't overflow fixes the problem.

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -18,15 +18,12 @@
    <recommendation>
       <p>Calculate the mid-point in a way that is not susceptible to overflow:
       </p>
+      <p>Instead of calculating <code>int mid = (low+high)/2</code>
+            or <code>int mid = (low+high) >> 1</code>, calculate one of the following:</p>
       <ul>
-         <li>Instead of calculating <code>int mid = (low+high)/2</code>
-            or <code>int mid = (low+high) >> 1</code>, calculate
-            <code>int mid = low + (high - low) / 2</code>
+         <li> <code>int mid = low + (high - low) / 2</code>
          </li>
-         or
          <li>
-            Instead of calculating <code>int mid = (low+high)/2</code>
-            or <code>int mid = (low+high) >> 1</code>, calculate
             <code>int mid = (low + high) >>> 1</code>
          </li>
       </ul>

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -34,7 +34,7 @@
          Both are divide and conquer algorithms.
          Both algorithms calculate the mid-point in a way that is susceptible to overflow when used for very large
          arrays (2^30 or more elements).
-         Calculating the mid-point in a way that not overflows, fixes the problem.
+         Calculating the mid-point in a way that doesn't overflow fixes the problem.
       </p>
       <sample src="BuggyDivideAndConquer.java" />
    </example>

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -32,7 +32,7 @@
       <p>
          In this example, a buggy binary search and merge sort is shown.
          Both are divide and conquer algorithms.
-         Both calculate the mid-point in a way that is susceptible to overflow when used for very large
+         Both algorithms calculate the mid-point in a way that is susceptible to overflow when used for very large
          arrays (2^30 or more elements).
          Calculating the mid-point in a way that not overflows, fixes the problem.
       </p>

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.qhelp
@@ -3,11 +3,10 @@
    "qhelp.dtd">
 <qhelp>
    <overview>
-      <p>Calculating the mid-point in a divide and conquer operation (binary
-         search, merge sort, ...)
-         may lead to overflow. The overflowed value
-         can then be negative and if used in an array access, will cause an
-         ArrayIndexOutOfBoundsException.
+      <p>Divide and conquer algorithms (binary search, merge sort, ...) 
+         will fail for large values. When the mid-point is calculated it overflows 
+         and the result of the algorithm may be negative. If this result is used in an 
+         array access, it will cause an <code>ArrayIndexOutOfBoundsException</code>.
       </p>
       <p>
          The mid-point may be calculated like this:

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
@@ -23,22 +23,16 @@ class DivideBy2Expr extends BinaryExpr {
   }
 }
 
-predicate hasALiteralOperand(AddExpr add) {
-  add.getLeftOperand() instanceof Literal 
-  or
-  add.getRightOperand() instanceof Literal
-}
-
 predicate refersToSameVar(Expr a, Expr b) {
   a.(VarAccess).getVariable() = b.(VarAccess).getVariable()
 }
 
-from DivideBy2Expr div, AddExpr add, LessThanComparison lt
+from DivideBy2Expr div, AddExpr add, LessThanComparison lt, VarAccess low, VarAccess high
 where div.getLeftOperand().getAChildExpr*() = add and
-  not hasALiteralOperand(add) and
-  refersToSameVar(lt.getLesserOperand(), add.getAnOperand()) and
-  refersToSameVar(lt.getGreaterOperand(), add.getAnOperand()) and
-  lt.getGreaterOperand() != lt.getLesserOperand()
+  refersToSameVar(add.getLeftOperand(), low) and
+  refersToSameVar(add.getRightOperand(), high) and
+  refersToSameVar(lt.getAnOperand(), low) and
+  refersToSameVar(lt.getAnOperand(), high) and
+  not refersToSameVar(lt.getLeftOperand(), lt.getRightOperand())
 select add, "Adding $@ and $@ may overflow before division takes place and lead to a crash.",
-  add.getLeftOperand(), add.getLeftOperand().(VarAccess).getVariable().getName(), add.getRightOperand(),
-  add.getRightOperand().(VarAccess).getVariable().getName()
+  add.getLeftOperand(), low.getVariable().getName(), add.getRightOperand(),  high.getVariable().getName()

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
@@ -6,8 +6,7 @@
  * @problem.severity warning
  * @precision medium
  * @id java/divide-and-conquer-mid-point-overflow
- * @tags security
- *       correctness
+ * @tags correctness
  *       external/cwe/cwe-190
  */
 

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
@@ -1,8 +1,7 @@
 /**
  * @name Query for detecting potential overflow in divide and conquer algorithms leading to crash
- * @description Divide and conquer algorithms (binary search, merge sort, ...)
- *              will fail for large values, when calculating the mid-point overflows.
- *              This can lead to an ArrayIndexOutOfBoundsException, if the (negative!) mid-point is used as an array index. 
+ * @description Calculating the mid-point in a divide and conquer operation
+ *             (binary search, merge sort, ...) may lead to overflow. 
  * @kind problem
  * @problem.severity error
  * @precision medium

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
@@ -3,7 +3,7 @@
  * @description Calculating the mid-point in a divide and conquer operation
  *             (binary search, merge sort, ...) may lead to overflow. 
  * @kind problem
- * @problem.severity error
+ * @problem.severity warning
  * @precision medium
  * @id java/divide-and-conquer-mid-point-overflow
  * @tags security

--- a/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
+++ b/java/ql/src/Security/CWE/CWE-190/BuggyDivideAndConquer.ql
@@ -1,0 +1,46 @@
+/**
+ * @name Query for detecting potential overflow in divide and conquer algorithms leading to crash
+ * @description Divide and conquer algorithms (binary search, merge sort, ...)
+ *              will fail for large values, when calculating the mid-point overflows.
+ *              This can lead to an ArrayIndexOutOfBoundsException, if the (negative!) mid-point is used as an array index. 
+ * @kind problem
+ * @problem.severity error
+ * @precision medium
+ * @id java/divide-and-conquer-mid-point-overflow
+ * @tags security
+ *       correctness
+ *       external/cwe/cwe-190
+ */
+
+import java
+
+/** Division by 2 can either be done using "/2" or right shifting by 1, which 
+  * is equivalent to a division by 2.
+  */
+class DivideBy2Expr extends BinaryExpr {
+  DivideBy2Expr() {
+    this.getRightOperand().(IntegerLiteral).getIntValue() = 2 and this instanceof DivExpr
+    or
+    this.getRightOperand().(IntegerLiteral).getIntValue() = 1 and this instanceof RShiftExpr
+  }
+}
+
+predicate hasALiteralOperand(AddExpr add) {
+  add.getLeftOperand() instanceof Literal 
+  or
+  add.getRightOperand() instanceof Literal
+}
+
+predicate refersToSameVar(Expr a, Expr b) {
+  a.(VarAccess).getVariable() = b.(VarAccess).getVariable()
+}
+
+from DivideBy2Expr div, AddExpr add, LessThanComparison lt
+where div.getLeftOperand().getAChildExpr*() = add and
+  not hasALiteralOperand(add) and
+  refersToSameVar(lt.getLesserOperand(), add.getAnOperand()) and
+  refersToSameVar(lt.getGreaterOperand(), add.getAnOperand()) and
+  lt.getGreaterOperand() != lt.getLesserOperand()
+select add, "Adding $@ and $@ may overflow before division takes place and lead to a crash.",
+  add.getLeftOperand(), add.getLeftOperand().(VarAccess).getVariable().getName(), add.getRightOperand(),
+  add.getRightOperand().(VarAccess).getVariable().getName()


### PR DESCRIPTION
Divide and conquer algorithms like binary search or merge sort
have to calculate a mid point, when they are dividing the task.
(Splitting the task into [0, mid] and [mid, arrayLength])
This is often done as mid = (low+high)/2, but this will fail, when
low and high are big numbers (2^30). In this case overflow will have happened,
leading to a negative value.
Using this negative value to access an array will then lead to an
ArrayIndexOutOfBoundsException.