### PR TITLE
Java: teach UnsafeDeserialization about ValidatingObjectInputStream

### DIFF
--- a/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
+++ b/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
@@ -51,7 +51,14 @@ class SafeKryo extends DataFlow2::Configuration {
 predicate unsafeDeserialization(MethodAccess ma, Expr sink) {
   exists(Method m | m = ma.getMethod() |
     m instanceof ObjectInputStreamReadObjectMethod and
-    sink = ma.getQualifier()
+    sink = ma.getQualifier() and
+    not exists(DataFlow::ExprNode node |
+      node.getExpr() = sink and
+      node
+          .getTypeBound()
+          .(RefType)
+          .hasQualifiedName("org.apache.commons.io.serialization", "ValidatingObjectInputStream")
+    )
     or
     m instanceof XMLDecoderReadObjectMethod and
     sink = ma.getQualifier()

--- a/java/ql/test/library-tests/UnsafeDeserialization/Test.java
+++ b/java/ql/test/library-tests/UnsafeDeserialization/Test.java
@@ -1,0 +1,12 @@
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
+
+class Test {
+	public void test() throws IOException, ClassNotFoundException {
+		ObjectInputStream objectStream = new ObjectInputStream(null);
+		ObjectInputStream validating = new ValidatingObjectInputStream(null);
+		objectStream.readObject();
+		validating.readObject();
+	}
+}

--- a/java/ql/test/library-tests/UnsafeDeserialization/unsafeDeserialization.expected
+++ b/java/ql/test/library-tests/UnsafeDeserialization/unsafeDeserialization.expected
@@ -1,0 +1,1 @@
+| Test.java:9:3:9:27 | readObject(...) | ObjectInputStream |

--- a/java/ql/test/library-tests/UnsafeDeserialization/unsafeDeserialization.ql
+++ b/java/ql/test/library-tests/UnsafeDeserialization/unsafeDeserialization.ql
@@ -1,0 +1,6 @@
+import default
+import semmle.code.java.security.UnsafeDeserialization
+
+from Method m, MethodAccess ma
+where ma.getMethod() = m and unsafeDeserialization(ma, _)
+select ma, m.getDeclaringType().getName()


### PR DESCRIPTION
The class org.apache.commons.io.serialization.ValidatingObjectInputStream
is an implementation of ObjectInputStream that validates the deserialized
classes against a white list. Therefore, this class should not be considered an
unsafe deserialization sink.