### PR TITLE
Data flow: Support stores into nodes that are not `PostUpdateNode`s

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -415,8 +415,7 @@ class CastingNode extends Node {
   CastingNode() {
     this instanceof ParameterNode or
     this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+    this instanceof OutNodeExt
   }
 }
 
@@ -565,6 +564,18 @@ class ReturnNodeExt extends Node {
 }
 
 /**
+ * A node to which data can flow from a call. Either an ordinary out node
+ * or a post-update node associated with a call argument.
+ */
+class OutNodeExt extends Node {
+  OutNodeExt() {
+    this instanceof OutNode
+    or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+/**
  * An extended return kind. A return kind describes how data can be returned
  * from a callable. This can either be through a returned value or an updated
  * parameter.
@@ -574,7 +585,7 @@ abstract class ReturnKindExt extends TReturnKindExt {
   abstract string toString();
 
   /** Gets a node corresponding to data flow out of `call`. */
-  abstract Node getAnOutNode(DataFlowCall call);
+  abstract OutNodeExt getAnOutNode(DataFlowCall call);
 }
 
 class ValueReturnKind extends ReturnKindExt, TValueReturn {
@@ -586,7 +597,9 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 
   override string toString() { result = kind.toString() }
 
-  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
+    result = getAnOutNode(call, this.getKind())
+  }
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
@@ -598,9 +611,9 @@ class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
 
   override string toString() { result = "param update " + pos }
 
-  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
     exists(ArgumentNode arg |
-      result.getPreUpdateNode() = arg and
+      result.(PostUpdateNode).getPreUpdateNode() = arg and
       arg.argumentOf(call, this.getPosition())
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -415,8 +415,7 @@ class CastingNode extends Node {
   CastingNode() {
     this instanceof ParameterNode or
     this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+    this instanceof OutNodeExt
   }
 }
 
@@ -565,6 +564,18 @@ class ReturnNodeExt extends Node {
 }
 
 /**
+ * A node to which data can flow from a call. Either an ordinary out node
+ * or a post-update node associated with a call argument.
+ */
+class OutNodeExt extends Node {
+  OutNodeExt() {
+    this instanceof OutNode
+    or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+/**
  * An extended return kind. A return kind describes how data can be returned
  * from a callable. This can either be through a returned value or an updated
  * parameter.
@@ -574,7 +585,7 @@ abstract class ReturnKindExt extends TReturnKindExt {
   abstract string toString();
 
   /** Gets a node corresponding to data flow out of `call`. */
-  abstract Node getAnOutNode(DataFlowCall call);
+  abstract OutNodeExt getAnOutNode(DataFlowCall call);
 }
 
 class ValueReturnKind extends ReturnKindExt, TValueReturn {
@@ -586,7 +597,9 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 
   override string toString() { result = kind.toString() }
 
-  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
+    result = getAnOutNode(call, this.getKind())
+  }
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
@@ -598,9 +611,9 @@ class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
 
   override string toString() { result = "param update " + pos }
 
-  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
     exists(ArgumentNode arg |
-      result.getPreUpdateNode() = arg and
+      result.(PostUpdateNode).getPreUpdateNode() = arg and
       arg.argumentOf(call, this.getPosition())
     )
   }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -415,8 +415,7 @@ class CastingNode extends Node {
   CastingNode() {
     this instanceof ParameterNode or
     this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+    this instanceof OutNodeExt
   }
 }
 
@@ -565,6 +564,18 @@ class ReturnNodeExt extends Node {
 }
 
 /**
+ * A node to which data can flow from a call. Either an ordinary out node
+ * or a post-update node associated with a call argument.
+ */
+class OutNodeExt extends Node {
+  OutNodeExt() {
+    this instanceof OutNode
+    or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+/**
  * An extended return kind. A return kind describes how data can be returned
  * from a callable. This can either be through a returned value or an updated
  * parameter.
@@ -574,7 +585,7 @@ abstract class ReturnKindExt extends TReturnKindExt {
   abstract string toString();
 
   /** Gets a node corresponding to data flow out of `call`. */
-  abstract Node getAnOutNode(DataFlowCall call);
+  abstract OutNodeExt getAnOutNode(DataFlowCall call);
 }
 
 class ValueReturnKind extends ReturnKindExt, TValueReturn {
@@ -586,7 +597,9 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 
   override string toString() { result = kind.toString() }
 
-  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
+    result = getAnOutNode(call, this.getKind())
+  }
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
@@ -598,9 +611,9 @@ class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
 
   override string toString() { result = "param update " + pos }
 
-  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
     exists(ArgumentNode arg |
-      result.getPreUpdateNode() = arg and
+      result.(PostUpdateNode).getPreUpdateNode() = arg and
       arg.argumentOf(call, this.getPosition())
     )
   }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1060,8 +1060,8 @@ private module LocalFlowBigStep {
       jumpStep(_, node, config) or
       additionalJumpStep(_, node, config) or
       node instanceof ParameterNode or
-      node instanceof OutNode or
-      node instanceof PostUpdateNode or
+      node instanceof OutNodeExt or
+      store(_, _, node) or
       read(_, _, node) or
       node instanceof CastNode
     )

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -415,8 +415,7 @@ class CastingNode extends Node {
   CastingNode() {
     this instanceof ParameterNode or
     this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+    this instanceof OutNodeExt
   }
 }
 
@@ -565,6 +564,18 @@ class ReturnNodeExt extends Node {
 }
 
 /**
+ * A node to which data can flow from a call. Either an ordinary out node
+ * or a post-update node associated with a call argument.
+ */
+class OutNodeExt extends Node {
+  OutNodeExt() {
+    this instanceof OutNode
+    or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+/**
  * An extended return kind. A return kind describes how data can be returned
  * from a callable. This can either be through a returned value or an updated
  * parameter.
@@ -574,7 +585,7 @@ abstract class ReturnKindExt extends TReturnKindExt {
   abstract string toString();
 
   /** Gets a node corresponding to data flow out of `call`. */
-  abstract Node getAnOutNode(DataFlowCall call);
+  abstract OutNodeExt getAnOutNode(DataFlowCall call);
 }
 
 class ValueReturnKind extends ReturnKindExt, TValueReturn {
@@ -586,7 +597,9 @@ class ValueReturnKind extends ReturnKindExt, TValueReturn {
 
   override string toString() { result = kind.toString() }
 
-  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
+    result = getAnOutNode(call, this.getKind())
+  }
 }
 
 class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
@@ -598,9 +611,9 @@ class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
 
   override string toString() { result = "param update " + pos }
 
-  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+  override OutNodeExt getAnOutNode(DataFlowCall call) {
     exists(ArgumentNode arg |
-      result.getPreUpdateNode() = arg and
+      result.(PostUpdateNode).getPreUpdateNode() = arg and
       arg.argumentOf(call, this.getPosition())
     )
   }


### PR DESCRIPTION
Stores are currently restricted to target `PostUpdateNode`s (or any other node in `localFlowEntry()`, such as `OutNode`s). However, for C# we are about to model collection-flow using field-flow, so for example
```
new string[] { "taint" };
```
will be considered a store from `"taint"` into the created array, which is not a `PostUpdateNode`.

~(This PR will conflict with https://github.com/Semmle/ql/pull/3110, which renames `storeDirect` to `store`.)~ Merge conflict resolved by rebasing onto latest `master`.