### PR TITLE
Java: CWE-532 sensitive info logging

### DIFF
--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.java
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.java
@@ -1,0 +1,18 @@
+public static void main(String[] args) {
+	{
+		private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
+  
+    		String password = "Pass@0rd";
+
+		// BAD: user password is written to debug log
+		logger.debug("User password is "+password);
+	}
+	
+	{
+		private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
+  
+    		String password = "Pass@0rd";
+
+		// GOOD: user password is never written to debug log
+	}
+}

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.java
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.java
@@ -1,18 +1,18 @@
 public static void main(String[] args) {
-	{
-		private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
-  
-    		String password = "Pass@0rd";
+    {
+        private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
 
-		// BAD: user password is written to debug log
-		logger.debug("User password is "+password);
-	}
+        String password = "Pass@0rd";
+
+        // BAD: user password is written to debug log
+        logger.debug("User password is "+password);
+    }
 	
-	{
-		private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
+    {
+        private static final Logger logger = LogManager.getLogger(SensitiveInfoLog.class);
   
-    		String password = "Pass@0rd";
+        String password = "Pass@0rd";
 
-		// GOOD: user password is never written to debug log
-	}
+        // GOOD: user password is never written to debug log
+    }
 }

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
@@ -22,8 +22,5 @@ the credentials are simply written to a debug log. In the 'GOOD' case, the crede
 <li>
 <a href="https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html">OWASP Logging Guide</a>
 </li>
-<li>
-<a href="https://cwe.mitre.org/data/definitions/532.html">CWE 532</a>
-</li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
@@ -1,0 +1,29 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Information written to log files can be of a sensitive nature and give valuable guidance to an attacker or expose sensitive user information. Third-party logging utilities like Log4J and SLF4J are widely used in Java projects. When sensitive information are written to logs without properly set logging levels, it is accessible to potential attackers who gains access to the
+file storage.</p>
+</overview>
+
+<recommendation>
+<p>Do not write secrets into the log files and enforce proper logging level control.</p>
+</recommendation>
+
+<example>
+<p>The following example shows two ways of logging sensitive information. In the 'BAD' case,
+the credentials are simply written to a debug log. In the 'GOOD' case, the credentials are never written to debug logs.</p>
+<sample src="SensitiveInfoLog.java" />
+</example>
+
+<references>
+<li>
+<a href="https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html">OWASP Logging Guide</a>
+</li>
+<li>
+<a href="https://cwe.mitre.org/data/definitions/532.html">CWE 532</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.qhelp
@@ -4,7 +4,7 @@
 <qhelp>
 
 <overview>
-<p>Information written to log files can be of a sensitive nature and give valuable guidance to an attacker or expose sensitive user information. Third-party logging utilities like Log4J and SLF4J are widely used in Java projects. When sensitive information are written to logs without properly set logging levels, it is accessible to potential attackers who gains access to the
+<p>Information written to log files can be of a sensitive nature and give valuable guidance to an attacker or expose sensitive user information. Third-party logging utilities like Log4J and SLF4J are widely used in Java projects. When sensitive information is written to logs without properly set logging levels, it is accessible to potential attackers who can use it to gain access to
 file storage.</p>
 </overview>
 

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -1,0 +1,83 @@
+/**
+ * @id java/sensitiveinfo-in-logfile
+ * @name Insertion of sensitive information into log files
+ * @description Writting sensitive information to log files can give valuable guidance to an attacker or expose sensitive user information.
+ * @kind problem
+ * @tags security
+ *       external/cwe-532
+ */
+
+import java
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow
+import PathGraph
+
+/** Class of popular logging utilities **/
+class LoggerType extends RefType {
+    LoggerType() {
+        this.hasQualifiedName("org.apache.log4j", "Category") or //Log4J
+        this.hasQualifiedName("org.slf4j", "Logger")  //SLF4j
+    }
+}
+
+/** Concatenated string with a variable that keeps sensitive information judging by its name **/
+class CredentialExpr extends Expr {
+    CredentialExpr() {
+        exists (Variable v | this.(AddExpr).getAnOperand() = v.getAnAccess() | v.getName().regexpMatch(getACredentialRegex()))
+    }
+}
+
+/** Source in concatenated string or variable itself  **/
+class CredentialSource extends DataFlow::ExprNode {
+    CredentialSource() {
+        exists (
+            Variable v | this.asExpr() = v.getAnAccess() | v.getName().regexpMatch(getACredentialRegex())
+        ) or
+        exists (
+            this.asExpr().(AddExpr).getAnOperand().(CredentialExpr)  
+        ) or
+        exists (
+            this.asExpr().(CredentialExpr)  
+        )
+    }
+}
+
+/**
+  * Gets a regular expression for matching names of variables that indicate the value being held is a credential.
+  */
+
+private string getACredentialRegex() {
+  result = "(?i).*pass(wd|word|code|phrase)(?!.*question).*" or
+  result = "(?i).*(uid|uuid|puid|username|userid|url).*"
+}
+
+class SensitiveLoggingSink extends DataFlow::ExprNode {
+    SensitiveLoggingSink() {
+        exists(MethodAccess ma |
+            ma.getMethod().getDeclaringType() instanceof LoggerType and
+            (
+                ma.getMethod().hasName("debug")
+            ) and
+            this.asExpr() = ma.getAnArgument()
+        )
+    }
+}
+
+class SensitiveLoggingConfig extends Configuration {
+    SensitiveLoggingConfig() {
+        this = "SensitiveLoggingConfig"
+    }
+
+    override predicate isSource(Node source) {
+        source instanceof CredentialSource
+    }
+
+    override predicate isSink(Node sink) {
+        sink instanceof SensitiveLoggingSink
+    }
+}
+
+from Node source, Node sink, SensitiveLoggingConfig conf, MethodAccess ma
+where conf.hasFlow(source, sink) and ma.getAnArgument() = source.asExpr() and ma.getAnArgument() = sink.asExpr()
+select "Outputting sensitive information $@ in method call $@.", source, ma, "to log files"
+

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -1,7 +1,7 @@
 /**
  * @id java/sensitiveinfo-in-logfile
  * @name Insertion of sensitive information into log files
- * @description Writting sensitive information to log files can give valuable guidance to an attacker or expose sensitive user information.
+ * @description Writing sensitive information to log files can give valuable guidance to an attacker or expose sensitive user information.
  * @kind problem
  * @tags security
  *       external/cwe-532
@@ -80,4 +80,3 @@ class SensitiveLoggingConfig extends Configuration {
 from Node source, Node sink, SensitiveLoggingConfig conf, MethodAccess ma
 where conf.hasFlow(source, sink) and ma.getAnArgument() = source.asExpr() and ma.getAnArgument() = sink.asExpr()
 select "Outputting sensitive information $@ in method call $@.", source, ma, "to log files"
-

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -2,7 +2,7 @@
  * @id java/sensitiveinfo-in-logfile
  * @name Insertion of sensitive information into log files
  * @description Writing sensitive information to log files can give valuable guidance to an attacker or expose sensitive user information.
- * @kind problem
+ * @kind path-problem
  * @tags security
  *       external/cwe-532
  */
