### PR TITLE
Add check for disabled HTTPOnly setting in Tomcat

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.qhelp
@@ -1,0 +1,35 @@
+<!DOCTYPE qhelp SYSTEM "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>When you add an application to a Tomcat server, it will generate a new <code>JSESSIONID</code> when you call <code>request.getSession()</code>
+or if you invoke a JSP from a servlet. If cookies are generated without the <code>HttpOnly</code> flag,
+an attacker can use a cross-site scripting (XSS) attack to get another user's session ID.
+</p>
+</overview>
+
+<recommendation>
+<p>Tomcat version 7+ automatically sets an <code>HttpOnly</code> flag on all session cookies to
+prevent client side scripts from accessing the session ID. 
+In most situations, you should not override this behavior.</p>
+</recommendation>
+
+<example>
+<p>The following example shows a Tomcat configuration with <code>useHttpOnly</code> disabled. Usually you should not to set this.</p>
+
+<sample src="insecure-web.xml" />
+</example>
+
+<references>
+<li>
+CWE:
+<a href="https://cwe.mitre.org/data/definitions/1004.html">Sensitive Cookie Without 'HttpOnly' Flag</a>.
+</li>
+<li>
+OWASP:
+<a href="https://www.owasp.org/index.php/HttpOnly">
+  HttpOnly
+</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.qhelp
@@ -15,7 +15,7 @@ In most situations, you should not override this behavior.</p>
 </recommendation>
 
 <example>
-<p>The following example shows a Tomcat configuration with <code>useHttpOnly</code> disabled. Usually you should not to set this.</p>
+<p>The following example shows a Tomcat configuration with <code>useHttpOnly</code> disabled. Usually you should not set this.</p>
 
 <sample src="insecure-web.xml" />
 </example>

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/InsecureTomcatConfig.ql
@@ -1,0 +1,26 @@
+/**
+ * @name Tomcat config disables 'HttpOnly' flag (XSS risk)
+ * @description Disabling 'HttpOnly' leaves session cookies vulnerable to an XSS attack.
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id java/tomcat-disabled-httponly
+ * @tags security
+ *       external/cwe/cwe-1004
+ */
+
+import java
+import semmle.code.xml.WebXML
+
+private class HttpOnlyConfig extends WebContextParameter {
+  HttpOnlyConfig() { this.getParamName().getValue() = "useHttpOnly" }
+
+  string getParamValueElementValue() { result = getParamValue().getValue() }
+
+  predicate isHTTPOnlySet() { getParamValueElementValue().toLowerCase() = "false" }
+}
+
+from HttpOnlyConfig config
+where config.isHTTPOnlySet()
+select config,
+  "httpOnly should be enabled in tomcat config file to help mitigate cross-site scripting (XSS) attacks"

--- a/java/ql/src/experimental/Security/CWE/CWE-1004/insecure-web.xml
+++ b/java/ql/src/experimental/Security/CWE/CWE-1004/insecure-web.xml
@@ -1,0 +1,9 @@
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+          http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+    <display-name>Sample Tomcat Web Application</display-name>
+    <context-param>
+        <param-name>useHttpOnly</param-name>
+        <param-value>false</param-value>
+    </context-param>
+</web-app>


### PR DESCRIPTION
Tomcat beyond vesion 6 has enable HTTPOnly for JSESSIONID by default. But, it's possible to disable it,  which allowed an attacker get another user's sessionid by  Cross-Site Scripting(XSS) attack,
 
[CWE-1004: Sensitive Cookie Without 'HttpOnly' ]Flag(https://cwe.mitre.org/data/definitions/1004.html)

Tomcat HTTPOnly  can be disabled via web.xml configuration by add config below

```
<context-param>
        <param-name>useHttpOnly</param-name>
        <param-value>false</param-value>
</context-param>
```

This PR adds a CodeQL check which finds all web.xml  set  useHttpOnly to false