### PR TITLE
Dataflow: Count callables instead of nodes for fieldFlowBranchLimit.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl2.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl3.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 

--- a/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
+++ b/python/ql/src/semmle/python/dataflow/new/internal/DataFlowImpl4.qll
@@ -86,7 +86,7 @@ abstract class Configuration extends string {
    * This can be overridden to a smaller value to improve performance (a
    * value of 0 disables field flow), or a larger value to get more results.
    */
-  int fieldFlowBranchLimit() { result = 2 }
+  int fieldFlowBranchLimit() { result = 1 }
 
   /**
    * Holds if data may flow from `source` to `sink` for this configuration.
@@ -703,8 +703,12 @@ private predicate flowIntoCallNodeCand1(
  */
 private int branch(Node n1, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n1, n, conf) or flowIntoCallNodeCand1(_, n1, n, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 
@@ -715,8 +719,12 @@ private int branch(Node n1, Configuration conf) {
  */
 private int join(Node n2, Configuration conf) {
   result =
-    strictcount(Node n |
-      flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+    strictcount(DataFlowCallable callable |
+      exists(Node n |
+        flowOutOfCallNodeCand1(_, n, n2, conf) or flowIntoCallNodeCand1(_, n, n2, conf)
+      |
+        callable = n.getEnclosingCallable()
+      )
     )
 }
 


### PR DESCRIPTION
This was intended to measure virtual dispatch, so this changes the `fieldFlowBranchLimit` to count callables instead of nodes, which gives a bit more flow.  The `fieldFlowBranchLimit` is still a rather ad-hoc mechanism, which causes false negative, so ideally we'd get rid of it, but it is unfortunately still a necessary performance concession. This PR could potentially also introduce performance problems, so it'll need a bit of performance testing.