@@ -55,6 +55,7 @@ class LoggerConfiguration extends DataFlow::Configuration {
   }
 }
 
-from LoggerConfiguration cfg, DataFlow::Node source, DataFlow::Node sink
-where cfg.hasFlow(source, sink)
-select "Outputting sensitive information in ", sink, "to log file"
+from LoggerConfiguration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Outputting $@ to log.", source.getNode(),
+  "sensitive information"

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -20,14 +20,10 @@ private string getACredentialRegex() {
   result = "(?i)(.*username|url).*"
 }
 
-/** The variable or concatenated string with the variable that keeps sensitive information judging by its name * */
+/** Variable keeps sensitive information judging by its name * */
 class CredentialExpr extends Expr {
   CredentialExpr() {
-    exists(Variable v |
-      (this.(AddExpr).getAnOperand() = v.getAnAccess() or this = v.getAnAccess())
-    |
-      v.getName().regexpMatch(getACredentialRegex())
-    )
+    exists(Variable v | this = v.getAnAccess() | v.getName().regexpMatch(getACredentialRegex()))
   }
 }
 

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -42,7 +42,7 @@ class LoggerType extends RefType {
 predicate isSensitiveLoggingSink(DataFlow::Node sink) {
   exists(MethodAccess ma |
     ma.getMethod().getDeclaringType() instanceof LoggerType and
-    (ma.getMethod().hasName("debug") or ma.getMethod().hasName("trace")) and
+    (ma.getMethod().hasName("debug") or ma.getMethod().hasName("trace")) and //Check low priority log levels which are more likely to be real issues to reduce false positives
     sink.asExpr() = ma.getAnArgument()
   )
 }

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -48,7 +48,7 @@ class CredentialSource extends DataFlow::ExprNode {
 
 private string getACredentialRegex() {
   result = "(?i).*pass(wd|word|code|phrase)(?!.*question).*" or
-  result = "(?i).*(uid|uuid|puid|username|userid|url).*"
+  result = "(?i).*(username|url).*"
 }
 
 class SensitiveLoggingSink extends DataFlow::ExprNode {

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -16,7 +16,7 @@ import PathGraph
 class LoggerType extends RefType {
     LoggerType() {
         this.hasQualifiedName("org.apache.log4j", "Category") or //Log4J
-        this.hasQualifiedName("org.slf4j", "Logger")  //SLF4j
+        this.hasQualifiedName("org.slf4j", "Logger")  //SLF4j and Gradle Logging
     }
 }
 

--- a/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
+++ b/java/ql/src/experimental/CWE-532/SensitiveInfoLog.ql
@@ -17,7 +17,7 @@ import PathGraph
  */
 private string getACredentialRegex() {
   result = "(?i).*pass(wd|word|code|phrase)(?!.*question).*" or
-  result = "(?i).*(username|url).*"
+  result = "(?i)(.*username|url).*"
 }
 
 /** The variable or concatenated string with the variable that keeps sensitive information judging by its name * */
@@ -42,7 +42,7 @@ class LoggerType extends RefType {
 predicate isSensitiveLoggingSink(DataFlow::Node sink) {
   exists(MethodAccess ma |
     ma.getMethod().getDeclaringType() instanceof LoggerType and
-    ma.getMethod().hasName("debug") and
+    (ma.getMethod().hasName("debug") or ma.getMethod().hasName("trace")) and
     sink.asExpr() = ma.getAnArgument()
   )
 }


### PR DESCRIPTION
 Third-party logging utilities like Log4J and SLF4J are widely used in Java projects. This PR adds a codeql check for writing sensitive information to debug logs.