### PR TITLE
Java : CWE - 297 - Check server identity when using SSL email

### DIFF
--- a/java/ql/src/experimental/CWE-297/Email.qll
+++ b/java/ql/src/experimental/CWE-297/Email.qll
@@ -1,0 +1,273 @@
+/* Definitions related to the Apache Commons Email library. */
+import semmle.code.java.Type
+
+class Email extends Class {
+  Email() {
+    exists(Class email |
+      email.getQualifiedName() = "org.apache.commons.mail.Email" and
+      this.extendsOrImplements(email)
+    )
+    or
+    this.hasQualifiedName("org.apache.commons.mail", "Email")
+  }
+}
+
+class EmailMethod extends Method {
+  EmailMethod() { getDeclaringType() instanceof Email }
+}
+
+class MethodEmailIsStartTLSRequired extends EmailMethod {
+  MethodEmailIsStartTLSRequired() { hasName("isStartTLSRequired") }
+}
+
+class MethodEmailSetTo extends EmailMethod {
+  MethodEmailSetTo() { hasName("setTo") }
+}
+
+class MethodEmailSetCharset extends EmailMethod {
+  MethodEmailSetCharset() { hasName("setCharset") }
+}
+
+class MethodEmailSetFrom extends EmailMethod {
+  MethodEmailSetFrom() { hasName("setFrom") }
+}
+
+class MethodEmailSetAuthentication extends EmailMethod {
+  MethodEmailSetAuthentication() { hasName("setAuthentication") }
+}
+
+class MethodEmailGetHeaders extends EmailMethod {
+  MethodEmailGetHeaders() { hasName("getHeaders") }
+}
+
+class MethodEmailUpdateContentType extends EmailMethod {
+  MethodEmailUpdateContentType() { hasName("updateContentType") }
+}
+
+class MethodEmailSend extends EmailMethod {
+  MethodEmailSend() { hasName("send") }
+}
+
+class MethodEmailGetSubject extends EmailMethod {
+  MethodEmailGetSubject() { hasName("getSubject") }
+}
+
+class MethodEmailGetCcAddresses extends EmailMethod {
+  MethodEmailGetCcAddresses() { hasName("getCcAddresses") }
+}
+
+class MethodEmailGetSentDate extends EmailMethod {
+  MethodEmailGetSentDate() { hasName("getSentDate") }
+}
+
+class MethodEmailSetSmtpPort extends EmailMethod {
+  MethodEmailSetSmtpPort() { hasName("setSmtpPort") }
+}
+
+class MethodEmailGetToAddresses extends EmailMethod {
+  MethodEmailGetToAddresses() { hasName("getToAddresses") }
+}
+
+class MethodEmailSetContent extends EmailMethod {
+  MethodEmailSetContent() { hasName("setContent") }
+}
+
+class MethodEmailIsSSL extends EmailMethod {
+  MethodEmailIsSSL() { hasName("isSSL") }
+}
+
+class MethodEmailGetMailSession extends EmailMethod {
+  MethodEmailGetMailSession() { hasName("getMailSession") }
+}
+
+class MethodEmailSetSocketConnectionTimeout extends EmailMethod {
+  MethodEmailSetSocketConnectionTimeout() { hasName("setSocketConnectionTimeout") }
+}
+
+class MethodEmailSetStartTLSRequired extends EmailMethod {
+  MethodEmailSetStartTLSRequired() { hasName("setStartTLSRequired") }
+}
+
+class MethodEmailGetHostName extends EmailMethod {
+  MethodEmailGetHostName() { hasName("getHostName") }
+}
+
+class MethodEmailIsSSLOnConnect extends EmailMethod {
+  MethodEmailIsSSLOnConnect() { hasName("isSSLOnConnect") }
+}
+
+class MethodEmailSetHostName extends EmailMethod {
+  MethodEmailSetHostName() { hasName("setHostName") }
+}
+
+class MethodEmailSetSocketTimeout extends EmailMethod {
+  MethodEmailSetSocketTimeout() { hasName("setSocketTimeout") }
+}
+
+class MethodEmailSetAuthenticator extends EmailMethod {
+  MethodEmailSetAuthenticator() { hasName("setAuthenticator") }
+}
+
+class MethodEmailIsTLS extends EmailMethod {
+  MethodEmailIsTLS() { hasName("isTLS") }
+}
+
+class MethodEmailAddHeader extends EmailMethod {
+  MethodEmailAddHeader() { hasName("addHeader") }
+}
+
+class MethodEmailSetStartTLSEnabled extends EmailMethod {
+  MethodEmailSetStartTLSEnabled() { hasName("setStartTLSEnabled") }
+}
+
+class MethodEmailGetBccAddresses extends EmailMethod {
+  MethodEmailGetBccAddresses() { hasName("getBccAddresses") }
+}
+
+class MethodEmailGetReplyToAddresses extends EmailMethod {
+  MethodEmailGetReplyToAddresses() { hasName("getReplyToAddresses") }
+}
+
+class MethodEmailAddTo extends EmailMethod {
+  MethodEmailAddTo() { hasName("addTo") }
+}
+
+class MethodEmailGetSocketTimeout extends EmailMethod {
+  MethodEmailGetSocketTimeout() { hasName("getSocketTimeout") }
+}
+
+class MethodEmailSetSSLOnConnect extends EmailMethod {
+  MethodEmailSetSSLOnConnect() { hasName("setSSLOnConnect") }
+}
+
+class MethodEmailSetSendPartial extends EmailMethod {
+  MethodEmailSetSendPartial() { hasName("setSendPartial") }
+}
+
+class MethodEmailSetTLS extends EmailMethod {
+  MethodEmailSetTLS() { hasName("setTLS") }
+}
+
+class MethodEmailSetSSLCheckServerIdentity extends EmailMethod {
+  MethodEmailSetSSLCheckServerIdentity() { hasName("setSSLCheckServerIdentity") }
+}
+
+class MethodEmailSetBcc extends EmailMethod {
+  MethodEmailSetBcc() { hasName("setBcc") }
+}
+
+class MethodEmailSetMailSessionFromJNDI extends EmailMethod {
+  MethodEmailSetMailSessionFromJNDI() { hasName("setMailSessionFromJNDI") }
+}
+
+class MethodEmailBuildMimeMessage extends EmailMethod {
+  MethodEmailBuildMimeMessage() { hasName("buildMimeMessage") }
+}
+
+class MethodEmailIsSendPartial extends EmailMethod {
+  MethodEmailIsSendPartial() { hasName("isSendPartial") }
+}
+
+class MethodEmailGetFromAddress extends EmailMethod {
+  MethodEmailGetFromAddress() { hasName("getFromAddress") }
+}
+
+class MethodEmailAddBcc extends EmailMethod {
+  MethodEmailAddBcc() { hasName("addBcc") }
+}
+
+class MethodEmailAddCc extends EmailMethod {
+  MethodEmailAddCc() { hasName("addCc") }
+}
+
+class MethodEmailSetBounceAddress extends EmailMethod {
+  MethodEmailSetBounceAddress() { hasName("setBounceAddress") }
+}
+
+class MethodEmailToInternetAddressArray extends EmailMethod {
+  MethodEmailToInternetAddressArray() { hasName("toInternetAddressArray") }
+}
+
+class MethodEmailSetHeaders extends EmailMethod {
+  MethodEmailSetHeaders() { hasName("setHeaders") }
+}
+
+class MethodEmailGetSocketConnectionTimeout extends EmailMethod {
+  MethodEmailGetSocketConnectionTimeout() { hasName("getSocketConnectionTimeout") }
+}
+
+class MethodEmailSetReplyTo extends EmailMethod {
+  MethodEmailSetReplyTo() { hasName("setReplyTo") }
+}
+
+class MethodEmailSetSslSmtpPort extends EmailMethod {
+  MethodEmailSetSslSmtpPort() { hasName("setSslSmtpPort") }
+}
+
+class MethodEmailIsStartTLSEnabled extends EmailMethod {
+  MethodEmailIsStartTLSEnabled() { hasName("isStartTLSEnabled") }
+}
+
+class MethodEmailSetMailSession extends EmailMethod {
+  MethodEmailSetMailSession() { hasName("setMailSession") }
+}
+
+class MethodEmailAddReplyTo extends EmailMethod {
+  MethodEmailAddReplyTo() { hasName("addReplyTo") }
+}
+
+class MethodEmailSendMimeMessage extends EmailMethod {
+  MethodEmailSendMimeMessage() { hasName("sendMimeMessage") }
+}
+
+class MethodEmailGetHeader extends EmailMethod {
+  MethodEmailGetHeader() { hasName("getHeader") }
+}
+
+class MethodEmailGetBounceAddress extends EmailMethod {
+  MethodEmailGetBounceAddress() { hasName("getBounceAddress") }
+}
+
+class MethodEmailGetSslSmtpPort extends EmailMethod {
+  MethodEmailGetSslSmtpPort() { hasName("getSslSmtpPort") }
+}
+
+class MethodEmailGetSmtpPort extends EmailMethod {
+  MethodEmailGetSmtpPort() { hasName("getSmtpPort") }
+}
+
+class MethodEmailSetCc extends EmailMethod {
+  MethodEmailSetCc() { hasName("setCc") }
+}
+
+class MethodEmailSetPopBeforeSmtp extends EmailMethod {
+  MethodEmailSetPopBeforeSmtp() { hasName("setPopBeforeSmtp") }
+}
+
+class MethodEmailSetSubject extends EmailMethod {
+  MethodEmailSetSubject() { hasName("setSubject") }
+}
+
+class MethodEmailSetSSL extends EmailMethod {
+  MethodEmailSetSSL() { hasName("setSSL") }
+}
+
+class MethodEmailIsSSLCheckServerIdentity extends EmailMethod {
+  MethodEmailIsSSLCheckServerIdentity() { hasName("isSSLCheckServerIdentity") }
+}
+
+class MethodEmailSetDebug extends EmailMethod {
+  MethodEmailSetDebug() { hasName("setDebug") }
+}
+
+class MethodEmailCreateMimeMessage extends EmailMethod {
+  MethodEmailCreateMimeMessage() { hasName("createMimeMessage") }
+}
+
+class MethodEmailSetSentDate extends EmailMethod {
+  MethodEmailSetSentDate() { hasName("setSentDate") }
+}
+
+class MethodEmailGetMimeMessage extends EmailMethod {
+  MethodEmailGetMimeMessage() { hasName("getMimeMessage") }
+}

