### PR TITLE
CodeQL query to detect JNDI injections

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.java
@@ -1,0 +1,21 @@
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+public void jndiLookup(HttpServletRequest request) throws NamingException {
+  String name = request.getParameter("name");
+
+  Hashtable<String, String> env = new Hashtable<String, String>();
+  env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.rmi.registry.RegistryContextFactory");
+  env.put(Context.PROVIDER_URL, "rmi://trusted-server:1099");
+  InitialContext ctx = new InitialContext(env);
+
+  // BAD: User input used in lookup
+  ctx.lookup(name);
+
+  // GOOD: The name is validated before being used in lookup
+  if (isValid(name)) {
+    ctx.lookup(name);
+  } else {
+    // Reject the request
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.qhelp
@@ -1,0 +1,36 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>The Java Naming and Directory Interface (JNDI) is a Java API for a directory service that allows
+Java software clients to discover and look up data and resources (in the form of Java objects) via
+a name. If the name being used to look up the data is controlled by the user, it can point to a
+malicious server, which can return an arbitrary object. In the worst case, this can allow remote
+code execution.</p>
+</overview>
+
+<recommendation>
+<p>The general recommendation is to not pass untrusted data to the <code>InitialContext.lookup
+</code> method. If the name being used to look up the object must be provided by the user, make
+sure that it's not in the form of an absolute URL or that it's the URL pointing to a trused server.
+</p>
+</recommendation>
+
+<example>
+<p>In the following examples, the code accepts a name from the user, which it uses to look up an
+object.</p>
+
+<p>In the first example, the user provided name is used to look up an object.</p>
+
+<p>The second example validates the name before using it to look up an object.</p>
+
+<sample src="JndiInjection.java" />
+</example>
+
+<references>
+<li>Oracle: <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/">Java Naming and Directory Interface (JNDI)</a>.</li>
+<li>Black Hat materials: <a href="https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE-wp.pdf">A Journey from JNDI/LDAP Manipulation to Remote Code Execution Dream Land</a>.</li>
+<li>Veracode: <a href="https://www.veracode.com/blog/research/exploiting-jndi-injections-java">Exploiting JNDI Injections in Java</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjection.ql
@@ -1,0 +1,21 @@
+/**
+ * @name JNDI lookup with user-controlled name
+ * @description Doing a JNDI lookup with user-controlled name can lead to download an untrusted
+ *              object and to execution of arbitrary code.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/jndi-injection
+ * @tags security
+ *       external/cwe/cwe-074
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import JndiInjectionLib
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, JndiInjectionFlowConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "JNDI lookup might include name from $@.", source.getNode(),
+  "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
@@ -38,7 +38,10 @@ class TypeSearchControls extends Class {
   TypeSearchControls() { this.hasQualifiedName("javax.naming.directory", "SearchControls") }
 }
 
-/** The interface `org.springframework.ldap.core.LdapOperations`. */
+/**
+ * The interface `org.springframework.ldap.core.LdapOperations` (spring-ldap 1.2.x and newer) or
+ * `org.springframework.ldap.LdapOperations` (spring-ldap 1.1.x).
+ */
 class TypeSpringLdapOperations extends Interface {
   TypeSpringLdapOperations() {
     this.hasQualifiedName("org.springframework.ldap.core", "LdapOperations") or
@@ -46,7 +49,10 @@ class TypeSpringLdapOperations extends Interface {
   }
 }
 
-/** The interface `org.springframework.ldap.core.ContextMapper`. */
+/**
+ * The interface `org.springframework.ldap.core.ContextMapper` (spring-ldap 1.2.x and newer) or
+ * `org.springframework.ldap.ContextMapper` (spring-ldap 1.1.x).
+ */
 class TypeSpringContextMapper extends Interface {
   TypeSpringContextMapper() {
     this.getSourceDeclaration().hasQualifiedName("org.springframework.ldap.core", "ContextMapper") or

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
@@ -160,7 +160,7 @@ predicate jmxConnectorFactorySinkMethod(Method m, int index) {
 }
 
 /**
- * Tainted value passed to env `Hashtable` as the prodiver UDL, i.e.
+ * Tainted value passed to env `Hashtable` as the provider URL, i.e.
  * `env.put(Context.PROVIDER_URL, tainted)` or `env.setProperty(Context.PROVIDER_URL, tainted)`.
  */
 predicate providerUrlEnv(MethodAccess ma, Method m, int index) {

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
@@ -49,8 +49,8 @@ class TypeSpringLdapOperations extends Interface {
 /** The interface `org.springframework.ldap.core.ContextMapper`. */
 class TypeSpringContextMapper extends Interface {
   TypeSpringContextMapper() {
-    this.hasQualifiedName("org.springframework.ldap.core", "ContextMapper<T>") or
-    this.hasQualifiedName("org.springframework.ldap", "ContextMapper<T>")
+    this.getSourceDeclaration().hasQualifiedName("org.springframework.ldap.core", "ContextMapper") or
+    this.getSourceDeclaration().hasQualifiedName("org.springframework.ldap", "ContextMapper")
   }
 }
 

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
@@ -1,0 +1,91 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow
+import experimental.semmle.code.java.frameworks.Jndi
+import experimental.semmle.code.java.frameworks.spring.SpringJndi
+import experimental.semmle.code.java.frameworks.Shiro
+
+/**
+ * A taint-tracking configuration for unvalidated user input that is used in JNDI lookup.
+ */
+class JndiInjectionFlowConfig extends TaintTracking::Configuration {
+  JndiInjectionFlowConfig() { this = "JndiInjectionFlowConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof JndiInjectionSink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    compositeNameStep(node1, node2)
+  }
+}
+
+/**
+ * JNDI sink for JNDI injection vulnerabilities, i.e. 1st argument to `lookup`, `lookupLink`,
+ * `doLookup`, `rename`, `list` or `listBindings` method from `InitialContext`.
+ */
+predicate jndiSinkMethod(Method m, int index) {
+  m.getDeclaringType().getAnAncestor() instanceof TypeInitialContext and
+  (
+    m.hasName("lookup") or
+    m.hasName("lookupLink") or
+    m.hasName("doLookup") or
+    m.hasName("rename") or
+    m.hasName("list") or
+    m.hasName("listBindings")
+  ) and
+  index = 0
+}
+
+/**
+ * Spring sink for JNDI injection vulnerabilities, i.e. 1st argument to `lookup` method from
+ * Spring's `JndiTemplate`.
+ */
+predicate springSinkMethod(Method m, int index) {
+  m.getDeclaringType() instanceof TypeSpringJndiTemplate and
+  m.hasName("lookup") and
+  index = 0
+}
+
+/**
+ * Apache Shiro sink for JNDI injection vulnerabilities, i.e. 1st argument to `lookup` method from
+ * Shiro's `JndiTemplate`.
+ */
+predicate shiroSinkMethod(Method m, int index) {
+  m.getDeclaringType() instanceof TypeShiroJndiTemplate and
+  m.hasName("lookup") and
+  index = 0
+}
+
+/** Holds if parameter at index `index` in method `m` is JNDI injection sink. */
+predicate jndiInjectionSinkMethod(Method m, int index) {
+  jndiSinkMethod(m, index) or
+  springSinkMethod(m, index) or
+  shiroSinkMethod(m, index)
+}
+
+/** A data flow sink for unvalidated user input that is used in JNDI lookup. */
+class JndiInjectionSink extends DataFlow::ExprNode {
+  JndiInjectionSink() {
+    exists(MethodAccess ma, Method m, int index |
+      ma.getMethod() = m and
+      ma.getArgument(index) = this.getExpr() and
+      jndiInjectionSinkMethod(m, index)
+    )
+  }
+}
+
+/**
+ * Holds if `n1` to `n2` is a dataflow step that converts between `String` and `CompositeName`,
+ * i.e. `new CompositeName(tainted)`.
+ */
+predicate compositeNameStep(ExprNode n1, ExprNode n2) {
+  exists(ConstructorCall cc | cc.getConstructedType() instanceof TypeCompositeName |
+    n1.asExpr() = cc.getAnArgument() and
+    n2.asExpr() = cc
+  )
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-074/JndiInjectionLib.qll
@@ -3,6 +3,7 @@ import semmle.code.java.dataflow.FlowSources
 import DataFlow
 import experimental.semmle.code.java.frameworks.Jndi
 import experimental.semmle.code.java.frameworks.spring.SpringJndi
+import semmle.code.java.frameworks.SpringLdap
 import experimental.semmle.code.java.frameworks.Shiro
 
 /**
@@ -20,8 +21,33 @@ class JndiInjectionFlowConfig extends TaintTracking::Configuration {
   }
 
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
-    compositeNameStep(node1, node2)
+    compositeNameStep(node1, node2) or
+    jmxServiceUrlStep(node1, node2) or
+    jmxConnectorStep(node1, node2) or
+    rmiConnectorStep(node1, node2)
   }
+}
+
+/** The interface `javax.management.remote.JMXConnector`. */
+class TypeJMXConnector extends Interface {
+  TypeJMXConnector() { this.hasQualifiedName("javax.management.remote", "JMXConnector") }
+}
+
+/** The class `javax.management.remote.rmi.RMIConnector`. */
+class TypeRMIConnector extends Class {
+  TypeRMIConnector() { this.hasQualifiedName("javax.management.remote.rmi", "RMIConnector") }
+}
+
+/** The class `javax.management.remote.JMXConnectorFactory`. */
+class TypeJMXConnectorFactory extends Class {
+  TypeJMXConnectorFactory() {
+    this.hasQualifiedName("javax.management.remote", "JMXConnectorFactory")
+  }
+}
+
+/** The class `javax.management.remote.JMXServiceURL`. */
+class TypeJMXServiceURL extends Class {
+  TypeJMXServiceURL() { this.hasQualifiedName("javax.management.remote", "JMXServiceURL") }
 }
 
 /**
@@ -45,9 +71,19 @@ predicate jndiSinkMethod(Method m, int index) {
  * Spring sink for JNDI injection vulnerabilities, i.e. 1st argument to `lookup` method from
  * Spring's `JndiTemplate`.
  */
-predicate springSinkMethod(Method m, int index) {
+predicate springJndiTemplateSinkMethod(Method m, int index) {
   m.getDeclaringType() instanceof TypeSpringJndiTemplate and
   m.hasName("lookup") and
+  index = 0
+}
+
+/**
+ * Spring sink for JNDI injection vulnerabilities, i.e. 1st argument to `lookup` or `lookupContext`
+ * method from Spring's `LdapTemplate`.
+ */
+predicate springLdapTemplateSinkMethod(Method m, int index) {
+  m.getDeclaringType() instanceof TypeSpringLdapTemplate and
+  (m.hasName("lookup") or m.hasName("lookupContext")) and
   index = 0
 }
 
@@ -61,11 +97,23 @@ predicate shiroSinkMethod(Method m, int index) {
   index = 0
 }
 
+/**
+ * `JMXConnectorFactory` sink for JNDI injection vulnerabilities, i.e. 1st argument to `connect`
+ * method from `JMXConnectorFactory`.
+ */
+predicate jmxConnectorFactorySinkMethod(Method m, int index) {
+  m.getDeclaringType() instanceof TypeJMXConnectorFactory and
+  m.hasName("connect") and
+  index = 0
+}
+
 /** Holds if parameter at index `index` in method `m` is JNDI injection sink. */
 predicate jndiInjectionSinkMethod(Method m, int index) {
   jndiSinkMethod(m, index) or
-  springSinkMethod(m, index) or
-  shiroSinkMethod(m, index)
+  springJndiTemplateSinkMethod(m, index) or
+  springLdapTemplateSinkMethod(m, index) or
+  shiroSinkMethod(m, index) or
+  jmxConnectorFactorySinkMethod(m, index)
 }
 
 /** A data flow sink for unvalidated user input that is used in JNDI lookup. */
@@ -76,6 +124,13 @@ class JndiInjectionSink extends DataFlow::ExprNode {
       ma.getArgument(index) = this.getExpr() and
       jndiInjectionSinkMethod(m, index)
     )
+    or
+    exists(MethodAccess ma, Method m |
+      ma.getMethod() = m and
+      ma.getQualifier() = this.getExpr() and
+      m.getDeclaringType().getAnAncestor() instanceof TypeJMXConnector and
+      m.hasName("connect")
+    )
   }
 }
 
@@ -85,6 +140,40 @@ class JndiInjectionSink extends DataFlow::ExprNode {
  */
 predicate compositeNameStep(ExprNode n1, ExprNode n2) {
   exists(ConstructorCall cc | cc.getConstructedType() instanceof TypeCompositeName |
+    n1.asExpr() = cc.getAnArgument() and
+    n2.asExpr() = cc
+  )
+}
+
+/**
+ * Holds if `n1` to `n2` is a dataflow step that converts between `String` and `JMXServiceURL`,
+ * i.e. `new JMXServiceURL(tainted)`.
+ */
+predicate jmxServiceUrlStep(ExprNode n1, ExprNode n2) {
+  exists(ConstructorCall cc | cc.getConstructedType() instanceof TypeJMXServiceURL |
+    n1.asExpr() = cc.getAnArgument() and
+    n2.asExpr() = cc
+  )
+}
+
+/**
+ * Holds if `n1` to `n2` is a dataflow step that converts between `JMXServiceURL` and
+ * `JMXConnector`, i.e. `JMXConnectorFactory.newJMXConnector(tainted)`.
+ */
+predicate jmxConnectorStep(ExprNode n1, ExprNode n2) {
+  exists(MethodAccess ma, Method m | n1.asExpr() = ma.getArgument(0) and n2.asExpr() = ma |
+    ma.getMethod() = m and
+    m.getDeclaringType() instanceof TypeJMXConnectorFactory and
+    m.hasName("newJMXConnector")
+  )
+}
+
+/**
+ * Holds if `n1` to `n2` is a dataflow step that converts between `JMXServiceURL` and
+ * `RMIConnector`, i.e. `new RMIConnector(tainted)`.
+ */
+predicate rmiConnectorStep(ExprNode n1, ExprNode n2) {
+  exists(ConstructorCall cc | cc.getConstructedType() instanceof TypeRMIConnector |
     n1.asExpr() = cc.getAnArgument() and
     n2.asExpr() = cc
   )

--- a/java/ql/src/experimental/qlpack.yml
+++ b/java/ql/src/experimental/qlpack.yml
@@ -1,4 +1,0 @@
-name: codeql-java-experimental
-version: 0.0.0
-libraryPathDependencies: codeql-java
-extractor: java

--- a/java/ql/src/experimental/qlpack.yml
+++ b/java/ql/src/experimental/qlpack.yml
@@ -1,0 +1,4 @@
+name: codeql-java-experimental
+version: 0.0.0
+libraryPathDependencies: codeql-java
+extractor: java

--- a/java/ql/src/experimental/semmle/code/java/frameworks/Jndi.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/Jndi.qll
@@ -1,0 +1,11 @@
+import java
+
+/** The class `javax.naming.InitialContext`. */
+class TypeInitialContext extends Class {
+  TypeInitialContext() { this.hasQualifiedName("javax.naming", "InitialContext") }
+}
+
+/** The class `javax.naming.CompositeName`. */
+class TypeCompositeName extends Class {
+  TypeCompositeName() { this.hasQualifiedName("javax.naming", "CompositeName") }
+}

--- a/java/ql/src/experimental/semmle/code/java/frameworks/Jndi.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/Jndi.qll
@@ -9,3 +9,8 @@ class TypeInitialContext extends Class {
 class TypeCompositeName extends Class {
   TypeCompositeName() { this.hasQualifiedName("javax.naming", "CompositeName") }
 }
+
+/** The class `javax.naming.CompoundName`. */
+class TypeCompoundName extends Class {
+  TypeCompoundName() { this.hasQualifiedName("javax.naming", "CompoundName") }
+}

--- a/java/ql/src/experimental/semmle/code/java/frameworks/Shiro.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/Shiro.qll
@@ -1,0 +1,6 @@
+import java
+
+/** The class `org.apache.shiro.jndi.JndiTemplate`. */
+class TypeShiroJndiTemplate extends Class {
+  TypeShiroJndiTemplate() { this.hasQualifiedName("org.apache.shiro.jndi", "JndiTemplate") }
+}

--- a/java/ql/src/experimental/semmle/code/java/frameworks/spring/SpringJndi.qll
+++ b/java/ql/src/experimental/semmle/code/java/frameworks/spring/SpringJndi.qll
@@ -1,0 +1,6 @@
+import java
+
+/** The class `org.springframework.jndi.JndiTemplate`. */
+class TypeSpringJndiTemplate extends Class {
+  TypeSpringJndiTemplate() { this.hasQualifiedName("org.springframework.jndi", "JndiTemplate") }
+}

--- a/java/ql/test/experimental/qlpack.yml
+++ b/java/ql/test/experimental/qlpack.yml
@@ -1,0 +1,4 @@
+name: codeql-java-experimental-tests
+version: 0.0.0
+libraryPathDependencies: codeql-java-experimental
+extractor: java

--- a/java/ql/test/experimental/qlpack.yml
+++ b/java/ql/test/experimental/qlpack.yml
@@ -1,4 +1,0 @@
-name: codeql-java-experimental-tests
-version: 0.0.0
-libraryPathDependencies: codeql-java-experimental
-extractor: java

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
@@ -1,0 +1,116 @@
+edges
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:16:16:16:22 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:17:20:17:26 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:18:29:18:35 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:19:16:19:22 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:20:14:20:20 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:21:22:21:28 | nameStr |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:23:16:23:19 | name |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:24:20:24:23 | name |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:25:29:25:32 | name |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:26:16:26:19 | name |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:27:14:27:17 | name |
+| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:28:22:28:25 | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:35:16:35:22 | nameStr |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:36:20:36:26 | nameStr |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:37:16:37:22 | nameStr |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:38:14:38:20 | nameStr |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:39:22:39:28 | nameStr |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:41:16:41:19 | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:42:20:42:23 | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:43:16:43:19 | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:44:14:44:17 | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:45:22:45:25 | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:52:16:52:22 | nameStr |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:53:20:53:26 | nameStr |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:54:16:54:22 | nameStr |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:55:14:55:20 | nameStr |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:56:22:56:28 | nameStr |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:58:16:58:19 | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:59:20:59:23 | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:60:16:60:19 | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:61:14:61:17 | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:62:22:62:25 | name |
+| JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr |
+| JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:69:16:69:22 | nameStr |
+| JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr |
+| JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:76:16:76:22 | nameStr |
+nodes
+| JndiInjection.java:12:38:12:65 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:16:16:16:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:17:20:17:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:18:29:18:35 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:19:16:19:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:20:14:20:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:21:22:21:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:23:16:23:19 | name | semmle.label | name |
+| JndiInjection.java:24:20:24:23 | name | semmle.label | name |
+| JndiInjection.java:25:29:25:32 | name | semmle.label | name |
+| JndiInjection.java:26:16:26:19 | name | semmle.label | name |
+| JndiInjection.java:27:14:27:17 | name | semmle.label | name |
+| JndiInjection.java:28:22:28:25 | name | semmle.label | name |
+| JndiInjection.java:31:41:31:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:35:16:35:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:36:20:36:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:37:16:37:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:38:14:38:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:39:22:39:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:41:16:41:19 | name | semmle.label | name |
+| JndiInjection.java:42:20:42:23 | name | semmle.label | name |
+| JndiInjection.java:43:16:43:19 | name | semmle.label | name |
+| JndiInjection.java:44:14:44:17 | name | semmle.label | name |
+| JndiInjection.java:45:22:45:25 | name | semmle.label | name |
+| JndiInjection.java:48:42:48:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:52:16:52:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:53:20:53:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:54:16:54:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:55:14:55:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:56:22:56:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:58:16:58:19 | name | semmle.label | name |
+| JndiInjection.java:59:20:59:23 | name | semmle.label | name |
+| JndiInjection.java:60:16:60:19 | name | semmle.label | name |
+| JndiInjection.java:61:14:61:17 | name | semmle.label | name |
+| JndiInjection.java:62:22:62:25 | name | semmle.label | name |
+| JndiInjection.java:65:42:65:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:68:16:68:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:69:16:69:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:72:41:72:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:75:16:75:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:76:16:76:22 | nameStr | semmle.label | nameStr |
+#select
+| JndiInjection.java:16:16:16:22 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:16:16:16:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:17:20:17:26 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:17:20:17:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:18:29:18:35 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:18:29:18:35 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:19:16:19:22 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:19:16:19:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:20:14:20:20 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:20:14:20:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:21:22:21:28 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:21:22:21:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:23:16:23:19 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:23:16:23:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:24:20:24:23 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:24:20:24:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:25:29:25:32 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:25:29:25:32 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:26:16:26:19 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:26:16:26:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:27:14:27:17 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:27:14:27:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:28:22:28:25 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:28:22:28:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
+| JndiInjection.java:35:16:35:22 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:35:16:35:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:36:20:36:26 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:36:20:36:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:37:16:37:22 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:37:16:37:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:38:14:38:20 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:38:14:38:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:39:22:39:28 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:39:22:39:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:41:16:41:19 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:41:16:41:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:42:20:42:23 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:42:20:42:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:43:16:43:19 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:43:16:43:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:44:14:44:17 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:44:14:44:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:45:22:45:25 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:45:22:45:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
+| JndiInjection.java:52:16:52:22 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:52:16:52:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:53:20:53:26 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:53:20:53:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:54:16:54:22 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:54:16:54:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:55:14:55:20 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:55:14:55:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:56:22:56:28 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:56:22:56:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:58:16:58:19 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:58:16:58:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:59:20:59:23 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:59:20:59:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:60:16:60:19 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:60:16:60:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:61:14:61:17 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:61:14:61:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:62:22:62:25 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:62:22:62:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
+| JndiInjection.java:68:16:68:22 | nameStr | JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:65:42:65:69 | nameStr | this user input |
+| JndiInjection.java:69:16:69:22 | nameStr | JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:69:16:69:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:65:42:65:69 | nameStr | this user input |
+| JndiInjection.java:75:16:75:22 | nameStr | JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:72:41:72:68 | nameStr | this user input |
+| JndiInjection.java:76:16:76:22 | nameStr | JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:76:16:76:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:72:41:72:68 | nameStr | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
@@ -49,11 +49,11 @@ edges
 | JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:110:16:110:22 | nameStr |
 | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) |
 | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:118:5:118:13 | connector |
-| JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:125:24:125:26 | env |
-| JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:132:27:132:29 | env |
-| JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:139:22:139:26 | props |
-| JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:146:22:146:26 | props |
-| JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:154:29:154:33 | props |
+| JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:124:35:124:40 | urlStr |
+| JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:131:41:131:46 | urlStr |
+| JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:138:37:138:42 | urlStr |
+| JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:145:51:145:56 | urlStr |
+| JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:152:51:152:56 | urlStr |
 nodes
 | JndiInjection.java:26:38:26:65 | nameStr : String | semmle.label | nameStr : String |
 | JndiInjection.java:30:16:30:22 | nameStr | semmle.label | nameStr |
@@ -113,15 +113,15 @@ nodes
 | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | semmle.label | new JMXServiceURL(...) |
 | JndiInjection.java:118:5:118:13 | connector | semmle.label | connector |
 | JndiInjection.java:121:27:121:53 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:125:24:125:26 | env | semmle.label | env |
+| JndiInjection.java:124:35:124:40 | urlStr | semmle.label | urlStr |
 | JndiInjection.java:128:27:128:53 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:132:27:132:29 | env | semmle.label | env |
+| JndiInjection.java:131:41:131:46 | urlStr | semmle.label | urlStr |
 | JndiInjection.java:135:52:135:78 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:139:22:139:26 | props | semmle.label | props |
+| JndiInjection.java:138:37:138:42 | urlStr | semmle.label | urlStr |
 | JndiInjection.java:142:52:142:78 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:146:22:146:26 | props | semmle.label | props |
+| JndiInjection.java:145:51:145:56 | urlStr | semmle.label | urlStr |
 | JndiInjection.java:149:52:149:78 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:154:29:154:33 | props | semmle.label | props |
+| JndiInjection.java:152:51:152:56 | urlStr | semmle.label | urlStr |
 #select
 | JndiInjection.java:30:16:30:22 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:30:16:30:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
 | JndiInjection.java:31:20:31:26 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:31:20:31:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
@@ -173,8 +173,8 @@ nodes
 | JndiInjection.java:110:16:110:22 | nameStr | JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:110:16:110:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:106:41:106:68 | nameStr | this user input |
 | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | JNDI lookup might include name from $@. | JndiInjection.java:113:37:113:63 | urlStr | this user input |
 | JndiInjection.java:118:5:118:13 | connector | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:118:5:118:13 | connector | JNDI lookup might include name from $@. | JndiInjection.java:113:37:113:63 | urlStr | this user input |
-| JndiInjection.java:125:24:125:26 | env | JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:125:24:125:26 | env | JNDI lookup might include name from $@. | JndiInjection.java:121:27:121:53 | urlStr | this user input |
-| JndiInjection.java:132:27:132:29 | env | JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:132:27:132:29 | env | JNDI lookup might include name from $@. | JndiInjection.java:128:27:128:53 | urlStr | this user input |
-| JndiInjection.java:139:22:139:26 | props | JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:139:22:139:26 | props | JNDI lookup might include name from $@. | JndiInjection.java:135:52:135:78 | urlStr | this user input |
-| JndiInjection.java:146:22:146:26 | props | JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:146:22:146:26 | props | JNDI lookup might include name from $@. | JndiInjection.java:142:52:142:78 | urlStr | this user input |
-| JndiInjection.java:154:29:154:33 | props | JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:154:29:154:33 | props | JNDI lookup might include name from $@. | JndiInjection.java:149:52:149:78 | urlStr | this user input |
+| JndiInjection.java:124:35:124:40 | urlStr | JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:124:35:124:40 | urlStr | JNDI lookup might include name from $@. | JndiInjection.java:121:27:121:53 | urlStr | this user input |
+| JndiInjection.java:131:41:131:46 | urlStr | JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:131:41:131:46 | urlStr | JNDI lookup might include name from $@. | JndiInjection.java:128:27:128:53 | urlStr | this user input |
+| JndiInjection.java:138:37:138:42 | urlStr | JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:138:37:138:42 | urlStr | JNDI lookup might include name from $@. | JndiInjection.java:135:52:135:78 | urlStr | this user input |
+| JndiInjection.java:145:51:145:56 | urlStr | JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:145:51:145:56 | urlStr | JNDI lookup might include name from $@. | JndiInjection.java:142:52:142:78 | urlStr | this user input |
+| JndiInjection.java:152:51:152:56 | urlStr | JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:152:51:152:56 | urlStr | JNDI lookup might include name from $@. | JndiInjection.java:149:52:149:78 | urlStr | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
@@ -1,116 +1,130 @@
 edges
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:16:16:16:22 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:17:20:17:26 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:18:29:18:35 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:19:16:19:22 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:20:14:20:20 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:21:22:21:28 | nameStr |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:23:16:23:19 | name |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:24:20:24:23 | name |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:25:29:25:32 | name |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:26:16:26:19 | name |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:27:14:27:17 | name |
-| JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:28:22:28:25 | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:35:16:35:22 | nameStr |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:36:20:36:26 | nameStr |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:37:16:37:22 | nameStr |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:38:14:38:20 | nameStr |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:39:22:39:28 | nameStr |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:41:16:41:19 | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:42:20:42:23 | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:43:16:43:19 | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:44:14:44:17 | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:45:22:45:25 | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:52:16:52:22 | nameStr |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:53:20:53:26 | nameStr |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:54:16:54:22 | nameStr |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:55:14:55:20 | nameStr |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:56:22:56:28 | nameStr |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:58:16:58:19 | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:59:20:59:23 | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:60:16:60:19 | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:61:14:61:17 | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:62:22:62:25 | name |
-| JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr |
-| JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:69:16:69:22 | nameStr |
-| JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr |
-| JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:76:16:76:22 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:22:16:22:22 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:23:20:23:26 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:24:29:24:35 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:25:16:25:22 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:26:14:26:20 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:27:22:27:28 | nameStr |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:29:16:29:19 | name |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:30:20:30:23 | name |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:31:29:31:32 | name |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:32:16:32:19 | name |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:33:14:33:17 | name |
+| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:34:22:34:25 | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:41:16:41:22 | nameStr |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:42:20:42:26 | nameStr |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:43:16:43:22 | nameStr |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:44:14:44:20 | nameStr |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:45:22:45:28 | nameStr |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:47:16:47:19 | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:48:20:48:23 | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:49:16:49:19 | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:50:14:50:17 | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:51:22:51:25 | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:58:16:58:22 | nameStr |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:59:20:59:26 | nameStr |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:60:16:60:22 | nameStr |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:61:14:61:20 | nameStr |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:62:22:62:28 | nameStr |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:64:16:64:19 | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:65:20:65:23 | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:66:16:66:19 | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:67:14:67:17 | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:68:22:68:25 | name |
+| JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:74:16:74:22 | nameStr |
+| JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr |
+| JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:81:16:81:22 | nameStr |
+| JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:82:23:82:29 | nameStr |
+| JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:88:16:88:22 | nameStr |
+| JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:89:16:89:22 | nameStr |
+| JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) |
+| JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:97:5:97:13 | connector |
 nodes
-| JndiInjection.java:12:38:12:65 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:16:16:16:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:17:20:17:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:18:29:18:35 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:19:16:19:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:20:14:20:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:21:22:21:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:23:16:23:19 | name | semmle.label | name |
-| JndiInjection.java:24:20:24:23 | name | semmle.label | name |
-| JndiInjection.java:25:29:25:32 | name | semmle.label | name |
-| JndiInjection.java:26:16:26:19 | name | semmle.label | name |
-| JndiInjection.java:27:14:27:17 | name | semmle.label | name |
-| JndiInjection.java:28:22:28:25 | name | semmle.label | name |
-| JndiInjection.java:31:41:31:68 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:35:16:35:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:36:20:36:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:37:16:37:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:38:14:38:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:39:22:39:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:41:16:41:19 | name | semmle.label | name |
-| JndiInjection.java:42:20:42:23 | name | semmle.label | name |
-| JndiInjection.java:43:16:43:19 | name | semmle.label | name |
-| JndiInjection.java:44:14:44:17 | name | semmle.label | name |
-| JndiInjection.java:45:22:45:25 | name | semmle.label | name |
-| JndiInjection.java:48:42:48:69 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:52:16:52:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:53:20:53:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:54:16:54:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:55:14:55:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:56:22:56:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:58:16:58:19 | name | semmle.label | name |
-| JndiInjection.java:59:20:59:23 | name | semmle.label | name |
-| JndiInjection.java:60:16:60:19 | name | semmle.label | name |
-| JndiInjection.java:61:14:61:17 | name | semmle.label | name |
-| JndiInjection.java:62:22:62:25 | name | semmle.label | name |
-| JndiInjection.java:65:42:65:69 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:68:16:68:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:69:16:69:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:72:41:72:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:18:38:18:65 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:22:16:22:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:23:20:23:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:24:29:24:35 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:25:16:25:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:26:14:26:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:27:22:27:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:29:16:29:19 | name | semmle.label | name |
+| JndiInjection.java:30:20:30:23 | name | semmle.label | name |
+| JndiInjection.java:31:29:31:32 | name | semmle.label | name |
+| JndiInjection.java:32:16:32:19 | name | semmle.label | name |
+| JndiInjection.java:33:14:33:17 | name | semmle.label | name |
+| JndiInjection.java:34:22:34:25 | name | semmle.label | name |
+| JndiInjection.java:37:41:37:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:41:16:41:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:42:20:42:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:43:16:43:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:44:14:44:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:45:22:45:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:47:16:47:19 | name | semmle.label | name |
+| JndiInjection.java:48:20:48:23 | name | semmle.label | name |
+| JndiInjection.java:49:16:49:19 | name | semmle.label | name |
+| JndiInjection.java:50:14:50:17 | name | semmle.label | name |
+| JndiInjection.java:51:22:51:25 | name | semmle.label | name |
+| JndiInjection.java:54:42:54:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:58:16:58:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:59:20:59:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:60:16:60:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:61:14:61:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:62:22:62:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:64:16:64:19 | name | semmle.label | name |
+| JndiInjection.java:65:20:65:23 | name | semmle.label | name |
+| JndiInjection.java:66:16:66:19 | name | semmle.label | name |
+| JndiInjection.java:67:14:67:17 | name | semmle.label | name |
+| JndiInjection.java:68:22:68:25 | name | semmle.label | name |
+| JndiInjection.java:71:42:71:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:74:16:74:22 | nameStr | semmle.label | nameStr |
 | JndiInjection.java:75:16:75:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:76:16:76:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:78:42:78:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:81:16:81:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:82:23:82:29 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:85:41:85:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:88:16:88:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:89:16:89:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:92:37:92:63 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | semmle.label | new JMXServiceURL(...) |
+| JndiInjection.java:97:5:97:13 | connector | semmle.label | connector |
 #select
-| JndiInjection.java:16:16:16:22 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:16:16:16:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:17:20:17:26 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:17:20:17:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:18:29:18:35 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:18:29:18:35 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:19:16:19:22 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:19:16:19:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:20:14:20:20 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:20:14:20:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:21:22:21:28 | nameStr | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:21:22:21:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:23:16:23:19 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:23:16:23:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:24:20:24:23 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:24:20:24:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:25:29:25:32 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:25:29:25:32 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:26:16:26:19 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:26:16:26:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:27:14:27:17 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:27:14:27:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:28:22:28:25 | name | JndiInjection.java:12:38:12:65 | nameStr : String | JndiInjection.java:28:22:28:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:12:38:12:65 | nameStr | this user input |
-| JndiInjection.java:35:16:35:22 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:35:16:35:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:36:20:36:26 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:36:20:36:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:37:16:37:22 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:37:16:37:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:38:14:38:20 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:38:14:38:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:39:22:39:28 | nameStr | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:39:22:39:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:41:16:41:19 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:41:16:41:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:42:20:42:23 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:42:20:42:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:43:16:43:19 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:43:16:43:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:44:14:44:17 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:44:14:44:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:45:22:45:25 | name | JndiInjection.java:31:41:31:68 | nameStr : String | JndiInjection.java:45:22:45:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:31:41:31:68 | nameStr | this user input |
-| JndiInjection.java:52:16:52:22 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:52:16:52:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:53:20:53:26 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:53:20:53:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:54:16:54:22 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:54:16:54:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:55:14:55:20 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:55:14:55:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:56:22:56:28 | nameStr | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:56:22:56:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:58:16:58:19 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:58:16:58:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:59:20:59:23 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:59:20:59:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:60:16:60:19 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:60:16:60:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:61:14:61:17 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:61:14:61:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:62:22:62:25 | name | JndiInjection.java:48:42:48:69 | nameStr : String | JndiInjection.java:62:22:62:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:48:42:48:69 | nameStr | this user input |
-| JndiInjection.java:68:16:68:22 | nameStr | JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:65:42:65:69 | nameStr | this user input |
-| JndiInjection.java:69:16:69:22 | nameStr | JndiInjection.java:65:42:65:69 | nameStr : String | JndiInjection.java:69:16:69:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:65:42:65:69 | nameStr | this user input |
-| JndiInjection.java:75:16:75:22 | nameStr | JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:72:41:72:68 | nameStr | this user input |
-| JndiInjection.java:76:16:76:22 | nameStr | JndiInjection.java:72:41:72:68 | nameStr : String | JndiInjection.java:76:16:76:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:72:41:72:68 | nameStr | this user input |
+| JndiInjection.java:22:16:22:22 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:22:16:22:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:23:20:23:26 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:23:20:23:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:24:29:24:35 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:24:29:24:35 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:25:16:25:22 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:25:16:25:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:26:14:26:20 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:26:14:26:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:27:22:27:28 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:27:22:27:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:29:16:29:19 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:29:16:29:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:30:20:30:23 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:30:20:30:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:31:29:31:32 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:31:29:31:32 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:32:16:32:19 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:32:16:32:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:33:14:33:17 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:33:14:33:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:34:22:34:25 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:34:22:34:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
+| JndiInjection.java:41:16:41:22 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:41:16:41:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:42:20:42:26 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:42:20:42:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:43:16:43:22 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:43:16:43:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:44:14:44:20 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:44:14:44:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:45:22:45:28 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:45:22:45:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:47:16:47:19 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:47:16:47:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:48:20:48:23 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:48:20:48:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:49:16:49:19 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:49:16:49:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:50:14:50:17 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:50:14:50:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:51:22:51:25 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:51:22:51:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
+| JndiInjection.java:58:16:58:22 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:58:16:58:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:59:20:59:26 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:59:20:59:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:60:16:60:22 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:60:16:60:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:61:14:61:20 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:61:14:61:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:62:22:62:28 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:62:22:62:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:64:16:64:19 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:64:16:64:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:65:20:65:23 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:65:20:65:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:66:16:66:19 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:66:16:66:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:67:14:67:17 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:67:14:67:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:68:22:68:25 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:68:22:68:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
+| JndiInjection.java:74:16:74:22 | nameStr | JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:74:16:74:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:71:42:71:69 | nameStr | this user input |
+| JndiInjection.java:75:16:75:22 | nameStr | JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:71:42:71:69 | nameStr | this user input |
+| JndiInjection.java:81:16:81:22 | nameStr | JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:81:16:81:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:78:42:78:69 | nameStr | this user input |
+| JndiInjection.java:82:23:82:29 | nameStr | JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:82:23:82:29 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:78:42:78:69 | nameStr | this user input |
+| JndiInjection.java:88:16:88:22 | nameStr | JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:88:16:88:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:85:41:85:68 | nameStr | this user input |
+| JndiInjection.java:89:16:89:22 | nameStr | JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:89:16:89:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:85:41:85:68 | nameStr | this user input |
+| JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | JNDI lookup might include name from $@. | JndiInjection.java:92:37:92:63 | urlStr | this user input |
+| JndiInjection.java:97:5:97:13 | connector | JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:97:5:97:13 | connector | JNDI lookup might include name from $@. | JndiInjection.java:92:37:92:63 | urlStr | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.expected
@@ -1,130 +1,180 @@
 edges
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:22:16:22:22 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:23:20:23:26 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:24:29:24:35 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:25:16:25:22 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:26:14:26:20 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:27:22:27:28 | nameStr |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:29:16:29:19 | name |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:30:20:30:23 | name |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:31:29:31:32 | name |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:32:16:32:19 | name |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:33:14:33:17 | name |
-| JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:34:22:34:25 | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:41:16:41:22 | nameStr |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:42:20:42:26 | nameStr |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:43:16:43:22 | nameStr |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:44:14:44:20 | nameStr |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:45:22:45:28 | nameStr |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:47:16:47:19 | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:48:20:48:23 | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:49:16:49:19 | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:50:14:50:17 | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:51:22:51:25 | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:58:16:58:22 | nameStr |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:59:20:59:26 | nameStr |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:60:16:60:22 | nameStr |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:61:14:61:20 | nameStr |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:62:22:62:28 | nameStr |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:64:16:64:19 | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:65:20:65:23 | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:66:16:66:19 | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:67:14:67:17 | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:68:22:68:25 | name |
-| JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:74:16:74:22 | nameStr |
-| JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr |
-| JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:81:16:81:22 | nameStr |
-| JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:82:23:82:29 | nameStr |
-| JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:88:16:88:22 | nameStr |
-| JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:89:16:89:22 | nameStr |
-| JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) |
-| JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:97:5:97:13 | connector |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:30:16:30:22 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:31:20:31:26 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:32:29:32:35 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:33:16:33:22 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:34:14:34:20 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:35:22:35:28 | nameStr |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:37:16:37:19 | name |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:38:20:38:23 | name |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:39:29:39:32 | name |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:40:16:40:19 | name |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:41:14:41:17 | name |
+| JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:42:22:42:25 | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:49:16:49:22 | nameStr |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:50:20:50:26 | nameStr |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:51:16:51:22 | nameStr |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:52:14:52:20 | nameStr |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:53:22:53:28 | nameStr |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:55:16:55:19 | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:56:20:56:23 | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:57:16:57:19 | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:58:14:58:17 | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:59:22:59:25 | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:66:16:66:22 | nameStr |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:67:20:67:26 | nameStr |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:69:14:69:20 | nameStr |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:70:22:70:28 | nameStr |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:72:16:72:19 | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:73:20:73:23 | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:74:16:74:19 | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:75:14:75:17 | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:76:22:76:25 | name |
+| JndiInjection.java:79:42:79:69 | nameStr : String | JndiInjection.java:82:16:82:22 | nameStr |
+| JndiInjection.java:79:42:79:69 | nameStr : String | JndiInjection.java:83:16:83:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:90:16:90:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:91:23:91:29 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:92:18:92:21 | name |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:93:16:93:19 | name |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:94:14:94:17 | name |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:95:22:95:25 | name |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:96:16:96:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:98:16:98:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:99:16:99:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:100:16:100:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:101:16:101:22 | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:103:25:103:31 | nameStr |
+| JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:109:16:109:22 | nameStr |
+| JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:110:16:110:22 | nameStr |
+| JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) |
+| JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:118:5:118:13 | connector |
+| JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:125:24:125:26 | env |
+| JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:132:27:132:29 | env |
+| JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:139:22:139:26 | props |
+| JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:146:22:146:26 | props |
+| JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:154:29:154:33 | props |
 nodes
-| JndiInjection.java:18:38:18:65 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:22:16:22:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:23:20:23:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:24:29:24:35 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:25:16:25:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:26:14:26:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:27:22:27:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:29:16:29:19 | name | semmle.label | name |
-| JndiInjection.java:30:20:30:23 | name | semmle.label | name |
-| JndiInjection.java:31:29:31:32 | name | semmle.label | name |
-| JndiInjection.java:32:16:32:19 | name | semmle.label | name |
-| JndiInjection.java:33:14:33:17 | name | semmle.label | name |
-| JndiInjection.java:34:22:34:25 | name | semmle.label | name |
-| JndiInjection.java:37:41:37:68 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:41:16:41:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:42:20:42:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:43:16:43:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:44:14:44:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:45:22:45:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:47:16:47:19 | name | semmle.label | name |
-| JndiInjection.java:48:20:48:23 | name | semmle.label | name |
-| JndiInjection.java:49:16:49:19 | name | semmle.label | name |
-| JndiInjection.java:50:14:50:17 | name | semmle.label | name |
-| JndiInjection.java:51:22:51:25 | name | semmle.label | name |
-| JndiInjection.java:54:42:54:69 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:58:16:58:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:59:20:59:26 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:60:16:60:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:61:14:61:20 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:62:22:62:28 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:64:16:64:19 | name | semmle.label | name |
-| JndiInjection.java:65:20:65:23 | name | semmle.label | name |
-| JndiInjection.java:66:16:66:19 | name | semmle.label | name |
-| JndiInjection.java:67:14:67:17 | name | semmle.label | name |
-| JndiInjection.java:68:22:68:25 | name | semmle.label | name |
-| JndiInjection.java:71:42:71:69 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:74:16:74:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:75:16:75:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:78:42:78:69 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:81:16:81:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:82:23:82:29 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:85:41:85:68 | nameStr : String | semmle.label | nameStr : String |
-| JndiInjection.java:88:16:88:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:89:16:89:22 | nameStr | semmle.label | nameStr |
-| JndiInjection.java:92:37:92:63 | urlStr : String | semmle.label | urlStr : String |
-| JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | semmle.label | new JMXServiceURL(...) |
-| JndiInjection.java:97:5:97:13 | connector | semmle.label | connector |
+| JndiInjection.java:26:38:26:65 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:30:16:30:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:31:20:31:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:32:29:32:35 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:33:16:33:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:34:14:34:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:35:22:35:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:37:16:37:19 | name | semmle.label | name |
+| JndiInjection.java:38:20:38:23 | name | semmle.label | name |
+| JndiInjection.java:39:29:39:32 | name | semmle.label | name |
+| JndiInjection.java:40:16:40:19 | name | semmle.label | name |
+| JndiInjection.java:41:14:41:17 | name | semmle.label | name |
+| JndiInjection.java:42:22:42:25 | name | semmle.label | name |
+| JndiInjection.java:45:41:45:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:49:16:49:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:50:20:50:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:51:16:51:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:52:14:52:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:53:22:53:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:55:16:55:19 | name | semmle.label | name |
+| JndiInjection.java:56:20:56:23 | name | semmle.label | name |
+| JndiInjection.java:57:16:57:19 | name | semmle.label | name |
+| JndiInjection.java:58:14:58:17 | name | semmle.label | name |
+| JndiInjection.java:59:22:59:25 | name | semmle.label | name |
+| JndiInjection.java:62:42:62:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:66:16:66:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:67:20:67:26 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:68:16:68:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:69:14:69:20 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:70:22:70:28 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:72:16:72:19 | name | semmle.label | name |
+| JndiInjection.java:73:20:73:23 | name | semmle.label | name |
+| JndiInjection.java:74:16:74:19 | name | semmle.label | name |
+| JndiInjection.java:75:14:75:17 | name | semmle.label | name |
+| JndiInjection.java:76:22:76:25 | name | semmle.label | name |
+| JndiInjection.java:79:42:79:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:82:16:82:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:83:16:83:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:86:42:86:69 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:90:16:90:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:91:23:91:29 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:92:18:92:21 | name | semmle.label | name |
+| JndiInjection.java:93:16:93:19 | name | semmle.label | name |
+| JndiInjection.java:94:14:94:17 | name | semmle.label | name |
+| JndiInjection.java:95:22:95:25 | name | semmle.label | name |
+| JndiInjection.java:96:16:96:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:98:16:98:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:99:16:99:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:100:16:100:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:101:16:101:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:103:25:103:31 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:106:41:106:68 | nameStr : String | semmle.label | nameStr : String |
+| JndiInjection.java:109:16:109:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:110:16:110:22 | nameStr | semmle.label | nameStr |
+| JndiInjection.java:113:37:113:63 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | semmle.label | new JMXServiceURL(...) |
+| JndiInjection.java:118:5:118:13 | connector | semmle.label | connector |
+| JndiInjection.java:121:27:121:53 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:125:24:125:26 | env | semmle.label | env |
+| JndiInjection.java:128:27:128:53 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:132:27:132:29 | env | semmle.label | env |
+| JndiInjection.java:135:52:135:78 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:139:22:139:26 | props | semmle.label | props |
+| JndiInjection.java:142:52:142:78 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:146:22:146:26 | props | semmle.label | props |
+| JndiInjection.java:149:52:149:78 | urlStr : String | semmle.label | urlStr : String |
+| JndiInjection.java:154:29:154:33 | props | semmle.label | props |
 #select
-| JndiInjection.java:22:16:22:22 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:22:16:22:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:23:20:23:26 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:23:20:23:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:24:29:24:35 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:24:29:24:35 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:25:16:25:22 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:25:16:25:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:26:14:26:20 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:26:14:26:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:27:22:27:28 | nameStr | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:27:22:27:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:29:16:29:19 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:29:16:29:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:30:20:30:23 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:30:20:30:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:31:29:31:32 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:31:29:31:32 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:32:16:32:19 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:32:16:32:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:33:14:33:17 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:33:14:33:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:34:22:34:25 | name | JndiInjection.java:18:38:18:65 | nameStr : String | JndiInjection.java:34:22:34:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:18:38:18:65 | nameStr | this user input |
-| JndiInjection.java:41:16:41:22 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:41:16:41:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:42:20:42:26 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:42:20:42:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:43:16:43:22 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:43:16:43:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:44:14:44:20 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:44:14:44:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:45:22:45:28 | nameStr | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:45:22:45:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:47:16:47:19 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:47:16:47:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:48:20:48:23 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:48:20:48:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:49:16:49:19 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:49:16:49:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:50:14:50:17 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:50:14:50:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:51:22:51:25 | name | JndiInjection.java:37:41:37:68 | nameStr : String | JndiInjection.java:51:22:51:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:37:41:37:68 | nameStr | this user input |
-| JndiInjection.java:58:16:58:22 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:58:16:58:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:59:20:59:26 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:59:20:59:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:60:16:60:22 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:60:16:60:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:61:14:61:20 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:61:14:61:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:62:22:62:28 | nameStr | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:62:22:62:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:64:16:64:19 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:64:16:64:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:65:20:65:23 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:65:20:65:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:66:16:66:19 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:66:16:66:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:67:14:67:17 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:67:14:67:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:68:22:68:25 | name | JndiInjection.java:54:42:54:69 | nameStr : String | JndiInjection.java:68:22:68:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:54:42:54:69 | nameStr | this user input |
-| JndiInjection.java:74:16:74:22 | nameStr | JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:74:16:74:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:71:42:71:69 | nameStr | this user input |
-| JndiInjection.java:75:16:75:22 | nameStr | JndiInjection.java:71:42:71:69 | nameStr : String | JndiInjection.java:75:16:75:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:71:42:71:69 | nameStr | this user input |
-| JndiInjection.java:81:16:81:22 | nameStr | JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:81:16:81:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:78:42:78:69 | nameStr | this user input |
-| JndiInjection.java:82:23:82:29 | nameStr | JndiInjection.java:78:42:78:69 | nameStr : String | JndiInjection.java:82:23:82:29 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:78:42:78:69 | nameStr | this user input |
-| JndiInjection.java:88:16:88:22 | nameStr | JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:88:16:88:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:85:41:85:68 | nameStr | this user input |
-| JndiInjection.java:89:16:89:22 | nameStr | JndiInjection.java:85:41:85:68 | nameStr : String | JndiInjection.java:89:16:89:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:85:41:85:68 | nameStr | this user input |
-| JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:93:33:93:57 | new JMXServiceURL(...) | JNDI lookup might include name from $@. | JndiInjection.java:92:37:92:63 | urlStr | this user input |
-| JndiInjection.java:97:5:97:13 | connector | JndiInjection.java:92:37:92:63 | urlStr : String | JndiInjection.java:97:5:97:13 | connector | JNDI lookup might include name from $@. | JndiInjection.java:92:37:92:63 | urlStr | this user input |
+| JndiInjection.java:30:16:30:22 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:30:16:30:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:31:20:31:26 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:31:20:31:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:32:29:32:35 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:32:29:32:35 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:33:16:33:22 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:33:16:33:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:34:14:34:20 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:34:14:34:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:35:22:35:28 | nameStr | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:35:22:35:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:37:16:37:19 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:37:16:37:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:38:20:38:23 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:38:20:38:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:39:29:39:32 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:39:29:39:32 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:40:16:40:19 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:40:16:40:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:41:14:41:17 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:41:14:41:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:42:22:42:25 | name | JndiInjection.java:26:38:26:65 | nameStr : String | JndiInjection.java:42:22:42:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:26:38:26:65 | nameStr | this user input |
+| JndiInjection.java:49:16:49:22 | nameStr | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:49:16:49:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:50:20:50:26 | nameStr | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:50:20:50:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:51:16:51:22 | nameStr | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:51:16:51:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:52:14:52:20 | nameStr | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:52:14:52:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:53:22:53:28 | nameStr | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:53:22:53:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:55:16:55:19 | name | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:55:16:55:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:56:20:56:23 | name | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:56:20:56:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:57:16:57:19 | name | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:57:16:57:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:58:14:58:17 | name | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:58:14:58:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:59:22:59:25 | name | JndiInjection.java:45:41:45:68 | nameStr : String | JndiInjection.java:59:22:59:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:45:41:45:68 | nameStr | this user input |
+| JndiInjection.java:66:16:66:22 | nameStr | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:66:16:66:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:67:20:67:26 | nameStr | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:67:20:67:26 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:68:16:68:22 | nameStr | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:68:16:68:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:69:14:69:20 | nameStr | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:69:14:69:20 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:70:22:70:28 | nameStr | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:70:22:70:28 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:72:16:72:19 | name | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:72:16:72:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:73:20:73:23 | name | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:73:20:73:23 | name | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:74:16:74:19 | name | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:74:16:74:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:75:14:75:17 | name | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:75:14:75:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:76:22:76:25 | name | JndiInjection.java:62:42:62:69 | nameStr : String | JndiInjection.java:76:22:76:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:62:42:62:69 | nameStr | this user input |
+| JndiInjection.java:82:16:82:22 | nameStr | JndiInjection.java:79:42:79:69 | nameStr : String | JndiInjection.java:82:16:82:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:79:42:79:69 | nameStr | this user input |
+| JndiInjection.java:83:16:83:22 | nameStr | JndiInjection.java:79:42:79:69 | nameStr : String | JndiInjection.java:83:16:83:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:79:42:79:69 | nameStr | this user input |
+| JndiInjection.java:90:16:90:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:90:16:90:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:91:23:91:29 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:91:23:91:29 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:92:18:92:21 | name | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:92:18:92:21 | name | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:93:16:93:19 | name | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:93:16:93:19 | name | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:94:14:94:17 | name | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:94:14:94:17 | name | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:95:22:95:25 | name | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:95:22:95:25 | name | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:96:16:96:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:96:16:96:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:98:16:98:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:98:16:98:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:99:16:99:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:99:16:99:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:100:16:100:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:100:16:100:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:101:16:101:22 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:101:16:101:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:103:25:103:31 | nameStr | JndiInjection.java:86:42:86:69 | nameStr : String | JndiInjection.java:103:25:103:31 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:86:42:86:69 | nameStr | this user input |
+| JndiInjection.java:109:16:109:22 | nameStr | JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:109:16:109:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:106:41:106:68 | nameStr | this user input |
+| JndiInjection.java:110:16:110:22 | nameStr | JndiInjection.java:106:41:106:68 | nameStr : String | JndiInjection.java:110:16:110:22 | nameStr | JNDI lookup might include name from $@. | JndiInjection.java:106:41:106:68 | nameStr | this user input |
+| JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:114:33:114:57 | new JMXServiceURL(...) | JNDI lookup might include name from $@. | JndiInjection.java:113:37:113:63 | urlStr | this user input |
+| JndiInjection.java:118:5:118:13 | connector | JndiInjection.java:113:37:113:63 | urlStr : String | JndiInjection.java:118:5:118:13 | connector | JNDI lookup might include name from $@. | JndiInjection.java:113:37:113:63 | urlStr | this user input |
+| JndiInjection.java:125:24:125:26 | env | JndiInjection.java:121:27:121:53 | urlStr : String | JndiInjection.java:125:24:125:26 | env | JNDI lookup might include name from $@. | JndiInjection.java:121:27:121:53 | urlStr | this user input |
+| JndiInjection.java:132:27:132:29 | env | JndiInjection.java:128:27:128:53 | urlStr : String | JndiInjection.java:132:27:132:29 | env | JNDI lookup might include name from $@. | JndiInjection.java:128:27:128:53 | urlStr | this user input |
+| JndiInjection.java:139:22:139:26 | props | JndiInjection.java:135:52:135:78 | urlStr : String | JndiInjection.java:139:22:139:26 | props | JNDI lookup might include name from $@. | JndiInjection.java:135:52:135:78 | urlStr | this user input |
+| JndiInjection.java:146:22:146:26 | props | JndiInjection.java:142:52:142:78 | urlStr : String | JndiInjection.java:146:22:146:26 | props | JNDI lookup might include name from $@. | JndiInjection.java:142:52:142:78 | urlStr | this user input |
+| JndiInjection.java:154:29:154:33 | props | JndiInjection.java:149:52:149:78 | urlStr : String | JndiInjection.java:154:29:154:33 | props | JNDI lookup might include name from $@. | JndiInjection.java:149:52:149:78 | urlStr | this user input |

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
@@ -1,0 +1,78 @@
+import javax.naming.CompositeName;
+import javax.naming.InitialContext;
+import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
+
+import org.springframework.jndi.JndiTemplate;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public class JndiInjection {
+  public void testInitialContextBad1(@RequestParam String nameStr) throws NamingException {
+    Name name = new CompositeName(nameStr);
+    InitialContext ctx = new InitialContext();
+
+    ctx.lookup(nameStr);
+    ctx.lookupLink(nameStr);
+    InitialContext.doLookup(nameStr);
+    ctx.rename(nameStr, "");
+    ctx.list(nameStr);
+    ctx.listBindings(nameStr);
+
+    ctx.lookup(name);
+    ctx.lookupLink(name);
+    InitialContext.doLookup(name);
+    ctx.rename(name, null);
+    ctx.list(name);
+    ctx.listBindings(name);
+  }
+
+  public void testInitialDirContextBad1(@RequestParam String nameStr) throws NamingException {
+    Name name = new CompositeName(nameStr);
+    InitialDirContext ctx = new InitialDirContext();
+
+    ctx.lookup(nameStr);
+    ctx.lookupLink(nameStr);
+    ctx.rename(nameStr, "");
+    ctx.list(nameStr);
+    ctx.listBindings(nameStr);
+
+    ctx.lookup(name);
+    ctx.lookupLink(name);
+    ctx.rename(name, null);
+    ctx.list(name);
+    ctx.listBindings(name);
+  }
+
+  public void testInitialLdapContextBad1(@RequestParam String nameStr) throws NamingException {
+    Name name = new CompositeName(nameStr);
+    InitialLdapContext ctx = new InitialLdapContext();
+
+    ctx.lookup(nameStr);
+    ctx.lookupLink(nameStr);
+    ctx.rename(nameStr, "");
+    ctx.list(nameStr);
+    ctx.listBindings(nameStr);
+
+    ctx.lookup(name);
+    ctx.lookupLink(name);
+    ctx.rename(name, null);
+    ctx.list(name);
+    ctx.listBindings(name);
+  }
+
+  public void testSpringJndiTemplateBad1(@RequestParam String nameStr) throws NamingException {
+    JndiTemplate ctx = new JndiTemplate();
+
+    ctx.lookup(nameStr);
+    ctx.lookup(nameStr, null);
+  }
+
+  public void testShiroJndiTemplateBad1(@RequestParam String nameStr) throws NamingException {
+    org.apache.shiro.jndi.JndiTemplate ctx = new org.apache.shiro.jndi.JndiTemplate();
+
+    ctx.lookup(nameStr);
+    ctx.lookup(nameStr, null);
+  }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
@@ -1,3 +1,8 @@
+import java.io.IOException;
+
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
 import javax.naming.CompositeName;
 import javax.naming.InitialContext;
 import javax.naming.Name;
@@ -6,6 +11,7 @@ import javax.naming.directory.InitialDirContext;
 import javax.naming.ldap.InitialLdapContext;
 
 import org.springframework.jndi.JndiTemplate;
+import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.web.bind.annotation.RequestParam;
 
 public class JndiInjection {
@@ -69,10 +75,25 @@ public class JndiInjection {
     ctx.lookup(nameStr, null);
   }
 
+  public void testSpringLdapTemplateBad1(@RequestParam String nameStr) throws NamingException {
+    LdapTemplate ctx = new LdapTemplate();
+
+    ctx.lookup(nameStr);
+    ctx.lookupContext(nameStr);
+  }
+
   public void testShiroJndiTemplateBad1(@RequestParam String nameStr) throws NamingException {
     org.apache.shiro.jndi.JndiTemplate ctx = new org.apache.shiro.jndi.JndiTemplate();
 
     ctx.lookup(nameStr);
     ctx.lookup(nameStr, null);
+  }
+
+  public void testJMXServiceUrlBad1(@RequestParam String urlStr) throws IOException {
+    JMXConnectorFactory.connect(new JMXServiceURL(urlStr));
+
+    JMXServiceURL url = new JMXServiceURL(urlStr);
+    JMXConnector connector = JMXConnectorFactory.newJMXConnector(url, null);
+    connector.connect();
   }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.java
@@ -174,4 +174,18 @@ public class JndiInjection {
 
     ctx.searchForObject(nameStr, "", new SearchControls(), (ContextMapper) new Object());
   }
+
+  public void testEnvOk1(@RequestParam String urlStr) throws NamingException {
+    Hashtable<String, String> env = new Hashtable<String, String>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.rmi.registry.RegistryContextFactory");
+    env.put(Context.SECURITY_PRINCIPAL, urlStr);
+    new InitialContext(env);
+  }
+
+  public void testEnvOk2(@RequestParam String urlStr) throws NamingException {
+    Hashtable<String, String> env = new Hashtable<String, String>();
+    env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.rmi.registry.RegistryContextFactory");
+    env.put("java.naming.security.principal", urlStr);
+    new InitialContext(env);
+  }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-074/JndiInjection.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/JndiInjection.qlref
@@ -1,1 +1,1 @@
-Security/CWE/CWE-074/JndiInjection.ql
+experimental/Security/CWE/CWE-074/JndiInjection.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-074/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/shiro-core-1.5.2
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/shiro-core-1.5.2:${testdir}/../../../stubs/spring-ldap-2.3.2

--- a/java/ql/test/experimental/query-tests/security/CWE-074/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-074/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.2.3:${testdir}/../../../stubs/shiro-core-1.5.2

--- a/java/ql/test/experimental/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiTemplate.java
+++ b/java/ql/test/experimental/stubs/shiro-core-1.5.2/org/apache/shiro/jndi/JndiTemplate.java
@@ -1,0 +1,13 @@
+package org.apache.shiro.jndi;
+
+import javax.naming.NamingException;
+
+public class JndiTemplate {
+  public Object lookup(final String name) throws NamingException {
+    return new Object();
+  }
+  
+  public Object lookup(String name, Class requiredType) throws NamingException {
+    return new Object();
+  }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributesMapper.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/AttributesMapper.java
@@ -1,0 +1,3 @@
+package org.springframework.ldap.core;
+
+public interface AttributesMapper<T> {}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextMapper.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/ContextMapper.java
@@ -1,0 +1,4 @@
+package org.springframework.ldap.core;
+
+public interface ContextMapper<T> {
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextOperations.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextOperations.java
@@ -1,0 +1,4 @@
+package org.springframework.ldap.core;
+
+public interface DirContextOperations {
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextProcessor.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/DirContextProcessor.java
@@ -1,0 +1,3 @@
+package org.springframework.ldap.core;
+
+public interface DirContextProcessor {}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapOperations.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapOperations.java
@@ -1,0 +1,3 @@
+package org.springframework.ldap.core;
+
+public interface LdapOperations {}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
@@ -1,5 +1,7 @@
 package org.springframework.ldap.core;
 
+import org.springframework.beans.factory.InitializingBean;
+
 import java.util.*;
 
 import javax.naming.Name;
@@ -9,7 +11,7 @@ import org.springframework.ldap.filter.Filter;
 
 import org.springframework.ldap.query.LdapQuery;
 
-public class LdapTemplate {
+public class LdapTemplate implements LdapOperations, InitializingBean {
   public void authenticate(LdapQuery query, String password) { }
 
   public boolean authenticate(Name base, String filter, String password) { return true; }
@@ -22,11 +24,53 @@ public class LdapTemplate {
 
   public void search(String base, String filter, int searchScope, boolean returningObjFlag, NameClassPairCallbackHandler handler) { }
 
+  public void search(final String base, final String filter, final SearchControls controls, NameClassPairCallbackHandler handler) {}
+
+  public void search(final String base, final String filter, final SearchControls controls,	NameClassPairCallbackHandler handler, DirContextProcessor processor) {}
+
+  public void search(String base, String filter, NameClassPairCallbackHandler handler) {}
+
+  public <T> List<T> search(String base, String filter, int searchScope, String[] attrs, AttributesMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, int searchScope, AttributesMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, AttributesMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, int searchScope, String[] attrs, ContextMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, int searchScope, ContextMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, ContextMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, SearchControls controls, ContextMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, SearchControls controls, AttributesMapper<T> mapper) { return null; }
+
+  public <T> List<T> search(String base, String filter, SearchControls controls, AttributesMapper<T> mapper, DirContextProcessor processor) { return null; }
+
+  public <T> List<T> search(String base, String filter, SearchControls controls, ContextMapper<T> mapper,	DirContextProcessor processor) { return null; }
+
   public DirContextOperations searchForContext(LdapQuery query) { return null; }
 
   public <T> T searchForObject(Name base, String filter, ContextMapper<T> mapper) { return null; }
 
+  public <T> T searchForObject(String base, String filter, ContextMapper<T> mapper) { return null; }
+
+  public <T> T searchForObject(String base, String filter, SearchControls searchControls, ContextMapper<T> mapper) { return null; }
+
   public Object lookup(final String dn) { return new Object(); }
 
   public DirContextOperations lookupContext(String dn) { return null; }
+
+  public <T> T findByDn(Name dn, final Class<T> clazz) { return null; }
+
+  public void rename(final Name oldDn, final Name newDn) {}
+
+  public List<String> list(final Name base) { return null; }
+
+  public List<String> listBindings(final Name base) { return null; }
+
+  public void unbind(final String dn) {}
+
+  public void unbind(final String dn, boolean recursive) {}
 }

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/LdapTemplate.java
@@ -1,0 +1,32 @@
+package org.springframework.ldap.core;
+
+import java.util.*;
+
+import javax.naming.Name;
+import javax.naming.directory.SearchControls;
+
+import org.springframework.ldap.filter.Filter;
+
+import org.springframework.ldap.query.LdapQuery;
+
+public class LdapTemplate {
+  public void authenticate(LdapQuery query, String password) { }
+
+  public boolean authenticate(Name base, String filter, String password) { return true; }
+
+  public <T> List<T> find(Name base, Filter filter, SearchControls searchControls, final Class<T> clazz) { return null; }
+
+  public <T> List<T> find(LdapQuery query, Class<T> clazz) { return null; }
+
+  public <T> T findOne(LdapQuery query, Class<T> clazz) { return null; }
+
+  public void search(String base, String filter, int searchScope, boolean returningObjFlag, NameClassPairCallbackHandler handler) { }
+
+  public DirContextOperations searchForContext(LdapQuery query) { return null; }
+
+  public <T> T searchForObject(Name base, String filter, ContextMapper<T> mapper) { return null; }
+
+  public Object lookup(final String dn) { return new Object(); }
+
+  public DirContextOperations lookupContext(String dn) { return null; }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairCallbackHandler.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/core/NameClassPairCallbackHandler.java
@@ -1,0 +1,3 @@
+package org.springframework.ldap.core;
+
+public interface NameClassPairCallbackHandler { }

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/EqualsFilter.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/EqualsFilter.java
@@ -1,0 +1,5 @@
+package org.springframework.ldap.filter;
+
+public class EqualsFilter implements Filter {
+  public EqualsFilter(String attribute, String value) { }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/Filter.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/Filter.java
@@ -1,0 +1,4 @@
+package org.springframework.ldap.filter;
+
+public interface Filter {
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/HardcodedFilter.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/filter/HardcodedFilter.java
@@ -1,0 +1,7 @@
+package org.springframework.ldap.filter;
+
+public class HardcodedFilter implements Filter {
+  public HardcodedFilter(String filter) { }
+  public StringBuffer encode(StringBuffer buff) { return buff; }
+  public String toString() { return ""; }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/ConditionCriteria.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/ConditionCriteria.java
@@ -1,0 +1,5 @@
+package org.springframework.ldap.query;
+
+public interface ConditionCriteria {
+  ContainerCriteria is(String value);
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/ContainerCriteria.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/ContainerCriteria.java
@@ -1,0 +1,4 @@
+package org.springframework.ldap.query;
+
+public interface ContainerCriteria extends LdapQuery {
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQuery.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQuery.java
@@ -1,0 +1,4 @@
+package org.springframework.ldap.query;
+
+public interface LdapQuery {
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQueryBuilder.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/query/LdapQueryBuilder.java
@@ -1,0 +1,14 @@
+package org.springframework.ldap.query;
+
+import javax.naming.Name;
+import org.springframework.ldap.filter.Filter;
+
+public class LdapQueryBuilder {
+  public static LdapQueryBuilder query() { return null; }
+  public LdapQuery filter(String hardcodedFilter) { return null; }
+  public LdapQuery filter(Filter filter) { return null; }
+  public LdapQuery filter(String filterFormat, Object... params) { return null; }
+  public LdapQueryBuilder base(String baseDn) { return this; }
+  public Name base() { return null; }
+  public ConditionCriteria where(String attribute) { return null; }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapEncoder.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapEncoder.java
@@ -1,0 +1,5 @@
+package org.springframework.ldap.support;
+
+public class LdapEncoder {
+  public static String filterEncode(String value) { return null; }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapNameBuilder.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapNameBuilder.java
@@ -1,0 +1,12 @@
+package org.springframework.ldap.support;
+
+import javax.naming.ldap.LdapName;
+
+public class LdapNameBuilder {
+  public static LdapNameBuilder newInstance() { return null; }
+  public static LdapNameBuilder newInstance(String name) { return null; }
+
+  public LdapNameBuilder add(String name) { return null; }
+  public LdapNameBuilder add(String key, Object value) { return null; }
+  public LdapName build() { return null; }
+}

--- a/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapUtils.java
+++ b/java/ql/test/experimental/stubs/spring-ldap-2.3.2/org/springframework/ldap/support/LdapUtils.java
@@ -1,0 +1,7 @@
+package org.springframework.ldap.support;
+
+import javax.naming.ldap.LdapName;
+
+public class LdapUtils {
+  public static LdapName newLdapName(String distinguishedName) { return null; }
+}

--- a/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/beans/factory/InitializingBean.java
+++ b/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/beans/factory/InitializingBean.java
@@ -1,0 +1,3 @@
+package org.springframework.beans.factory;
+
+public interface InitializingBean {}

--- a/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/jndi/JndiTemplate.java
+++ b/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/jndi/JndiTemplate.java
@@ -1,8 +1,13 @@
 package org.springframework.jndi;
 
+import java.util.Properties;
 import javax.naming.NamingException;
 
 public class JndiTemplate {
+	public JndiTemplate() {}
+
+	public JndiTemplate(Properties environment) {}
+
   public Object lookup(final String name) throws NamingException {
 		return new Object();
 	}
@@ -10,5 +15,7 @@ public class JndiTemplate {
 	@SuppressWarnings("unchecked")
 	public <T> T lookup(String name, Class<T> requiredType) throws NamingException {
 		return (T) new Object();
-  }
+	}
+	
+	public void setEnvironment(Properties environment) {}
 }

--- a/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/jndi/JndiTemplate.java
+++ b/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/jndi/JndiTemplate.java
@@ -1,0 +1,14 @@
+package org.springframework.jndi;
+
+import javax.naming.NamingException;
+
+public class JndiTemplate {
+  public Object lookup(final String name) throws NamingException {
+		return new Object();
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T lookup(String name, Class<T> requiredType) throws NamingException {
+		return (T) new Object();
+  }
+}

--- a/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestParam.java
+++ b/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/web/bind/annotation/RequestParam.java
@@ -1,0 +1,8 @@
+package org.springframework.web.bind.annotation;
+
+import java.lang.annotation.*;
+
+@Target(value=ElementType.PARAMETER)
+@Retention(value=RetentionPolicy.RUNTIME)
+@Documented
+public @interface RequestParam { }


### PR DESCRIPTION
This PR adds a query to detect JNDI injections. It flags the code where user-provided input is used in JNDI lookup:

```java
public void jndiLookup(HttpServletRequest request) throws NamingException {
  String name = request.getParameter("name");

  Hashtable<String, String> env = new Hashtable<String, String>();
  env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.rmi.registry.RegistryContextFactory");
  env.put(Context.PROVIDER_URL, "rmi://trusted-server:1099");
  InitialContext ctx = new InitialContext(env);

  // BAD: User input used in lookup
  ctx.lookup(name);
}
```
It also supports Spring's and Apache Shiro's `JndiTemplate`.

If the name being used to look up the data is controlled by the user, it can point to a
malicious server, which can return an arbitrary object. In the worst case, this can allow remote
code execution.

The tests and required `qlpack.yml` in `src/experimental` and `test/experimental` are also included.