### PR TITLE
Add queries for VS Code jump-to-definition

### DIFF
--- a/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
+++ b/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
@@ -12,3 +12,8 @@
       - Critical/FileNeverClosed.ql
       - Critical/MemoryMayNotBeFreed.ql
       - Critical/MemoryNeverFreed.ql
+# These are only for IDE use.
+- exclude:
+    tags contain:
+      - ide-contextual-queries/local-definitions
+      - ide-contextual-queries/local-references

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -132,7 +132,8 @@ private predicate constructorCallTypeMention(ConstructorCall cc, TypeMention tm)
  *  - `"X"` for macro accesses
  *  - `"I"` for import / include directives
  */
-cached Top definitionOf(Top e, string kind) {
+cached
+Top definitionOf(Top e, string kind) {
   (
     // call -> function called
     kind = "M" and

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -215,5 +215,10 @@ Top definitionOf(Top e, string kind) {
   strictcount(result.getLocation()) < 10
 }
 
+/**
+ * Returns an appropriately encoded version of a filename `name`
+ * passed by the VS Code extension in order to coincide with the
+ * output of `.getFile()` on locatable entities.
+ */
 cached
 File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -132,7 +132,7 @@ private predicate constructorCallTypeMention(ConstructorCall cc, TypeMention tm)
  *  - `"X"` for macro accesses
  *  - `"I"` for import / include directives
  */
-Top definitionOf(Top e, string kind) {
+cached Top definitionOf(Top e, string kind) {
   (
     // call -> function called
     kind = "M" and

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -214,3 +214,6 @@ Top definitionOf(Top e, string kind) {
   // later on.
   strictcount(result.getLocation()) < 10
 }
+
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -11,11 +11,8 @@ import definitions
 
 external string selectedSourceFile();
 
-cached File getEncodedFile(string name) {
-        result.getAbsolutePath().replaceAll(":", "_") = name
-}
-
-
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
 
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -3,7 +3,7 @@
  * @description Generates use-definition pairs that provide the data
  *              for jump-to-definition in the code viewer.
  * @kind definitions
- * @id cpp/jump-to-definition
+ * @id cpp/ide-jump-to-definition
  * @tags ide-contextual-queries/local-definitions
  */
 

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -4,6 +4,7 @@
  *              for jump-to-definition in the code viewer.
  * @kind definitions
  * @id cpp/jump-to-definition
+ * @tags local-definitions
  */
 
 import definitions

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -11,9 +11,6 @@ import definitions
 
 external string selectedSourceFile();
 
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
-
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Jump-to-definition links
+ * @description Generates use-definition pairs that provide the data
+ *              for jump-to-definition in the code viewer.
+ * @kind definitions
+ * @id cpp/jump-to-definition
+ */
+
+import definitions
+
+external string selectedSourceFile();
+
+cached File getEncodedFile(string name) {
+        result.getAbsolutePath().replaceAll(":", "_") = name
+}
+
+
+
+from Top e, Top def, string kind
+where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+select e, def, kind

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -4,7 +4,7 @@
  *              for jump-to-definition in the code viewer.
  * @kind definitions
  * @id cpp/jump-to-definition
- * @tags local-definitions
+ * @tags ide-contextual-queries/local-definitions
  */
 
 import definitions

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -11,9 +11,6 @@ import definitions
 
 external string selectedSourceFile();
 
-cached
-File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
-
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -4,6 +4,7 @@
  *              for jump-to-definition in the code viewer.
  * @kind definitions
  * @id cpp/jump-to-definition
+ * @tags local-references
  */
 
 import definitions
@@ -11,10 +12,8 @@ import definitions
 external string selectedSourceFile();
 
 cached File getEncodedFile(string name) {
-        result.getAbsolutePath().replaceAll(":", "_") = name
+  result.getAbsolutePath().replaceAll(":", "_") = name
 }
-
-
 
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -3,7 +3,7 @@
  * @description Generates use-definition pairs that provide the data
  *              for jump-to-definition in the code viewer.
  * @kind definitions
- * @id cpp/jump-to-definition
+ * @id cpp/ide-find-references
  * @tags ide-contextual-queries/local-references
  */
 

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -1,7 +1,7 @@
 /**
- * @name Jump-to-definition links
+ * @name Find-references links
  * @description Generates use-definition pairs that provide the data
- *              for jump-to-definition in the code viewer.
+ *              for find-references in the code viewer.
  * @kind definitions
  * @id cpp/ide-find-references
  * @tags ide-contextual-queries/local-references

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Jump-to-definition links
+ * @description Generates use-definition pairs that provide the data
+ *              for jump-to-definition in the code viewer.
+ * @kind definitions
+ * @id cpp/jump-to-definition
+ */
+
+import definitions
+
+external string selectedSourceFile();
+
+cached File getEncodedFile(string name) {
+        result.getAbsolutePath().replaceAll(":", "_") = name
+}
+
+
+
+from Top e, Top def, string kind
+where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+select e, def, kind

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -4,7 +4,7 @@
  *              for jump-to-definition in the code viewer.
  * @kind definitions
  * @id cpp/jump-to-definition
- * @tags local-references
+ * @tags ide-contextual-queries/local-references
  */
 
 import definitions

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -11,9 +11,8 @@ import definitions
 
 external string selectedSourceFile();
 
-cached File getEncodedFile(string name) {
-  result.getAbsolutePath().replaceAll(":", "_") = name
-}
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }
 
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())


### PR DESCRIPTION
The tags on these queries are a tentative proposal for how to signal to the vscode extension that they are the right template queries to run for jump-to-definition and find-references. I am very open to anything from bikeshedding their exact names, to arguments for using other mechanisms instead of tags.