--- a/java/ql/src/experimental/CWE-297/apache_insecure_smtp.qhelp
+++ b/java/ql/src/experimental/CWE-297/apache_insecure_smtp.qhelp
@@ -1,0 +1,37 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd"> 
+<qhelp>
+<overview>
+<p>
+The Apache Commons Mail library by default, does not verify the host 
+when connecting to the server.  This is equivalent to trusting all certificates. 
+This may lead to Man in the Middle attacks and the application leaking sensitive 
+user information on a broken SSL connection.
+</p>
+</overview>
+
+<recommendation>
+<p>
+The identity of the serve should be checked using the 
+<code>setSSLCheckServerIdentity(true);</code> call.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+Here since the send() is called without the SSLCheckServerIdentity variable 
+set to true, the application is vulnerable to attacks.
+ <sample language="java" src="example/email.java">
+</p>
+
+<p>
+Here in this case, we enable the server idenetitiy checks. Hence, fixing the issue.
+</p>
+<sample src="example/emailCorrect.java" />
+</example>
+
+<references>
+<li>MITRE: <a href="https://cwe.mitre.org/data/definitions/297.html">CWE 297</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-project-top-ten/OWASP_Top_Ten_2017/Top_10-2017_A3-Sensitive_Data_Exposure">A3 - Sensitive Data Exposure</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/CWE-297/apache_insecure_smtp.ql
+++ b/java/ql/src/experimental/CWE-297/apache_insecure_smtp.ql
@@ -1,0 +1,81 @@
+/*
+ * @description  Server identity verification by default is disabled
+ *    when making SSL connections. This is equivalent to trusting all certificates.
+ *    When trying to connect to the server, this application would readily
+ *    accept a certificate issued to any domain potentially leaking sensitive
+ *    user information on a broken SSL connection to the server.
+ * @id java/apache-insecure-smtp-ssl
+ * @kind path-problem
+ * @name Apache Commons Email Insecure SMTP SSL Connection
+ * @tags security
+ * CWE-297: Improper Validation of Certificate with Host Mismatch
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.dataflow.DefUse
+import semmle.code.java.dataflow.TaintTracking
+import Email
+
+// Declare a new class for variables which are instances of the Email Class or its subclasses.
+class EmailVar extends Variable {
+  EmailVar() { this.getType() instanceof Email }
+}
+
+class SendMethods extends EmailMethod {
+  SendMethods() {
+    this instanceof MethodEmailSend
+    or
+    this instanceof MethodEmailSendMimeMessage
+    or
+    this instanceof MethodEmailSetStartTLSEnabled
+  }
+}
+
+class SSLOnMethods extends EmailMethod {
+  SSLOnMethods() {
+    this instanceof MethodEmailIsSSL
+    or
+    this instanceof MethodEmailIsTLS
+    or
+    this instanceof MethodEmailSetSSLOnConnect
+    or
+    this instanceof MethodEmailSetSSLOnConnect
+    or
+    this instanceof MethodEmailSetStartTLSRequired
+    or
+    this instanceof MethodEmailSetStartTLSEnabled
+  }
+}
+
+class EmailConfiguration extends DataFlow::Configuration {
+  EmailConfiguration() { this = "EmailConfiguration" }
+
+  // Since by default, certificate checks are disabled,
+  // object inititalisation is the source of the weakness
+  override predicate isSource(DataFlow::Node source) {
+    // exists(EmailVar e | source.asExpr()  = e.getInitializer())
+    exists(SSLOnMethods s |
+      s.getAReference().getQualifier() = source.asExpr() and
+      s.getAReference().getArgument(0).toString() = "true"
+    )
+  }
+
+  // The flow should stop when the email is sent.
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodEmailSend s | s.getAReference().getQualifier() = sink.asExpr())
+  }
+
+  // Call to Email.setSSLCheckServerIdentity will correct the defect
+  // and is hence a barrier
+  override predicate isBarrier(DataFlow::Node sink) {
+    exists(MethodEmailSetSSLCheckServerIdentity s |
+      s.getAReference().getQualifier() = sink.asExpr()
+    )
+  }
+}
+
+from EmailConfiguration dataflow, DataFlow::Node source, DataFlow::Node sink
+where dataflow.hasFlow(source, sink)
+select source.getLocation(), source, sink,
+  "SMTP connections with SSL on should should check the server identity to prevent attacks"

--- a/java/ql/src/experimental/CWE-297/example/email.java
+++ b/java/ql/src/experimental/CWE-297/example/email.java
@@ -1,0 +1,25 @@
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.mail.*;
+
+public class email  
+{
+    public static void main(String[] args) throws Exception {
+        Email email = new SimpleEmail();
+        email.setHostName("smtp.googlemail.com");
+        email.setSmtpPort(465);
+        email.setAuthenticator(new DefaultAuthenticator("username", "password"));
+        email.setSSLOnConnect(true);
+        email.setFrom("user@gmail.com");
+        email.setSubject("TestMail");
+        email.setMsg("This is a test mail ... :-)");
+        email.addTo("foo@bar.com");
+        email.send(); // This is bad.
+    }
+}

--- a/java/ql/src/experimental/CWE-297/example/emailCorrect.java
+++ b/java/ql/src/experimental/CWE-297/example/emailCorrect.java
@@ -1,0 +1,19 @@
+
+import org.apache.commons.mail.*;
+
+public class emailCorrect 
+{
+    public static void main(String[] args) throws Exception{
+        Email email = new SimpleEmail();
+        email.setHostName("smtp.googlemail.com");
+        email.setSmtpPort(465);
+        email.setAuthenticator(new DefaultAuthenticator("username", "password"));
+        email.setSSLOnConnect(true);
+        email.setFrom("user@gmail.com");
+        email.setSubject("TestMail");
+        email.setMsg("This is a test mail ... :-)");
+        email.addTo("foo@bar.com");
+        email.setSSLCheckServerIdentity(true); // This fixes the issue.
+        email.send();
+    }
+}


### PR DESCRIPTION
The Apache Commons Email library by default does not verify host headers. This PR adds a codeql check for the same. 