### PR TITLE
Java: Using Custom Approval template with old spring security oauth library can lead to remote code execution

### DIFF
--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.java
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.java
@@ -1,0 +1,18 @@
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class AuthorizationEndpointConfigurer {
+
+    @Autowired
+    private AuthorizationEndpoint authorizationEndpoint;
+
+    @PostConstruct
+    public void init() {
+      //BAD: if spring security oauth version is old, RCE attack can be used.
+      authorizationEndpoint.setUserApprovalPage("forward:/oauth/confirm_access");
+    }
+}

--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.qhelp
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.qhelp
@@ -1,0 +1,32 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+
+<overview>
+<p>
+This rule finds functions that use act in the role of an authorization server (e.g. @EnableAuthorizationServer) and default the default approval endpoint(forward:/oauth/confirm_access).
+Also checks the pom.xml for specific jar version. Versions 2.3 prior to 2.3.3 and 2.2 prior to 2.2.2 and 2.1 prior to 2.1.2 and 2.0 prior to 2.0.15 and older are affected from this vulnerability.
+If this version is from the vulnerable set, rule will display it.
+</p>
+
+</overview>
+<recommendation>
+<p>Custom approval page should be used for prevent this vulnerability.
+Latest jar version for "OAuth2 For Spring Security" library should be used.</p>
+
+</recommendation>
+<references>
+<li>
+  Detailed summary of CVE-2018-1260: <a href="https://chybeta.github.io/2018/05/12/RCE-with-spring-security-oauth2-%E5%88%86%E6%9E%90-%E3%80%90CVE-2018-1260%E3%80%91/">CVE-2018-1260 detailed description</a>
+</li>
+<li>
+  National Vulnerability Database: <a href="https://nvd.nist.gov/vuln/detail/CVE-2018-1260">CVE-2018-1260</a>
+</li>
+
+
+
+
+</references>
+</qhelp>

--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.ql
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.ql
@@ -1,0 +1,44 @@
+/**
+ * @name CVE-2018-1260: Remote Code Execution with spring-security-oauth2
+ * @description A malicious user or attacker can craft an authorization request to the authorization endpoint that can lead to a remote code execution when the resource owner is forwarded to the approval endpoint.
+ * @kind Remote Code Execution
+ */
+import java
+import semmle.code.xml.MavenPom
+
+private class PomVersionChecker extends Dependency {
+  PomVersionChecker() { this.getShortCoordinate().toString() = "org.springframework.security.oauth:spring-security-oauth2" }
+
+  string getShortCoordinateData() { result = this.getShortCoordinate().toString() }
+
+  float first2digit() {
+    result = this.getVersionString().replaceAll(".", "").substring(0, 2).toFloat()
+  }
+
+  float getversiondata() { result = this.getVersionString().replaceAll(".RELEASE", "").replaceAll(".", "").toFloat() }
+
+  predicate getLibraryData() { getShortCoordinateData().toString() = "org.springframework.security.oauth:spring-security-oauth2" }
+
+  predicate isVersionNumberVulnerable() {
+    (this.first2digit() = 23 and getversiondata() >= 23 and getversiondata() < 233)
+    or
+    (this.first2digit() = 22 and this.getversiondata() >= 22 and getversiondata() < 222)
+    or
+    (this.first2digit() = 21 and this.getversiondata() >= 21 and getversiondata() < 211)
+    or
+    (this.first2digit() = 20 and this.getversiondata() >= 20 and getversiondata() < 2014)
+  }
+}
+
+from Annotation ann, MethodAccess call, StringLiteral arg, PomVersionChecker config
+where
+  ann
+      .getType()
+      .hasQualifiedName("org.springframework.security.oauth2.config.annotation.web.configuration",
+        "EnableAuthorizationServer") and
+  call.getMethod().hasName("setUserApprovalPage") and
+  call.getArgument(0) = arg and
+  arg.getValue() = "forward:/oauth2/confirm_access" and
+  config.getLibraryData() and  config.isVersionNumberVulnerable()
+select ann, config,  "Remote code execution attacks can be occured with OAuth template injection."
+

--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.xml
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.xml
@@ -1,0 +1,18 @@
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class AuthorizationEndpointConfigurer {
+
+    @Autowired
+    private AuthorizationEndpoint authorizationEndpoint;
+
+    @PostConstruct
+    public void init() {
+      //BAD: if spring security oauth version is old, RCE attack can be used.
+      authorizationEndpoint.setUserApprovalPage("forward:/oauth/confirm_access");
+    }
+}

--- a/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.xml
+++ b/java/ql/src/Frameworks/Spring/XML Configuration Errors/insecureOAuthVersion.xml
@@ -1,18 +1,25 @@
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint;
-import org.springframework.stereotype.Component;
+<project xmlns="http://maven.apache.org/POM/4.0.0"   
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   
+http://maven.apache.org/xsd/maven-4.0.0.xsd">  
+  
+  <modelVersion>4.0.0</modelVersion>  
+  
+  <groupId>com.test.</groupId>  
+  <artifactId>my-vulnerable-application</artifactId>  
+  <version>1.0</version>  
+  <packaging>jar</packaging>  
+  
+  <name>Spring Security OAuth</name>  
+  <url>http://maven.apache.org</url>  
 
-import javax.annotation.PostConstruct;
-
-@Component
-public class AuthorizationEndpointConfigurer {
-
-    @Autowired
-    private AuthorizationEndpoint authorizationEndpoint;
-
-    @PostConstruct
-    public void init() {
-      //BAD: if spring security oauth version is old, RCE attack can be used.
-      authorizationEndpoint.setUserApprovalPage("forward:/oauth/confirm_access");
-    }
-}
+  <dependencies>  
+    <dependency>  
+      <groupId>org.springframework.security.oauth</groupId>  
+      <artifactId>spring-security-oauth2</artifactId>  
+      <!--BAD: This version is affected from this vulnerability-->
+      <version>2.0.7.RELEASE</version>  
+      <scope>test</scope>  
+    </dependency>  
+  </dependencies>  
+</project>  


### PR DESCRIPTION
This rule is written for CVE-2018-1260.
Spring Security OAuth, versions 2.3 prior to 2.3.3 and 2.2 prior to 2.2.2 and 2.1 prior to 2.1.2 and 2.0 prior to 2.0.15 and older unsupported versions, contains a remote code execution vulnerability. A malicious user or attacker can craft an authorization request to the authorization endpoint that can lead to a remote code execution when the resource owner is forwarded to the approval endpoint.

This vulnerability exposes applications that meet all of the following requirements:

- Act in the role of an Authorization Server (e.g. @EnableAuthorizationServer)

- Use the default Approval Endpoint

Spring security has OAuth solution for solve single sign on requirements. If developers use this library with old spring security oauth library and default approval page , developer will be affected from this vulnerability. 

OAuth authorization code flow is like below. CVE-2018-1260 is focused on  step 4. RCE attacks happened in step 4, if developer used default approval page. For prevent it , custom approval page or latest jar should be used.
![image](https://user-images.githubusercontent.com/12141715/77737475-1d887280-701f-11ea-8416-a7a1462fc769.png)

This rule finds functions that use act in the role of an authorization server (e.g. @EnableAuthorizationServer) and default the default approval endpoint(forward:/oauth/confirm_access).
Also checks the pom.xml for specific jar version. Versions 2.3 prior to 2.3.3 and 2.2 prior to 2.2.2 and 2.1 prior to 2.1.2 and 2.0 prior to 2.0.15 and older are affected from this vulnerability.
If this version is from the vulnerable set, rule will display it.