### PR TITLE
C++: Replace "min = max" with "unique"

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Buffer.qll
@@ -92,13 +92,7 @@ int getBufferSize(Expr bufferExpr, Element why) {
     // dataflow (all sources must be the same size)
     bufferExprNode = DataFlow::exprNode(bufferExpr) and
     result =
-      min(Expr def |
-        DataFlow::localFlowStep(DataFlow::exprNode(def), bufferExprNode)
-      |
-        getBufferSize(def, _)
-      ) and
-    result =
-      max(Expr def |
+      unique(Expr def |
         DataFlow::localFlowStep(DataFlow::exprNode(def), bufferExprNode)
       |
         getBufferSize(def, _)

--- a/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/internal/ConstantExprs.qll
@@ -532,13 +532,7 @@ library class ExprEvaluator extends int {
       interestingVariableAccess(e, va, v, true) and
       // All assignments must have the same int value
       result =
-        min(Expr value |
-          value = v.getAnAssignedValue() and not ignoreVariableAssignment(e, v, value)
-        |
-          getValueInternalNonSubExpr(value)
-        ) and
-      result =
-        max(Expr value |
+        unique(Expr value |
           value = v.getAnAssignedValue() and not ignoreVariableAssignment(e, v, value)
         |
           getValueInternalNonSubExpr(value)

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/constant/ConstantAnalysis.qll
@@ -14,8 +14,7 @@ int getConstantValue(Instruction instr) {
   or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
-    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
+    result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll
@@ -14,8 +14,7 @@ int getConstantValue(Instruction instr) {
   or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
-    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
+    result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll
@@ -14,8 +14,7 @@ int getConstantValue(Instruction instr) {
   or
   exists(PhiInstruction phi |
     phi = instr and
-    result = max(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef())) and
-    result = min(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
+    result = unique(Operand op | op = phi.getAnInputOperand() | getConstantValue(op.getDef()))
   )
 }
 


### PR DESCRIPTION
With the new `unique` aggregate added to QL, we can express directly what the "min = max" pattern emulates.

Replacing "min and max" with `unique` [might in general lead to fewer results](https://github.slack.com/archives/CPNQ6CE1L/p1584096913248200), but that happens [only in cases where the aggregate expression has multiple values](https://github.slack.com/archives/CPNQ6CE1L/p1584113591297300). For the three predicates changed in this PR, that should only happen on malformed databases.

**Do not merge** until at least a point where `unique` is in a stable CodeQL release that has been out for a while.

Cc @ginsbach.