### PR TITLE
Python: ObjectAPI to ValueAPI: IncorrectRaiseInSpecialMethod

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -573,6 +573,9 @@ class ClassValue extends Value {
 abstract class FunctionValue extends CallableValue {
     abstract string getQualifiedName();
 
+    /** Gets a longer, more descriptive version of toString() */
+    abstract string descriptiveString();
+
     /** Gets the minimum number of parameters that can be correctly passed to this function */
     abstract int minParameters();
 
@@ -605,6 +608,20 @@ abstract class FunctionValue extends CallableValue {
         )
     }
 
+    /** Gets a class that may be raised by this function */
+    abstract ClassValue getARaisedType();
+
+    /** Gets a call-site from where this function is called as a function */
+    CallNode getAFunctionCall() { result.getFunction().pointsTo() = this }
+
+    /** Gets a call-site from where this function is called as a method */
+    CallNode getAMethodCall() {
+        exists(BoundMethodObjectInternal bm |
+            result.getFunction().pointsTo() = bm and
+            bm.getFunction() = this
+        )
+    }
+
     /** Gets a class that this function may return */
     abstract ClassValue getAnInferredReturnType();
 }
@@ -612,6 +629,15 @@ abstract class FunctionValue extends CallableValue {
 /** Class representing Python functions */
 class PythonFunctionValue extends FunctionValue {
     PythonFunctionValue() { this instanceof PythonFunctionObjectInternal }
+
+    override string descriptiveString() {
+        if this.getScope().isMethod()
+        then
+            exists(Class cls | this.getScope().getScope() = cls |
+                result = "method " + this.getQualifiedName()
+            )
+        else result = "function " + this.getQualifiedName()
+    }
 
     override string getQualifiedName() {
         result = this.(PythonFunctionObjectInternal).getScope().getQualifiedName()
@@ -636,6 +662,8 @@ class PythonFunctionValue extends FunctionValue {
     /** Gets a control flow node corresponding to a return statement in this function */
     ControlFlowNode getAReturnedNode() { result = this.getScope().getAReturnValueFlowNode() }
 
+    override ClassValue getARaisedType() { scope_raises(result, this.getScope()) }
+    
     override ClassValue getAnInferredReturnType() {
         /* We have to do a special version of this because builtin functions have no
          * explicit return nodes that we can query and get the class of.
@@ -650,9 +678,16 @@ class BuiltinFunctionValue extends FunctionValue {
 
     override string getQualifiedName() { result = this.(BuiltinFunctionObjectInternal).getName() }
 
+    override string descriptiveString() { result = "builtin-function " + this.getName() }
+
     override int minParameters() { none() }
 
     override int maxParameters() { none() }
+
+    override ClassValue getARaisedType() {
+        /* Information is unavailable for C code in general */
+        none()
+    }
 
     override ClassValue getAnInferredReturnType() {
         /* We have to do a special version of this because builtin functions have no
@@ -674,10 +709,17 @@ class BuiltinMethodValue extends FunctionValue {
         )
     }
 
+    override string descriptiveString() { result = "builtin-method " + this.getQualifiedName() }
+
     override int minParameters() { none() }
 
     override int maxParameters() { none() }
 
+    override ClassValue getARaisedType() {
+        /* Information is unavailable for C code in general */
+        none()
+    }
+    
     override ClassValue getAnInferredReturnType() {
         result = TBuiltinClassObject(this.(BuiltinMethodObjectInternal).getReturnType())
     }
@@ -905,6 +947,9 @@ module ClassValue {
     /** Get the `ClassValue` for the `LookupError` class. */
     ClassValue lookupError() { result = TBuiltinClassObject(Builtin::builtin("LookupError")) }
 
+    /** Get the `ClassValue` for the `IndexError` class. */
+    ClassValue indexError() { result = TBuiltinClassObject(Builtin::builtin("IndexError")) }
+
     /** Get the `ClassValue` for the `IOError` class. */
     ClassValue ioError() { result = TBuiltinClassObject(Builtin::builtin("IOError")) }
 
@@ -924,5 +969,13 @@ module ClassValue {
     /** Get the `ClassValue` for the `UnicodeDecodeError` class. */
     ClassValue unicodeDecodeError() {
         result = TBuiltinClassObject(Builtin::builtin("UnicodeDecodeError"))
+    }
+
+    /** Get the `ClassValue` for the `SystemExit` class. */
+    ClassValue systemExit() { result = TBuiltinClassObject(Builtin::builtin("SystemExit")) }
+
+    /** Get the `ClassValue` for the `ArithmeticError` class. */
+    ClassValue arithmeticError() {
+        result = TBuiltinClassObject(Builtin::builtin("ArithmeticError"))
     }
 }

--- a/python/ql/src/semmle/python/types/Exceptions.qll
+++ b/python/ql/src/semmle/python/types/Exceptions.qll
@@ -36,19 +36,36 @@ class RaisingNode extends ControlFlowNode {
      * Gets the type of an exception that may be raised
      * at this control flow node
      */
-    ClassObject getARaisedType() {
-        result = this.localRaisedType()
+    ClassObject getARaisedType_objectapi() {
+        result = this.localRaisedType_objectapi()
         or
         exists(FunctionObject func | this = func.getACall() | result = func.getARaisedType())
+        or
+        result = systemExitRaise_objectapi()
+    }
+
+    /**
+     * Gets the type of an exception that may be raised
+     * at this control flow node
+     */
+    ClassValue getARaisedType() {
+        result = this.localRaisedType()
+        or
+        exists(FunctionValue func | this = func.getACall() | result = func.getARaisedType())
         or
         result = systemExitRaise()
     }
 
     pragma[noinline]
-    private ClassObject systemExitRaise() { this.quits() and result = Object::builtin("SystemExit") }
+    private ClassObject systemExitRaise_objectapi() {
+        this.quits() and result = Object::builtin("SystemExit")
+    }
+
+    pragma[noinline]
+    private ClassValue systemExitRaise() { this.quits() and result = ClassValue::systemExit() }
 
     pragma[noinline, nomagic]
-    private ClassObject localRaisedType() {
+    private ClassObject localRaisedType_objectapi() {
         result.isSubclassOf(theBaseExceptionType()) and
         (
             exists(ControlFlowNode ex |
@@ -62,8 +79,8 @@ class RaisingNode extends ControlFlowNode {
             or
             exists(ExceptFlowNode except |
                 except = this.getAnExceptionalSuccessor() and
-                except.handles(result) and
-                result = this.innateException()
+                except.handles_objectapi(result) and
+                result = this.innateException_objectapi()
             )
             or
             not exists(ExceptFlowNode except | except = this.getAnExceptionalSuccessor()) and
@@ -74,8 +91,36 @@ class RaisingNode extends ControlFlowNode {
         )
     }
 
+    pragma[noinline, nomagic]
+    private ClassValue localRaisedType() {
+        result.getASuperType() = ClassValue::baseException() and
+        (
+            exists(ControlFlowNode ex |
+                ex = this.getExceptionNode() and
+                (ex.pointsTo(result) or ex.pointsTo().getClass() = result)
+            )
+            or
+            this.getNode() instanceof ImportExpr and result = ClassValue::importError()
+            or
+            this.getNode() instanceof Print and result = ClassValue::ioError()
+            or
+            exists(ExceptFlowNode except |
+                except = this.getAnExceptionalSuccessor() and
+                except.handles(result) and
+                result = this.innateException()
+            )
+            or
+            not exists(ExceptFlowNode except | except = this.getAnExceptionalSuccessor()) and
+            sequence_or_mapping(this) and
+            result = ClassValue::lookupError()
+            or
+            this.read_write_call() and result = ClassValue::ioError()
+        )
+    }
+
+    /** Holds if this is an innate exception (AttributeError, NameError, IndexError, or KeyError). */
     pragma[noinline]
-    ClassObject innateException() {
+    ClassObject innateException_objectapi() {
         this.getNode() instanceof Attribute and result = theAttributeErrorType()
         or
         this.getNode() instanceof Name and result = theNameErrorType()
@@ -83,6 +128,18 @@ class RaisingNode extends ControlFlowNode {
         this.getNode() instanceof Subscript and result = theIndexErrorType()
         or
         this.getNode() instanceof Subscript and result = theKeyErrorType()
+    }
+
+    /** Holds if this is an innate exception (AttributeError, NameError, IndexError, or KeyError). */
+    pragma[noinline]
+    ClassValue innateException() {
+        this.getNode() instanceof Attribute and result = ClassValue::attributeError()
+        or
+        this.getNode() instanceof Name and result = ClassValue::nameError()
+        or
+        this.getNode() instanceof Subscript and result = ClassValue::indexError()
+        or
+        this.getNode() instanceof Subscript and result = ClassValue::keyError()
     }
 
     /**
@@ -114,7 +171,7 @@ class RaisingNode extends ControlFlowNode {
     /** Whether (as inferred by type inference) it is highly unlikely (or impossible) for control to flow from this to succ. */
     predicate unlikelySuccessor(ControlFlowNode succ) {
         succ = this.getAnExceptionalSuccessor() and
-        not this.viableExceptionEdge(succ, _) and
+        not this.viableExceptionEdge_objectapi(succ, _) and
         not this.raisesUnknownType()
         or
         exists(FunctionObject func |
@@ -132,7 +189,30 @@ class RaisingNode extends ControlFlowNode {
     }
 
     /** Whether it is considered plausible that 'raised' can be raised across the edge this-succ */
-    predicate viableExceptionEdge(ControlFlowNode succ, ClassObject raised) {
+    predicate viableExceptionEdge_objectapi(ControlFlowNode succ, ClassObject raised) {
+        raised.isLegalExceptionType() and
+        raised = this.getARaisedType_objectapi() and
+        succ = this.getAnExceptionalSuccessor() and
+        (
+            /* An 'except' that handles raised and there is no more previous handler */
+            succ.(ExceptFlowNode).handles_objectapi(raised) and
+            not exists(ExceptFlowNode other, StmtList s, int i, int j |
+                not other = succ and
+                other.handles_objectapi(raised) and
+                s.getItem(i) = succ.getNode() and
+                s.getItem(j) = other.getNode()
+            |
+                j < i
+            )
+            or
+            /* Any successor that is not an 'except', provided that 'raised' is not handled by a different successor. */
+            not this.getAnExceptionalSuccessor().(ExceptFlowNode).handles_objectapi(raised) and
+            not succ instanceof ExceptFlowNode
+        )
+    }
+
+    /** Whether it is considered plausible that 'raised' can be raised across the edge this-succ */
+    predicate viableExceptionEdge(ControlFlowNode succ, ClassValue raised) {
         raised.isLegalExceptionType() and
         raised = this.getARaisedType() and
         succ = this.getAnExceptionalSuccessor() and
@@ -159,7 +239,19 @@ class RaisingNode extends ControlFlowNode {
      * plausible that the scope `s` can be exited with exception `raised`
      * at this point.
      */
-    predicate viableExceptionalExit(Scope s, ClassObject raised) {
+    predicate viableExceptionalExit_objectapi(Scope s, ClassObject raised) {
+        raised.isLegalExceptionType() and
+        raised = this.getARaisedType_objectapi() and
+        this.isExceptionalExit(s) and
+        not this.getAnExceptionalSuccessor().(ExceptFlowNode).handles_objectapi(raised)
+    }
+
+    /**
+     * Whether this exceptional exit is viable. That is, is it
+     * plausible that the scope `s` can be exited with exception `raised`
+     * at this point.
+     */
+    predicate viableExceptionalExit(Scope s, ClassValue raised) {
         raised.isLegalExceptionType() and
         raised = this.getARaisedType() and
         this.isExceptionalExit(s) and
@@ -170,7 +262,29 @@ class RaisingNode extends ControlFlowNode {
 /** Is this a sequence or mapping subscript x[i]? */
 private predicate sequence_or_mapping(RaisingNode r) { r.getNode() instanceof Subscript }
 
-private predicate current_exception(ClassObject ex, BasicBlock b) {
+private predicate current_exception_objectapi(ClassObject ex, BasicBlock b) {
+    exists(RaisingNode r |
+        r.viableExceptionEdge_objectapi(b.getNode(0), ex) and not b.getNode(0) instanceof ExceptFlowNode
+    )
+    or
+    exists(BasicBlock prev |
+        current_exception_objectapi(ex, prev) and
+        exists(ControlFlowNode pred, ControlFlowNode succ |
+            pred = prev.getLastNode() and succ = b.getNode(0)
+        |
+            pred.getASuccessor() = succ and
+            (
+                /* Normal control flow */
+                not pred.getAnExceptionalSuccessor() = succ
+                or
+                /* Re-raise the current exception, propagating to the successor */
+                pred instanceof ReraisingNode
+            )
+        )
+    )
+}
+
+private predicate current_exception(ClassValue ex, BasicBlock b) {
     exists(RaisingNode r |
         r.viableExceptionEdge(b.getNode(0), ex) and not b.getNode(0) instanceof ExceptFlowNode
     )
@@ -211,7 +325,19 @@ private predicate unknown_current_exception(BasicBlock b) {
 }
 
 /** INTERNAL -- Use FunctionObject.getARaisedType() instead */
-predicate scope_raises(ClassObject ex, Scope s) {
+predicate scope_raises_objectapi(ClassObject ex, Scope s) {
+    exists(BasicBlock b |
+        current_exception_objectapi(ex, b) and
+        b.getLastNode().isExceptionalExit(s)
+    |
+        b.getLastNode() instanceof ReraisingNode
+    )
+    or
+    exists(RaisingNode r | r.viableExceptionalExit_objectapi(s, ex))
+}
+
+/** INTERNAL -- Use FunctionObject.getARaisedType() instead */
+predicate scope_raises(ClassValue ex, Scope s) {
     exists(BasicBlock b |
         current_exception(ex, b) and
         b.getLastNode().isExceptionalExit(s)
@@ -299,9 +425,16 @@ class ExceptFlowNode extends ControlFlowNode {
     }
 
     /** Whether this `except` handles `cls` */
-    predicate handles(ClassObject cls) {
+    predicate handles_objectapi(ClassObject cls) {
         exists(ClassObject handled | this.handledException_objectapi(handled, _, _) |
             cls.getAnImproperSuperType() = handled
+        )
+    }
+
+    /** Whether this `except` handles `cls` */
+    predicate handles(ClassValue cls) {
+        exists(ClassValue handled | this.handledException(handled, _, _) |
+            cls.getASuperType() = handled
         )
     }
 }
@@ -324,7 +457,15 @@ class ReraisingNode extends RaisingNode {
     }
 
     /** Gets a class that may be raised by this node */
-    override ClassObject getARaisedType() {
+    override ClassObject getARaisedType_objectapi() {
+        exists(BasicBlock b |
+            current_exception_objectapi(result, b) and
+            b.getNode(_) = this
+        )
+    }
+
+    /** Gets a class that may be raised by this node */
+    override ClassValue getARaisedType() {
         exists(BasicBlock b |
             current_exception(result, b) and
             b.getNode(_) = this

--- a/python/ql/src/semmle/python/types/FunctionObject.qll
+++ b/python/ql/src/semmle/python/types/FunctionObject.qll
@@ -135,7 +135,7 @@ class PyFunctionObject extends FunctionObject {
     /** Whether this function is a procedure, that is, it has no explicit return statement and is not a generator function */
     override predicate isProcedure() { this.getFunction().isProcedure() }
 
-    override ClassObject getARaisedType() { scope_raises(result, this.getFunction()) }
+    override ClassObject getARaisedType() { scope_raises_objectapi(result, this.getFunction()) }
 
     override predicate raisesUnknownType() { scope_raises_unknown(this.getFunction()) }
 

--- a/python/ql/test/query-tests/Functions/general/IncorrectRaiseInSpecialMethod.expected
+++ b/python/ql/test/query-tests/Functions/general/IncorrectRaiseInSpecialMethod.expected
@@ -1,2 +1,2 @@
-| protocols.py:98:5:98:33 | Function __getitem__ | Function always raises $@; raise LookupError instead | file://:Compiled Code:0:0:0:0 | builtin-class ZeroDivisionError | builtin-class ZeroDivisionError |
-| protocols.py:101:5:101:26 | Function __getattr__ | Function always raises $@; raise AttributeError instead | file://:Compiled Code:0:0:0:0 | builtin-class ZeroDivisionError | builtin-class ZeroDivisionError |
+| protocols.py:98:5:98:33 | Function IncorrectSpecialMethods.__getitem__ | Function always raises $@; raise LookupError instead | file://:0:0:0:0 | builtin-class ZeroDivisionError | builtin-class ZeroDivisionError |
+| protocols.py:101:5:101:26 | Function IncorrectSpecialMethods.__getattr__ | Function always raises $@; raise AttributeError instead | file://:0:0:0:0 | builtin-class ZeroDivisionError | builtin-class ZeroDivisionError |


### PR DESCRIPTION
This PR is part of the ValueAPI modernization effort.

There are some big changes to some files, but only because of cross dependencies elsewhere. I expect that the target test will pass but others will likely fail.

Waiting on #2880 to merge, basically.