### PR TITLE
JS: more precise warnings for implicit string conversion

### DIFF
--- a/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
+++ b/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
@@ -163,23 +163,23 @@ class PlusConversion extends NullOrUndefinedConversion {
   PlusConversion() { parent instanceof AddExpr or parent instanceof AssignAddExpr }
 
   override string getConversionTarget() {
-    result = getDefiniteCousinType()
+    result = getDefiniteSiblingType()
     or
-    not exists(getDefiniteCousinType()) and
+    not exists(getDefiniteSiblingType()) and
     result = "number or string"
   }
 
   /**
-   * Gets the cousin of this implicit conversion.
-   * E.g. if this is `a` in the expression `a + b`, then the cousin is `b`.
+   * Gets the sibling of this implicit conversion.
+   * E.g. if this is `a` in the expression `a + b`, then the sibling is `b`.
    */
-  private Expr getCousin() { result = parent.getAChild() and not result = this.getEnclosingExpr() }
+  private Expr getSibling() { result = parent.getAChild() and not result = this.getEnclosingExpr() }
 
   /**
-   * Gets the unique type of the cousin expression, if that type is `string` or `number`.
+   * Gets the unique type of the sibling expression, if that type is `string` or `number`.
    */
-  private string getDefiniteCousinType() {
-    result = unique(InferredType t | t = getCousin().flow().analyze().getAType()).getTypeofTag() and
+  private string getDefiniteSiblingType() {
+    result = unique(InferredType t | t = getSibling().flow().analyze().getAType()).getTypeofTag() and
     result = ["string", "number"]
   }
 }

--- a/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
+++ b/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
@@ -162,7 +162,26 @@ abstract class NullOrUndefinedConversion extends ImplicitConversion {
 class PlusConversion extends NullOrUndefinedConversion {
   PlusConversion() { parent instanceof AddExpr or parent instanceof AssignAddExpr }
 
-  override string getConversionTarget() { result = "number or string" }
+  override string getConversionTarget() {
+    result = getDefiniteCousinType()
+    or
+    not exists(getDefiniteCousinType()) and
+    result = "number or string"
+  }
+
+  /**
+   * Gets the cousin of this implicit conversion.
+   * E.g. if this is `a` in the expression `a + b`, then the cousin is `b`.
+   */
+  private Expr getCousin() { result = parent.getAChild() and not result = this.getEnclosingExpr() }
+
+  /**
+   * Gets the unique type of the cousin expression, if that type is `string` or `number`.
+   */
+  private string getDefiniteCousinType() {
+    result = unique(InferredType t | t = getCousin().flow().analyze().getAType()).getTypeofTag() and
+    result = ["string", "number"]
+  }
 }
 
 /**

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/ImplicitOperandConversion.expected
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/ImplicitOperandConversion.expected
@@ -3,7 +3,7 @@
 | tst.js:20:6:20:13 | 'string' | This expression will be implicitly converted from string to object. |
 | tst.js:26:13:26:53 | "Settin ... o '%s'" | This expression will be implicitly converted from string to number. |
 | tst.js:29:18:29:26 | !callback | This expression will be implicitly converted from boolean to object. |
-| tst.js:53:5:53:10 | void 0 | This expression will be implicitly converted from undefined to number or string. |
+| tst.js:53:5:53:10 | void 0 | This expression will be implicitly converted from undefined to number. |
 | tst.js:61:3:61:3 | x | This expression will be implicitly converted from undefined to number. |
 | tst.js:67:8:67:8 | y | This expression will be implicitly converted from undefined to number. |
 | tst.js:73:5:73:5 | x | This expression will be implicitly converted from undefined to number. |
@@ -11,3 +11,5 @@
 | tst.js:85:3:85:3 | x | This expression will be implicitly converted from undefined to number. |
 | tst.js:100:5:100:7 | f() | This expression will be implicitly converted from undefined to number. |
 | tst.js:106:5:106:7 | g() | This expression will be implicitly converted from undefined to number. |
+| tst.js:109:13:109:15 | g() | This expression will be implicitly converted from undefined to number. |
+| tst.js:110:13:110:15 | g() | This expression will be implicitly converted from undefined to string. |

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
@@ -105,5 +105,8 @@ function l() {
     }
     g()|0;
     g();
+
+    var a = g() + 2;
+    var b = g() + "str";
 });
 


### PR DESCRIPTION
Makes the alert message more precise for `js/implicit-operand-conversion` in situations where the conversion is known to convert to a string/number. 

This happens e.g. here: https://lgtm.com/projects/g/nodeGame/nodegame-client/snapshot/2820d3392201fce670fb56f4950b055e945234f1/files/lib/stager/stager_setters_getters.js?sort=name&dir=ASC&mode=heatmap#x55f35f26977a8cc6:1

Also, I got to try out the new `unique` aggregate and set literals, which is why this is a draft PR for now. 