### PR TITLE
Java: use ObjectInput instead of ObjectInputStream

### DIFF
--- a/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
+++ b/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
@@ -4,7 +4,7 @@ import semmle.code.java.frameworks.SnakeYaml
 
 class ObjectInputStreamReadObjectMethod extends Method {
   ObjectInputStreamReadObjectMethod() {
-    this.getDeclaringType().getASourceSupertype*().hasQualifiedName("java.io", "ObjectInputStream") and
+    this.getDeclaringType().getASourceSupertype*().hasQualifiedName("java.io", "ObjectInput") and
     (this.hasName("readObject") or this.hasName("readUnshared"))
   }
 }

--- a/java/ql/test/library-tests/UnsafeDeserialization/Test.java
+++ b/java/ql/test/library-tests/UnsafeDeserialization/Test.java
@@ -1,0 +1,12 @@
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+
+class Test {
+	public void test() throws IOException, ClassNotFoundException {
+		ObjectInputStream objectStream = new ObjectInputStream(null);
+		ObjectInput objectInput = new ObjectInputStream(null);
+		objectStream.readObject();
+		objectInput.readObject();
+	}
+}

--- a/java/ql/test/library-tests/UnsafeDeserialization/objectinput.expected
+++ b/java/ql/test/library-tests/UnsafeDeserialization/objectinput.expected
@@ -1,0 +1,2 @@
+| Test.java:9:3:9:27 | readObject(...) | ObjectInputStream |
+| Test.java:10:3:10:26 | readObject(...) | ObjectInput |

--- a/java/ql/test/library-tests/UnsafeDeserialization/objectinput.ql
+++ b/java/ql/test/library-tests/UnsafeDeserialization/objectinput.ql
@@ -1,0 +1,6 @@
+import default
+import semmle.code.java.security.UnsafeDeserialization
+
+from ObjectInputStreamReadObjectMethod m, MethodAccess ma
+where ma.getMethod() = m
+select ma, m.getDeclaringType().getName()


### PR DESCRIPTION
The readObject method is actually declared in the ObjectInput interface.
This change captures cases like:

```
ObjectInput in = new ObjectInputStream(...);
in.readObject();
```