### PR TITLE
C#: Field-sensitive summaries for library code

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -68,6 +68,8 @@ module Stages {
       or
       exists(any(DataFlow::Node n).getType())
       or
+      exists(any(DataFlow::Node n).getTypeBound())
+      or
       exists(any(DataFlow::Node n).getLocation())
       or
       exists(any(DataFlow::Node n).toString())

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -163,7 +163,7 @@ class CallableFlowSink extends TCallableFlowSink {
   Expr getSink(Call c) { none() }
 
   /**
-   * Gets the type of the sink for call `c`. Unlik `getSink()`, this is defined
+   * Gets the type of the sink for call `c`. Unlike `getSink()`, this is defined
    * for all flow sink specifications.
    */
   Type getSinkType(Call c) { result = this.getSink(c).getType() }
@@ -235,18 +235,22 @@ private CallableFlowSinkDelegateArg getDelegateFlowSinkArg(
 
 /** A flow sink specification: parameter of a delegate argument. */
 class CallableFlowSinkDelegateArg extends CallableFlowSink, TCallableFlowSinkDelegateArg {
-  private int i;
-  private int j;
+  private int delegateIndex;
+  private int parameterIndex;
 
-  CallableFlowSinkDelegateArg() { this = TCallableFlowSinkDelegateArg(i, j) }
+  CallableFlowSinkDelegateArg() {
+    this = TCallableFlowSinkDelegateArg(delegateIndex, parameterIndex)
+  }
 
   /** Gets the index of the delegate argument. */
-  int getDelegateIndex() { result = i }
+  int getDelegateIndex() { result = delegateIndex }
 
   /** Gets the index of the delegate parameter. */
-  int getDelegateParameterIndex() { result = j }
+  int getDelegateParameterIndex() { result = parameterIndex }
 
-  override string toString() { result = "parameter " + j + " of argument " + i }
+  override string toString() {
+    result = "parameter " + parameterIndex + " of argument " + delegateIndex
+  }
 
   override Expr getSink(Call c) {
     // The uses of the `j`th parameter are the actual sinks
@@ -256,10 +260,10 @@ class CallableFlowSinkDelegateArg extends CallableFlowSink, TCallableFlowSinkDel
   override Type getSinkType(Call c) {
     result =
       c
-          .getArgument(i)
+          .getArgument(delegateIndex)
           .(DelegateArgumentToLibraryCallable)
           .getDelegateType()
-          .getParameter(j)
+          .getParameter(parameterIndex)
           .getType()
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -16,113 +16,49 @@ private import semmle.code.csharp.frameworks.system.threading.Tasks
 private import semmle.code.csharp.frameworks.system.Web
 private import semmle.code.csharp.frameworks.system.web.ui.WebControls
 private import semmle.code.csharp.frameworks.system.Xml
+private import semmle.code.csharp.dataflow.internal.DataFlowPublic
+private import semmle.code.csharp.dataflow.internal.DelegateDataFlow
 
-cached
-private module Cached {
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if `source` can flow to `sink` using a call to a library
-   * callable.
-   */
-  cached
-  predicate libraryFlow(Expr source, Expr sink, boolean preservesValue) {
-    exists(LibraryTypeDataFlow ltdf, CallableFlowSource csource, CallableFlowSink csink, Call c |
-      source = csource.getSource(c) and
-      ltdf.callableFlow(csource, csink, c.getTarget().getSourceDeclaration(), preservesValue) and
-      sink = csink.getSink(c)
-    )
-  }
+private newtype TAccessPath =
+  TNilAccessPath() or
+  TAccessPathConsNil(Content c)
 
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if `source` can flow to the `out`/`ref` argument `outRef` using a call to a library
-   * callable.
-   */
-  cached
-  predicate libraryFlowOutRef(MethodCall mc, Expr source, Parameter outRef, boolean preservesValue) {
-    exists(
-      LibraryTypeDataFlow ltdf, CallableFlowSource csource, CallableFlowSinkArg csink, Method sm
-    |
-      source = csource.getSource(mc) and
-      mc.getTarget().getAParameter() = outRef and
-      sm = mc.getTarget().getSourceDeclaration() and
-      ltdf.callableFlow(csource, csink, sm, preservesValue) and
-      csink = getFlowSinkArg(sm, outRef.getPosition())
-    )
-  }
+/** An access path of length 0 or 1. */
+class AccessPath extends TAccessPath {
+  /** Gets the head of this access path, if any. */
+  Content getHead() { this = TAccessPathConsNil(result) }
 
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if output from the `i`th delegate argument of `call` can flow to `sink`, using
-   * the library target `callable`.
-   */
-  cached
-  predicate libraryFlowDelegateCallOut(
-    Call call, Callable callable, Expr sink, boolean preservesValue, int i
-  ) {
-    exists(LibraryTypeDataFlow ltdf, CallableFlowSourceDelegateArg csource, CallableFlowSink csink |
-      ltdf.callableFlow(csource, csink, callable, preservesValue) and
-      call.getTarget().getSourceDeclaration() = callable and
-      csource = getDelegateFlowSourceArg(callable, i) and
-      sink = csink.getSink(call)
-    )
-  }
+  /** Holds if this access path contains content `c`. */
+  predicate contains(Content c) { this = TAccessPathConsNil(c) }
 
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if `source` can flow to the `i`th parameter of the delegate at argument
-   * `j`. The call `call` is the call in which `sink` is an argument and`callable`
-   * is the library target.
-   */
-  cached
-  predicate libraryFlowDelegateCallIn(
-    Call call, Callable callable, Expr source, boolean preservesValue, int i, int j
-  ) {
-    exists(LibraryTypeDataFlow ltdf, CallableFlowSource csource, CallableFlowSinkDelegateArg csink |
-      ltdf.callableFlow(csource, csink, callable, preservesValue) and
-      call.getTarget().getSourceDeclaration() = callable and
-      csink = getDelegateFlowSinkArg(callable, j, i) and
-      source = csource.getSource(call)
-    )
-  }
-
-  /**
-   * INTERNAL: Do not use.
-   *
-   * Holds if output from the `i`th delegate argument of `call` can flow to the `j`th parameter
-   * of the of delegate at argument `k`, using the library target `callable`.
-   */
-  cached
-  predicate libraryFlowDelegateCallOutIn(
-    Call call, Callable callable, boolean preservesValue, int i, int j, int k
-  ) {
-    exists(
-      LibraryTypeDataFlow ltdf, CallableFlowSourceDelegateArg csource,
-      CallableFlowSinkDelegateArg csink
-    |
-      ltdf.callableFlow(csource, csink, callable, preservesValue) and
-      call.getTarget().getSourceDeclaration() = callable and
-      csource = getDelegateFlowSourceArg(callable, i) and
-      csink = getDelegateFlowSinkArg(callable, k, j)
-    )
+  /** Gets a textual representation of this access path. */
+  string toString() {
+    result = this.getHead().toString()
+    or
+    this = TNilAccessPath() and
+    result = "<empty>"
   }
 }
 
-import Cached
+/** Provides predicates for constructing access paths. */
+module AccessPath {
+  /** Gets the empty access path. */
+  AccessPath empty() { result = TNilAccessPath() }
+
+  /** Gets a singleton property access path. */
+  AccessPath property(Property p) {
+    result = TAccessPathConsNil(any(PropertyContent c | c.getProperty() = p.getSourceDeclaration()))
+  }
+}
 
 /** An unbound callable. */
-library class SourceDeclarationCallable extends Callable {
-  SourceDeclarationCallable() { this = getSourceDeclaration() }
+class SourceDeclarationCallable extends Callable {
+  SourceDeclarationCallable() { this = this.getSourceDeclaration() }
 }
 
 /** An unbound method. */
-library class SourceDeclarationMethod extends SourceDeclarationCallable, Method { }
+class SourceDeclarationMethod extends SourceDeclarationCallable, Method { }
 
-// Internal representation of callable flow sources
 private newtype TCallableFlowSource =
   TCallableFlowSourceQualifier() or
   TCallableFlowSourceArg(int i) { hasArgumentPosition(_, i) } or
@@ -160,93 +96,123 @@ private predicate hasDelegateArgumentPosition2(SourceDeclarationCallable c, int 
   )
 }
 
-/** A flow source in a call to a library callable. */
+/** A flow source specification. */
 class CallableFlowSource extends TCallableFlowSource {
-  /** Gets a textual representation of this flow source. */
+  /** Gets a textual representation of this flow source specification. */
   string toString() { none() }
 
   /** Gets the source of flow for call `c`, if any. */
   Expr getSource(Call c) { none() }
+
+  /**
+   * Gets the type of the source for call `c`. Unlike `getSource()`, this
+   * is defined for all flow source specifications.
+   */
+  Type getSourceType(Call c) { result = this.getSource(c).getType() }
 }
 
-/** A flow source in a call to a library callable: qualifier. */
+/** A flow source specification: (method call) qualifier. */
 class CallableFlowSourceQualifier extends CallableFlowSource, TCallableFlowSourceQualifier {
   override string toString() { result = "qualifier" }
 
   override Expr getSource(Call c) { result = c.getChild(-1) }
 }
 
-/** A flow source in a call to a library callable: argument. */
+/** A flow source specification: (method call) argument. */
 class CallableFlowSourceArg extends CallableFlowSource, TCallableFlowSourceArg {
-  override string toString() { result = "argument " + this.getArgumentIndex() }
+  private int i;
+
+  CallableFlowSourceArg() { this = TCallableFlowSourceArg(i) }
 
   /** Gets the index of this argument. */
-  int getArgumentIndex() { this = TCallableFlowSourceArg(result) }
+  int getArgumentIndex() { result = i }
 
-  override Expr getSource(Call c) { result = c.getArgument(getArgumentIndex()) }
+  override string toString() { result = "argument " + i }
+
+  override Expr getSource(Call c) { result = c.getArgument(i) }
 }
 
-/** A flow source in a call to a library callable: output from delegate argument. */
+/** A flow source specification: output from delegate argument. */
 class CallableFlowSourceDelegateArg extends CallableFlowSource, TCallableFlowSourceDelegateArg {
-  override string toString() { result = "output from argument " + getArgumentIndex().toString() }
+  private int i;
+
+  CallableFlowSourceDelegateArg() { this = TCallableFlowSourceDelegateArg(i) }
 
   /** Gets the index of this delegate argument. */
-  int getArgumentIndex() { this = TCallableFlowSourceDelegateArg(result) }
+  int getArgumentIndex() { result = i }
+
+  override string toString() { result = "output from argument " + i }
 
   override Expr getSource(Call c) { none() }
+
+  override Type getSourceType(Call c) { result = c.getArgument(i).getType() }
 }
 
-// Internal representation of callable flow sinks
 private newtype TCallableFlowSink =
   TCallableFlowSinkQualifier() or
   TCallableFlowSinkReturn() or
   TCallableFlowSinkArg(int i) { exists(SourceDeclarationCallable c | exists(c.getParameter(i))) } or
   TCallableFlowSinkDelegateArg(int i, int j) { hasDelegateArgumentPosition2(_, i, j) }
 
-/** A flow sink in a call to a library callable. */
+/** A flow sink specification. */
 class CallableFlowSink extends TCallableFlowSink {
-  /** Gets a textual representation of this flow sink. */
+  /** Gets a textual representation of this flow sink specification. */
   string toString() { none() }
 
   /** Gets the sink of flow for call `c`, if any. */
   Expr getSink(Call c) { none() }
+
+  /**
+   * Gets the type of the sink for call `c`. Unlik `getSink()`, this is defined
+   * for all flow sink specifications.
+   */
+  Type getSinkType(Call c) { result = this.getSink(c).getType() }
 }
 
-/** A flow sink in a call to a library callable: qualifier. */
+/** A flow sink specification: (method call) qualifier. */
 class CallableFlowSinkQualifier extends CallableFlowSink, TCallableFlowSinkQualifier {
   override string toString() { result = "qualifier" }
 
   override Expr getSink(Call c) { result = c.getChild(-1) }
 }
 
-/** A flow sink in a call to a library callable: return value. */
+/** A flow sink specification: return value. */
 class CallableFlowSinkReturn extends CallableFlowSink, TCallableFlowSinkReturn {
   override string toString() { result = "return" }
 
   override Expr getSink(Call c) { result = c }
 }
 
-/** The flow sink in an argument to a call to a library method. */
+/** A flow sink specification: (method call) argument. */
 class CallableFlowSinkArg extends CallableFlowSink, TCallableFlowSinkArg {
-  override string toString() { result = "argument " + this.getArgumentIndex() }
+  private int i;
+
+  CallableFlowSinkArg() { this = TCallableFlowSinkArg(i) }
 
   /** Gets the index of this `out`/`ref` argument. */
-  int getArgumentIndex() { this = TCallableFlowSinkArg(result) }
+  int getArgumentIndex() { result = i }
+
+  /** Gets the `out`/`ref` argument of method call `mc` matching this specification. */
+  Expr getArgument(MethodCall mc) {
+    exists(Parameter p |
+      p = mc.getTarget().getParameter(i) and
+      p.isOutOrRef() and
+      result = mc.getArgumentForParameter(p)
+    )
+  }
+
+  override string toString() { result = "argument " + i }
 
   override Expr getSink(Call c) {
     // The uses of the `i`th argument are the actual sinks
     none()
   }
+
+  override Type getSinkType(Call c) { result = this.getArgument(c).getType() }
 }
 
 /** Gets the flow source for argument `i` of callable `callable`. */
 private CallableFlowSourceArg getFlowSourceArg(SourceDeclarationCallable callable, int i) {
-  i = result.getArgumentIndex() and
-  hasArgumentPosition(callable, i)
-}
-
-/** Gets the flow sink for argument `i` of callable `callable`. */
-private CallableFlowSinkArg getFlowSinkArg(SourceDeclarationCallable callable, int i) {
   i = result.getArgumentIndex() and
   hasArgumentPosition(callable, i)
 }
@@ -267,30 +233,40 @@ private CallableFlowSinkDelegateArg getDelegateFlowSinkArg(
   hasDelegateArgumentPosition2(callable, i, j)
 }
 
-/** The flow sink in a call to a library callable: parameter of a delegate argument. */
+/** A flow sink specification: parameter of a delegate argument. */
 class CallableFlowSinkDelegateArg extends CallableFlowSink, TCallableFlowSinkDelegateArg {
-  override string toString() {
-    result =
-      "parameter " + getDelegateParameterIndex() + " of argument " + getDelegateIndex().toString()
-  }
+  private int i;
+  private int j;
+
+  CallableFlowSinkDelegateArg() { this = TCallableFlowSinkDelegateArg(i, j) }
+
+  /** Gets the index of the delegate argument. */
+  int getDelegateIndex() { result = i }
+
+  /** Gets the index of the delegate parameter. */
+  int getDelegateParameterIndex() { result = j }
+
+  override string toString() { result = "parameter " + j + " of argument " + i }
 
   override Expr getSink(Call c) {
     // The uses of the `j`th parameter are the actual sinks
     none()
   }
 
-  /** Gets the index of the delegate argument. */
-  int getDelegateIndex() { this = TCallableFlowSinkDelegateArg(result, _) }
-
-  /** Gets the index of the delegate parameter. */
-  int getDelegateParameterIndex() { this = TCallableFlowSinkDelegateArg(_, result) }
+  override Type getSinkType(Call c) {
+    result =
+      c
+          .getArgument(i)
+          .(DelegateArgumentToLibraryCallable)
+          .getDelegateType()
+          .getParameter(j)
+          .getType()
+  }
 }
 
-/**
- * A specification of data flow for a library (non-source code) type.
- */
+/** A specification of data flow for a library (non-source code) type. */
 abstract class LibraryTypeDataFlow extends Type {
-  LibraryTypeDataFlow() { this = getSourceDeclaration() }
+  LibraryTypeDataFlow() { this = this.getSourceDeclaration() }
 
   /**
    * Holds if data may flow from `source` to `sink` when calling callable `c`.
@@ -300,10 +276,27 @@ abstract class LibraryTypeDataFlow extends Type {
    * to `x.ToString()` when `x` is a `string`, but not from `x` to `x.ToLower()`.
    */
   pragma[nomagic]
-  abstract predicate callableFlow(
+  predicate callableFlow(
     CallableFlowSource source, CallableFlowSink sink, SourceDeclarationCallable c,
     boolean preservesValue
-  );
+  ) {
+    none()
+  }
+
+  /**
+   * Holds if data may flow from `source` to `sink` when calling callable `c`.
+   *
+   * `sourceAp` describes the contents of `source` that flows to `sink`
+   * (if any), and `sinkContent` describes the contents of `sink` that it
+   * flows to (if any).
+   */
+  pragma[nomagic]
+  predicate callableFlow(
+    CallableFlowSource source, AccessPath sourceAp, CallableFlowSink sink, AccessPath sinkAp,
+    SourceDeclarationCallable c
+  ) {
+    none()
+  }
 }
 
 /** Data flow for `System.Int32`. */
@@ -614,38 +607,20 @@ class SystemTextStringBuilderFlow extends LibraryTypeDataFlow, SystemTextStringB
 }
 
 /** Data flow for `System.Lazy<>`. */
-class SystemLazyFlow extends LibraryTypeDataFlow {
-  SystemLazyFlow() { this instanceof SystemLazyClass }
-
+class SystemLazyFlow extends LibraryTypeDataFlow, SystemLazyClass {
   override predicate callableFlow(
-    CallableFlowSource source, CallableFlowSink sink, SourceDeclarationCallable c,
-    boolean preservesValue
-  ) {
-    (
-      constructorFlow(source, sink, c)
-      or
-      exists(Property p |
-        propertyFlow(p) and
-        source = TCallableFlowSourceQualifier() and
-        sink = TCallableFlowSinkReturn() and
-        c = p.getGetter()
-      )
-    ) and
-    preservesValue = true
-  }
-
-  private predicate constructorFlow(
-    CallableFlowSourceDelegateArg source, CallableFlowSink sink, Constructor c
+    CallableFlowSource source, AccessPath sourceAp, CallableFlowSink sink, AccessPath sinkAp,
+    SourceDeclarationCallable c
   ) {
     exists(SystemFuncDelegateType t, int i | t.getNumberOfTypeParameters() = 1 |
-      c.getDeclaringType() = this and
+      c.(Constructor).getDeclaringType() = this and
       c.getParameter(i).getType().getSourceDeclaration() = t and
       source = getDelegateFlowSourceArg(c, i) and
-      sink = TCallableFlowSinkReturn()
+      sourceAp = AccessPath::empty() and
+      sink = TCallableFlowSinkReturn() and
+      sinkAp = AccessPath::property(this.getValueProperty())
     )
   }
-
-  private predicate propertyFlow(Property p) { p = this.(SystemLazyClass).getValueProperty() }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/ControlFlowReachability.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/ControlFlowReachability.qll
@@ -173,15 +173,16 @@ abstract class ControlFlowReachabilityConfiguration extends string {
    * Holds if there is a control-flow path from `cfn1` to `cfn2`, where `cfn1` is a
    * control-flow node for `e1` and `cfn2` is a control-flow node for `e2`.
    */
+  pragma[nomagic]
   predicate hasExprPath(Expr e1, ControlFlow::Node cfn1, Expr e2, ControlFlow::Node cfn2) {
     exists(ControlFlow::BasicBlock bb, boolean isSuccessor, int i, int j |
       this.reachesBasicBlockExprBase(e1, e2, _, _, isSuccessor, cfn1, i, bb) and
       cfn2 = bb.getNode(j) and
       cfn2 = e2.getAControlFlowNode()
     |
-      isSuccessor = true and j > i
+      isSuccessor = true and j >= i
       or
-      isSuccessor = false and i > j
+      isSuccessor = false and i >= j
     )
     or
     exists(ControlFlow::BasicBlock bb |
@@ -195,6 +196,7 @@ abstract class ControlFlowReachabilityConfiguration extends string {
    * Holds if there is a control-flow path from `cfn` to `cfnDef`, where `cfn` is a
    * control-flow node for `e` and `cfnDef` is a control-flow node for `def`.
    */
+  pragma[nomagic]
   predicate hasDefPath(
     Expr e, ControlFlow::Node cfn, AssignableDefinition def, ControlFlow::Node cfnDef
   ) {
@@ -203,9 +205,9 @@ abstract class ControlFlowReachabilityConfiguration extends string {
       cfnDef = bb.getNode(j) and
       def.getAControlFlowNode() = cfnDef
     |
-      isSuccessor = true and j > i
+      isSuccessor = true and j >= i
       or
-      isSuccessor = false and i > j
+      isSuccessor = false and i >= j
     )
     or
     exists(ControlFlow::BasicBlock bb |
@@ -219,6 +221,7 @@ abstract class ControlFlowReachabilityConfiguration extends string {
    * Holds if there is a control-flow path from `n1` to `n2`. `n2` is either an
    * expression node or an SSA definition node.
    */
+  pragma[nomagic]
   predicate hasNodePath(ExprNode n1, Node n2) {
     exists(Expr e1, ControlFlow::Node cfn1, Expr e2, ControlFlow::Node cfn2 |
       this.hasExprPath(e1, cfn1, e2, cfn2)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -346,11 +346,14 @@ class ImplicitDelegateDataFlowCall extends DelegateDataFlowCall, TImplicitDelega
   /** Gets the number of parameters of the supplied delegate. */
   int getNumberOfDelegateParameters() { result = arg.getDelegateType().getNumberOfParameters() }
 
+  /** Gets the type of the `i`th parameter of the supplied delegate. */
+  Type getDelegateParameterType(int i) { result = arg.getDelegateType().getParameter(i).getType() }
+
   /** Gets the return type of the supplied delegate. */
   Type getDelegateReturnType() { result = arg.getDelegateType().getReturnType() }
 
   override DotNet::Callable getARuntimeTarget(CallContext::CallContext cc) {
-    result = cfn.getElement().(DelegateArgumentToLibraryCallable).getARuntimeTarget(cc)
+    result = arg.getARuntimeTarget(cc)
   }
 
   override ControlFlow::Nodes::ElementNode getControlFlowNode() { result = cfn }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -81,9 +81,6 @@ module LocalFlow {
     ) {
       exactScope = false and
       (
-        // Flow using library code
-        libraryFlow(e1, e2, scope, isSuccessor, true)
-        or
         e1 = e2.(ParenthesizedExpr).getExpr() and
         scope = e2 and
         isSuccessor = true
@@ -244,39 +241,9 @@ module LocalFlow {
       nodeTo = TImplicitCapturedArgumentNode(call, def.getSourceVariable().getAssignable())
     )
   }
-
-  private Expr getALibraryFlowParentFrom(Expr exprFrom, Expr exprTo, boolean preservesValue) {
-    libraryFlow(exprFrom, exprTo, preservesValue) and
-    result = exprFrom
-    or
-    result.getAChildExpr() = getALibraryFlowParentFrom(exprFrom, exprTo, preservesValue)
-  }
-
-  private Expr getALibraryFlowParentTo(Expr exprFrom, Expr exprTo, boolean preservesValue) {
-    libraryFlow(exprFrom, exprTo, preservesValue) and
-    result = exprTo
-    or
-    exists(Expr mid | mid = getALibraryFlowParentTo(exprFrom, exprTo, preservesValue) |
-      result.getAChildExpr() = mid and
-      not mid = getALibraryFlowParentFrom(exprFrom, exprTo, preservesValue)
-    )
-  }
-
-  pragma[noinline]
-  predicate libraryFlow(
-    Expr exprFrom, Expr exprTo, Expr scope, boolean isSuccessor, boolean preservesValue
-  ) {
-    // To not pollute the definitions in `LibraryTypeDataFlow.qll` with syntactic scope,
-    // simply use the nearest common parent expression for `exprFrom` and `exprTo`
-    scope = getALibraryFlowParentFrom(exprFrom, exprTo, preservesValue) and
-    scope = getALibraryFlowParentTo(exprFrom, exprTo, preservesValue) and
-    // Similarly, for simplicity allow following both forwards and backwards edges from
-    // `exprFrom` to `exprTo`
-    (isSuccessor = true or isSuccessor = false)
-  }
 }
 
-/** An argument of a C# call. */
+/** An argument of a C# call (including qualifier arguments). */
 private class Argument extends Expr {
   private Expr call;
   private int arg;
@@ -292,39 +259,85 @@ private class Argument extends Expr {
     this = call.(DelegateCall).getArgument(arg)
   }
 
-  /** Holds if this expression is the `i`th argument of `c`. */
+  /**
+   * Holds if this expression is the `i`th argument of `c`.
+   *
+   * Qualifier arguments have index `-1`.
+   */
   predicate isArgumentOf(Expr c, int i) { c = call and i = arg }
 }
 
 /**
- * Holds if `e` is an assignment of `src` to a non-static field or field-like
- * property `f` of `q`.
+ * Holds if `e` is an assignment of `src` to field or property `c` of `q`.
  */
-private predicate instanceFieldLikeAssign(Expr e, FieldLike f, Expr src, Expr q) {
-  exists(FieldLikeAccess fa, AssignableDefinition def |
+private predicate fieldOrPropertyAssign(Expr e, Content c, Expr src, Expr q) {
+  exists(FieldOrPropertyAccess fa, FieldOrProperty f, AssignableDefinition def |
     def.getTargetAccess() = fa and
-    f = fa.getTarget().getSourceDeclaration() and
-    not f.isStatic() and
+    f = fa.getTarget() and
+    c = f.getContent() and
     src = def.getSource() and
     q = fa.getQualifier() and
     e = def.getExpr()
+  |
+    f.isFieldLike() and
+    f instanceof InstanceFieldOrProperty
+    or
+    exists(AccessPath ap |
+      LibraryFlow::libraryFlow(_, _, ap, _, _, _) and
+      ap.contains(f.getContent())
+    )
   )
 }
 
 /**
- * Holds if `oc` has an object initializer that assigns `src` to non-static field or
- * field-like property `f`.
+ * Holds if `oc` has an object initializer that assigns `src` to field or
+ * property `c`.
  */
-private predicate instanceFieldLikeInit(ObjectCreation oc, FieldLike f, Expr src) {
-  exists(MemberInitializer mi |
+private predicate fieldOrPropertyInit(ObjectCreation oc, Content c, Expr src) {
+  exists(MemberInitializer mi, FieldOrProperty f |
     mi = oc.getInitializer().(ObjectInitializer).getAMemberInitializer() and
-    f = mi.getInitializedMember().getSourceDeclaration() and
-    not f.isStatic() and
+    f = mi.getInitializedMember() and
+    c = f.getContent() and
     src = mi.getRValue()
+  |
+    f.isFieldLike() and
+    f instanceof InstanceFieldOrProperty
+    or
+    exists(AccessPath ap |
+      LibraryFlow::libraryFlow(_, _, ap, _, _, _) and
+      ap.contains(f.getContent())
+    )
   )
 }
 
-private Type getCSharpType(DotNet::Type t) {
+/** Holds if property `p1` overrides or implements source declaration property `p2`. */
+private predicate overridesOrImplementsSourceDecl(Property p1, Property p2) {
+  p1.getOverridee*().getSourceDeclaration() = p2
+  or
+  p1.getAnUltimateImplementee().getSourceDeclaration() = p2
+}
+
+/**
+ * Holds if `e2` is an expression that reads field or property `c` from
+ * expresion `e1`. This takes overriding into account for properties written
+ * from library code.
+ */
+private predicate fieldOrPropertyRead(Expr e1, Content c, FieldOrPropertyRead e2) {
+  e1 = e2.getQualifier() and
+  exists(FieldOrProperty ret | c = ret.getContent() |
+    ret.isFieldLike() and
+    ret = e2.getTarget()
+    or
+    exists(AccessPath ap, Property target |
+      LibraryFlow::libraryFlow(_, _, _, _, ap, _) and
+      ap.contains(ret.getContent()) and
+      target.getGetter() = e2.(PropertyCall).getARuntimeTarget() and
+      overridesOrImplementsSourceDecl(target, ret)
+    )
+  )
+}
+
+Type getCSharpType(DotNet::Type t) {
   result = t
   or
   result.matchesHandle(t)
@@ -359,8 +372,7 @@ private module Cached {
     TSsaDefinitionNode(Ssa::Definition def) or
     TInstanceParameterNode(Callable c) { c.hasBody() and not c.(Modifiable).isStatic() } or
     TCilParameterNode(CIL::Parameter p) { p.getMethod().hasBody() } or
-    TTaintedParameterNode(Parameter p) { explicitParameterNode(_, p) } or
-    TTaintedReturnNode(ControlFlow::Nodes::ElementNode cfn) {
+    TYieldReturnNode(ControlFlow::Nodes::ElementNode cfn) {
       any(Callable c).canYieldReturn(cfn.getElement())
     } or
     TImplicitCapturedArgumentNode(ControlFlow::Nodes::ElementNode cfn, LocalScopeVariable v) {
@@ -374,6 +386,14 @@ private module Cached {
       cfn.getElement() instanceof DelegateArgumentToLibraryCallable and
       any(DelegateArgumentConfiguration x).hasExprPath(_, cfn, _, call)
     } or
+    TImplicitDelegateArgumentNode(ControlFlow::Nodes::ElementNode cfn, int i, int j) {
+      exists(Call call, CallableFlowSinkDelegateArg sink |
+        LibraryFlow::libraryFlow(call, _, _, sink, _, _) and
+        i = sink.getDelegateIndex() and
+        j = sink.getDelegateParameterIndex() and
+        call.getArgument(i).getAControlFlowNode() = cfn
+      )
+    } or
     TMallocNode(ControlFlow::Nodes::ElementNode cfn) { cfn.getElement() instanceof ObjectCreation } or
     TExprPostUpdateNode(ControlFlow::Nodes::ElementNode cfn) {
       exists(Argument a, Type t |
@@ -386,13 +406,19 @@ private module Cached {
         t = any(TypeParameter tp | not tp.isValueType())
       )
       or
-      instanceFieldLikeAssign(_, _, _, cfn.getElement())
+      fieldOrPropertyAssign(_, _, _, cfn.getElement())
       or
-      exists(TExprPostUpdateNode upd, FieldLikeAccess fla |
+      exists(TExprPostUpdateNode upd, FieldOrPropertyAccess fla |
         upd = TExprPostUpdateNode(fla.getAControlFlowNode())
       |
         cfn.getElement() = fla.getQualifier()
       )
+    } or
+    TLibraryCodeNode(
+      ControlFlow::Node callCfn, CallableFlowSource source, AccessPath sourceAp,
+      CallableFlowSink sink, AccessPath sinkAp, boolean preservesValue
+    ) {
+      LibraryFlow::libraryFlow(callCfn.getElement(), source, sourceAp, sink, sinkAp, preservesValue)
     }
 
   /**
@@ -415,11 +441,15 @@ private module Cached {
     or
     LocalFlow::localFlowCapturedVarStep(nodeFrom, nodeTo)
     or
-    flowOutOfDelegateLibraryCall(nodeFrom, nodeTo, true)
-    or
-    flowThroughLibraryCallableOutRef(_, nodeFrom, nodeTo, true)
-    or
     LocalFlow::localFlowStepCil(nodeFrom, nodeTo)
+    or
+    exists(LibraryCodeNode n | n.preservesValue() |
+      n = nodeTo and
+      nodeFrom = n.getPredecessor(AccessPath::empty())
+      or
+      n = nodeFrom and
+      nodeTo = n.getSuccessor(AccessPath::empty())
+    )
   }
 
   /**
@@ -446,25 +476,26 @@ private module Cached {
 
   cached
   newtype TContent =
-    TFieldLikeContent(FieldLike f) { not f.isStatic() and f.getSourceDeclaration() = f }
+    TFieldContent(Field f) { f = f.getSourceDeclaration() } or
+    TPropertyContent(Property p) { p = p.getSourceDeclaration() }
 
   /**
    * Holds if data can flow from `node1` to `node2` via an assignment to
    * content `c`.
    */
   cached
-  predicate storeStepImpl(ExprNode node1, Content c, PostUpdateNode node2) {
-    exists(StoreStepConfiguration x, Node preNode2 |
-      preNode2 = node2.getPreUpdateNode() and
+  predicate storeStepImpl(Node node1, Content c, Node node2) {
+    exists(StoreStepConfiguration x, ExprNode preNode2 |
+      preNode2 = node2.(PostUpdateNode).getPreUpdateNode() and
       x.hasNodePath(node1, preNode2) and
-      instanceFieldLikeAssign(_, c.(FieldLikeContent).getField(), node1.asExpr(), preNode2.asExpr())
+      fieldOrPropertyAssign(_, c, node1.asExpr(), preNode2.getExpr())
     )
     or
-    exists(StoreStepConfiguration x |
-      x.hasNodePath(node1, node2) and
-      instanceFieldLikeInit(node2.(ObjectCreationNode).getExpr(), c.(FieldLikeContent).getField(),
-        node1.asExpr())
+    exists(StoreStepConfiguration x | x.hasNodePath(node1, node2) |
+      fieldOrPropertyInit(node2.(ObjectCreationNode).getExpr(), c, node1.asExpr())
     )
+    or
+    node2 = node1.(LibraryCodeNode).getSuccessor(any(AccessPath ap | ap.getHead() = c))
   }
 
   /**
@@ -474,9 +505,10 @@ private module Cached {
   predicate readStepImpl(Node node1, Content c, Node node2) {
     exists(ReadStepConfiguration x |
       x.hasNodePath(node1, node2) and
-      c.(FieldLikeContent).getField() =
-        node2.asExpr().(FieldLikeRead).getTarget().getSourceDeclaration()
+      fieldOrPropertyRead(node1.asExpr(), c, node2.asExpr())
     )
+    or
+    node1 = node2.(LibraryCodeNode).getPredecessor(any(AccessPath ap | ap.getHead() = c))
   }
 
   /**
@@ -492,19 +524,6 @@ private module Cached {
       paramNode.getDefinition() = param and
       param.getARead() = guard and
       guard.controlsBlock(n.getControlFlowNode().getBasicBlock(), bs)
-    )
-  }
-
-  /**
-   * Gets a representative type for `t` for the purpose of pruning possible flow.
-   */
-  cached
-  DataFlowType getErasedRepr(DotNet::Type t) {
-    exists(Type t0 | result = Gvn::getGlobalValueNumber(t0) |
-      t0 = getCSharpType(t)
-      or
-      not exists(getCSharpType(t)) and
-      t0 instanceof ObjectType
     )
   }
 
@@ -607,44 +626,6 @@ private module ParameterNodes {
     override string toString() { result = "this" }
   }
 
-  /**
-   * A tainted parameter. Tainted parameters are a mere implementation detail, used
-   * to restrict tainted flow into callables to just taint tracking (just like flow
-   * out of `TaintedReturnNode`s is restricted to taint tracking).
-   */
-  class TaintedParameterNode extends ParameterNode, TTaintedParameterNode {
-    private Parameter parameter;
-
-    TaintedParameterNode() { this = TTaintedParameterNode(parameter) }
-
-    /** Gets the underlying parameter node. */
-    ExplicitParameterNode getUnderlyingNode() { explicitParameterNode(result, parameter) }
-
-    // `getParameter()` is explicitly *not* overriden to return `parameter`,
-    // as that would otherwise enable tainted parameters to accidentally be
-    // used by users of the library
-    override predicate isParameterOf(DataFlowCallable c, int i) {
-      c = parameter.getCallable() and
-      // we model tainted parameters as if they had been extra parameters after
-      // the actual parameters
-      i = parameter.getPosition() + c.getNumberOfParameters()
-    }
-
-    override Callable getEnclosingCallable() {
-      result = this.getUnderlyingNode().getEnclosingCallable()
-    }
-
-    override Type getType() {
-      // Taint tracking steps are allowed to change the type of the tracked object,
-      // so `result = this.getUnderlyingNode().getType()` is too restrictive
-      result instanceof ObjectType
-    }
-
-    override Location getLocation() { result = this.getUnderlyingNode().getLocation() }
-
-    override string toString() { result = this.getUnderlyingNode().toString() }
-  }
-
   module ImplicitCapturedParameterNodeImpl {
     /** An implicit entry definition for a captured variable. */
     class SsaCapturedEntryDefinition extends Ssa::ImplicitEntryDefinition {
@@ -688,7 +669,7 @@ private module ParameterNodes {
    * An implicit parameter is added in order to be able to track flow into
    * capturing callables, as if an explicit `ref` parameter had been used:
    *
-   * ```
+   * ```csharp
    * void M() {             void M() {
    *   int i = 0;             int i = 0;
    *   void In() {    =>      void In(ref int i0) { // implicit i0 parameter
@@ -741,47 +722,6 @@ private module ArgumentNodes {
     }
   }
 
-  /**
-   * Holds if `arg` is an argument of a call, which resolves to a library callable
-   * that is known to forward `arg` into the `i`th parameter of a supplied
-   * delegate `delegate`.
-   *
-   * For example, in
-   *
-   * ```
-   * x.Select(Foo);
-   * ```
-   *
-   * `arg = x`, `i = 0`, `call = x.Select(Foo)`, and `delegate = Foo`.
-   */
-  private predicate flowIntoCallableLibraryCall(
-    ExplicitArgumentNode arg, ImplicitDelegateDataFlowCall delegate, int i
-  ) {
-    exists(DataFlowCall call, int j, boolean preservesValue |
-      preservesValue = true and i = j
-      or
-      preservesValue = false and i = j + delegate.getNumberOfDelegateParameters()
-    |
-      exists(DelegateArgumentConfiguration x, Call callExpr, ExprNode argExpr |
-        x
-            .hasExprPath(argExpr.getExpr(), argExpr.getControlFlowNode(), callExpr,
-              call.getControlFlowNode())
-      |
-        exists(int k |
-          libraryFlowDelegateCallIn(callExpr, _, argExpr.getExpr(), preservesValue, j, k) and
-          arg = argExpr and
-          delegate.isArgumentOf(call, k)
-        )
-        or
-        exists(int k, int l | libraryFlowDelegateCallOutIn(callExpr, _, preservesValue, k, j, l) |
-          delegate.isArgumentOf(call, l) and
-          arg.(ImplicitDelegateOutNode).isArgumentOf(call, k) and
-          arg = TImplicitDelegateOutNode(argExpr.getControlFlowNode(), _)
-        )
-      )
-    )
-  }
-
   private class ArgumentConfiguration extends ControlFlowReachabilityConfiguration {
     ArgumentConfiguration() { this = "ArgumentConfiguration" }
 
@@ -801,10 +741,6 @@ private module ArgumentNodes {
       this.asExpr() instanceof Argument
       or
       this.asExpr() = any(CIL::Call call).getAnArgument()
-      or
-      libraryFlowDelegateCallIn(_, _, this.asExpr(), _, _, _)
-      or
-      this.(ImplicitDelegateOutNode).isArgumentOf(_, _)
     }
 
     override predicate argumentOf(DataFlowCall call, int pos) {
@@ -821,8 +757,6 @@ private module ArgumentNodes {
         c = call.getExpr() and
         arg = c.getArgument(pos)
       )
-      or
-      flowIntoCallableLibraryCall(this, call, pos)
     }
   }
 
@@ -833,7 +767,7 @@ private module ArgumentNodes {
    * An implicit node is added in order to be able to track flow into capturing
    * callables, as if an explicit parameter had been used:
    *
-   * ```
+   * ```csharp
    * void M() {                       void M() {
    *   int i = 0;                       int i = 0;
    *   void Out() { i = 1; }    =>      void Out(ref int i0) { i0 = 1; }
@@ -913,6 +847,39 @@ private module ArgumentNodes {
 
     override string toString() { result = "malloc" }
   }
+
+  /**
+   * A data flow node that represents an implicit argument of an implicit delegate
+   * call in library code. For example, in
+   *
+   * ```csharp
+   * x.Select(Foo);
+   * ```
+   *
+   * `x` is an implicit argument of the implicit call to `Foo`.
+   */
+  class ImplicitDelegateArgumentNode extends ArgumentNode, TImplicitDelegateArgumentNode {
+    private ControlFlow::Node cfn;
+    private int i;
+    private int j;
+
+    ImplicitDelegateArgumentNode() { this = TImplicitDelegateArgumentNode(cfn, i, j) }
+
+    private ImplicitDelegateDataFlowCall getDelegateCall() { result.getControlFlowNode() = cfn }
+
+    override predicate argumentOf(DataFlowCall call, int pos) {
+      call = this.getDelegateCall() and
+      pos = j
+    }
+
+    override Callable getEnclosingCallable() { result = cfn.getEnclosingCallable() }
+
+    override Type getType() { result = this.getDelegateCall().getDelegateParameterType(j) }
+
+    override Location getLocation() { result = cfn.getLocation() }
+
+    override string toString() { result = "[implicit argument " + j + "] " + cfn }
+  }
 }
 
 import ArgumentNodes
@@ -964,31 +931,29 @@ private module ReturnNodes {
   }
 
   /**
-   * A tainted return node. Tainted return nodes are a mere implementation detail,
-   * used to restrict tainted flow out of callables to just taint tracking (just
-   * like flow in to `TaintedReturnParameter`s is restricted to taint tracking).
+   * A `yield return` node. A node is synthesized in order to be able to model
+   * `yield return`s as stores into collections, i.e., there is flow from `e`
+   * to `yield return e [e]`.
    */
-  class TaintedReturnNode extends ReturnNode, TTaintedReturnNode {
+  class YieldReturnNode extends ReturnNode, PostUpdateNode, TYieldReturnNode {
     private ControlFlow::Nodes::ElementNode cfn;
+    private YieldReturnStmt yrs;
 
-    TaintedReturnNode() { this = TTaintedReturnNode(cfn) }
+    YieldReturnNode() { this = TYieldReturnNode(cfn) and yrs.getExpr().getAControlFlowNode() = cfn }
 
-    /** Gets the underlying return node. */
-    ExprReturnNode getUnderlyingNode() { result.getControlFlowNode() = cfn }
+    YieldReturnStmt getYieldReturnStmt() { result = yrs }
 
     override YieldReturnKind getKind() { any() }
 
-    override Callable getEnclosingCallable() {
-      result = this.getUnderlyingNode().getEnclosingCallable()
-    }
+    override ExprNode getPreUpdateNode() { result.getControlFlowNode() = cfn }
 
-    override Type getType() {
-      result = this.getUnderlyingNode().getEnclosingCallable().getReturnType()
-    }
+    override Callable getEnclosingCallable() { result = yrs.getEnclosingCallable() }
 
-    override Location getLocation() { result = this.getUnderlyingNode().getLocation() }
+    override Type getType() { result = yrs.getEnclosingCallable().getReturnType() }
 
-    override string toString() { result = this.getUnderlyingNode().toString() }
+    override Location getLocation() { result = yrs.getLocation() }
+
+    override string toString() { result = yrs.toString() }
   }
 
   /**
@@ -998,7 +963,7 @@ private module ReturnNodes {
    * An implicit node is added in order to be able to track flow out of capturing
    * callables, as if an explicit `ref` parameter had been used:
    *
-   * ```
+   * ```csharp
    * void M() {              void M() {
    *   int i = 0;              int i = 0;
    *   void Out() {            void Out(ref int i0) {
@@ -1188,68 +1153,273 @@ private module OutNodes {
 
 import OutNodes
 
-private class FlowThroughLibraryCallableOutRefConfiguration extends ControlFlowReachabilityConfiguration {
-  FlowThroughLibraryCallableOutRefConfiguration() {
-    this = "FlowThroughLibraryCallableOutRefConfiguration"
-  }
-
-  override predicate candidateDef(
-    Expr e, AssignableDefinition def, ControlFlowElement scope, boolean exactScope,
-    boolean isSuccessor
+/**
+ * Provides predicates related to flow through library code, based on
+ * the flow summaries in `LibraryTypeDataFlow.qll`.
+ */
+module LibraryFlow {
+  pragma[nomagic]
+  private ValueOrRefType getPreciseSourceProperty0(
+    Call call, CallableFlowSource source, AccessPath sourceAp, Property p
   ) {
-    exists(MethodCall mc, Parameter outRef | libraryFlowOutRef(mc, e, outRef, _) |
-      def.getTargetAccess() = mc.getArgumentForParameter(outRef) and
-      def instanceof AssignableDefinitions::OutRefDefinition and
-      scope = mc and
-      isSuccessor = true and
-      exactScope = false
+    exists(LibraryTypeDataFlow ltdf, Property p0 |
+      ltdf.callableFlow(source, sourceAp, _, _, call.getTarget().getSourceDeclaration()) and
+      sourceAp = AccessPath::property(p0) and
+      overridesOrImplementsSourceDecl(p, p0) and
+      result = source.getSourceType(call)
     )
   }
+
+  /**
+   * Gets a precise source property for source `source` and access path `sourceAp`,
+   * in the context of `call`. For example, in
+   *
+   * ```csharp
+   * var list = new List<string>();
+   * var count = list.Count();
+   * ```
+   *
+   * the step from `list` to `list.Count()`, which may be modeled as a read of
+   * the `Count` property from `ICollection<T>`, can be strengthened to be a
+   * read of the `Count` property from `List<T>`.
+   */
+  pragma[nomagic]
+  private Property getPreciseSourceProperty(
+    Call call, CallableFlowSource source, AccessPath sourceAp
+  ) {
+    getPreciseSourceProperty0(call, source, sourceAp, result).hasMember(result)
+  }
+
+  pragma[nomagic]
+  private ValueOrRefType getPreciseSinkProperty0(
+    Call call, CallableFlowSink sink, AccessPath sinkAp, Property p
+  ) {
+    exists(LibraryTypeDataFlow ltdf, Property p0 |
+      ltdf.callableFlow(_, _, sink, sinkAp, call.getTarget().getSourceDeclaration()) and
+      sinkAp = AccessPath::property(p0) and
+      overridesOrImplementsSourceDecl(p, p0) and
+      result = sink.getSinkType(call)
+    )
+  }
+
+  /**
+   * Gets a precise sink property for sink `sink` and access path `sinkAp`,
+   * in the context of `call`. For example, in
+   *
+   * ```csharp
+   * var list = new List<string>();
+   * list.Add("taint");
+   * var enumerator = list.getEnumerator();
+   * ```
+   *
+   * the step from `list` to `list.getEnumerator()`, which may be modeled as a
+   * read of a collection element followed by a store into the `Current`
+   * property, can be strengthened to be a store into the `Current` property
+   * from `List<T>.Enumerator`, rather than the generic `Current` property
+   * from `IEnumerator<T>`.
+   */
+  pragma[nomagic]
+  private Property getPreciseSinkProperty(Call call, CallableFlowSink sink, AccessPath sinkAp) {
+    getPreciseSinkProperty0(call, sink, sinkAp, result).hasMember(result)
+  }
+
+  /**
+   * Holds if data can flow from a node of kind `source` to a node of kind `sink`,
+   * using a call to a library callable.
+   *
+   * `sourceAp` describes the contents of the source node that flows to the sink
+   * (if any), and `sinkAp` describes the contents of the sink that it flows to
+   * (if any).
+   *
+   * `preservesValue = false` implies that both `sourceAp` and `sinkAp` are empty.
+   */
+  pragma[nomagic]
+  predicate libraryFlow(
+    Call call, CallableFlowSource source, AccessPath sourceAp, CallableFlowSink sink,
+    AccessPath sinkAp, boolean preservesValue
+  ) {
+    exists(LibraryTypeDataFlow ltdf, SourceDeclarationCallable c |
+      c = call.getTarget().getSourceDeclaration()
+    |
+      ltdf.callableFlow(source, sink, c, preservesValue) and
+      sourceAp = AccessPath::empty() and
+      sinkAp = AccessPath::empty()
+      or
+      preservesValue = true and
+      exists(AccessPath sourceAp0, AccessPath sinkAp0 |
+        ltdf.callableFlow(source, sourceAp0, sink, sinkAp0, c) and
+        (
+          not sourceAp0 = AccessPath::property(_) and
+          sourceAp = sourceAp0
+          or
+          exists(Property p |
+            overridesOrImplementsSourceDecl(p,
+              getPreciseSourceProperty(call, source, sourceAp0).getSourceDeclaration()) and
+            sourceAp = AccessPath::property(p)
+          )
+        ) and
+        (
+          not sinkAp0 = AccessPath::property(_) and
+          sinkAp = sinkAp0
+          or
+          sinkAp = AccessPath::property(getPreciseSinkProperty(call, sink, sinkAp0))
+        )
+      )
+    )
+  }
+
+  class LibrarySourceConfiguration extends ControlFlowReachabilityConfiguration {
+    LibrarySourceConfiguration() { this = "LibrarySourceConfiguration" }
+
+    override predicate candidate(
+      Expr e1, Expr e2, ControlFlowElement scope, boolean exactScope, boolean isSuccessor
+    ) {
+      exists(CallableFlowSource source |
+        libraryFlow(e2, source, _, _, _, _) and
+        e1 = source.getSource(e2) and
+        scope = e2 and
+        exactScope = false and
+        isSuccessor = true
+      )
+    }
+  }
+
+  class LibrarySinkConfiguration extends ControlFlowReachabilityConfiguration {
+    LibrarySinkConfiguration() { this = "LibrarySinkConfiguration" }
+
+    override predicate candidate(
+      Expr e1, Expr e2, ControlFlowElement scope, boolean exactScope, boolean isSuccessor
+    ) {
+      exists(CallableFlowSink sink |
+        libraryFlow(e1, _, _, sink, _, _) and
+        e2 = sink.getSink(e1) and
+        scope = e1 and
+        exactScope = false and
+        isSuccessor = false
+      )
+    }
+
+    override predicate candidateDef(
+      Expr e, AssignableDefinition def, ControlFlowElement scope, boolean exactScope,
+      boolean isSuccessor
+    ) {
+      exists(CallableFlowSinkArg sink |
+        libraryFlow(e, _, _, sink, _, _) and
+        scope = e and
+        exactScope = false and
+        isSuccessor = true and
+        def.getTargetAccess() = sink.getArgument(e) and
+        def instanceof AssignableDefinitions::OutRefDefinition
+      )
+    }
+  }
 }
 
-/**
- * Holds if `arg` is an argument of the method call `mc`, where the target
- * of `mc` is a library callable that forwards `arg` to an `out`/`ref` argument
- * `node`. Example:
- *
- * ```
- * int i;
- * Int32.TryParse("42", out i);
- * ```
- *
- * `mc = Int32.TryParse("42", out i)`, `arg = "42"`, and `node` is the access
- * to `i` in `out i`.
- */
-predicate flowThroughLibraryCallableOutRef(
-  MethodCall mc, ExprNode arg, SsaDefinitionNode node, boolean preservesValue
-) {
-  libraryFlowOutRef(mc, arg.getExpr(), _, preservesValue) and
-  any(FlowThroughLibraryCallableOutRefConfiguration x).hasNodePath(arg, node)
+/** A data-flow node used to model flow through library code. */
+class LibraryCodeNode extends Node, TLibraryCodeNode {
+  private ControlFlow::Node callCfn;
+  private CallableFlowSource source;
+  private AccessPath sourceAp;
+  private CallableFlowSink sink;
+  private AccessPath sinkAp;
+  private boolean preservesValue;
+
+  LibraryCodeNode() {
+    this = TLibraryCodeNode(callCfn, source, sourceAp, sink, sinkAp, preservesValue)
+  }
+
+  /** Holds if this node is part of a value-preserving library step. */
+  predicate preservesValue() { preservesValue = true }
+
+  /**
+   * Gets the predecessor of this library-code node. `ap` describes the content
+   * that is read from when entering this node (if any).
+   */
+  Node getPredecessor(AccessPath ap) {
+    ap = sourceAp and
+    (
+      exists(LibraryFlow::LibrarySourceConfiguration x, Call call |
+        callCfn = call.getAControlFlowNode() and
+        x.hasExprPath(source.getSource(call), result.(ExprNode).getControlFlowNode(), _, callCfn)
+      )
+      or
+      exists(DataFlowCall call, int pos |
+        pos = source.(CallableFlowSourceDelegateArg).getArgumentIndex() and
+        result.(ImplicitDelegateOutNode).isArgumentOf(call, pos) and
+        callCfn = call.getControlFlowNode()
+      )
+    )
+  }
+
+  /**
+   * Gets the successor of this library-code node. `ap` describes the content that
+   * is stored into when leaving this node (if any).
+   */
+  Node getSuccessor(AccessPath ap) {
+    ap = sinkAp and
+    (
+      exists(LibraryFlow::LibrarySinkConfiguration x, Call call, ExprNode e |
+        callCfn = call.getAControlFlowNode() and
+        x.hasExprPath(_, callCfn, sink.getSink(call), e.getControlFlowNode())
+      |
+        sink instanceof CallableFlowSinkReturn and
+        result = e
+        or
+        sink instanceof CallableFlowSinkQualifier and
+        if sinkAp = AccessPath::empty()
+        then result = e
+        else result.(ExprPostUpdateNode).getPreUpdateNode() = e
+      )
+      or
+      exists(LibraryFlow::LibrarySinkConfiguration x, OutRefReturnKind k |
+        result =
+          any(ParamOutNode out |
+            out.getCall(k).getControlFlowNode() = callCfn and
+            sink.(CallableFlowSinkArg).getArgumentIndex() = k.getPosition() and
+            x.hasDefPath(_, callCfn, out.getDefinition(), _)
+          )
+      )
+      or
+      exists(DataFlowCall call, ImplicitDelegateDataFlowCall dcall, int i, int j |
+        sink =
+          any(CallableFlowSinkDelegateArg s |
+            i = s.getDelegateIndex() and j = s.getDelegateParameterIndex()
+          ) and
+        result = TImplicitDelegateArgumentNode(dcall.getControlFlowNode(), _, j) and
+        dcall.isArgumentOf(call, i) and
+        callCfn = call.getControlFlowNode()
+      )
+    )
+  }
+
+  override Callable getEnclosingCallable() { result = callCfn.getEnclosingCallable() }
+
+  override DataFlowType getTypeBound() {
+    preservesValue = true and
+    sourceAp = AccessPath::empty() and
+    result = this.getPredecessor(_).getTypeBound()
+    or
+    result = sourceAp.getHead().getType()
+    or
+    preservesValue = false and
+    result = this.getSuccessor(_).getTypeBound()
+  }
+
+  override Location getLocation() { result = callCfn.getLocation() }
+
+  override string toString() { result = "[library code] " + callCfn }
 }
 
-/**
- * Holds if the output from the delegate `delegate` flows to `out`. The delegate
- * is passed as an argument to a library callable, which invokes the delegate.
- * Example:
- *
- * ```
- * x.Select(Foo);
- * ```
- *
- * `delegate = Foo`, `out = x.Select(Foo)`, and `preservesValue = false`.
- */
-predicate flowOutOfDelegateLibraryCall(
-  ImplicitDelegateOutNode delegate, ExprOutNode out, boolean preservesValue
-) {
-  exists(DataFlowCall call, int i |
-    libraryFlowDelegateCallOut(call.getExpr(), _, out.getExpr(), preservesValue, i) and
-    delegate.isArgumentOf(call, i) and
-    out.getControlFlowNode() = call.getControlFlowNode()
-  )
-}
+/** A field or a property. */
+private class FieldOrProperty extends Assignable, Modifiable {
+  FieldOrProperty() {
+    this instanceof Field
+    or
+    this instanceof Property
+  }
 
-private class FieldLike extends Assignable, Modifiable {
-  FieldLike() {
+  /** Holds if this is either a field or a field-like property. */
+  predicate isFieldLike() {
     this instanceof Field or
     this =
       any(Property p |
@@ -1261,42 +1431,54 @@ private class FieldLike extends Assignable, Modifiable {
         )
       )
   }
+
+  /** Gets the content that matches this field or property. */
+  Content getContent() {
+    result.(FieldContent).getField() = this.getSourceDeclaration()
+    or
+    result.(PropertyContent).getProperty() = this.getSourceDeclaration()
+  }
 }
 
-private class FieldLikeAccess extends AssignableAccess, QualifiableExpr {
-  FieldLikeAccess() { this.getTarget() instanceof FieldLike }
+private class InstanceFieldOrProperty extends FieldOrProperty {
+  InstanceFieldOrProperty() { not this.isStatic() }
 }
 
-private class FieldLikeRead extends FieldLikeAccess, AssignableRead { }
+private class FieldOrPropertyAccess extends AssignableAccess, QualifiableExpr {
+  FieldOrPropertyAccess() { this.getTarget() instanceof FieldOrProperty }
+}
 
-/**
- * Holds if the field-like read `flr` is not completely determined by explicit
- * SSA updates.
- */
-private predicate hasNonlocalValue(FieldLikeRead flr) {
-  flr = any(Ssa::ImplicitUntrackedDefinition udef).getARead()
-  or
-  exists(Ssa::Definition def, Ssa::ImplicitDefinition idef |
-    def.getARead() = flr and
-    idef = def.getAnUltimateDefinition()
-  |
-    idef instanceof Ssa::ImplicitEntryDefinition or
-    idef instanceof Ssa::ImplicitCallDefinition
-  )
+private class FieldOrPropertyRead extends FieldOrPropertyAccess, AssignableRead {
+  /**
+   * Holds if this field-like read is not completely determined by explicit
+   * SSA updates.
+   */
+  predicate hasNonlocalValue() {
+    this = any(Ssa::ImplicitUntrackedDefinition udef).getARead()
+    or
+    exists(Ssa::Definition def, Ssa::ImplicitDefinition idef |
+      def.getARead() = this and
+      idef = def.getAnUltimateDefinition()
+    |
+      idef instanceof Ssa::ImplicitEntryDefinition or
+      idef instanceof Ssa::ImplicitCallDefinition
+    )
+  }
 }
 
 /** A write to a static field/property. */
 private class StaticFieldLikeJumpNode extends NonLocalJumpNode, ExprNode {
-  FieldLike fl;
-  FieldLikeRead flr;
+  FieldOrProperty fl;
+  FieldOrPropertyRead flr;
   ExprNode succ;
 
   StaticFieldLikeJumpNode() {
     fl.isStatic() and
+    fl.isFieldLike() and
     fl.getAnAssignedValue() = this.getExpr() and
     fl.getAnAccess() = flr and
     flr = succ.getExpr() and
-    hasNonlocalValue(flr)
+    flr.hasNonlocalValue()
   }
 
   override ExprNode getAJumpSuccessor(boolean preservesValue) {
@@ -1306,41 +1488,6 @@ private class StaticFieldLikeJumpNode extends NonLocalJumpNode, ExprNode {
 
 predicate jumpStep = jumpStepImpl/2;
 
-/**
- * A reference contained in an object. Currently limited to instance fields
- * and field-like instance properties.
- */
-class Content extends TContent {
-  /** Gets a textual representation of this content. */
-  abstract string toString();
-
-  abstract Location getLocation();
-
-  /** Gets the type of the object containing this content. */
-  abstract DataFlowType getContainerType();
-
-  /** Gets the type of this content. */
-  abstract DataFlowType getType();
-}
-
-private class FieldLikeContent extends Content, TFieldLikeContent {
-  private FieldLike f;
-
-  FieldLikeContent() { this = TFieldLikeContent(f) }
-
-  FieldLike getField() { result = f }
-
-  override string toString() { result = f.toString() }
-
-  override Location getLocation() { result = f.getLocation() }
-
-  override DataFlowType getContainerType() {
-    result = Gvn::getGlobalValueNumber(f.getDeclaringType())
-  }
-
-  override DataFlowType getType() { result = Gvn::getGlobalValueNumber(f.getType()) }
-}
-
 private class StoreStepConfiguration extends ControlFlowReachabilityConfiguration {
   StoreStepConfiguration() { this = "StoreStepConfiguration" }
 
@@ -1349,11 +1496,11 @@ private class StoreStepConfiguration extends ControlFlowReachabilityConfiguratio
   ) {
     exactScope = false and
     isSuccessor = false and
-    instanceFieldLikeAssign(scope, _, e1, e2)
+    fieldOrPropertyAssign(scope, _, e1, e2)
     or
     exactScope = false and
     isSuccessor = false and
-    instanceFieldLikeInit(e2, _, e1) and
+    fieldOrPropertyInit(e2, _, e1) and
     scope = e2
   }
 }
@@ -1368,7 +1515,7 @@ private class ReadStepConfiguration extends ControlFlowReachabilityConfiguration
   ) {
     exactScope = false and
     isSuccessor = true and
-    e1 = e2.(FieldLikeRead).getQualifier() and
+    fieldOrPropertyRead(e1, _, e2) and
     scope = e2
   }
 }
@@ -1432,7 +1579,7 @@ private module PostUpdateNodes {
     override MallocNode getPreUpdateNode() { this = TExprNode(result.getControlFlowNode()) }
   }
 
-  private class ExprPostUpdateNode extends PostUpdateNode, TExprPostUpdateNode {
+  class ExprPostUpdateNode extends PostUpdateNode, TExprPostUpdateNode {
     private ControlFlow::Nodes::ElementNode cfn;
 
     ExprPostUpdateNode() { this = TExprPostUpdateNode(cfn) }
@@ -1508,3 +1655,6 @@ int accessPathLimit() { result = 3 }
  * This predicate is only used for consistency checks.
  */
 predicate isImmutableOrUnobservable(Node n) { none() }
+
+pragma[inline]
+DataFlowType getErasedRepr(DataFlowType t) { result = t }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -860,25 +860,29 @@ private module ArgumentNodes {
    */
   class ImplicitDelegateArgumentNode extends ArgumentNode, TImplicitDelegateArgumentNode {
     private ControlFlow::Node cfn;
-    private int i;
-    private int j;
+    private int delegateIndex;
+    private int parameterIndex;
 
-    ImplicitDelegateArgumentNode() { this = TImplicitDelegateArgumentNode(cfn, i, j) }
+    ImplicitDelegateArgumentNode() {
+      this = TImplicitDelegateArgumentNode(cfn, delegateIndex, parameterIndex)
+    }
 
     private ImplicitDelegateDataFlowCall getDelegateCall() { result.getControlFlowNode() = cfn }
 
     override predicate argumentOf(DataFlowCall call, int pos) {
       call = this.getDelegateCall() and
-      pos = j
+      pos = parameterIndex
     }
 
     override Callable getEnclosingCallable() { result = cfn.getEnclosingCallable() }
 
-    override Type getType() { result = this.getDelegateCall().getDelegateParameterType(j) }
+    override Type getType() {
+      result = this.getDelegateCall().getDelegateParameterType(parameterIndex)
+    }
 
     override Location getLocation() { result = cfn.getLocation() }
 
-    override string toString() { result = "[implicit argument " + j + "] " + cfn }
+    override string toString() { result = "[implicit argument " + parameterIndex + "] " + cfn }
   }
 }
 
@@ -1332,8 +1336,8 @@ class LibraryCodeNode extends Node, TLibraryCodeNode {
   predicate preservesValue() { preservesValue = true }
 
   /**
-   * Gets the predecessor of this library-code node. `ap` describes the content
-   * that is read from when entering this node (if any).
+   * Gets the predecessor of this library-code node. The head of `ap` describes
+   * the content that is read from when entering this node (if any).
    */
   Node getPredecessor(AccessPath ap) {
     ap = sourceAp and
@@ -1352,8 +1356,8 @@ class LibraryCodeNode extends Node, TLibraryCodeNode {
   }
 
   /**
-   * Gets the successor of this library-code node. `ap` describes the content that
-   * is stored into when leaving this node (if any).
+   * Gets the successor of this library-code node. The head of `ap` describes
+   * the content that is stored into when leaving this node (if any).
    */
   Node getSuccessor(AccessPath ap) {
     ap = sinkAp and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
@@ -119,7 +119,7 @@ library class DelegateArgumentToLibraryCallable extends Expr {
   Call getCall() { result = call }
 
   /** Gets the index of this delegate argument in the call. */
-  int getArgumentIndex() { this.getCall().getArgument(result) = this }
+  int getArgumentIndex() { this = this.getCall().getArgument(result) }
 
   /** Gets the delegate type of this argument. */
   DelegateType getDelegateType() { result = dt }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
@@ -118,6 +118,9 @@ library class DelegateArgumentToLibraryCallable extends Expr {
   /** Gets the call that this argument belongs to. */
   Call getCall() { result = call }
 
+  /** Gets the index of this delegate argument in the call. */
+  int getArgumentIndex() { this.getCall().getArgument(result) = this }
+
   /** Gets the delegate type of this argument. */
   DelegateType getDelegateType() { result = dt }
 

--- a/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
@@ -566,10 +566,10 @@ class IndexerAccess extends AssignableMemberAccess, ElementAccess, IndexerAccess
  * }
  * ```
  */
-class IndexerRead extends IndexerAccess, AssignableRead {
-  override IndexerRead getANextRead() { result = AssignableRead.super.getANextRead() }
+class IndexerRead extends IndexerAccess, ElementRead {
+  override IndexerRead getANextRead() { result = ElementRead.super.getANextRead() }
 
-  override IndexerRead getAReachableRead() { result = AssignableRead.super.getAReachableRead() }
+  override IndexerRead getAReachableRead() { result = ElementRead.super.getAReachableRead() }
 }
 
 /**
@@ -586,7 +586,7 @@ class IndexerRead extends IndexerAccess, AssignableRead {
  * }
  * ```
  */
-class IndexerWrite extends IndexerAccess, AssignableWrite { }
+class IndexerWrite extends IndexerAccess, ElementWrite { }
 
 /**
  * An access to a virtual indexer - an indexer that is virtual or defined in
@@ -818,7 +818,7 @@ class ArrayAccess extends ElementAccess, @array_access_expr {
  * }
  * ```
  */
-class ArrayRead extends ArrayAccess, AssignableRead { }
+class ArrayRead extends ArrayAccess, ElementRead { }
 
 /**
  * An access to an array that updates the underlying value, for example
@@ -830,7 +830,7 @@ class ArrayRead extends ArrayAccess, AssignableRead { }
  * }
  * ```
  */
-class ArrayWrite extends ArrayAccess, AssignableWrite { }
+class ArrayWrite extends ArrayAccess, ElementWrite { }
 
 /**
  * An access to a namespace, for example `System` in `nameof(System)`.

--- a/csharp/ql/src/semmle/code/csharp/frameworks/JsonNET.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/JsonNET.qll
@@ -3,7 +3,7 @@
  */
 
 import csharp
-import semmle.code.csharp.dataflow.LibraryTypeDataFlow
+private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
 
 /** Definitions relating to the `Json.NET` package. */
 module JsonNET {

--- a/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
+++ b/csharp/ql/test/library-tests/csharp7/LocalTaintFlow.expected
@@ -7,18 +7,15 @@
 | CSharp7.cs:17:9:17:11 | this | CSharp7.cs:17:18:17:22 | this access |
 | CSharp7.cs:21:9:21:11 | this | CSharp7.cs:21:16:21:20 | this access |
 | CSharp7.cs:22:9:22:11 | this | CSharp7.cs:22:16:22:20 | this access |
-| CSharp7.cs:22:9:22:11 | value | CSharp7.cs:22:9:22:11 | value |
 | CSharp7.cs:22:9:22:11 | value | CSharp7.cs:22:24:22:28 | access to parameter value |
 | CSharp7.cs:25:5:25:27 | this | CSharp7.cs:16:9:16:13 | this access |
 | CSharp7.cs:26:6:26:28 | this | CSharp7.cs:26:35:26:39 | this access |
-| CSharp7.cs:31:19:31:19 | i | CSharp7.cs:31:19:31:19 | i |
 | CSharp7.cs:31:19:31:19 | i | CSharp7.cs:33:16:33:16 | access to parameter i |
 | CSharp7.cs:33:16:33:16 | access to parameter i | CSharp7.cs:33:16:33:20 | ... > ... |
 | CSharp7.cs:33:16:33:16 | access to parameter i | CSharp7.cs:33:24:33:24 | access to parameter i |
 | CSharp7.cs:33:24:33:24 | access to parameter i | CSharp7.cs:33:16:33:59 | ... ? ... : ... |
 | CSharp7.cs:33:28:33:59 | throw ... | CSharp7.cs:33:16:33:59 | ... ? ... : ... |
 | CSharp7.cs:41:13:41:21 | "tainted" | CSharp7.cs:41:9:41:21 | SSA def(x) |
-| CSharp7.cs:44:19:44:19 | x | CSharp7.cs:44:19:44:19 | x |
 | CSharp7.cs:44:19:44:19 | x | CSharp7.cs:46:13:46:13 | access to parameter x |
 | CSharp7.cs:46:13:46:13 | access to parameter x | CSharp7.cs:46:9:46:13 | SSA def(y) |
 | CSharp7.cs:49:10:49:10 | this | CSharp7.cs:51:9:51:24 | this access |
@@ -65,7 +62,6 @@
 | CSharp7.cs:78:31:78:31 | access to local variable a | CSharp7.cs:78:27:78:32 | (..., ...) |
 | CSharp7.cs:79:23:79:24 | "" | CSharp7.cs:79:22:79:28 | (..., ...) |
 | CSharp7.cs:79:27:79:27 | access to local variable x | CSharp7.cs:79:22:79:28 | (..., ...) |
-| CSharp7.cs:82:21:82:21 | x | CSharp7.cs:82:21:82:21 | x |
 | CSharp7.cs:82:21:82:21 | x | CSharp7.cs:84:20:84:20 | access to parameter x |
 | CSharp7.cs:84:16:84:24 | (..., ...) | CSharp7.cs:84:16:84:26 | access to field a |
 | CSharp7.cs:84:20:84:20 | access to parameter x | CSharp7.cs:84:16:84:24 | (..., ...) |
@@ -116,19 +112,15 @@
 | CSharp7.cs:119:19:119:20 | access to local variable m2 | CSharp7.cs:119:19:119:26 | access to field Item1 |
 | CSharp7.cs:123:28:123:36 | "DefUse3" | CSharp7.cs:123:22:123:36 | ... = ... |
 | CSharp7.cs:129:9:129:12 | this | CSharp7.cs:135:24:135:25 | this access |
-| CSharp7.cs:131:20:131:20 | x | CSharp7.cs:131:20:131:20 | x |
 | CSharp7.cs:131:20:131:20 | x | CSharp7.cs:131:32:131:32 | access to parameter x |
 | CSharp7.cs:131:32:131:32 | access to parameter x | CSharp7.cs:131:32:131:36 | ... + ... |
 | CSharp7.cs:131:36:131:36 | 1 | CSharp7.cs:131:32:131:36 | ... + ... |
-| CSharp7.cs:133:22:133:22 | t | CSharp7.cs:133:22:133:22 | t |
 | CSharp7.cs:133:22:133:22 | t | CSharp7.cs:133:39:133:39 | access to parameter t |
 | CSharp7.cs:135:24:135:25 | this access | CSharp7.cs:155:16:155:17 | this access |
-| CSharp7.cs:139:29:139:29 | x | CSharp7.cs:139:29:139:29 | x |
 | CSharp7.cs:139:29:139:29 | x | CSharp7.cs:139:34:139:34 | access to parameter x |
 | CSharp7.cs:139:34:139:34 | access to parameter x | CSharp7.cs:139:34:139:38 | ... + ... |
 | CSharp7.cs:139:38:139:38 | 1 | CSharp7.cs:139:34:139:38 | ... + ... |
 | CSharp7.cs:141:9:141:51 | this | CSharp7.cs:141:38:141:39 | this access |
-| CSharp7.cs:141:20:141:20 | x | CSharp7.cs:141:20:141:20 | x |
 | CSharp7.cs:141:20:141:20 | x | CSharp7.cs:141:26:141:26 | access to parameter x |
 | CSharp7.cs:141:26:141:26 | access to parameter x | CSharp7.cs:141:26:141:30 | ... > ... |
 | CSharp7.cs:141:26:141:26 | access to parameter x | CSharp7.cs:141:41:141:41 | access to parameter x |
@@ -137,17 +129,13 @@
 | CSharp7.cs:141:38:141:46 | call to local function f7 | CSharp7.cs:141:34:141:46 | ... + ... |
 | CSharp7.cs:141:50:141:50 | 0 | CSharp7.cs:141:26:141:50 | ... ? ... : ... |
 | CSharp7.cs:143:9:143:31 | this | CSharp7.cs:143:26:143:27 | this access |
-| CSharp7.cs:143:20:143:20 | x | CSharp7.cs:143:20:143:20 | x |
 | CSharp7.cs:143:20:143:20 | x | CSharp7.cs:143:29:143:29 | access to parameter x |
 | CSharp7.cs:145:9:149:9 | this | CSharp7.cs:148:20:148:21 | this access |
 | CSharp7.cs:147:13:147:35 | this | CSharp7.cs:147:30:147:31 | this access |
-| CSharp7.cs:147:24:147:24 | x | CSharp7.cs:147:24:147:24 | x |
 | CSharp7.cs:147:24:147:24 | x | CSharp7.cs:147:33:147:33 | access to parameter x |
 | CSharp7.cs:158:10:158:17 | this | CSharp7.cs:170:9:170:9 | this access |
-| CSharp7.cs:161:18:161:18 | t | CSharp7.cs:161:18:161:18 | t |
 | CSharp7.cs:161:18:161:18 | t | CSharp7.cs:161:24:161:24 | access to parameter t |
 | CSharp7.cs:163:9:168:9 | this | CSharp7.cs:166:13:166:16 | this access |
-| CSharp7.cs:163:26:163:26 | u | CSharp7.cs:163:26:163:26 | u |
 | CSharp7.cs:163:26:163:26 | u | CSharp7.cs:167:22:167:22 | access to parameter u |
 | CSharp7.cs:165:13:165:43 | this | CSharp7.cs:165:37:165:40 | this access |
 | CSharp7.cs:166:13:166:16 | this access | CSharp7.cs:167:20:167:20 | this access |
@@ -156,13 +144,10 @@
 | CSharp7.cs:176:16:176:30 | SSA def(src) | CSharp7.cs:181:23:181:25 | access to local variable src |
 | CSharp7.cs:176:22:176:30 | "tainted" | CSharp7.cs:176:16:176:30 | SSA def(src) |
 | CSharp7.cs:177:9:177:40 | this | CSharp7.cs:177:31:177:31 | this access |
-| CSharp7.cs:177:25:177:25 | s | CSharp7.cs:177:25:177:25 | s |
 | CSharp7.cs:177:25:177:25 | s | CSharp7.cs:177:33:177:33 | access to parameter s |
 | CSharp7.cs:177:31:177:34 | call to local function g | CSharp7.cs:177:31:177:39 | ... + ... |
 | CSharp7.cs:177:38:177:39 | "" | CSharp7.cs:177:31:177:39 | ... + ... |
-| CSharp7.cs:178:25:178:25 | s | CSharp7.cs:178:25:178:25 | s |
 | CSharp7.cs:178:25:178:25 | s | CSharp7.cs:178:31:178:31 | access to parameter s |
-| CSharp7.cs:179:25:179:25 | s | CSharp7.cs:179:25:179:25 | s |
 | CSharp7.cs:179:25:179:25 | s | CSharp7.cs:179:37:179:37 | access to parameter s |
 | CSharp7.cs:181:21:181:21 | this access | CSharp7.cs:182:21:182:21 | this access |
 | CSharp7.cs:181:23:181:25 | [post] access to local variable src | CSharp7.cs:182:23:182:25 | access to local variable src |
@@ -189,9 +174,7 @@
 | CSharp7.cs:199:26:199:35 | [post] this access | CSharp7.cs:200:9:200:18 | this access |
 | CSharp7.cs:199:26:199:35 | this access | CSharp7.cs:200:9:200:18 | this access |
 | CSharp7.cs:199:33:199:34 | access to local variable r1 | CSharp7.cs:200:16:200:17 | access to local variable r1 |
-| CSharp7.cs:203:24:203:24 | p | CSharp7.cs:203:24:203:24 | p |
 | CSharp7.cs:203:24:203:24 | p | CSharp7.cs:206:20:206:20 | access to parameter p |
-| CSharp7.cs:205:28:205:28 | q | CSharp7.cs:205:28:205:28 | q |
 | CSharp7.cs:205:28:205:28 | q | CSharp7.cs:205:44:205:44 | access to parameter q |
 | CSharp7.cs:216:13:216:17 | false | CSharp7.cs:216:9:216:17 | SSA def(x) |
 | CSharp7.cs:217:17:217:17 | 0 | CSharp7.cs:217:16:217:23 | (..., ...) |
@@ -248,13 +231,16 @@
 | CSharp7.cs:283:13:283:48 | SSA def(dict) | CSharp7.cs:284:20:284:23 | access to local variable dict |
 | CSharp7.cs:283:20:283:48 | object creation of type Dictionary<Int32,String> | CSharp7.cs:283:13:283:48 | SSA def(dict) |
 | CSharp7.cs:284:13:284:62 | SSA def(list) | CSharp7.cs:286:39:286:42 | access to local variable list |
+| CSharp7.cs:284:20:284:23 | access to local variable dict | CSharp7.cs:284:20:284:62 | [library code] call to method Select |
+| CSharp7.cs:284:20:284:62 | [library code] call to method Select | CSharp7.cs:284:20:284:62 | call to method Select |
+| CSharp7.cs:284:20:284:62 | [library code] call to method Select | CSharp7.cs:284:32:284:61 | [implicit argument 0] (...) => ... |
 | CSharp7.cs:284:20:284:62 | call to method Select | CSharp7.cs:284:13:284:62 | SSA def(list) |
-| CSharp7.cs:284:32:284:35 | item | CSharp7.cs:284:32:284:35 | item |
 | CSharp7.cs:284:32:284:35 | item | CSharp7.cs:284:41:284:44 | access to parameter item |
-| CSharp7.cs:284:32:284:61 | [output] (...) => ... | CSharp7.cs:284:20:284:62 | call to method Select |
+| CSharp7.cs:284:32:284:61 | [output] (...) => ... | CSharp7.cs:284:20:284:62 | [library code] call to method Select |
 | CSharp7.cs:284:41:284:44 | access to parameter item | CSharp7.cs:284:51:284:54 | access to parameter item |
 | CSharp7.cs:284:41:284:48 | access to property Key | CSharp7.cs:284:40:284:61 | (..., ...) |
-| CSharp7.cs:284:51:284:54 | access to parameter item | CSharp7.cs:284:51:284:60 | access to property Value |
+| CSharp7.cs:284:51:284:54 | access to parameter item | CSharp7.cs:284:51:284:60 | [library code] access to property Value |
+| CSharp7.cs:284:51:284:60 | [library code] access to property Value | CSharp7.cs:284:51:284:60 | access to property Value |
 | CSharp7.cs:284:51:284:60 | access to property Value | CSharp7.cs:284:40:284:61 | (..., ...) |
 | CSharp7.cs:286:39:286:42 | access to local variable list | CSharp7.cs:288:36:288:39 | access to local variable list |
 | CSharp7.cs:288:36:288:39 | access to local variable list | CSharp7.cs:290:32:290:35 | access to local variable list |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -149,7 +149,10 @@ edges
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:179:35:179:48 | "taint source" : String | GlobalDataFlow.cs:180:21:180:26 | delegate call : String |
 | GlobalDataFlow.cs:180:21:180:26 | delegate call : String | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String | GlobalDataFlow.cs:189:22:189:48 | access to property Value : String |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value : String | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String |
 | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty : String | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
 | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String | GlobalDataFlow.cs:238:16:238:25 | access to parameter sinkParam0 : String |
 | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String | GlobalDataFlow.cs:239:15:239:24 | access to parameter sinkParam0 |
@@ -300,6 +303,9 @@ nodes
 | GlobalDataFlow.cs:179:35:179:48 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:180:21:180:26 | delegate call : String | semmle.label | delegate call : String |
 | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String | semmle.label | [library code] object creation of type Lazy<String> : String |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String | semmle.label | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value : String | semmle.label | access to property Value : String |
 | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | semmle.label | [output] delegate creation of type Func<String> : String |
 | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
 | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -142,22 +142,28 @@ edges
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven : IEnumerable<T> | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 |
 | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven : IEnumerable<T> | GlobalDataFlow.cs:82:23:82:66 | (...) ... : String[] |
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... : String[] | GlobalDataFlow.cs:80:22:80:85 | call to method SelectEven : IEnumerable<T> |
-| GlobalDataFlow.cs:82:23:82:66 | (...) ... : String[] | GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T |
-| GlobalDataFlow.cs:82:23:82:66 | (...) ... : String[] | GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String[] |
-| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 |
-| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T | GlobalDataFlow.cs:84:23:84:66 | (...) ... : String[] |
-| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T | GlobalDataFlow.cs:88:23:88:66 | (...) ... : String[] |
-| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T | GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 : String |
-| GlobalDataFlow.cs:84:23:84:66 | (...) ... : String[] | GlobalDataFlow.cs:84:117:84:127 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:82:23:82:66 | (...) ... : String[] | GlobalDataFlow.cs:82:76:82:86 | [implicit argument 0] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:82:76:82:86 | [implicit argument 0] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:82:76:82:86 | [implicit argument 0] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String |
+| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 |
+| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:84:23:84:66 | (...) ... : String[] |
+| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:88:23:88:66 | (...) ... : String[] |
+| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:90:83:90:101 | [implicit argument 0] (...) => ... : String |
+| GlobalDataFlow.cs:84:23:84:66 | (...) ... : String[] | GlobalDataFlow.cs:84:117:84:127 | [implicit argument 0] (...) => ... : String |
+| GlobalDataFlow.cs:84:117:84:127 | [implicit argument 0] (...) => ... : String | GlobalDataFlow.cs:84:117:84:127 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:84:117:84:127 | [output] (...) => ... : String | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 |
 | GlobalDataFlow.cs:84:117:84:127 | [output] (...) => ... : String | GlobalDataFlow.cs:86:70:86:113 | (...) ... : String[] |
-| GlobalDataFlow.cs:86:70:86:113 | (...) ... : String[] | GlobalDataFlow.cs:86:117:86:127 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:86:70:86:113 | (...) ... : String[] | GlobalDataFlow.cs:86:117:86:127 | [implicit argument 1] (...) => ... : String |
+| GlobalDataFlow.cs:86:117:86:127 | [implicit argument 1] (...) => ... : String | GlobalDataFlow.cs:86:117:86:127 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:86:117:86:127 | [output] (...) => ... : String | GlobalDataFlow.cs:87:15:87:20 | access to local variable sink16 |
-| GlobalDataFlow.cs:88:23:88:66 | (...) ... : String[] | GlobalDataFlow.cs:88:83:88:101 | [output] (...) => ... : String |
-| GlobalDataFlow.cs:88:83:88:101 | [output] (...) => ... : String | GlobalDataFlow.cs:88:104:88:109 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:88:23:88:66 | (...) ... : String[] | GlobalDataFlow.cs:88:83:88:101 | [implicit argument 1] (...) => ... : String |
+| GlobalDataFlow.cs:88:83:88:101 | [implicit argument 1] (...) => ... : String | GlobalDataFlow.cs:88:83:88:101 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:88:83:88:101 | [output] (...) => ... : String | GlobalDataFlow.cs:88:104:88:109 | [implicit argument 0] (...) => ... : String |
+| GlobalDataFlow.cs:88:104:88:109 | [implicit argument 0] (...) => ... : String | GlobalDataFlow.cs:88:104:88:109 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:88:104:88:109 | [output] (...) => ... : String | GlobalDataFlow.cs:89:15:89:20 | access to local variable sink17 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 : String | GlobalDataFlow.cs:90:83:90:101 | [output] (...) => ... : String |
-| GlobalDataFlow.cs:90:83:90:101 | [output] (...) => ... : String | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:90:83:90:101 | [implicit argument 0] (...) => ... : String | GlobalDataFlow.cs:90:83:90:101 | [output] (...) => ... : String |
+| GlobalDataFlow.cs:90:83:90:101 | [output] (...) => ... : String | GlobalDataFlow.cs:90:104:90:109 | [implicit argument 0] (...) => ... : String |
+| GlobalDataFlow.cs:90:104:90:109 | [implicit argument 0] (...) => ... : String | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 |
 | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String | GlobalDataFlow.cs:97:15:97:20 | access to local variable sink22 |
@@ -173,23 +179,26 @@ edges
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:179:35:179:48 | "taint source" : String | GlobalDataFlow.cs:180:21:180:26 | delegate call : String |
 | GlobalDataFlow.cs:180:21:180:26 | delegate call : String | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 |
-| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String | GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String | GlobalDataFlow.cs:189:22:189:48 | access to property Value : String |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value : String | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 |
+| GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String |
 | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty : String | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 |
-| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:212:22:212:28 | access to local variable tainted : IQueryable<String> |
-| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:214:22:214:28 | access to local variable tainted : IQueryable<String> |
-| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<String> |
-| GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : IQueryable<String> | GlobalDataFlow.cs:210:58:210:68 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:211:71:211:71 | x : IQueryable<String> | GlobalDataFlow.cs:211:89:211:89 | access to parameter x : String |
+| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:212:37:212:38 | [implicit argument 0] access to local variable f1 : String |
+| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:214:37:214:38 | [implicit argument 0] access to local variable f2 : String |
+| GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | GlobalDataFlow.cs:216:37:216:48 | [implicit argument 0] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : String | GlobalDataFlow.cs:210:58:210:68 | access to parameter sinkParam10 |
+| GlobalDataFlow.cs:211:71:211:71 | x : String | GlobalDataFlow.cs:211:89:211:89 | access to parameter x : String |
 | GlobalDataFlow.cs:211:89:211:89 | access to parameter x : String | GlobalDataFlow.cs:300:32:300:41 | sinkParam9 : String |
-| GlobalDataFlow.cs:212:22:212:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : IQueryable<String> |
-| GlobalDataFlow.cs:212:22:212:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f1 : String |
+| GlobalDataFlow.cs:212:37:212:38 | [implicit argument 0] access to local variable f1 : String | GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : String |
+| GlobalDataFlow.cs:212:37:212:38 | [implicit argument 0] access to local variable f1 : String | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f1 : String |
 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f1 : String | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink24 |
-| GlobalDataFlow.cs:214:22:214:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:211:71:211:71 | x : IQueryable<String> |
-| GlobalDataFlow.cs:214:22:214:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:214:37:214:38 | [output] access to local variable f2 : String |
+| GlobalDataFlow.cs:214:37:214:38 | [implicit argument 0] access to local variable f2 : String | GlobalDataFlow.cs:211:71:211:71 | x : String |
+| GlobalDataFlow.cs:214:37:214:38 | [implicit argument 0] access to local variable f2 : String | GlobalDataFlow.cs:214:37:214:38 | [output] access to local variable f2 : String |
 | GlobalDataFlow.cs:214:37:214:38 | [output] access to local variable f2 : String | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink25 |
-| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : T |
-| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<String> | GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : IQueryable<String> |
-| GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : T | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink26 |
+| GlobalDataFlow.cs:216:37:216:48 | [implicit argument 0] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:216:37:216:48 | [implicit argument 0] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : String |
+| GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : String | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink26 |
 | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String | GlobalDataFlow.cs:238:16:238:25 | access to parameter sinkParam0 : String |
 | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String | GlobalDataFlow.cs:239:15:239:24 | access to parameter sinkParam0 |
 | GlobalDataFlow.cs:238:16:238:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String |
@@ -199,17 +208,17 @@ edges
 | GlobalDataFlow.cs:257:26:257:35 | sinkParam5 : String | GlobalDataFlow.cs:259:15:259:24 | access to parameter sinkParam5 |
 | GlobalDataFlow.cs:262:26:262:35 | sinkParam6 : String | GlobalDataFlow.cs:264:15:264:24 | access to parameter sinkParam6 |
 | GlobalDataFlow.cs:267:26:267:35 | sinkParam7 : String | GlobalDataFlow.cs:269:15:269:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String[] | GlobalDataFlow.cs:296:15:296:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String | GlobalDataFlow.cs:296:15:296:24 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:300:32:300:41 | sinkParam9 : String | GlobalDataFlow.cs:302:15:302:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : IQueryable<String> | GlobalDataFlow.cs:308:15:308:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : String | GlobalDataFlow.cs:308:15:308:25 | access to parameter sinkParam11 |
 | GlobalDataFlow.cs:320:16:320:29 | "taint source" : String | GlobalDataFlow.cs:153:21:153:25 | call to method Out : String |
 | GlobalDataFlow.cs:320:16:320:29 | "taint source" : String | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String |
 | GlobalDataFlow.cs:325:9:325:26 | SSA def(x) : String | GlobalDataFlow.cs:156:20:156:24 | SSA def(sink7) : String |
 | GlobalDataFlow.cs:325:13:325:26 | "taint source" : String | GlobalDataFlow.cs:325:9:325:26 | SSA def(x) : String |
 | GlobalDataFlow.cs:330:9:330:26 | SSA def(x) : String | GlobalDataFlow.cs:159:20:159:24 | SSA def(sink8) : String |
 | GlobalDataFlow.cs:330:13:330:26 | "taint source" : String | GlobalDataFlow.cs:330:9:330:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:336:22:336:35 | "taint source" : IEnumerable<String> | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield : IEnumerable<String> |
-| GlobalDataFlow.cs:336:22:336:35 | "taint source" : String | GlobalDataFlow.cs:336:22:336:35 | "taint source" : IEnumerable<String> |
+| GlobalDataFlow.cs:336:9:336:36 | yield return ...; : IEnumerable<String> | GlobalDataFlow.cs:161:22:161:31 | call to method OutYield : IEnumerable<String> |
+| GlobalDataFlow.cs:336:22:336:35 | "taint source" : String | GlobalDataFlow.cs:336:9:336:36 | yield return ...; : IEnumerable<String> |
 | GlobalDataFlow.cs:361:41:361:41 | x : String | GlobalDataFlow.cs:363:11:363:11 | access to parameter x : String |
 | GlobalDataFlow.cs:361:41:361:41 | x : String | GlobalDataFlow.cs:363:11:363:11 | access to parameter x : String |
 | GlobalDataFlow.cs:363:11:363:11 | access to parameter x : String | GlobalDataFlow.cs:53:15:53:15 | x : String |
@@ -334,20 +343,26 @@ nodes
 | GlobalDataFlow.cs:80:23:80:65 | (...) ... : String[] | semmle.label | (...) ... : String[] |
 | GlobalDataFlow.cs:81:15:81:20 | access to local variable sink13 | semmle.label | access to local variable sink13 |
 | GlobalDataFlow.cs:82:23:82:66 | (...) ... : String[] | semmle.label | (...) ... : String[] |
-| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : T | semmle.label | [output] delegate creation of type Func<String,String> : T |
+| GlobalDataFlow.cs:82:76:82:86 | [implicit argument 0] delegate creation of type Func<String,String> : String | semmle.label | [implicit argument 0] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:82:76:82:86 | [output] delegate creation of type Func<String,String> : String | semmle.label | [output] delegate creation of type Func<String,String> : String |
 | GlobalDataFlow.cs:83:15:83:20 | access to local variable sink14 | semmle.label | access to local variable sink14 |
 | GlobalDataFlow.cs:84:23:84:66 | (...) ... : String[] | semmle.label | (...) ... : String[] |
+| GlobalDataFlow.cs:84:117:84:127 | [implicit argument 0] (...) => ... : String | semmle.label | [implicit argument 0] (...) => ... : String |
 | GlobalDataFlow.cs:84:117:84:127 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
 | GlobalDataFlow.cs:85:15:85:20 | access to local variable sink15 | semmle.label | access to local variable sink15 |
 | GlobalDataFlow.cs:86:70:86:113 | (...) ... : String[] | semmle.label | (...) ... : String[] |
+| GlobalDataFlow.cs:86:117:86:127 | [implicit argument 1] (...) => ... : String | semmle.label | [implicit argument 1] (...) => ... : String |
 | GlobalDataFlow.cs:86:117:86:127 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
 | GlobalDataFlow.cs:87:15:87:20 | access to local variable sink16 | semmle.label | access to local variable sink16 |
 | GlobalDataFlow.cs:88:23:88:66 | (...) ... : String[] | semmle.label | (...) ... : String[] |
+| GlobalDataFlow.cs:88:83:88:101 | [implicit argument 1] (...) => ... : String | semmle.label | [implicit argument 1] (...) => ... : String |
 | GlobalDataFlow.cs:88:83:88:101 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
+| GlobalDataFlow.cs:88:104:88:109 | [implicit argument 0] (...) => ... : String | semmle.label | [implicit argument 0] (...) => ... : String |
 | GlobalDataFlow.cs:88:104:88:109 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
 | GlobalDataFlow.cs:89:15:89:20 | access to local variable sink17 | semmle.label | access to local variable sink17 |
-| GlobalDataFlow.cs:90:75:90:80 | access to local variable sink14 : String | semmle.label | access to local variable sink14 : String |
+| GlobalDataFlow.cs:90:83:90:101 | [implicit argument 0] (...) => ... : String | semmle.label | [implicit argument 0] (...) => ... : String |
 | GlobalDataFlow.cs:90:83:90:101 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
+| GlobalDataFlow.cs:90:104:90:109 | [implicit argument 0] (...) => ... : String | semmle.label | [implicit argument 0] (...) => ... : String |
 | GlobalDataFlow.cs:90:104:90:109 | [output] (...) => ... : String | semmle.label | [output] (...) => ... : String |
 | GlobalDataFlow.cs:91:15:91:20 | access to local variable sink18 | semmle.label | access to local variable sink18 |
 | GlobalDataFlow.cs:94:15:94:20 | access to local variable sink21 | semmle.label | access to local variable sink21 |
@@ -371,23 +386,26 @@ nodes
 | GlobalDataFlow.cs:179:35:179:48 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:180:21:180:26 | delegate call : String | semmle.label | delegate call : String |
 | GlobalDataFlow.cs:181:15:181:19 | access to local variable sink9 | semmle.label | access to local variable sink9 |
+| GlobalDataFlow.cs:189:22:189:42 | [library code] object creation of type Lazy<String> : String | semmle.label | [library code] object creation of type Lazy<String> : String |
+| GlobalDataFlow.cs:189:22:189:42 | object creation of type Lazy<String> [Value] : String | semmle.label | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:189:22:189:48 | access to property Value : String | semmle.label | access to property Value : String |
 | GlobalDataFlow.cs:189:39:189:41 | [output] delegate creation of type Func<String> : String | semmle.label | [output] delegate creation of type Func<String> : String |
 | GlobalDataFlow.cs:190:15:190:20 | access to local variable sink10 | semmle.label | access to local variable sink10 |
 | GlobalDataFlow.cs:197:22:197:32 | access to property OutProperty : String | semmle.label | access to property OutProperty : String |
 | GlobalDataFlow.cs:198:15:198:20 | access to local variable sink19 | semmle.label | access to local variable sink19 |
 | GlobalDataFlow.cs:207:46:207:59 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : IQueryable<String> | semmle.label | sinkParam10 : IQueryable<String> |
+| GlobalDataFlow.cs:210:35:210:45 | sinkParam10 : String | semmle.label | sinkParam10 : String |
 | GlobalDataFlow.cs:210:58:210:68 | access to parameter sinkParam10 | semmle.label | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:211:71:211:71 | x : IQueryable<String> | semmle.label | x : IQueryable<String> |
+| GlobalDataFlow.cs:211:71:211:71 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:211:89:211:89 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:212:22:212:28 | access to local variable tainted : IQueryable<String> | semmle.label | access to local variable tainted : IQueryable<String> |
+| GlobalDataFlow.cs:212:37:212:38 | [implicit argument 0] access to local variable f1 : String | semmle.label | [implicit argument 0] access to local variable f1 : String |
 | GlobalDataFlow.cs:212:37:212:38 | [output] access to local variable f1 : String | semmle.label | [output] access to local variable f1 : String |
 | GlobalDataFlow.cs:213:15:213:20 | access to local variable sink24 | semmle.label | access to local variable sink24 |
-| GlobalDataFlow.cs:214:22:214:28 | access to local variable tainted : IQueryable<String> | semmle.label | access to local variable tainted : IQueryable<String> |
+| GlobalDataFlow.cs:214:37:214:38 | [implicit argument 0] access to local variable f2 : String | semmle.label | [implicit argument 0] access to local variable f2 : String |
 | GlobalDataFlow.cs:214:37:214:38 | [output] access to local variable f2 : String | semmle.label | [output] access to local variable f2 : String |
 | GlobalDataFlow.cs:215:15:215:20 | access to local variable sink25 | semmle.label | access to local variable sink25 |
-| GlobalDataFlow.cs:216:22:216:28 | access to local variable tainted : IQueryable<String> | semmle.label | access to local variable tainted : IQueryable<String> |
-| GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : T | semmle.label | [output] delegate creation of type Func<String,String> : T |
+| GlobalDataFlow.cs:216:37:216:48 | [implicit argument 0] delegate creation of type Func<String,String> : String | semmle.label | [implicit argument 0] delegate creation of type Func<String,String> : String |
+| GlobalDataFlow.cs:216:37:216:48 | [output] delegate creation of type Func<String,String> : String | semmle.label | [output] delegate creation of type Func<String,String> : String |
 | GlobalDataFlow.cs:217:15:217:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
 | GlobalDataFlow.cs:236:26:236:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
 | GlobalDataFlow.cs:238:16:238:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
@@ -404,18 +422,18 @@ nodes
 | GlobalDataFlow.cs:264:15:264:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
 | GlobalDataFlow.cs:267:26:267:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
 | GlobalDataFlow.cs:269:15:269:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String[] | semmle.label | sinkParam8 : String[] |
+| GlobalDataFlow.cs:294:31:294:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
 | GlobalDataFlow.cs:296:15:296:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:300:32:300:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
 | GlobalDataFlow.cs:302:15:302:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : IQueryable<String> | semmle.label | sinkParam11 : IQueryable<String> |
+| GlobalDataFlow.cs:306:32:306:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
 | GlobalDataFlow.cs:308:15:308:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
 | GlobalDataFlow.cs:320:16:320:29 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:325:9:325:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
 | GlobalDataFlow.cs:325:13:325:26 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:330:9:330:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
 | GlobalDataFlow.cs:330:13:330:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:336:22:336:35 | "taint source" : IEnumerable<String> | semmle.label | "taint source" : IEnumerable<String> |
+| GlobalDataFlow.cs:336:9:336:36 | yield return ...; : IEnumerable<String> | semmle.label | yield return ...; : IEnumerable<String> |
 | GlobalDataFlow.cs:336:22:336:35 | "taint source" : String | semmle.label | "taint source" : String |
 | GlobalDataFlow.cs:361:41:361:41 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:361:41:361:41 | x : String | semmle.label | x : String |

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
@@ -1683,7 +1683,7 @@ callableFlow
 | System.Web.HttpUtility.HtmlEncode(string) | argument 0 -> return | false |
 | System.Web.HttpUtility.UrlEncode(string) | argument 0 -> return | false |
 | System.Web.UI.WebControls.TextBox.get_Text() | qualifier -> return | false |
-callableFlowAp
+callableFlowAccessPath
 | System.Lazy<>.Lazy(Func<T>) | output from argument 0 [<empty>] -> return [Value] |
 | System.Lazy<>.Lazy(Func<T>, LazyThreadSafetyMode) | output from argument 0 [<empty>] -> return [Value] |
 | System.Lazy<>.Lazy(Func<T>, bool) | output from argument 0 [<empty>] -> return [Value] |

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
@@ -1,3 +1,4 @@
+callableFlow
 | LibraryTypeDataFlow.DataContract.get_AString() | qualifier -> return | false |
 | System.Array.Add(object) | argument 0 -> qualifier | false |
 | System.Array.AsReadOnly<T>(T[]) | qualifier -> return | false |
@@ -661,10 +662,6 @@
 | System.Int32.TryParse(string, NumberStyles, IFormatProvider, out int) | argument 0 -> return | false |
 | System.Int32.TryParse(string, out int) | argument 0 -> argument 1 | false |
 | System.Int32.TryParse(string, out int) | argument 0 -> return | false |
-| System.Lazy<>.Lazy(Func<T>) | output from argument 0 -> return | true |
-| System.Lazy<>.Lazy(Func<T>, LazyThreadSafetyMode) | output from argument 0 -> return | true |
-| System.Lazy<>.Lazy(Func<T>, bool) | output from argument 0 -> return | true |
-| System.Lazy<>.get_Value() | qualifier -> return | true |
 | System.Linq.Enumerable.Aggregate<TSource, TAccumulate, TResult>(IEnumerable<TSource>, TAccumulate, Func<TAccumulate, TSource, TAccumulate>, Func<TAccumulate, TResult>) | argument 0 -> parameter 1 of argument 2 | false |
 | System.Linq.Enumerable.Aggregate<TSource, TAccumulate, TResult>(IEnumerable<TSource>, TAccumulate, Func<TAccumulate, TSource, TAccumulate>, Func<TAccumulate, TResult>) | argument 1 -> parameter 0 of argument 2 | false |
 | System.Linq.Enumerable.Aggregate<TSource, TAccumulate, TResult>(IEnumerable<TSource>, TAccumulate, Func<TAccumulate, TSource, TAccumulate>, Func<TAccumulate, TResult>) | output from argument 2 -> parameter 0 of argument 3 | false |
@@ -1686,3 +1683,7 @@
 | System.Web.HttpUtility.HtmlEncode(string) | argument 0 -> return | false |
 | System.Web.HttpUtility.UrlEncode(string) | argument 0 -> return | false |
 | System.Web.UI.WebControls.TextBox.get_Text() | qualifier -> return | false |
+callableFlowAp
+| System.Lazy<>.Lazy(Func<T>) | output from argument 0 [<empty>] -> return [Value] |
+| System.Lazy<>.Lazy(Func<T>, LazyThreadSafetyMode) | output from argument 0 [<empty>] -> return [Value] |
+| System.Lazy<>.Lazy(Func<T>, bool) | output from argument 0 [<empty>] -> return [Value] |

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.ql
@@ -13,7 +13,7 @@ query predicate callableFlow(string callable, string flow, boolean preservesValu
   )
 }
 
-query predicate callableFlowAp(string callable, string flow) {
+query predicate callableFlowAccessPath(string callable, string flow) {
   exists(
     LibraryTypeDataFlow x, CallableFlowSource source, AccessPath sourceAp, CallableFlowSink sink,
     AccessPath sinkAp, Callable c

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.ql
@@ -1,22 +1,27 @@
 import semmle.code.csharp.dataflow.LibraryTypeDataFlow
 
-predicate callableFlow(string callable, string flow, boolean preservesValue) {
+query predicate callableFlow(string callable, string flow, boolean preservesValue) {
   exists(LibraryTypeDataFlow x, CallableFlowSource source, CallableFlowSink sink, Callable c |
     c.(Modifiable).isPublic() and
     c.getDeclaringType().isPublic() and
     x.callableFlow(source, sink, c, preservesValue) and
     callable = c.getQualifiedNameWithTypes() and
-    flow = source.toString() + " -> " + sink.toString()
+    flow = source + " -> " + sink and
+    // Remove certain results to make the test output consistent
+    // between different versions of .NET Core.
+    not callable = "System.IO.FileStream.CopyToAsync(Stream, int, CancellationToken)"
   )
 }
 
-from string entity, string flow, boolean preservesValue
-where
-  callableFlow(entity, flow, preservesValue) and
-  /*
-   * Remove certain results to make the test output consistent
-   * between different versions of .NET Core.
-   */
-
-  not entity = "System.IO.FileStream.CopyToAsync(Stream, int, CancellationToken)"
-select entity, flow, preservesValue
+query predicate callableFlowAp(string callable, string flow) {
+  exists(
+    LibraryTypeDataFlow x, CallableFlowSource source, AccessPath sourceAp, CallableFlowSink sink,
+    AccessPath sinkAp, Callable c
+  |
+    c.(Modifiable).isPublic() and
+    c.getDeclaringType().isPublic() and
+    x.callableFlow(source, sourceAp, sink, sinkAp, c) and
+    callable = c.getQualifiedNameWithTypes() and
+    flow = source + " [" + sourceAp + "] -> " + sink + " [" + sinkAp + "]"
+  )
+}

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -143,8 +143,9 @@
 | LocalDataFlow.cs:128:15:128:20 | [post] access to local variable sink49 | LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 |
 | LocalDataFlow.cs:128:15:128:20 | access to local variable sink49 | LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 |
 | LocalDataFlow.cs:129:13:129:40 | SSA def(sink50) | LocalDataFlow.cs:130:15:130:20 | access to local variable sink50 |
+| LocalDataFlow.cs:129:22:129:40 | [library code] call to method Copy | LocalDataFlow.cs:129:22:129:40 | call to method Copy |
 | LocalDataFlow.cs:129:22:129:40 | call to method Copy | LocalDataFlow.cs:129:13:129:40 | SSA def(sink50) |
-| LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 | LocalDataFlow.cs:129:22:129:40 | call to method Copy |
+| LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 | LocalDataFlow.cs:129:22:129:40 | [library code] call to method Copy |
 | LocalDataFlow.cs:130:15:130:20 | [post] access to local variable sink50 | LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 |
 | LocalDataFlow.cs:130:15:130:20 | access to local variable sink50 | LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 |
 | LocalDataFlow.cs:131:13:131:54 | SSA def(sink51) | LocalDataFlow.cs:132:15:132:20 | access to local variable sink51 |
@@ -189,8 +190,9 @@
 | LocalDataFlow.cs:152:15:152:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:152:15:152:22 | access to local variable nonSink0 | LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:153:9:153:40 | SSA def(nonSink0) | LocalDataFlow.cs:154:15:154:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:153:20:153:40 | [library code] call to method Copy | LocalDataFlow.cs:153:20:153:40 | call to method Copy |
 | LocalDataFlow.cs:153:20:153:40 | call to method Copy | LocalDataFlow.cs:153:9:153:40 | SSA def(nonSink0) |
-| LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 | LocalDataFlow.cs:153:20:153:40 | call to method Copy |
+| LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 | LocalDataFlow.cs:153:20:153:40 | [library code] call to method Copy |
 | LocalDataFlow.cs:154:15:154:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 |
 | LocalDataFlow.cs:154:15:154:22 | access to local variable nonSink0 | LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 |
 | LocalDataFlow.cs:155:9:155:54 | SSA def(nonSink0) | LocalDataFlow.cs:156:15:156:22 | access to local variable nonSink0 |
@@ -284,7 +286,8 @@
 | LocalDataFlow.cs:216:15:216:22 | access to local variable nonSink0 | LocalDataFlow.cs:225:28:225:35 | access to local variable nonSink0 |
 | LocalDataFlow.cs:219:13:219:127 | SSA def(sink33) | LocalDataFlow.cs:220:15:220:20 | access to local variable sink33 |
 | LocalDataFlow.cs:219:22:219:127 | (...) ... | LocalDataFlow.cs:219:13:219:127 | SSA def(sink33) |
-| LocalDataFlow.cs:219:30:219:119 | call to method Insert | LocalDataFlow.cs:219:30:219:127 | call to method Clone |
+| LocalDataFlow.cs:219:30:219:119 | call to method Insert | LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone | LocalDataFlow.cs:219:30:219:127 | call to method Clone |
 | LocalDataFlow.cs:219:30:219:127 | call to method Clone | LocalDataFlow.cs:219:22:219:127 | (...) ... |
 | LocalDataFlow.cs:220:15:220:20 | [post] access to local variable sink33 | LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 |
 | LocalDataFlow.cs:220:15:220:20 | access to local variable sink33 | LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 |
@@ -294,7 +297,8 @@
 | LocalDataFlow.cs:221:22:221:63 | call to method Split | LocalDataFlow.cs:221:13:221:63 | SSA def(sink48) |
 | LocalDataFlow.cs:225:9:225:127 | SSA def(nonSink0) | LocalDataFlow.cs:226:15:226:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:225:20:225:127 | (...) ... | LocalDataFlow.cs:225:9:225:127 | SSA def(nonSink0) |
-| LocalDataFlow.cs:225:28:225:119 | call to method Insert | LocalDataFlow.cs:225:28:225:127 | call to method Clone |
+| LocalDataFlow.cs:225:28:225:119 | call to method Insert | LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone | LocalDataFlow.cs:225:28:225:127 | call to method Clone |
 | LocalDataFlow.cs:225:28:225:127 | call to method Clone | LocalDataFlow.cs:225:20:225:127 | (...) ... |
 | LocalDataFlow.cs:226:15:226:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 |
 | LocalDataFlow.cs:226:15:226:22 | access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 |
@@ -358,16 +362,18 @@
 | LocalDataFlow.cs:270:9:270:41 | SSA def(nonSink0) | LocalDataFlow.cs:271:15:271:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:270:20:270:41 | access to property Text | LocalDataFlow.cs:270:9:270:41 | SSA def(nonSink0) |
 | LocalDataFlow.cs:274:13:274:51 | SSA def(sink67) | LocalDataFlow.cs:275:15:275:20 | access to local variable sink67 |
+| LocalDataFlow.cs:274:22:274:51 | [library code] call to method Run | LocalDataFlow.cs:274:22:274:51 | call to method Run |
 | LocalDataFlow.cs:274:22:274:51 | call to method Run | LocalDataFlow.cs:274:13:274:51 | SSA def(sink67) |
-| LocalDataFlow.cs:274:31:274:50 | [output] (...) => ... | LocalDataFlow.cs:274:22:274:51 | call to method Run |
+| LocalDataFlow.cs:274:31:274:50 | [output] (...) => ... | LocalDataFlow.cs:274:22:274:51 | [library code] call to method Run |
 | LocalDataFlow.cs:275:15:275:20 | [post] access to local variable sink67 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 |
 | LocalDataFlow.cs:275:15:275:20 | access to local variable sink67 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 |
 | LocalDataFlow.cs:276:13:276:33 | SSA def(sink68) | LocalDataFlow.cs:277:15:277:20 | access to local variable sink68 |
 | LocalDataFlow.cs:276:22:276:33 | await ... | LocalDataFlow.cs:276:13:276:33 | SSA def(sink68) |
 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 | LocalDataFlow.cs:276:22:276:33 | await ... |
 | LocalDataFlow.cs:280:13:280:42 | SSA def(nonSink21) | LocalDataFlow.cs:281:15:281:23 | access to local variable nonSink21 |
+| LocalDataFlow.cs:280:25:280:42 | [library code] call to method Run | LocalDataFlow.cs:280:25:280:42 | call to method Run |
 | LocalDataFlow.cs:280:25:280:42 | call to method Run | LocalDataFlow.cs:280:13:280:42 | SSA def(nonSink21) |
-| LocalDataFlow.cs:280:34:280:41 | [output] (...) => ... | LocalDataFlow.cs:280:25:280:42 | call to method Run |
+| LocalDataFlow.cs:280:34:280:41 | [output] (...) => ... | LocalDataFlow.cs:280:25:280:42 | [library code] call to method Run |
 | LocalDataFlow.cs:281:15:281:23 | [post] access to local variable nonSink21 | LocalDataFlow.cs:282:26:282:34 | access to local variable nonSink21 |
 | LocalDataFlow.cs:281:15:281:23 | access to local variable nonSink21 | LocalDataFlow.cs:282:26:282:34 | access to local variable nonSink21 |
 | LocalDataFlow.cs:282:9:282:34 | SSA def(nonSink0) | LocalDataFlow.cs:283:15:283:22 | access to local variable nonSink0 |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -24,7 +24,6 @@
 | Capture.cs:58:21:58:21 | 1 | Capture.cs:58:17:58:21 | SSA def(i) |
 | Capture.cs:61:17:61:17 | 1 | Capture.cs:61:13:61:17 | SSA def(i) |
 | Capture.cs:63:9:63:17 | SSA call def(i) | Capture.cs:64:13:64:13 | access to local variable i |
-| LocalDataFlow.cs:49:30:49:30 | b | LocalDataFlow.cs:49:30:49:30 | b |
 | LocalDataFlow.cs:49:30:49:30 | b | LocalDataFlow.cs:85:21:85:21 | access to parameter b |
 | LocalDataFlow.cs:52:13:52:34 | SSA def(sink0) | LocalDataFlow.cs:53:15:53:19 | access to local variable sink0 |
 | LocalDataFlow.cs:52:21:52:34 | "taint source" | LocalDataFlow.cs:52:13:52:34 | SSA def(sink0) |
@@ -108,142 +107,184 @@
 | LocalDataFlow.cs:106:15:106:22 | [post] access to local variable nonSink3 | LocalDataFlow.cs:171:33:171:40 | access to local variable nonSink3 |
 | LocalDataFlow.cs:106:15:106:22 | access to local variable nonSink3 | LocalDataFlow.cs:171:33:171:40 | access to local variable nonSink3 |
 | LocalDataFlow.cs:109:13:109:39 | SSA def(sink15) | LocalDataFlow.cs:110:15:110:20 | access to local variable sink15 |
+| LocalDataFlow.cs:109:22:109:39 | [library code] call to method Parse | LocalDataFlow.cs:109:22:109:39 | call to method Parse |
 | LocalDataFlow.cs:109:22:109:39 | call to method Parse | LocalDataFlow.cs:109:13:109:39 | SSA def(sink15) |
 | LocalDataFlow.cs:109:34:109:38 | [post] access to local variable sink9 | LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 |
-| LocalDataFlow.cs:109:34:109:38 | access to local variable sink9 | LocalDataFlow.cs:109:22:109:39 | call to method Parse |
+| LocalDataFlow.cs:109:34:109:38 | access to local variable sink9 | LocalDataFlow.cs:109:22:109:39 | [library code] call to method Parse |
 | LocalDataFlow.cs:109:34:109:38 | access to local variable sink9 | LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 |
 | LocalDataFlow.cs:110:15:110:20 | access to local variable sink15 | LocalDataFlow.cs:161:22:161:27 | access to local variable sink15 |
 | LocalDataFlow.cs:112:13:112:56 | SSA def(sink16) | LocalDataFlow.cs:113:15:113:20 | access to local variable sink16 |
+| LocalDataFlow.cs:112:22:112:56 | [library code] call to method TryParse | LocalDataFlow.cs:112:22:112:56 | call to method TryParse |
 | LocalDataFlow.cs:112:22:112:56 | call to method TryParse | LocalDataFlow.cs:112:13:112:56 | SSA def(sink16) |
 | LocalDataFlow.cs:112:37:112:41 | [post] access to local variable sink9 | LocalDataFlow.cs:114:44:114:48 | access to local variable sink9 |
-| LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 | LocalDataFlow.cs:112:22:112:56 | call to method TryParse |
+| LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 | LocalDataFlow.cs:112:22:112:56 | [library code] call to method TryParse |
+| LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 | LocalDataFlow.cs:112:22:112:56 | [library code] call to method TryParse |
 | LocalDataFlow.cs:112:37:112:41 | access to local variable sink9 | LocalDataFlow.cs:114:44:114:48 | access to local variable sink9 |
 | LocalDataFlow.cs:114:13:114:49 | SSA def(sink17) | LocalDataFlow.cs:115:15:115:20 | access to local variable sink17 |
 | LocalDataFlow.cs:114:22:114:29 | [post] access to local variable nonSink0 | LocalDataFlow.cs:116:36:116:43 | access to local variable nonSink0 |
-| LocalDataFlow.cs:114:22:114:29 | access to local variable nonSink0 | LocalDataFlow.cs:114:22:114:49 | call to method Replace |
+| LocalDataFlow.cs:114:22:114:29 | access to local variable nonSink0 | LocalDataFlow.cs:114:22:114:49 | [library code] call to method Replace |
 | LocalDataFlow.cs:114:22:114:29 | access to local variable nonSink0 | LocalDataFlow.cs:116:36:116:43 | access to local variable nonSink0 |
+| LocalDataFlow.cs:114:22:114:49 | [library code] call to method Replace | LocalDataFlow.cs:114:22:114:49 | call to method Replace |
+| LocalDataFlow.cs:114:22:114:49 | [library code] call to method Replace | LocalDataFlow.cs:114:22:114:49 | call to method Replace |
 | LocalDataFlow.cs:114:22:114:49 | call to method Replace | LocalDataFlow.cs:114:13:114:49 | SSA def(sink17) |
 | LocalDataFlow.cs:114:44:114:48 | [post] access to local variable sink9 | LocalDataFlow.cs:116:46:116:50 | access to local variable sink9 |
-| LocalDataFlow.cs:114:44:114:48 | access to local variable sink9 | LocalDataFlow.cs:114:22:114:49 | call to method Replace |
+| LocalDataFlow.cs:114:44:114:48 | access to local variable sink9 | LocalDataFlow.cs:114:22:114:49 | [library code] call to method Replace |
 | LocalDataFlow.cs:114:44:114:48 | access to local variable sink9 | LocalDataFlow.cs:116:46:116:50 | access to local variable sink9 |
 | LocalDataFlow.cs:116:13:116:51 | SSA def(sink18) | LocalDataFlow.cs:117:15:117:20 | access to local variable sink18 |
+| LocalDataFlow.cs:116:22:116:51 | [library code] call to method Format | LocalDataFlow.cs:116:22:116:51 | call to method Format |
+| LocalDataFlow.cs:116:22:116:51 | [library code] call to method Format | LocalDataFlow.cs:116:22:116:51 | call to method Format |
 | LocalDataFlow.cs:116:22:116:51 | call to method Format | LocalDataFlow.cs:116:13:116:51 | SSA def(sink18) |
 | LocalDataFlow.cs:116:36:116:43 | [post] access to local variable nonSink0 | LocalDataFlow.cs:118:44:118:51 | access to local variable nonSink0 |
-| LocalDataFlow.cs:116:36:116:43 | access to local variable nonSink0 | LocalDataFlow.cs:116:22:116:51 | call to method Format |
+| LocalDataFlow.cs:116:36:116:43 | access to local variable nonSink0 | LocalDataFlow.cs:116:22:116:51 | [library code] call to method Format |
 | LocalDataFlow.cs:116:36:116:43 | access to local variable nonSink0 | LocalDataFlow.cs:118:44:118:51 | access to local variable nonSink0 |
 | LocalDataFlow.cs:116:46:116:50 | [post] access to local variable sink9 | LocalDataFlow.cs:120:33:120:37 | access to local variable sink9 |
-| LocalDataFlow.cs:116:46:116:50 | access to local variable sink9 | LocalDataFlow.cs:116:22:116:51 | call to method Format |
+| LocalDataFlow.cs:116:46:116:50 | access to local variable sink9 | LocalDataFlow.cs:116:22:116:51 | [library code] call to method Format |
 | LocalDataFlow.cs:116:46:116:50 | access to local variable sink9 | LocalDataFlow.cs:120:33:120:37 | access to local variable sink9 |
 | LocalDataFlow.cs:117:15:117:20 | [post] access to local variable sink18 | LocalDataFlow.cs:118:36:118:41 | access to local variable sink18 |
 | LocalDataFlow.cs:117:15:117:20 | access to local variable sink18 | LocalDataFlow.cs:118:36:118:41 | access to local variable sink18 |
 | LocalDataFlow.cs:118:13:118:52 | SSA def(sink19) | LocalDataFlow.cs:119:15:119:20 | access to local variable sink19 |
+| LocalDataFlow.cs:118:22:118:52 | [library code] call to method Format | LocalDataFlow.cs:118:22:118:52 | call to method Format |
+| LocalDataFlow.cs:118:22:118:52 | [library code] call to method Format | LocalDataFlow.cs:118:22:118:52 | call to method Format |
 | LocalDataFlow.cs:118:22:118:52 | call to method Format | LocalDataFlow.cs:118:13:118:52 | SSA def(sink19) |
-| LocalDataFlow.cs:118:36:118:41 | access to local variable sink18 | LocalDataFlow.cs:118:22:118:52 | call to method Format |
+| LocalDataFlow.cs:118:36:118:41 | access to local variable sink18 | LocalDataFlow.cs:118:22:118:52 | [library code] call to method Format |
 | LocalDataFlow.cs:118:44:118:51 | [post] access to local variable nonSink0 | LocalDataFlow.cs:137:32:137:39 | access to local variable nonSink0 |
-| LocalDataFlow.cs:118:44:118:51 | access to local variable nonSink0 | LocalDataFlow.cs:118:22:118:52 | call to method Format |
+| LocalDataFlow.cs:118:44:118:51 | access to local variable nonSink0 | LocalDataFlow.cs:118:22:118:52 | [library code] call to method Format |
 | LocalDataFlow.cs:118:44:118:51 | access to local variable nonSink0 | LocalDataFlow.cs:137:32:137:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:120:13:120:38 | SSA def(sink45) | LocalDataFlow.cs:121:15:121:20 | access to local variable sink45 |
+| LocalDataFlow.cs:120:22:120:38 | [library code] call to method Parse | LocalDataFlow.cs:120:22:120:38 | call to method Parse |
 | LocalDataFlow.cs:120:22:120:38 | call to method Parse | LocalDataFlow.cs:120:13:120:38 | SSA def(sink45) |
 | LocalDataFlow.cs:120:33:120:37 | [post] access to local variable sink9 | LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 |
-| LocalDataFlow.cs:120:33:120:37 | access to local variable sink9 | LocalDataFlow.cs:120:22:120:38 | call to method Parse |
+| LocalDataFlow.cs:120:33:120:37 | access to local variable sink9 | LocalDataFlow.cs:120:22:120:38 | [library code] call to method Parse |
 | LocalDataFlow.cs:120:33:120:37 | access to local variable sink9 | LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 |
 | LocalDataFlow.cs:123:13:123:56 | SSA def(sink46) | LocalDataFlow.cs:124:15:124:20 | access to local variable sink46 |
+| LocalDataFlow.cs:123:22:123:56 | [library code] call to method TryParse | LocalDataFlow.cs:123:22:123:56 | call to method TryParse |
 | LocalDataFlow.cs:123:22:123:56 | call to method TryParse | LocalDataFlow.cs:123:13:123:56 | SSA def(sink46) |
 | LocalDataFlow.cs:123:36:123:40 | [post] access to local variable sink9 | LocalDataFlow.cs:163:22:163:26 | access to local variable sink9 |
-| LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 | LocalDataFlow.cs:123:22:123:56 | call to method TryParse |
+| LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 | LocalDataFlow.cs:123:22:123:56 | [library code] call to method TryParse |
+| LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 | LocalDataFlow.cs:123:22:123:56 | [library code] call to method TryParse |
 | LocalDataFlow.cs:123:36:123:40 | access to local variable sink9 | LocalDataFlow.cs:163:22:163:26 | access to local variable sink9 |
 | LocalDataFlow.cs:124:15:124:20 | access to local variable sink46 | LocalDataFlow.cs:125:37:125:42 | access to local variable sink46 |
 | LocalDataFlow.cs:125:13:125:43 | SSA def(sink47) | LocalDataFlow.cs:126:15:126:20 | access to local variable sink47 |
+| LocalDataFlow.cs:125:22:125:43 | [library code] call to method ToByte | LocalDataFlow.cs:125:22:125:43 | call to method ToByte |
 | LocalDataFlow.cs:125:22:125:43 | call to method ToByte | LocalDataFlow.cs:125:13:125:43 | SSA def(sink47) |
-| LocalDataFlow.cs:125:37:125:42 | access to local variable sink46 | LocalDataFlow.cs:125:22:125:43 | call to method ToByte |
+| LocalDataFlow.cs:125:37:125:42 | access to local variable sink46 | LocalDataFlow.cs:125:22:125:43 | [library code] call to method ToByte |
 | LocalDataFlow.cs:126:15:126:20 | access to local variable sink47 | LocalDataFlow.cs:127:40:127:45 | access to local variable sink47 |
 | LocalDataFlow.cs:127:13:127:46 | SSA def(sink49) | LocalDataFlow.cs:128:15:128:20 | access to local variable sink49 |
+| LocalDataFlow.cs:127:22:127:46 | [library code] call to method Concat | LocalDataFlow.cs:127:22:127:46 | call to method Concat |
+| LocalDataFlow.cs:127:22:127:46 | [library code] call to method Concat | LocalDataFlow.cs:127:22:127:46 | call to method Concat |
 | LocalDataFlow.cs:127:22:127:46 | call to method Concat | LocalDataFlow.cs:127:13:127:46 | SSA def(sink49) |
-| LocalDataFlow.cs:127:36:127:37 | "" | LocalDataFlow.cs:127:22:127:46 | call to method Concat |
-| LocalDataFlow.cs:127:40:127:45 | (...) ... | LocalDataFlow.cs:127:22:127:46 | call to method Concat |
+| LocalDataFlow.cs:127:36:127:37 | "" | LocalDataFlow.cs:127:22:127:46 | [library code] call to method Concat |
+| LocalDataFlow.cs:127:40:127:45 | (...) ... | LocalDataFlow.cs:127:22:127:46 | [library code] call to method Concat |
 | LocalDataFlow.cs:127:40:127:45 | access to local variable sink47 | LocalDataFlow.cs:127:40:127:45 | (...) ... |
 | LocalDataFlow.cs:128:15:128:20 | [post] access to local variable sink49 | LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 |
 | LocalDataFlow.cs:128:15:128:20 | access to local variable sink49 | LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 |
 | LocalDataFlow.cs:129:13:129:40 | SSA def(sink50) | LocalDataFlow.cs:130:15:130:20 | access to local variable sink50 |
+| LocalDataFlow.cs:129:22:129:40 | [library code] call to method Copy | LocalDataFlow.cs:129:22:129:40 | call to method Copy |
 | LocalDataFlow.cs:129:22:129:40 | call to method Copy | LocalDataFlow.cs:129:13:129:40 | SSA def(sink50) |
-| LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 | LocalDataFlow.cs:129:22:129:40 | call to method Copy |
+| LocalDataFlow.cs:129:34:129:39 | access to local variable sink49 | LocalDataFlow.cs:129:22:129:40 | [library code] call to method Copy |
 | LocalDataFlow.cs:130:15:130:20 | [post] access to local variable sink50 | LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 |
 | LocalDataFlow.cs:130:15:130:20 | access to local variable sink50 | LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 |
 | LocalDataFlow.cs:131:13:131:54 | SSA def(sink51) | LocalDataFlow.cs:132:15:132:20 | access to local variable sink51 |
+| LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join | LocalDataFlow.cs:131:22:131:54 | call to method Join |
+| LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join | LocalDataFlow.cs:131:22:131:54 | call to method Join |
+| LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join | LocalDataFlow.cs:131:22:131:54 | call to method Join |
+| LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join | LocalDataFlow.cs:131:22:131:54 | call to method Join |
 | LocalDataFlow.cs:131:22:131:54 | call to method Join | LocalDataFlow.cs:131:13:131:54 | SSA def(sink51) |
-| LocalDataFlow.cs:131:34:131:37 | ", " | LocalDataFlow.cs:131:22:131:54 | call to method Join |
-| LocalDataFlow.cs:131:40:131:41 | "" | LocalDataFlow.cs:131:22:131:54 | call to method Join |
-| LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 | LocalDataFlow.cs:131:22:131:54 | call to method Join |
-| LocalDataFlow.cs:131:52:131:53 | "" | LocalDataFlow.cs:131:22:131:54 | call to method Join |
+| LocalDataFlow.cs:131:34:131:37 | ", " | LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join |
+| LocalDataFlow.cs:131:40:131:41 | "" | LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join |
+| LocalDataFlow.cs:131:44:131:49 | access to local variable sink50 | LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join |
+| LocalDataFlow.cs:131:52:131:53 | "" | LocalDataFlow.cs:131:22:131:54 | [library code] call to method Join |
 | LocalDataFlow.cs:132:15:132:20 | [post] access to local variable sink51 | LocalDataFlow.cs:133:35:133:40 | access to local variable sink51 |
 | LocalDataFlow.cs:132:15:132:20 | access to local variable sink51 | LocalDataFlow.cs:133:35:133:40 | access to local variable sink51 |
 | LocalDataFlow.cs:133:13:133:41 | SSA def(sink52) | LocalDataFlow.cs:134:15:134:20 | access to local variable sink52 |
-| LocalDataFlow.cs:133:22:133:23 | "" | LocalDataFlow.cs:133:22:133:41 | call to method Insert |
+| LocalDataFlow.cs:133:22:133:23 | "" | LocalDataFlow.cs:133:22:133:41 | [library code] call to method Insert |
+| LocalDataFlow.cs:133:22:133:41 | [library code] call to method Insert | LocalDataFlow.cs:133:22:133:41 | call to method Insert |
+| LocalDataFlow.cs:133:22:133:41 | [library code] call to method Insert | LocalDataFlow.cs:133:22:133:41 | call to method Insert |
 | LocalDataFlow.cs:133:22:133:41 | call to method Insert | LocalDataFlow.cs:133:13:133:41 | SSA def(sink52) |
-| LocalDataFlow.cs:133:35:133:40 | access to local variable sink51 | LocalDataFlow.cs:133:22:133:41 | call to method Insert |
+| LocalDataFlow.cs:133:35:133:40 | access to local variable sink51 | LocalDataFlow.cs:133:22:133:41 | [library code] call to method Insert |
 | LocalDataFlow.cs:137:9:137:40 | SSA def(nonSink2) | LocalDataFlow.cs:138:15:138:22 | access to local variable nonSink2 |
+| LocalDataFlow.cs:137:20:137:40 | [library code] call to method Parse | LocalDataFlow.cs:137:20:137:40 | call to method Parse |
 | LocalDataFlow.cs:137:20:137:40 | call to method Parse | LocalDataFlow.cs:137:9:137:40 | SSA def(nonSink2) |
 | LocalDataFlow.cs:137:32:137:39 | [post] access to local variable nonSink0 | LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 |
-| LocalDataFlow.cs:137:32:137:39 | access to local variable nonSink0 | LocalDataFlow.cs:137:20:137:40 | call to method Parse |
+| LocalDataFlow.cs:137:32:137:39 | access to local variable nonSink0 | LocalDataFlow.cs:137:20:137:40 | [library code] call to method Parse |
 | LocalDataFlow.cs:137:32:137:39 | access to local variable nonSink0 | LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 |
 | LocalDataFlow.cs:139:13:139:61 | SSA def(nonSink7) | LocalDataFlow.cs:140:15:140:22 | access to local variable nonSink7 |
+| LocalDataFlow.cs:139:24:139:61 | [library code] call to method TryParse | LocalDataFlow.cs:139:24:139:61 | call to method TryParse |
 | LocalDataFlow.cs:139:24:139:61 | call to method TryParse | LocalDataFlow.cs:139:13:139:61 | SSA def(nonSink7) |
 | LocalDataFlow.cs:139:39:139:46 | [post] access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:27 | access to local variable nonSink0 |
-| LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 | LocalDataFlow.cs:139:24:139:61 | call to method TryParse |
+| LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 | LocalDataFlow.cs:139:24:139:61 | [library code] call to method TryParse |
+| LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 | LocalDataFlow.cs:139:24:139:61 | [library code] call to method TryParse |
 | LocalDataFlow.cs:139:39:139:46 | access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:27 | access to local variable nonSink0 |
 | LocalDataFlow.cs:141:9:141:50 | SSA def(nonSink0) | LocalDataFlow.cs:142:15:142:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:141:20:141:27 | [post] access to local variable nonSink0 | LocalDataFlow.cs:141:42:141:49 | access to local variable nonSink0 |
-| LocalDataFlow.cs:141:20:141:27 | access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:50 | call to method Replace |
+| LocalDataFlow.cs:141:20:141:27 | access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:50 | [library code] call to method Replace |
 | LocalDataFlow.cs:141:20:141:27 | access to local variable nonSink0 | LocalDataFlow.cs:141:42:141:49 | access to local variable nonSink0 |
+| LocalDataFlow.cs:141:20:141:50 | [library code] call to method Replace | LocalDataFlow.cs:141:20:141:50 | call to method Replace |
+| LocalDataFlow.cs:141:20:141:50 | [library code] call to method Replace | LocalDataFlow.cs:141:20:141:50 | call to method Replace |
 | LocalDataFlow.cs:141:20:141:50 | call to method Replace | LocalDataFlow.cs:141:9:141:50 | SSA def(nonSink0) |
-| LocalDataFlow.cs:141:42:141:49 | access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:50 | call to method Replace |
+| LocalDataFlow.cs:141:42:141:49 | access to local variable nonSink0 | LocalDataFlow.cs:141:20:141:50 | [library code] call to method Replace |
 | LocalDataFlow.cs:142:15:142:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:143:34:143:41 | access to local variable nonSink0 |
 | LocalDataFlow.cs:142:15:142:22 | access to local variable nonSink0 | LocalDataFlow.cs:143:34:143:41 | access to local variable nonSink0 |
 | LocalDataFlow.cs:143:9:143:52 | SSA def(nonSink0) | LocalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:143:20:143:52 | [library code] call to method Format | LocalDataFlow.cs:143:20:143:52 | call to method Format |
+| LocalDataFlow.cs:143:20:143:52 | [library code] call to method Format | LocalDataFlow.cs:143:20:143:52 | call to method Format |
 | LocalDataFlow.cs:143:20:143:52 | call to method Format | LocalDataFlow.cs:143:9:143:52 | SSA def(nonSink0) |
 | LocalDataFlow.cs:143:34:143:41 | [post] access to local variable nonSink0 | LocalDataFlow.cs:143:44:143:51 | access to local variable nonSink0 |
-| LocalDataFlow.cs:143:34:143:41 | access to local variable nonSink0 | LocalDataFlow.cs:143:20:143:52 | call to method Format |
+| LocalDataFlow.cs:143:34:143:41 | access to local variable nonSink0 | LocalDataFlow.cs:143:20:143:52 | [library code] call to method Format |
 | LocalDataFlow.cs:143:34:143:41 | access to local variable nonSink0 | LocalDataFlow.cs:143:44:143:51 | access to local variable nonSink0 |
-| LocalDataFlow.cs:143:44:143:51 | access to local variable nonSink0 | LocalDataFlow.cs:143:20:143:52 | call to method Format |
+| LocalDataFlow.cs:143:44:143:51 | access to local variable nonSink0 | LocalDataFlow.cs:143:20:143:52 | [library code] call to method Format |
 | LocalDataFlow.cs:144:15:144:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:145:31:145:38 | access to local variable nonSink0 |
 | LocalDataFlow.cs:144:15:144:22 | access to local variable nonSink0 | LocalDataFlow.cs:145:31:145:38 | access to local variable nonSink0 |
 | LocalDataFlow.cs:145:9:145:39 | SSA def(nonSink7) | LocalDataFlow.cs:146:15:146:22 | access to local variable nonSink7 |
+| LocalDataFlow.cs:145:20:145:39 | [library code] call to method Parse | LocalDataFlow.cs:145:20:145:39 | call to method Parse |
 | LocalDataFlow.cs:145:20:145:39 | call to method Parse | LocalDataFlow.cs:145:9:145:39 | SSA def(nonSink7) |
 | LocalDataFlow.cs:145:31:145:38 | [post] access to local variable nonSink0 | LocalDataFlow.cs:147:34:147:41 | access to local variable nonSink0 |
-| LocalDataFlow.cs:145:31:145:38 | access to local variable nonSink0 | LocalDataFlow.cs:145:20:145:39 | call to method Parse |
+| LocalDataFlow.cs:145:31:145:38 | access to local variable nonSink0 | LocalDataFlow.cs:145:20:145:39 | [library code] call to method Parse |
 | LocalDataFlow.cs:145:31:145:38 | access to local variable nonSink0 | LocalDataFlow.cs:147:34:147:41 | access to local variable nonSink0 |
 | LocalDataFlow.cs:147:9:147:57 | SSA def(nonSink7) | LocalDataFlow.cs:148:15:148:22 | access to local variable nonSink7 |
+| LocalDataFlow.cs:147:20:147:57 | [library code] call to method TryParse | LocalDataFlow.cs:147:20:147:57 | call to method TryParse |
 | LocalDataFlow.cs:147:20:147:57 | call to method TryParse | LocalDataFlow.cs:147:9:147:57 | SSA def(nonSink7) |
-| LocalDataFlow.cs:147:34:147:41 | access to local variable nonSink0 | LocalDataFlow.cs:147:20:147:57 | call to method TryParse |
+| LocalDataFlow.cs:147:34:147:41 | access to local variable nonSink0 | LocalDataFlow.cs:147:20:147:57 | [library code] call to method TryParse |
+| LocalDataFlow.cs:147:34:147:41 | access to local variable nonSink0 | LocalDataFlow.cs:147:20:147:57 | [library code] call to method TryParse |
 | LocalDataFlow.cs:148:15:148:22 | access to local variable nonSink7 | LocalDataFlow.cs:149:40:149:47 | access to local variable nonSink7 |
 | LocalDataFlow.cs:149:13:149:48 | SSA def(nonSink14) | LocalDataFlow.cs:150:15:150:23 | access to local variable nonSink14 |
+| LocalDataFlow.cs:149:25:149:48 | [library code] call to method ToByte | LocalDataFlow.cs:149:25:149:48 | call to method ToByte |
 | LocalDataFlow.cs:149:25:149:48 | call to method ToByte | LocalDataFlow.cs:149:13:149:48 | SSA def(nonSink14) |
-| LocalDataFlow.cs:149:40:149:47 | access to local variable nonSink7 | LocalDataFlow.cs:149:25:149:48 | call to method ToByte |
+| LocalDataFlow.cs:149:40:149:47 | access to local variable nonSink7 | LocalDataFlow.cs:149:25:149:48 | [library code] call to method ToByte |
 | LocalDataFlow.cs:149:40:149:47 | access to local variable nonSink7 | LocalDataFlow.cs:151:38:151:45 | access to local variable nonSink7 |
 | LocalDataFlow.cs:151:9:151:46 | SSA def(nonSink0) | LocalDataFlow.cs:152:15:152:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:151:20:151:46 | [library code] call to method Concat | LocalDataFlow.cs:151:20:151:46 | call to method Concat |
+| LocalDataFlow.cs:151:20:151:46 | [library code] call to method Concat | LocalDataFlow.cs:151:20:151:46 | call to method Concat |
 | LocalDataFlow.cs:151:20:151:46 | call to method Concat | LocalDataFlow.cs:151:9:151:46 | SSA def(nonSink0) |
-| LocalDataFlow.cs:151:34:151:35 | "" | LocalDataFlow.cs:151:20:151:46 | call to method Concat |
-| LocalDataFlow.cs:151:38:151:45 | (...) ... | LocalDataFlow.cs:151:20:151:46 | call to method Concat |
+| LocalDataFlow.cs:151:34:151:35 | "" | LocalDataFlow.cs:151:20:151:46 | [library code] call to method Concat |
+| LocalDataFlow.cs:151:38:151:45 | (...) ... | LocalDataFlow.cs:151:20:151:46 | [library code] call to method Concat |
 | LocalDataFlow.cs:151:38:151:45 | access to local variable nonSink7 | LocalDataFlow.cs:151:38:151:45 | (...) ... |
 | LocalDataFlow.cs:152:15:152:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:152:15:152:22 | access to local variable nonSink0 | LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 |
 | LocalDataFlow.cs:153:9:153:40 | SSA def(nonSink0) | LocalDataFlow.cs:154:15:154:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:153:20:153:40 | [library code] call to method Copy | LocalDataFlow.cs:153:20:153:40 | call to method Copy |
 | LocalDataFlow.cs:153:20:153:40 | call to method Copy | LocalDataFlow.cs:153:9:153:40 | SSA def(nonSink0) |
-| LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 | LocalDataFlow.cs:153:20:153:40 | call to method Copy |
+| LocalDataFlow.cs:153:32:153:39 | access to local variable nonSink0 | LocalDataFlow.cs:153:20:153:40 | [library code] call to method Copy |
 | LocalDataFlow.cs:154:15:154:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 |
 | LocalDataFlow.cs:154:15:154:22 | access to local variable nonSink0 | LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 |
 | LocalDataFlow.cs:155:9:155:54 | SSA def(nonSink0) | LocalDataFlow.cs:156:15:156:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join | LocalDataFlow.cs:155:20:155:54 | call to method Join |
+| LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join | LocalDataFlow.cs:155:20:155:54 | call to method Join |
+| LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join | LocalDataFlow.cs:155:20:155:54 | call to method Join |
+| LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join | LocalDataFlow.cs:155:20:155:54 | call to method Join |
 | LocalDataFlow.cs:155:20:155:54 | call to method Join | LocalDataFlow.cs:155:9:155:54 | SSA def(nonSink0) |
-| LocalDataFlow.cs:155:32:155:35 | ", " | LocalDataFlow.cs:155:20:155:54 | call to method Join |
-| LocalDataFlow.cs:155:38:155:39 | "" | LocalDataFlow.cs:155:20:155:54 | call to method Join |
-| LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 | LocalDataFlow.cs:155:20:155:54 | call to method Join |
-| LocalDataFlow.cs:155:52:155:53 | "" | LocalDataFlow.cs:155:20:155:54 | call to method Join |
+| LocalDataFlow.cs:155:32:155:35 | ", " | LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join |
+| LocalDataFlow.cs:155:38:155:39 | "" | LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join |
+| LocalDataFlow.cs:155:42:155:49 | access to local variable nonSink0 | LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join |
+| LocalDataFlow.cs:155:52:155:53 | "" | LocalDataFlow.cs:155:20:155:54 | [library code] call to method Join |
 | LocalDataFlow.cs:156:15:156:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:157:33:157:40 | access to local variable nonSink0 |
 | LocalDataFlow.cs:156:15:156:22 | access to local variable nonSink0 | LocalDataFlow.cs:157:33:157:40 | access to local variable nonSink0 |
 | LocalDataFlow.cs:157:9:157:41 | SSA def(nonSink0) | LocalDataFlow.cs:158:15:158:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:157:20:157:21 | "" | LocalDataFlow.cs:157:20:157:41 | call to method Insert |
+| LocalDataFlow.cs:157:20:157:21 | "" | LocalDataFlow.cs:157:20:157:41 | [library code] call to method Insert |
+| LocalDataFlow.cs:157:20:157:41 | [library code] call to method Insert | LocalDataFlow.cs:157:20:157:41 | call to method Insert |
+| LocalDataFlow.cs:157:20:157:41 | [library code] call to method Insert | LocalDataFlow.cs:157:20:157:41 | call to method Insert |
 | LocalDataFlow.cs:157:20:157:41 | call to method Insert | LocalDataFlow.cs:157:9:157:41 | SSA def(nonSink0) |
-| LocalDataFlow.cs:157:33:157:40 | access to local variable nonSink0 | LocalDataFlow.cs:157:20:157:41 | call to method Insert |
+| LocalDataFlow.cs:157:33:157:40 | access to local variable nonSink0 | LocalDataFlow.cs:157:20:157:41 | [library code] call to method Insert |
 | LocalDataFlow.cs:158:15:158:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:195:39:195:46 | access to local variable nonSink0 |
 | LocalDataFlow.cs:158:15:158:22 | access to local variable nonSink0 | LocalDataFlow.cs:195:39:195:46 | access to local variable nonSink0 |
 | LocalDataFlow.cs:161:13:161:32 | SSA def(sink20) | LocalDataFlow.cs:162:15:162:20 | access to local variable sink20 |
@@ -279,199 +320,262 @@
 | LocalDataFlow.cs:179:20:179:36 | ... \|\| ... | LocalDataFlow.cs:179:9:179:36 | SSA def(nonSink7) |
 | LocalDataFlow.cs:179:32:179:36 | false | LocalDataFlow.cs:179:20:179:36 | ... \|\| ... |
 | LocalDataFlow.cs:183:13:183:42 | SSA def(sink26) | LocalDataFlow.cs:184:15:184:20 | access to local variable sink26 |
+| LocalDataFlow.cs:183:22:183:42 | [library code] object creation of type Uri | LocalDataFlow.cs:183:22:183:42 | object creation of type Uri |
 | LocalDataFlow.cs:183:22:183:42 | object creation of type Uri | LocalDataFlow.cs:183:13:183:42 | SSA def(sink26) |
-| LocalDataFlow.cs:183:37:183:41 | access to local variable sink9 | LocalDataFlow.cs:183:22:183:42 | object creation of type Uri |
+| LocalDataFlow.cs:183:37:183:41 | access to local variable sink9 | LocalDataFlow.cs:183:22:183:42 | [library code] object creation of type Uri |
 | LocalDataFlow.cs:184:15:184:20 | [post] access to local variable sink26 | LocalDataFlow.cs:185:22:185:27 | access to local variable sink26 |
 | LocalDataFlow.cs:184:15:184:20 | access to local variable sink26 | LocalDataFlow.cs:185:22:185:27 | access to local variable sink26 |
 | LocalDataFlow.cs:185:13:185:38 | SSA def(sink27) | LocalDataFlow.cs:186:15:186:20 | access to local variable sink27 |
 | LocalDataFlow.cs:185:22:185:27 | [post] access to local variable sink26 | LocalDataFlow.cs:187:22:187:27 | access to local variable sink26 |
-| LocalDataFlow.cs:185:22:185:27 | access to local variable sink26 | LocalDataFlow.cs:185:22:185:38 | call to method ToString |
+| LocalDataFlow.cs:185:22:185:27 | access to local variable sink26 | LocalDataFlow.cs:185:22:185:38 | [library code] call to method ToString |
 | LocalDataFlow.cs:185:22:185:27 | access to local variable sink26 | LocalDataFlow.cs:187:22:187:27 | access to local variable sink26 |
+| LocalDataFlow.cs:185:22:185:38 | [library code] call to method ToString | LocalDataFlow.cs:185:22:185:38 | call to method ToString |
 | LocalDataFlow.cs:185:22:185:38 | call to method ToString | LocalDataFlow.cs:185:13:185:38 | SSA def(sink27) |
 | LocalDataFlow.cs:187:13:187:40 | SSA def(sink28) | LocalDataFlow.cs:188:15:188:20 | access to local variable sink28 |
 | LocalDataFlow.cs:187:22:187:27 | [post] access to local variable sink26 | LocalDataFlow.cs:189:22:189:27 | access to local variable sink26 |
-| LocalDataFlow.cs:187:22:187:27 | access to local variable sink26 | LocalDataFlow.cs:187:22:187:40 | access to property PathAndQuery |
+| LocalDataFlow.cs:187:22:187:27 | access to local variable sink26 | LocalDataFlow.cs:187:22:187:40 | [library code] access to property PathAndQuery |
 | LocalDataFlow.cs:187:22:187:27 | access to local variable sink26 | LocalDataFlow.cs:189:22:189:27 | access to local variable sink26 |
+| LocalDataFlow.cs:187:22:187:40 | [library code] access to property PathAndQuery | LocalDataFlow.cs:187:22:187:40 | access to property PathAndQuery |
 | LocalDataFlow.cs:187:22:187:40 | access to property PathAndQuery | LocalDataFlow.cs:187:13:187:40 | SSA def(sink28) |
 | LocalDataFlow.cs:189:13:189:33 | SSA def(sink29) | LocalDataFlow.cs:190:15:190:20 | access to local variable sink29 |
 | LocalDataFlow.cs:189:22:189:27 | [post] access to local variable sink26 | LocalDataFlow.cs:191:22:191:27 | access to local variable sink26 |
-| LocalDataFlow.cs:189:22:189:27 | access to local variable sink26 | LocalDataFlow.cs:189:22:189:33 | access to property Query |
+| LocalDataFlow.cs:189:22:189:27 | access to local variable sink26 | LocalDataFlow.cs:189:22:189:33 | [library code] access to property Query |
 | LocalDataFlow.cs:189:22:189:27 | access to local variable sink26 | LocalDataFlow.cs:191:22:191:27 | access to local variable sink26 |
+| LocalDataFlow.cs:189:22:189:33 | [library code] access to property Query | LocalDataFlow.cs:189:22:189:33 | access to property Query |
 | LocalDataFlow.cs:189:22:189:33 | access to property Query | LocalDataFlow.cs:189:13:189:33 | SSA def(sink29) |
 | LocalDataFlow.cs:191:13:191:42 | SSA def(sink30) | LocalDataFlow.cs:192:15:192:20 | access to local variable sink30 |
-| LocalDataFlow.cs:191:22:191:27 | access to local variable sink26 | LocalDataFlow.cs:191:22:191:42 | access to property OriginalString |
+| LocalDataFlow.cs:191:22:191:27 | access to local variable sink26 | LocalDataFlow.cs:191:22:191:42 | [library code] access to property OriginalString |
+| LocalDataFlow.cs:191:22:191:42 | [library code] access to property OriginalString | LocalDataFlow.cs:191:22:191:42 | access to property OriginalString |
 | LocalDataFlow.cs:191:22:191:42 | access to property OriginalString | LocalDataFlow.cs:191:13:191:42 | SSA def(sink30) |
 | LocalDataFlow.cs:192:15:192:20 | [post] access to local variable sink30 | LocalDataFlow.cs:207:49:207:54 | access to local variable sink30 |
 | LocalDataFlow.cs:192:15:192:20 | access to local variable sink30 | LocalDataFlow.cs:207:49:207:54 | access to local variable sink30 |
 | LocalDataFlow.cs:195:13:195:47 | SSA def(nonSink8) | LocalDataFlow.cs:196:15:196:22 | access to local variable nonSink8 |
+| LocalDataFlow.cs:195:24:195:47 | [library code] object creation of type Uri | LocalDataFlow.cs:195:24:195:47 | object creation of type Uri |
 | LocalDataFlow.cs:195:24:195:47 | object creation of type Uri | LocalDataFlow.cs:195:13:195:47 | SSA def(nonSink8) |
-| LocalDataFlow.cs:195:39:195:46 | access to local variable nonSink0 | LocalDataFlow.cs:195:24:195:47 | object creation of type Uri |
+| LocalDataFlow.cs:195:39:195:46 | access to local variable nonSink0 | LocalDataFlow.cs:195:24:195:47 | [library code] object creation of type Uri |
 | LocalDataFlow.cs:196:15:196:22 | [post] access to local variable nonSink8 | LocalDataFlow.cs:197:20:197:27 | access to local variable nonSink8 |
 | LocalDataFlow.cs:196:15:196:22 | access to local variable nonSink8 | LocalDataFlow.cs:197:20:197:27 | access to local variable nonSink8 |
 | LocalDataFlow.cs:197:9:197:38 | SSA def(nonSink0) | LocalDataFlow.cs:198:15:198:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:197:20:197:27 | [post] access to local variable nonSink8 | LocalDataFlow.cs:199:20:199:27 | access to local variable nonSink8 |
-| LocalDataFlow.cs:197:20:197:27 | access to local variable nonSink8 | LocalDataFlow.cs:197:20:197:38 | call to method ToString |
+| LocalDataFlow.cs:197:20:197:27 | access to local variable nonSink8 | LocalDataFlow.cs:197:20:197:38 | [library code] call to method ToString |
 | LocalDataFlow.cs:197:20:197:27 | access to local variable nonSink8 | LocalDataFlow.cs:199:20:199:27 | access to local variable nonSink8 |
+| LocalDataFlow.cs:197:20:197:38 | [library code] call to method ToString | LocalDataFlow.cs:197:20:197:38 | call to method ToString |
 | LocalDataFlow.cs:197:20:197:38 | call to method ToString | LocalDataFlow.cs:197:9:197:38 | SSA def(nonSink0) |
 | LocalDataFlow.cs:199:9:199:40 | SSA def(nonSink0) | LocalDataFlow.cs:200:15:200:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:199:20:199:27 | [post] access to local variable nonSink8 | LocalDataFlow.cs:201:20:201:27 | access to local variable nonSink8 |
-| LocalDataFlow.cs:199:20:199:27 | access to local variable nonSink8 | LocalDataFlow.cs:199:20:199:40 | access to property PathAndQuery |
+| LocalDataFlow.cs:199:20:199:27 | access to local variable nonSink8 | LocalDataFlow.cs:199:20:199:40 | [library code] access to property PathAndQuery |
 | LocalDataFlow.cs:199:20:199:27 | access to local variable nonSink8 | LocalDataFlow.cs:201:20:201:27 | access to local variable nonSink8 |
+| LocalDataFlow.cs:199:20:199:40 | [library code] access to property PathAndQuery | LocalDataFlow.cs:199:20:199:40 | access to property PathAndQuery |
 | LocalDataFlow.cs:199:20:199:40 | access to property PathAndQuery | LocalDataFlow.cs:199:9:199:40 | SSA def(nonSink0) |
 | LocalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) | LocalDataFlow.cs:202:15:202:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:201:20:201:27 | [post] access to local variable nonSink8 | LocalDataFlow.cs:203:20:203:27 | access to local variable nonSink8 |
-| LocalDataFlow.cs:201:20:201:27 | access to local variable nonSink8 | LocalDataFlow.cs:201:20:201:33 | access to property Query |
+| LocalDataFlow.cs:201:20:201:27 | access to local variable nonSink8 | LocalDataFlow.cs:201:20:201:33 | [library code] access to property Query |
 | LocalDataFlow.cs:201:20:201:27 | access to local variable nonSink8 | LocalDataFlow.cs:203:20:203:27 | access to local variable nonSink8 |
+| LocalDataFlow.cs:201:20:201:33 | [library code] access to property Query | LocalDataFlow.cs:201:20:201:33 | access to property Query |
 | LocalDataFlow.cs:201:20:201:33 | access to property Query | LocalDataFlow.cs:201:9:201:33 | SSA def(nonSink0) |
 | LocalDataFlow.cs:203:9:203:42 | SSA def(nonSink0) | LocalDataFlow.cs:204:15:204:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:203:20:203:27 | access to local variable nonSink8 | LocalDataFlow.cs:203:20:203:42 | access to property OriginalString |
+| LocalDataFlow.cs:203:20:203:27 | access to local variable nonSink8 | LocalDataFlow.cs:203:20:203:42 | [library code] access to property OriginalString |
+| LocalDataFlow.cs:203:20:203:42 | [library code] access to property OriginalString | LocalDataFlow.cs:203:20:203:42 | access to property OriginalString |
 | LocalDataFlow.cs:203:20:203:42 | access to property OriginalString | LocalDataFlow.cs:203:9:203:42 | SSA def(nonSink0) |
 | LocalDataFlow.cs:204:15:204:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:213:51:213:58 | access to local variable nonSink0 |
 | LocalDataFlow.cs:204:15:204:22 | access to local variable nonSink0 | LocalDataFlow.cs:213:51:213:58 | access to local variable nonSink0 |
 | LocalDataFlow.cs:207:13:207:55 | SSA def(sink31) | LocalDataFlow.cs:208:15:208:20 | access to local variable sink31 |
+| LocalDataFlow.cs:207:22:207:55 | [library code] object creation of type StringReader | LocalDataFlow.cs:207:22:207:55 | object creation of type StringReader |
 | LocalDataFlow.cs:207:22:207:55 | object creation of type StringReader | LocalDataFlow.cs:207:13:207:55 | SSA def(sink31) |
-| LocalDataFlow.cs:207:49:207:54 | access to local variable sink30 | LocalDataFlow.cs:207:22:207:55 | object creation of type StringReader |
+| LocalDataFlow.cs:207:49:207:54 | access to local variable sink30 | LocalDataFlow.cs:207:22:207:55 | [library code] object creation of type StringReader |
 | LocalDataFlow.cs:208:15:208:20 | [post] access to local variable sink31 | LocalDataFlow.cs:209:22:209:27 | access to local variable sink31 |
 | LocalDataFlow.cs:208:15:208:20 | access to local variable sink31 | LocalDataFlow.cs:209:22:209:27 | access to local variable sink31 |
 | LocalDataFlow.cs:209:13:209:39 | SSA def(sink32) | LocalDataFlow.cs:210:15:210:20 | access to local variable sink32 |
-| LocalDataFlow.cs:209:22:209:27 | access to local variable sink31 | LocalDataFlow.cs:209:22:209:39 | call to method ReadToEnd |
+| LocalDataFlow.cs:209:22:209:27 | access to local variable sink31 | LocalDataFlow.cs:209:22:209:39 | [library code] call to method ReadToEnd |
+| LocalDataFlow.cs:209:22:209:39 | [library code] call to method ReadToEnd | LocalDataFlow.cs:209:22:209:39 | call to method ReadToEnd |
 | LocalDataFlow.cs:209:22:209:39 | call to method ReadToEnd | LocalDataFlow.cs:209:13:209:39 | SSA def(sink32) |
 | LocalDataFlow.cs:210:15:210:20 | [post] access to local variable sink32 | LocalDataFlow.cs:219:30:219:35 | access to local variable sink32 |
 | LocalDataFlow.cs:210:15:210:20 | access to local variable sink32 | LocalDataFlow.cs:219:30:219:35 | access to local variable sink32 |
 | LocalDataFlow.cs:213:13:213:59 | SSA def(nonSink9) | LocalDataFlow.cs:214:15:214:22 | access to local variable nonSink9 |
+| LocalDataFlow.cs:213:24:213:59 | [library code] object creation of type StringReader | LocalDataFlow.cs:213:24:213:59 | object creation of type StringReader |
 | LocalDataFlow.cs:213:24:213:59 | object creation of type StringReader | LocalDataFlow.cs:213:13:213:59 | SSA def(nonSink9) |
-| LocalDataFlow.cs:213:51:213:58 | access to local variable nonSink0 | LocalDataFlow.cs:213:24:213:59 | object creation of type StringReader |
+| LocalDataFlow.cs:213:51:213:58 | access to local variable nonSink0 | LocalDataFlow.cs:213:24:213:59 | [library code] object creation of type StringReader |
 | LocalDataFlow.cs:214:15:214:22 | [post] access to local variable nonSink9 | LocalDataFlow.cs:215:20:215:27 | access to local variable nonSink9 |
 | LocalDataFlow.cs:214:15:214:22 | access to local variable nonSink9 | LocalDataFlow.cs:215:20:215:27 | access to local variable nonSink9 |
 | LocalDataFlow.cs:215:9:215:39 | SSA def(nonSink0) | LocalDataFlow.cs:216:15:216:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:215:20:215:27 | access to local variable nonSink9 | LocalDataFlow.cs:215:20:215:39 | call to method ReadToEnd |
+| LocalDataFlow.cs:215:20:215:27 | access to local variable nonSink9 | LocalDataFlow.cs:215:20:215:39 | [library code] call to method ReadToEnd |
+| LocalDataFlow.cs:215:20:215:39 | [library code] call to method ReadToEnd | LocalDataFlow.cs:215:20:215:39 | call to method ReadToEnd |
 | LocalDataFlow.cs:215:20:215:39 | call to method ReadToEnd | LocalDataFlow.cs:215:9:215:39 | SSA def(nonSink0) |
 | LocalDataFlow.cs:216:15:216:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:225:28:225:35 | access to local variable nonSink0 |
 | LocalDataFlow.cs:216:15:216:22 | access to local variable nonSink0 | LocalDataFlow.cs:225:28:225:35 | access to local variable nonSink0 |
 | LocalDataFlow.cs:219:13:219:127 | SSA def(sink33) | LocalDataFlow.cs:220:15:220:20 | access to local variable sink33 |
 | LocalDataFlow.cs:219:22:219:127 | (...) ... | LocalDataFlow.cs:219:13:219:127 | SSA def(sink33) |
-| LocalDataFlow.cs:219:30:219:35 | access to local variable sink32 | LocalDataFlow.cs:219:30:219:48 | call to method Substring |
-| LocalDataFlow.cs:219:30:219:48 | call to method Substring | LocalDataFlow.cs:219:30:219:67 | call to method ToLowerInvariant |
-| LocalDataFlow.cs:219:30:219:67 | call to method ToLowerInvariant | LocalDataFlow.cs:219:30:219:77 | call to method ToUpper |
-| LocalDataFlow.cs:219:30:219:77 | call to method ToUpper | LocalDataFlow.cs:219:30:219:87 | call to method Trim |
-| LocalDataFlow.cs:219:30:219:87 | call to method Trim | LocalDataFlow.cs:219:30:219:105 | call to method Replace |
-| LocalDataFlow.cs:219:30:219:105 | call to method Replace | LocalDataFlow.cs:219:30:219:119 | call to method Insert |
-| LocalDataFlow.cs:219:30:219:119 | call to method Insert | LocalDataFlow.cs:219:30:219:127 | call to method Clone |
+| LocalDataFlow.cs:219:30:219:35 | access to local variable sink32 | LocalDataFlow.cs:219:30:219:48 | [library code] call to method Substring |
+| LocalDataFlow.cs:219:30:219:48 | [library code] call to method Substring | LocalDataFlow.cs:219:30:219:48 | call to method Substring |
+| LocalDataFlow.cs:219:30:219:48 | call to method Substring | LocalDataFlow.cs:219:30:219:67 | [library code] call to method ToLowerInvariant |
+| LocalDataFlow.cs:219:30:219:67 | [library code] call to method ToLowerInvariant | LocalDataFlow.cs:219:30:219:67 | call to method ToLowerInvariant |
+| LocalDataFlow.cs:219:30:219:67 | call to method ToLowerInvariant | LocalDataFlow.cs:219:30:219:77 | [library code] call to method ToUpper |
+| LocalDataFlow.cs:219:30:219:77 | [library code] call to method ToUpper | LocalDataFlow.cs:219:30:219:77 | call to method ToUpper |
+| LocalDataFlow.cs:219:30:219:77 | call to method ToUpper | LocalDataFlow.cs:219:30:219:87 | [library code] call to method Trim |
+| LocalDataFlow.cs:219:30:219:87 | [library code] call to method Trim | LocalDataFlow.cs:219:30:219:87 | call to method Trim |
+| LocalDataFlow.cs:219:30:219:87 | call to method Trim | LocalDataFlow.cs:219:30:219:105 | [library code] call to method Replace |
+| LocalDataFlow.cs:219:30:219:105 | [library code] call to method Replace | LocalDataFlow.cs:219:30:219:105 | call to method Replace |
+| LocalDataFlow.cs:219:30:219:105 | [library code] call to method Replace | LocalDataFlow.cs:219:30:219:105 | call to method Replace |
+| LocalDataFlow.cs:219:30:219:105 | call to method Replace | LocalDataFlow.cs:219:30:219:119 | [library code] call to method Insert |
+| LocalDataFlow.cs:219:30:219:119 | [library code] call to method Insert | LocalDataFlow.cs:219:30:219:119 | call to method Insert |
+| LocalDataFlow.cs:219:30:219:119 | [library code] call to method Insert | LocalDataFlow.cs:219:30:219:119 | call to method Insert |
+| LocalDataFlow.cs:219:30:219:119 | call to method Insert | LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:219:30:219:119 | call to method Insert | LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone | LocalDataFlow.cs:219:30:219:127 | call to method Clone |
+| LocalDataFlow.cs:219:30:219:127 | [library code] call to method Clone | LocalDataFlow.cs:219:30:219:127 | call to method Clone |
 | LocalDataFlow.cs:219:30:219:127 | call to method Clone | LocalDataFlow.cs:219:22:219:127 | (...) ... |
-| LocalDataFlow.cs:219:102:219:104 | "b" | LocalDataFlow.cs:219:30:219:105 | call to method Replace |
-| LocalDataFlow.cs:219:117:219:118 | "" | LocalDataFlow.cs:219:30:219:119 | call to method Insert |
+| LocalDataFlow.cs:219:102:219:104 | "b" | LocalDataFlow.cs:219:30:219:105 | [library code] call to method Replace |
+| LocalDataFlow.cs:219:117:219:118 | "" | LocalDataFlow.cs:219:30:219:119 | [library code] call to method Insert |
 | LocalDataFlow.cs:220:15:220:20 | [post] access to local variable sink33 | LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 |
 | LocalDataFlow.cs:220:15:220:20 | access to local variable sink33 | LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 |
 | LocalDataFlow.cs:221:13:221:63 | SSA def(sink48) | LocalDataFlow.cs:222:15:222:20 | access to local variable sink48 |
 | LocalDataFlow.cs:221:22:221:27 | [post] access to local variable sink33 | LocalDataFlow.cs:231:40:231:45 | access to local variable sink33 |
-| LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 | LocalDataFlow.cs:221:22:221:39 | call to method Normalize |
+| LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 | LocalDataFlow.cs:221:22:221:39 | [library code] call to method Normalize |
 | LocalDataFlow.cs:221:22:221:27 | access to local variable sink33 | LocalDataFlow.cs:231:40:231:45 | access to local variable sink33 |
-| LocalDataFlow.cs:221:22:221:39 | call to method Normalize | LocalDataFlow.cs:221:22:221:52 | call to method Remove |
-| LocalDataFlow.cs:221:22:221:52 | call to method Remove | LocalDataFlow.cs:221:22:221:63 | call to method Split |
+| LocalDataFlow.cs:221:22:221:39 | [library code] call to method Normalize | LocalDataFlow.cs:221:22:221:39 | call to method Normalize |
+| LocalDataFlow.cs:221:22:221:39 | call to method Normalize | LocalDataFlow.cs:221:22:221:52 | [library code] call to method Remove |
+| LocalDataFlow.cs:221:22:221:52 | [library code] call to method Remove | LocalDataFlow.cs:221:22:221:52 | call to method Remove |
+| LocalDataFlow.cs:221:22:221:52 | call to method Remove | LocalDataFlow.cs:221:22:221:63 | [library code] call to method Split |
+| LocalDataFlow.cs:221:22:221:63 | [library code] call to method Split | LocalDataFlow.cs:221:22:221:63 | call to method Split |
 | LocalDataFlow.cs:221:22:221:63 | call to method Split | LocalDataFlow.cs:221:13:221:63 | SSA def(sink48) |
 | LocalDataFlow.cs:225:9:225:127 | SSA def(nonSink0) | LocalDataFlow.cs:226:15:226:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:225:20:225:127 | (...) ... | LocalDataFlow.cs:225:9:225:127 | SSA def(nonSink0) |
-| LocalDataFlow.cs:225:28:225:35 | access to local variable nonSink0 | LocalDataFlow.cs:225:28:225:48 | call to method Substring |
-| LocalDataFlow.cs:225:28:225:48 | call to method Substring | LocalDataFlow.cs:225:28:225:67 | call to method ToLowerInvariant |
-| LocalDataFlow.cs:225:28:225:67 | call to method ToLowerInvariant | LocalDataFlow.cs:225:28:225:77 | call to method ToUpper |
-| LocalDataFlow.cs:225:28:225:77 | call to method ToUpper | LocalDataFlow.cs:225:28:225:87 | call to method Trim |
-| LocalDataFlow.cs:225:28:225:87 | call to method Trim | LocalDataFlow.cs:225:28:225:105 | call to method Replace |
-| LocalDataFlow.cs:225:28:225:105 | call to method Replace | LocalDataFlow.cs:225:28:225:119 | call to method Insert |
-| LocalDataFlow.cs:225:28:225:119 | call to method Insert | LocalDataFlow.cs:225:28:225:127 | call to method Clone |
+| LocalDataFlow.cs:225:28:225:35 | access to local variable nonSink0 | LocalDataFlow.cs:225:28:225:48 | [library code] call to method Substring |
+| LocalDataFlow.cs:225:28:225:48 | [library code] call to method Substring | LocalDataFlow.cs:225:28:225:48 | call to method Substring |
+| LocalDataFlow.cs:225:28:225:48 | call to method Substring | LocalDataFlow.cs:225:28:225:67 | [library code] call to method ToLowerInvariant |
+| LocalDataFlow.cs:225:28:225:67 | [library code] call to method ToLowerInvariant | LocalDataFlow.cs:225:28:225:67 | call to method ToLowerInvariant |
+| LocalDataFlow.cs:225:28:225:67 | call to method ToLowerInvariant | LocalDataFlow.cs:225:28:225:77 | [library code] call to method ToUpper |
+| LocalDataFlow.cs:225:28:225:77 | [library code] call to method ToUpper | LocalDataFlow.cs:225:28:225:77 | call to method ToUpper |
+| LocalDataFlow.cs:225:28:225:77 | call to method ToUpper | LocalDataFlow.cs:225:28:225:87 | [library code] call to method Trim |
+| LocalDataFlow.cs:225:28:225:87 | [library code] call to method Trim | LocalDataFlow.cs:225:28:225:87 | call to method Trim |
+| LocalDataFlow.cs:225:28:225:87 | call to method Trim | LocalDataFlow.cs:225:28:225:105 | [library code] call to method Replace |
+| LocalDataFlow.cs:225:28:225:105 | [library code] call to method Replace | LocalDataFlow.cs:225:28:225:105 | call to method Replace |
+| LocalDataFlow.cs:225:28:225:105 | [library code] call to method Replace | LocalDataFlow.cs:225:28:225:105 | call to method Replace |
+| LocalDataFlow.cs:225:28:225:105 | call to method Replace | LocalDataFlow.cs:225:28:225:119 | [library code] call to method Insert |
+| LocalDataFlow.cs:225:28:225:119 | [library code] call to method Insert | LocalDataFlow.cs:225:28:225:119 | call to method Insert |
+| LocalDataFlow.cs:225:28:225:119 | [library code] call to method Insert | LocalDataFlow.cs:225:28:225:119 | call to method Insert |
+| LocalDataFlow.cs:225:28:225:119 | call to method Insert | LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:225:28:225:119 | call to method Insert | LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone |
+| LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone | LocalDataFlow.cs:225:28:225:127 | call to method Clone |
+| LocalDataFlow.cs:225:28:225:127 | [library code] call to method Clone | LocalDataFlow.cs:225:28:225:127 | call to method Clone |
 | LocalDataFlow.cs:225:28:225:127 | call to method Clone | LocalDataFlow.cs:225:20:225:127 | (...) ... |
-| LocalDataFlow.cs:225:102:225:104 | "b" | LocalDataFlow.cs:225:28:225:105 | call to method Replace |
-| LocalDataFlow.cs:225:117:225:118 | "" | LocalDataFlow.cs:225:28:225:119 | call to method Insert |
+| LocalDataFlow.cs:225:102:225:104 | "b" | LocalDataFlow.cs:225:28:225:105 | [library code] call to method Replace |
+| LocalDataFlow.cs:225:117:225:118 | "" | LocalDataFlow.cs:225:28:225:119 | [library code] call to method Insert |
 | LocalDataFlow.cs:226:15:226:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 |
 | LocalDataFlow.cs:226:15:226:22 | access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 |
 | LocalDataFlow.cs:227:13:227:68 | SSA def(nonSink15) | LocalDataFlow.cs:228:15:228:23 | access to local variable nonSink15 |
 | LocalDataFlow.cs:227:25:227:32 | [post] access to local variable nonSink0 | LocalDataFlow.cs:240:43:240:50 | access to local variable nonSink0 |
-| LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:44 | call to method Normalize |
+| LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 | LocalDataFlow.cs:227:25:227:44 | [library code] call to method Normalize |
 | LocalDataFlow.cs:227:25:227:32 | access to local variable nonSink0 | LocalDataFlow.cs:240:43:240:50 | access to local variable nonSink0 |
-| LocalDataFlow.cs:227:25:227:44 | call to method Normalize | LocalDataFlow.cs:227:25:227:57 | call to method Remove |
-| LocalDataFlow.cs:227:25:227:57 | call to method Remove | LocalDataFlow.cs:227:25:227:68 | call to method Split |
+| LocalDataFlow.cs:227:25:227:44 | [library code] call to method Normalize | LocalDataFlow.cs:227:25:227:44 | call to method Normalize |
+| LocalDataFlow.cs:227:25:227:44 | call to method Normalize | LocalDataFlow.cs:227:25:227:57 | [library code] call to method Remove |
+| LocalDataFlow.cs:227:25:227:57 | [library code] call to method Remove | LocalDataFlow.cs:227:25:227:57 | call to method Remove |
+| LocalDataFlow.cs:227:25:227:57 | call to method Remove | LocalDataFlow.cs:227:25:227:68 | [library code] call to method Split |
+| LocalDataFlow.cs:227:25:227:68 | [library code] call to method Split | LocalDataFlow.cs:227:25:227:68 | call to method Split |
 | LocalDataFlow.cs:227:25:227:68 | call to method Split | LocalDataFlow.cs:227:13:227:68 | SSA def(nonSink15) |
 | LocalDataFlow.cs:231:13:231:46 | SSA def(sink34) | LocalDataFlow.cs:232:15:232:20 | access to local variable sink34 |
+| LocalDataFlow.cs:231:22:231:46 | [library code] object creation of type StringBuilder | LocalDataFlow.cs:231:22:231:46 | object creation of type StringBuilder |
 | LocalDataFlow.cs:231:22:231:46 | object creation of type StringBuilder | LocalDataFlow.cs:231:13:231:46 | SSA def(sink34) |
-| LocalDataFlow.cs:231:40:231:45 | access to local variable sink33 | LocalDataFlow.cs:231:22:231:46 | object creation of type StringBuilder |
+| LocalDataFlow.cs:231:40:231:45 | access to local variable sink33 | LocalDataFlow.cs:231:22:231:46 | [library code] object creation of type StringBuilder |
 | LocalDataFlow.cs:232:15:232:20 | [post] access to local variable sink34 | LocalDataFlow.cs:233:22:233:27 | access to local variable sink34 |
 | LocalDataFlow.cs:232:15:232:20 | access to local variable sink34 | LocalDataFlow.cs:233:22:233:27 | access to local variable sink34 |
 | LocalDataFlow.cs:233:13:233:38 | SSA def(sink35) | LocalDataFlow.cs:234:15:234:20 | access to local variable sink35 |
-| LocalDataFlow.cs:233:22:233:27 | access to local variable sink34 | LocalDataFlow.cs:233:22:233:38 | call to method ToString |
+| LocalDataFlow.cs:233:22:233:27 | access to local variable sink34 | LocalDataFlow.cs:233:22:233:38 | [library code] call to method ToString |
+| LocalDataFlow.cs:233:22:233:38 | [library code] call to method ToString | LocalDataFlow.cs:233:22:233:38 | call to method ToString |
 | LocalDataFlow.cs:233:22:233:38 | call to method ToString | LocalDataFlow.cs:233:13:233:38 | SSA def(sink35) |
 | LocalDataFlow.cs:234:15:234:20 | [post] access to local variable sink35 | LocalDataFlow.cs:236:27:236:32 | access to local variable sink35 |
 | LocalDataFlow.cs:234:15:234:20 | access to local variable sink35 | LocalDataFlow.cs:236:27:236:32 | access to local variable sink35 |
 | LocalDataFlow.cs:235:13:235:42 | SSA def(sink36) | LocalDataFlow.cs:236:9:236:14 | access to local variable sink36 |
+| LocalDataFlow.cs:235:22:235:42 | [library code] object creation of type StringBuilder | LocalDataFlow.cs:235:22:235:42 | object creation of type StringBuilder |
 | LocalDataFlow.cs:235:22:235:42 | object creation of type StringBuilder | LocalDataFlow.cs:235:13:235:42 | SSA def(sink36) |
-| LocalDataFlow.cs:235:40:235:41 | "" | LocalDataFlow.cs:235:22:235:42 | object creation of type StringBuilder |
+| LocalDataFlow.cs:235:40:235:41 | "" | LocalDataFlow.cs:235:22:235:42 | [library code] object creation of type StringBuilder |
 | LocalDataFlow.cs:236:9:236:14 | [post] access to local variable sink36 | LocalDataFlow.cs:237:15:237:20 | access to local variable sink36 |
 | LocalDataFlow.cs:236:9:236:14 | access to local variable sink36 | LocalDataFlow.cs:237:15:237:20 | access to local variable sink36 |
-| LocalDataFlow.cs:236:27:236:32 | access to local variable sink35 | LocalDataFlow.cs:236:9:236:14 | access to local variable sink36 |
+| LocalDataFlow.cs:236:9:236:33 | [library code] call to method AppendLine | LocalDataFlow.cs:236:9:236:14 | access to local variable sink36 |
+| LocalDataFlow.cs:236:27:236:32 | access to local variable sink35 | LocalDataFlow.cs:236:9:236:33 | [library code] call to method AppendLine |
 | LocalDataFlow.cs:240:13:240:51 | SSA def(nonSink10) | LocalDataFlow.cs:241:15:241:23 | access to local variable nonSink10 |
+| LocalDataFlow.cs:240:25:240:51 | [library code] object creation of type StringBuilder | LocalDataFlow.cs:240:25:240:51 | object creation of type StringBuilder |
 | LocalDataFlow.cs:240:25:240:51 | object creation of type StringBuilder | LocalDataFlow.cs:240:13:240:51 | SSA def(nonSink10) |
-| LocalDataFlow.cs:240:43:240:50 | access to local variable nonSink0 | LocalDataFlow.cs:240:25:240:51 | object creation of type StringBuilder |
+| LocalDataFlow.cs:240:43:240:50 | access to local variable nonSink0 | LocalDataFlow.cs:240:25:240:51 | [library code] object creation of type StringBuilder |
 | LocalDataFlow.cs:241:15:241:23 | [post] access to local variable nonSink10 | LocalDataFlow.cs:242:20:242:28 | access to local variable nonSink10 |
 | LocalDataFlow.cs:241:15:241:23 | access to local variable nonSink10 | LocalDataFlow.cs:242:20:242:28 | access to local variable nonSink10 |
 | LocalDataFlow.cs:242:9:242:39 | SSA def(nonSink0) | LocalDataFlow.cs:243:15:243:22 | access to local variable nonSink0 |
 | LocalDataFlow.cs:242:20:242:28 | [post] access to local variable nonSink10 | LocalDataFlow.cs:244:9:244:17 | access to local variable nonSink10 |
-| LocalDataFlow.cs:242:20:242:28 | access to local variable nonSink10 | LocalDataFlow.cs:242:20:242:39 | call to method ToString |
+| LocalDataFlow.cs:242:20:242:28 | access to local variable nonSink10 | LocalDataFlow.cs:242:20:242:39 | [library code] call to method ToString |
 | LocalDataFlow.cs:242:20:242:28 | access to local variable nonSink10 | LocalDataFlow.cs:244:9:244:17 | access to local variable nonSink10 |
+| LocalDataFlow.cs:242:20:242:39 | [library code] call to method ToString | LocalDataFlow.cs:242:20:242:39 | call to method ToString |
 | LocalDataFlow.cs:242:20:242:39 | call to method ToString | LocalDataFlow.cs:242:9:242:39 | SSA def(nonSink0) |
 | LocalDataFlow.cs:243:15:243:22 | [post] access to local variable nonSink0 | LocalDataFlow.cs:244:30:244:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:243:15:243:22 | access to local variable nonSink0 | LocalDataFlow.cs:244:30:244:37 | access to local variable nonSink0 |
 | LocalDataFlow.cs:244:9:244:17 | [post] access to local variable nonSink10 | LocalDataFlow.cs:245:15:245:23 | access to local variable nonSink10 |
 | LocalDataFlow.cs:244:9:244:17 | access to local variable nonSink10 | LocalDataFlow.cs:245:15:245:23 | access to local variable nonSink10 |
-| LocalDataFlow.cs:244:30:244:37 | access to local variable nonSink0 | LocalDataFlow.cs:244:9:244:17 | access to local variable nonSink10 |
+| LocalDataFlow.cs:244:9:244:38 | [library code] call to method AppendLine | LocalDataFlow.cs:244:9:244:17 | access to local variable nonSink10 |
+| LocalDataFlow.cs:244:30:244:37 | access to local variable nonSink0 | LocalDataFlow.cs:244:9:244:38 | [library code] call to method AppendLine |
 | LocalDataFlow.cs:248:13:248:52 | SSA def(taintedDataContract) | LocalDataFlow.cs:249:22:249:40 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:248:13:248:52 | SSA qualifier def(taintedDataContract.AList) | LocalDataFlow.cs:251:22:251:46 | access to property AList |
 | LocalDataFlow.cs:248:35:248:52 | object creation of type DataContract | LocalDataFlow.cs:248:13:248:52 | SSA def(taintedDataContract) |
 | LocalDataFlow.cs:249:13:249:48 | SSA def(sink53) | LocalDataFlow.cs:250:15:250:20 | access to local variable sink53 |
 | LocalDataFlow.cs:249:22:249:40 | [post] access to local variable taintedDataContract | LocalDataFlow.cs:251:22:251:40 | access to local variable taintedDataContract |
+| LocalDataFlow.cs:249:22:249:40 | access to local variable taintedDataContract | LocalDataFlow.cs:249:22:249:48 | [library code] access to property AString |
 | LocalDataFlow.cs:249:22:249:40 | access to local variable taintedDataContract | LocalDataFlow.cs:249:22:249:48 | access to property AString |
 | LocalDataFlow.cs:249:22:249:40 | access to local variable taintedDataContract | LocalDataFlow.cs:251:22:251:40 | access to local variable taintedDataContract |
+| LocalDataFlow.cs:249:22:249:48 | [library code] access to property AString | LocalDataFlow.cs:249:22:249:48 | access to property AString |
 | LocalDataFlow.cs:249:22:249:48 | access to property AString | LocalDataFlow.cs:249:13:249:48 | SSA def(sink53) |
 | LocalDataFlow.cs:251:13:251:57 | SSA def(sink54) | LocalDataFlow.cs:252:15:252:20 | access to local variable sink54 |
 | LocalDataFlow.cs:251:22:251:40 | [post] access to local variable taintedDataContract | LocalDataFlow.cs:258:20:258:38 | access to local variable taintedDataContract |
+| LocalDataFlow.cs:251:22:251:40 | access to local variable taintedDataContract | LocalDataFlow.cs:251:22:251:46 | [library code] access to property AList |
 | LocalDataFlow.cs:251:22:251:40 | access to local variable taintedDataContract | LocalDataFlow.cs:251:22:251:46 | access to property AList |
 | LocalDataFlow.cs:251:22:251:40 | access to local variable taintedDataContract | LocalDataFlow.cs:258:20:258:38 | access to local variable taintedDataContract |
+| LocalDataFlow.cs:251:22:251:46 | [library code] access to property AList | LocalDataFlow.cs:251:22:251:46 | access to property AList |
 | LocalDataFlow.cs:251:22:251:46 | [post] access to property AList | LocalDataFlow.cs:260:20:260:44 | access to property AList |
 | LocalDataFlow.cs:251:22:251:46 | access to property AList | LocalDataFlow.cs:251:22:251:49 | access to indexer |
 | LocalDataFlow.cs:251:22:251:46 | access to property AList | LocalDataFlow.cs:260:20:260:44 | access to property AList |
+| LocalDataFlow.cs:251:22:251:49 | access to indexer | LocalDataFlow.cs:251:22:251:57 | [library code] access to property AString |
 | LocalDataFlow.cs:251:22:251:49 | access to indexer | LocalDataFlow.cs:251:22:251:57 | access to property AString |
+| LocalDataFlow.cs:251:22:251:57 | [library code] access to property AString | LocalDataFlow.cs:251:22:251:57 | access to property AString |
 | LocalDataFlow.cs:251:22:251:57 | access to property AString | LocalDataFlow.cs:251:13:251:57 | SSA def(sink54) |
 | LocalDataFlow.cs:255:13:255:55 | SSA def(nonTaintedDataContract) | LocalDataFlow.cs:256:20:256:41 | access to local variable nonTaintedDataContract |
 | LocalDataFlow.cs:255:38:255:55 | object creation of type DataContract | LocalDataFlow.cs:255:13:255:55 | SSA def(nonTaintedDataContract) |
 | LocalDataFlow.cs:256:9:256:49 | SSA def(nonSink0) | LocalDataFlow.cs:257:15:257:22 | access to local variable nonSink0 |
+| LocalDataFlow.cs:256:20:256:41 | access to local variable nonTaintedDataContract | LocalDataFlow.cs:256:20:256:49 | [library code] access to property AString |
 | LocalDataFlow.cs:256:20:256:41 | access to local variable nonTaintedDataContract | LocalDataFlow.cs:256:20:256:49 | access to property AString |
+| LocalDataFlow.cs:256:20:256:49 | [library code] access to property AString | LocalDataFlow.cs:256:20:256:49 | access to property AString |
 | LocalDataFlow.cs:256:20:256:49 | access to property AString | LocalDataFlow.cs:256:9:256:49 | SSA def(nonSink0) |
 | LocalDataFlow.cs:258:9:258:44 | SSA def(nonSink2) | LocalDataFlow.cs:259:15:259:22 | access to local variable nonSink2 |
 | LocalDataFlow.cs:258:20:258:38 | [post] access to local variable taintedDataContract | LocalDataFlow.cs:260:20:260:38 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:258:20:258:38 | access to local variable taintedDataContract | LocalDataFlow.cs:260:20:260:38 | access to local variable taintedDataContract |
 | LocalDataFlow.cs:258:20:258:44 | access to property AnInt | LocalDataFlow.cs:258:9:258:44 | SSA def(nonSink2) |
 | LocalDataFlow.cs:260:9:260:53 | SSA def(nonSink2) | LocalDataFlow.cs:261:15:261:22 | access to local variable nonSink2 |
+| LocalDataFlow.cs:260:20:260:38 | access to local variable taintedDataContract | LocalDataFlow.cs:260:20:260:44 | [library code] access to property AList |
 | LocalDataFlow.cs:260:20:260:38 | access to local variable taintedDataContract | LocalDataFlow.cs:260:20:260:44 | access to property AList |
+| LocalDataFlow.cs:260:20:260:44 | [library code] access to property AList | LocalDataFlow.cs:260:20:260:44 | access to property AList |
 | LocalDataFlow.cs:260:20:260:44 | access to property AList | LocalDataFlow.cs:260:20:260:47 | access to indexer |
 | LocalDataFlow.cs:260:20:260:53 | access to property AnInt | LocalDataFlow.cs:260:9:260:53 | SSA def(nonSink2) |
 | LocalDataFlow.cs:264:17:264:37 | SSA def(taintedTextBox) | LocalDataFlow.cs:265:22:265:35 | access to local variable taintedTextBox |
 | LocalDataFlow.cs:264:34:264:37 | null | LocalDataFlow.cs:264:17:264:37 | SSA def(taintedTextBox) |
 | LocalDataFlow.cs:265:13:265:40 | SSA def(sink60) | LocalDataFlow.cs:266:15:266:20 | access to local variable sink60 |
-| LocalDataFlow.cs:265:22:265:35 | access to local variable taintedTextBox | LocalDataFlow.cs:265:22:265:40 | access to property Text |
+| LocalDataFlow.cs:265:22:265:35 | access to local variable taintedTextBox | LocalDataFlow.cs:265:22:265:40 | [library code] access to property Text |
+| LocalDataFlow.cs:265:22:265:40 | [library code] access to property Text | LocalDataFlow.cs:265:22:265:40 | access to property Text |
 | LocalDataFlow.cs:265:22:265:40 | access to property Text | LocalDataFlow.cs:265:13:265:40 | SSA def(sink60) |
 | LocalDataFlow.cs:269:17:269:40 | SSA def(nonTaintedTextBox) | LocalDataFlow.cs:270:20:270:36 | access to local variable nonTaintedTextBox |
 | LocalDataFlow.cs:269:37:269:40 | null | LocalDataFlow.cs:269:17:269:40 | SSA def(nonTaintedTextBox) |
 | LocalDataFlow.cs:270:9:270:41 | SSA def(nonSink0) | LocalDataFlow.cs:271:15:271:22 | access to local variable nonSink0 |
-| LocalDataFlow.cs:270:20:270:36 | access to local variable nonTaintedTextBox | LocalDataFlow.cs:270:20:270:41 | access to property Text |
+| LocalDataFlow.cs:270:20:270:36 | access to local variable nonTaintedTextBox | LocalDataFlow.cs:270:20:270:41 | [library code] access to property Text |
+| LocalDataFlow.cs:270:20:270:41 | [library code] access to property Text | LocalDataFlow.cs:270:20:270:41 | access to property Text |
 | LocalDataFlow.cs:270:20:270:41 | access to property Text | LocalDataFlow.cs:270:9:270:41 | SSA def(nonSink0) |
 | LocalDataFlow.cs:274:13:274:51 | SSA def(sink67) | LocalDataFlow.cs:275:15:275:20 | access to local variable sink67 |
+| LocalDataFlow.cs:274:22:274:51 | [library code] call to method Run | LocalDataFlow.cs:274:22:274:51 | call to method Run |
 | LocalDataFlow.cs:274:22:274:51 | call to method Run | LocalDataFlow.cs:274:13:274:51 | SSA def(sink67) |
-| LocalDataFlow.cs:274:31:274:50 | [output] (...) => ... | LocalDataFlow.cs:274:22:274:51 | call to method Run |
+| LocalDataFlow.cs:274:31:274:50 | [output] (...) => ... | LocalDataFlow.cs:274:22:274:51 | [library code] call to method Run |
 | LocalDataFlow.cs:275:15:275:20 | [post] access to local variable sink67 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 |
 | LocalDataFlow.cs:275:15:275:20 | access to local variable sink67 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 |
 | LocalDataFlow.cs:276:13:276:33 | SSA def(sink68) | LocalDataFlow.cs:277:15:277:20 | access to local variable sink68 |
 | LocalDataFlow.cs:276:22:276:33 | await ... | LocalDataFlow.cs:276:13:276:33 | SSA def(sink68) |
 | LocalDataFlow.cs:276:28:276:33 | access to local variable sink67 | LocalDataFlow.cs:276:22:276:33 | await ... |
 | LocalDataFlow.cs:280:13:280:42 | SSA def(nonSink21) | LocalDataFlow.cs:281:15:281:23 | access to local variable nonSink21 |
+| LocalDataFlow.cs:280:25:280:42 | [library code] call to method Run | LocalDataFlow.cs:280:25:280:42 | call to method Run |
 | LocalDataFlow.cs:280:25:280:42 | call to method Run | LocalDataFlow.cs:280:13:280:42 | SSA def(nonSink21) |
-| LocalDataFlow.cs:280:34:280:41 | [output] (...) => ... | LocalDataFlow.cs:280:25:280:42 | call to method Run |
+| LocalDataFlow.cs:280:34:280:41 | [output] (...) => ... | LocalDataFlow.cs:280:25:280:42 | [library code] call to method Run |
 | LocalDataFlow.cs:281:15:281:23 | [post] access to local variable nonSink21 | LocalDataFlow.cs:282:26:282:34 | access to local variable nonSink21 |
 | LocalDataFlow.cs:281:15:281:23 | access to local variable nonSink21 | LocalDataFlow.cs:282:26:282:34 | access to local variable nonSink21 |
 | LocalDataFlow.cs:282:9:282:34 | SSA def(nonSink0) | LocalDataFlow.cs:283:15:283:22 | access to local variable nonSink0 |
@@ -525,28 +629,20 @@
 | LocalDataFlow.cs:327:31:327:38 | access to local variable nonSink0 | LocalDataFlow.cs:327:22:327:38 | ... ?? ... |
 | LocalDataFlow.cs:347:28:347:30 | this | LocalDataFlow.cs:347:41:347:45 | this access |
 | LocalDataFlow.cs:347:50:347:52 | this | LocalDataFlow.cs:347:56:347:60 | this access |
-| LocalDataFlow.cs:347:50:347:52 | value | LocalDataFlow.cs:347:50:347:52 | value |
 | LocalDataFlow.cs:347:50:347:52 | value | LocalDataFlow.cs:347:64:347:68 | access to parameter value |
-| LocalDataFlow.cs:353:41:353:47 | tainted | LocalDataFlow.cs:353:41:353:47 | tainted |
 | LocalDataFlow.cs:353:41:353:47 | tainted | LocalDataFlow.cs:355:15:355:21 | access to parameter tainted |
-| LocalDataFlow.cs:358:44:358:53 | nonTainted | LocalDataFlow.cs:358:44:358:53 | nonTainted |
 | LocalDataFlow.cs:358:44:358:53 | nonTainted | LocalDataFlow.cs:360:15:360:24 | access to parameter nonTainted |
-| LocalDataFlow.cs:363:44:363:44 | x | LocalDataFlow.cs:363:44:363:44 | x |
 | LocalDataFlow.cs:363:44:363:44 | x | LocalDataFlow.cs:366:21:366:21 | access to parameter x |
-| LocalDataFlow.cs:363:67:363:68 | os | LocalDataFlow.cs:363:67:363:68 | os |
 | LocalDataFlow.cs:363:67:363:68 | os | LocalDataFlow.cs:369:32:369:33 | access to parameter os |
 | LocalDataFlow.cs:366:21:366:21 | access to parameter x | LocalDataFlow.cs:366:16:366:21 | ... = ... |
 | LocalDataFlow.cs:369:32:369:33 | access to parameter os | LocalDataFlow.cs:369:26:369:33 | ... = ... |
-| LocalDataFlow.cs:374:41:374:44 | args | LocalDataFlow.cs:374:41:374:44 | args |
 | LocalDataFlow.cs:374:41:374:44 | args | LocalDataFlow.cs:376:29:376:32 | access to parameter args |
 | LocalDataFlow.cs:376:29:376:32 | [post] access to parameter args | LocalDataFlow.cs:377:27:377:30 | access to parameter args |
 | LocalDataFlow.cs:376:29:376:32 | access to parameter args | LocalDataFlow.cs:376:29:376:32 | call to operator implicit conversion |
 | LocalDataFlow.cs:376:29:376:32 | access to parameter args | LocalDataFlow.cs:377:27:377:30 | access to parameter args |
 | SSA.cs:5:17:5:17 | SSA entry def(this.S) | SSA.cs:67:9:67:14 | access to field S |
 | SSA.cs:5:17:5:17 | this | SSA.cs:67:9:67:12 | this access |
-| SSA.cs:5:26:5:32 | tainted | SSA.cs:5:26:5:32 | tainted |
 | SSA.cs:5:26:5:32 | tainted | SSA.cs:8:24:8:30 | access to parameter tainted |
-| SSA.cs:5:42:5:51 | nonTainted | SSA.cs:5:42:5:51 | nonTainted |
 | SSA.cs:5:42:5:51 | nonTainted | SSA.cs:12:24:12:33 | access to parameter nonTainted |
 | SSA.cs:8:13:8:30 | SSA def(ssaSink0) | SSA.cs:9:15:9:22 | access to local variable ssaSink0 |
 | SSA.cs:8:24:8:30 | access to parameter tainted | SSA.cs:8:13:8:30 | SSA def(ssaSink0) |
@@ -826,7 +922,6 @@
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:144:34:144:34 | t | SSA.cs:144:34:144:34 | t |
 | SSA.cs:144:34:144:34 | t | SSA.cs:146:13:146:13 | access to parameter t |
 | SSA.cs:146:13:146:13 | (...) ... | SSA.cs:146:13:146:21 | ... == ... |
 | SSA.cs:146:13:146:13 | access to parameter t | SSA.cs:146:13:146:13 | (...) ... |
@@ -835,7 +930,6 @@
 | SSA.cs:147:17:147:26 | default(...) | SSA.cs:147:13:147:26 | SSA def(t) |
 | SSA.cs:149:13:149:17 | SSA def(t) | SSA.cs:144:17:144:26 | SSA phi(t) |
 | SSA.cs:149:17:149:17 | access to parameter t | SSA.cs:149:13:149:17 | SSA def(t) |
-| SSA.cs:152:36:152:36 | t | SSA.cs:152:36:152:36 | t |
 | SSA.cs:152:36:152:36 | t | SSA.cs:154:13:154:13 | access to parameter t |
 | SSA.cs:154:13:154:13 | (...) ... | SSA.cs:154:13:154:21 | ... == ... |
 | SSA.cs:154:13:154:13 | access to parameter t | SSA.cs:152:17:152:28 | SSA phi(t) |
@@ -844,9 +938,7 @@
 | SSA.cs:155:25:155:25 | SSA def(t) | SSA.cs:152:17:152:28 | SSA phi(t) |
 | SSA.cs:155:25:155:25 | access to parameter t | SSA.cs:152:17:152:28 | SSA phi(t) |
 | SSA.cs:166:10:166:13 | this | SSA.cs:166:19:166:22 | this access |
-| SSA.cs:168:22:168:28 | tainted | SSA.cs:168:22:168:28 | tainted |
 | SSA.cs:168:22:168:28 | tainted | SSA.cs:173:24:173:30 | access to parameter tainted |
-| SSA.cs:168:35:168:35 | i | SSA.cs:168:35:168:35 | i |
 | SSA.cs:168:35:168:35 | i | SSA.cs:171:13:171:13 | access to parameter i |
 | SSA.cs:170:16:170:28 | SSA def(ssaSink5) | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:170:27:170:28 | "" | SSA.cs:170:16:170:28 | SSA def(ssaSink5) |
@@ -863,9 +955,7 @@
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:176:21:176:28 | access to local variable ssaSink5 |
 | SSA.cs:177:21:177:28 | access to local variable ssaSink5 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) |
 | SSA.cs:180:9:180:24 | SSA phi(ssaSink5) | SSA.cs:180:15:180:22 | access to local variable ssaSink5 |
-| Splitting.cs:3:18:3:18 | b | Splitting.cs:3:18:3:18 | b |
 | Splitting.cs:3:18:3:18 | b | Splitting.cs:6:13:6:13 | access to parameter b |
-| Splitting.cs:3:28:3:34 | tainted | Splitting.cs:3:28:3:34 | tainted |
 | Splitting.cs:3:28:3:34 | tainted | Splitting.cs:5:17:5:23 | access to parameter tainted |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:8:19:8:19 | [b (line 3): true] access to local variable x |
 | Splitting.cs:5:13:5:23 | SSA def(x) | Splitting.cs:12:15:12:15 | [b (line 3): false] access to local variable x |
@@ -878,7 +968,6 @@
 | Splitting.cs:9:17:9:17 | [b (line 3): true] access to local variable x | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:12:15:12:15 | [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
 | Splitting.cs:12:15:12:15 | [post] [b (line 3): true] access to local variable x | Splitting.cs:14:19:14:19 | access to local variable x |
-| Splitting.cs:17:18:17:18 | b | Splitting.cs:17:18:17:18 | b |
 | Splitting.cs:17:18:17:18 | b | Splitting.cs:20:13:20:13 | access to parameter b |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:22:19:22:19 | [b (line 17): true] access to local variable x |
 | Splitting.cs:19:13:19:18 | SSA def(x) | Splitting.cs:25:15:25:15 | [b (line 17): false] access to local variable x |
@@ -891,7 +980,6 @@
 | Splitting.cs:25:15:25:15 | [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): false] access to local variable x | Splitting.cs:29:19:29:19 | access to local variable x |
 | Splitting.cs:25:15:25:15 | [post] [b (line 17): true] access to local variable x | Splitting.cs:27:19:27:19 | access to local variable x |
-| Splitting.cs:32:18:32:18 | b | Splitting.cs:32:18:32:18 | b |
 | Splitting.cs:32:18:32:18 | b | Splitting.cs:35:13:35:13 | access to parameter b |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): false] access to parameter b |
 | Splitting.cs:35:13:35:13 | access to parameter b | Splitting.cs:39:15:39:15 | [b (line 32): true] access to parameter b |
@@ -912,7 +1000,6 @@
 | Splitting.cs:40:23:40:23 | [b (line 32): true] access to local variable x | Splitting.cs:40:15:40:23 | [b (line 32): true] (...) ... |
 | Splitting.cs:41:19:41:21 | [b (line 32): false] "d" | Splitting.cs:41:15:41:21 | [b (line 32): false] ... = ... |
 | Splitting.cs:41:19:41:21 | [b (line 32): true] "d" | Splitting.cs:41:15:41:21 | [b (line 32): true] ... = ... |
-| Splitting.cs:46:18:46:18 | b | Splitting.cs:46:18:46:18 | b |
 | Splitting.cs:46:18:46:18 | b | Splitting.cs:49:13:49:13 | access to parameter b |
 | Splitting.cs:48:13:48:18 | SSA def(x) | Splitting.cs:53:13:53:13 | [b (line 46): false] access to local variable x |
 | Splitting.cs:48:17:48:18 | "" | Splitting.cs:48:13:48:18 | SSA def(x) |


### PR DESCRIPTION
This is [another](https://github.com/Semmle/ql/pull/3257) PR in preparation for modeling collection flow as field flow. The contributions of this PR are, however, interesting in their own right. The [`CSharp-Differences` job](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/109/) shows that performance is unchanged.

### Overview

A new predicate
```
predicate callableFlow(
  CallableFlowSource source,
  AccessPath sourceAp,
  CallableFlowSink sink,
  AccessPath sinkAp,
  SourceDeclarationCallable c)
```
has been added to the class `LibraryTypeDataFlow`, allowing one to specify summaries for library code taking access paths into account (currently limited to access paths of length at most 1). This enables us to model flow for e.g.
```
new Lazy(Foo);
```
as taking the output from `Foo` and storing it into the `Value` property of the created object.

### Implementation

In order to support flow summaries with access paths, a new data-flow node `LibraryCodeNode` has been introduced: All flow through library code now goes through such a node, possibly reading from a field/property upon entry, and possibly storing into a field/property upon exit.

The example above gives rise to entry edge 
```
[output] Foo --> [library code] new Lazy(Foo)
```
and exit edge
```
[library code] new Lazy(Foo) --store--> new Lazy(Foo) [Value]
```

A new type `ImplicitDelegateArgumentNode` has been added as well, in order to distinguish normal argument nodes from implicit arguments to implicit delegate calls. For example, `x` gives rise to both a (normal) `ExplicitArgumentNode` (argument 0 of the call to `Select`) and an `ImplicitDelegateArgumentNode` (argument 0 of the implicit call to `Foo`) in
```
x.Select(Foo)
```
Consequently, the entry/exit edges for this example are
```
x --> [library code] x.Select(Foo)
[library code] x.Select(Foo) --> [implicit argument 0] Foo
```
for flow from `x` into `Foo`, and
```
[output] Foo --> [library code] x.Select(Foo)
[library code] x.Select(Foo) --> x.Select(Foo)
```
for flow out of `Foo` to the `Select` call itself. (Note that the nodes `[library code] x.Select(Foo)` in the two snippets above are _different_.)

### Future work

- The upcoming PR for modeling collection-based flow as field flow will model flow for `x.Select(Foo)` as first an element read-step from `x` to `[implicit argument 0] Foo`, followed by an element store-step from `[output] Foo` to `x.Select(Foo)`.
- The approach should generalize to access paths of length > 1, but I have not yet encountered examples where it is needed.