### PR TITLE
Java: Add a query for MVEL injections

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.qhelp
@@ -23,6 +23,7 @@ The following example uses untrusted data to build a MVEL expression
 and then runs it in the default powerfull context.
 </p>
 <sample src="UnsafeMvelExpressionEvaluation.java" />
+</example>
 
 <references>
 <li>

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.qhelp
@@ -1,0 +1,37 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+MVEL is an expression language based on Java-syntax. 
+The language offers many features
+including invocation of methods available in the JVM.
+If a MVEL expression is built using attacker-controlled data, 
+and then evaluated, then it may allow the attacker to run arbitrary code.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Including user input in a MVEL expression should be avoided.
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example uses untrusted data to build a MVEL expression
+and then runs it in the default powerfull context.
+</p>
+<sample src="UnsafeMvelExpressionEvaluation.java" />
+
+<references>
+<li>
+  MVEL Documentation:
+  <a href="http://mvel.documentnode.com/">Language Guide for 2.0</a>.
+</li>
+<li>
+  OWASP:
+  <a href="https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection">Expression Language Injection</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjection.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Expression language injection (MVEL)
+ * @description Evaluation of a user-controlled MVEL expression
+ *              may lead to remote code execution.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/mvel-expression-injection
+ * @tags security
+ *       external/cwe/cwe-094
+ */
+
+import java
+import MvelInjectionLib
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, MvelInjectionConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "MVEL injection from $@.", source.getNode(), "this user input"

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -37,7 +37,8 @@ class MvelEvaluationSink extends DataFlow::ExprNode {
       (
         m instanceof ExecutableStatementEvaluationMethod or
         m instanceof CompiledExpressionEvaluationMethod or
-        m instanceof CompiledAccExpressionEvaluationMethod
+        m instanceof CompiledAccExpressionEvaluationMethod or
+        m instanceof AccessorEvaluationMethod
       ) and
       (ma = asExpr() or ma.getQualifier() = asExpr())
     )
@@ -159,6 +160,16 @@ class CompiledAccExpressionEvaluationMethod extends Method {
   }
 }
 
+/**
+ * Methods in `Accessor` that trigger evaluating a MVEL expression.
+ */
+class AccessorEvaluationMethod extends Method {
+  AccessorEvaluationMethod() {
+    getDeclaringType() instanceof Accessor and
+    hasName("getValue")
+  }
+}
+
 class MVEL extends RefType {
   MVEL() { hasQualifiedName("org.mvel2", "MVEL") }
 }
@@ -177,4 +188,8 @@ class CompiledExpression extends RefType {
 
 class CompiledAccExpression extends RefType {
   CompiledAccExpression() { hasQualifiedName("org.mvel2.compiler", "CompiledAccExpression") }
+}
+
+class Accessor extends RefType {
+  Accessor() { hasQualifiedName("org.mvel2.compiler", "Accessor") }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -100,10 +100,6 @@ predicate createCompiledAccExpressionStep(DataFlow::Node node1, DataFlow::Node n
   )
 }
 
-predicate test() {
-  exists(ConstructorCall cc | cc.getConstructedType() instanceof CompiledAccExpression)
-}
-
 /**
  * Holds if `node1` to `node2` is a dataflow step that compiles a MVEL expression
  * by calling `ExpressionCompiler.compile()`.

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -1,7 +1,6 @@
 import java
 import semmle.code.java.dataflow.FlowSources
 import semmle.code.java.dataflow.TaintTracking
-import DataFlow::PathGraph
 
 /**
  * A taint-tracking configuration for unsafe user input
@@ -54,7 +53,7 @@ class MvelEvaluationSink extends DataFlow::ExprNode {
         m instanceof CompiledScriptEvaluationMethod or
         m instanceof MvelCompiledScriptEvaluationMethod
       ) and
-      (ma = asExpr() or ma.getQualifier() = asExpr())
+      ma.getQualifier() = asExpr()
     )
     or
     exists(StaticMethodAccess ma, Method m | m = ma.getMethod() |
@@ -73,7 +72,7 @@ predicate expressionCompilationStep(DataFlow::Node node1, DataFlow::Node node2) 
     m.getDeclaringType() instanceof MVEL and
     m.hasName("compileExpression") and
     ma.getAnArgument() = node1.asExpr() and
-    (node2.asExpr() = ma.getQualifier() or node2.asExpr() = ma)
+    node2.asExpr() = ma
   )
 }
 
@@ -84,7 +83,7 @@ predicate expressionCompilationStep(DataFlow::Node node1, DataFlow::Node node2) 
 predicate createExpressionCompilerStep(DataFlow::Node node1, DataFlow::Node node2) {
   exists(ConstructorCall cc |
     cc.getConstructedType() instanceof ExpressionCompiler and
-    (cc = node2.asExpr() or cc.getQualifier() = node2.asExpr()) and
+    cc = node2.asExpr() and
     cc.getArgument(0) = node1.asExpr()
   )
 }
@@ -96,7 +95,7 @@ predicate createExpressionCompilerStep(DataFlow::Node node1, DataFlow::Node node
 predicate createCompiledAccExpressionStep(DataFlow::Node node1, DataFlow::Node node2) {
   exists(ConstructorCall cc |
     cc.getConstructedType() instanceof CompiledAccExpression and
-    (cc = node2.asExpr() or cc.getQualifier() = node2.asExpr()) and
+    cc = node2.asExpr() and
     cc.getArgument(0) = node1.asExpr()
   )
 }
@@ -125,7 +124,7 @@ predicate expressionCompilerCompileStep(DataFlow::Node node1, DataFlow::Node nod
 predicate scriptCompileStep(DataFlow::Node node1, DataFlow::Node node2) {
   exists(MethodAccess ma, Method m | ma.getMethod() = m |
     m instanceof MvelScriptEngineCompilationMethod and
-    (ma = node2.asExpr() or ma.getQualifier() = node2.asExpr()) and
+    ma = node2.asExpr() and
     ma.getArgument(0) = node1.asExpr()
   )
 }
@@ -137,7 +136,7 @@ predicate scriptCompileStep(DataFlow::Node node1, DataFlow::Node node2) {
 predicate createMvelCompiledScriptStep(DataFlow::Node node1, DataFlow::Node node2) {
   exists(ConstructorCall cc |
     cc.getConstructedType() instanceof MvelCompiledScript and
-    (cc = node2.asExpr() or cc.getQualifier() = node2.asExpr()) and
+    cc = node2.asExpr() and
     cc.getArgument(1) = node1.asExpr()
   )
 }
@@ -149,7 +148,7 @@ predicate createMvelCompiledScriptStep(DataFlow::Node node1, DataFlow::Node node
 predicate createTemplateCompilerStep(DataFlow::Node node1, DataFlow::Node node2) {
   exists(ConstructorCall cc |
     cc.getConstructedType() instanceof TemplateCompiler and
-    (cc = node2.asExpr() or cc.getQualifier() = node2.asExpr()) and
+    cc = node2.asExpr() and
     cc.getArgument(0) = node1.asExpr()
   )
 }
@@ -167,7 +166,7 @@ predicate templateCompileStep(DataFlow::Node node1, DataFlow::Node node2) {
   or
   exists(StaticMethodAccess ma, Method m | ma.getMethod() = m |
     m instanceof TemplateCompilerCompileTemplateMethod and
-    (ma = node2.asExpr() or ma.getQualifier() = node2.asExpr()) and
+    ma = node2.asExpr() and
     ma.getArgument(0) = node1.asExpr()
   )
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -36,6 +36,11 @@ class MvelEvaluationSink extends DataFlow::ExprNode {
       m instanceof ExecutableStatementEvaluationMethod and
       (ma = asExpr() or ma.getQualifier() = asExpr())
     )
+    or
+    exists(MethodAccess ma, Method m | m = ma.getMethod() |
+      m instanceof CompiledExpressionEvaluationMethod and
+      (ma = asExpr() or ma.getQualifier() = asExpr())
+    )
   }
 }
 
@@ -118,6 +123,16 @@ class ExecutableStatementEvaluationMethod extends Method {
   }
 }
 
+/**
+ * Methods in `CompiledExpression` that trigger evaluating a MVEL expression.
+ */
+class CompiledExpressionEvaluationMethod extends Method {
+  CompiledExpressionEvaluationMethod() {
+    getDeclaringType() instanceof CompiledExpression and
+    hasName("getDirectValue")
+  }
+}
+
 class MVEL extends RefType {
   MVEL() { hasQualifiedName("org.mvel2", "MVEL") }
 }
@@ -128,4 +143,8 @@ class ExpressionCompiler extends RefType {
 
 class ExecutableStatement extends RefType {
   ExecutableStatement() { hasQualifiedName("org.mvel2.compiler", "ExecutableStatement") }
+}
+
+class CompiledExpression extends RefType {
+    CompiledExpression() { hasQualifiedName("org.mvel2.compiler", "CompiledExpression") }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -56,6 +56,11 @@ class MvelEvaluationSink extends DataFlow::ExprNode {
       ) and
       (ma = asExpr() or ma.getQualifier() = asExpr())
     )
+    or
+    exists(StaticMethodAccess ma, Method m | m = ma.getMethod() |
+      m instanceof MvelRuntimeEvaluationMethod and
+      ma.getArgument(1) = asExpr()
+    )
   }
 }
 
@@ -308,6 +313,16 @@ class MvelCompiledScriptEvaluationMethod extends Method {
   }
 }
 
+/**
+ * Methods in `MVELRuntime` that evaluate a MVEL expression.
+ */
+class MvelRuntimeEvaluationMethod extends Method {
+  MvelRuntimeEvaluationMethod() {
+    getDeclaringType() instanceof MVELRuntime and
+    hasName("execute")
+  }
+}
+
 class MVEL extends RefType {
   MVEL() { hasQualifiedName("org.mvel2", "MVEL") }
 }
@@ -350,4 +365,8 @@ class TemplateRuntime extends RefType {
 
 class TemplateCompiler extends RefType {
   TemplateCompiler() { hasQualifiedName("org.mvel2.templates", "TemplateCompiler") }
+}
+
+class MVELRuntime extends RefType {
+  MVELRuntime() { hasQualifiedName("org.mvel2", "MVELRuntime") }
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/MvelInjectionLib.qll
@@ -1,0 +1,131 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/**
+ * A taint-tracking configuration for unsafe user input
+ * that is used to construct and evaluate a MVEL expression.
+ */
+class MvelInjectionConfig extends TaintTracking::Configuration {
+  MvelInjectionConfig() { this = "MvelInjectionConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof MvelEvaluationSink }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    expressionCompilationStep(node1, node2) or
+    createExpressionCompilerStep(node1, node2) or
+    expressionCompilerCompileStep(node1, node2)
+  }
+}
+
+/**
+ * A sink for EL injection vulnerabilities via MVEL,
+ * i.e. methods that run evaluation of a MVEL expression.
+ */
+class MvelEvaluationSink extends DataFlow::ExprNode {
+  MvelEvaluationSink() {
+    exists(StaticMethodAccess ma, Method m | m = ma.getMethod() |
+      m instanceof MvelEvalMethod and
+      ma.getAnArgument() = asExpr()
+    )
+    or
+    exists(MethodAccess ma, Method m | m = ma.getMethod() |
+      m instanceof ExecutableStatementEvaluationMethod and
+      (ma = asExpr() or ma.getQualifier() = asExpr())
+    )
+  }
+}
+
+/**
+ * Holds if `node1` to `node2` is a dataflow step that compiles a MVEL expression
+ * by callilng `MVEL.compileExpression(tainted)`.
+ */
+predicate expressionCompilationStep(DataFlow::Node node1, DataFlow::Node node2) {
+  exists(StaticMethodAccess ma, Method m | ma.getMethod() = m |
+    m.getDeclaringType() instanceof MVEL and
+    m.hasName("compileExpression") and
+    ma.getAnArgument() = node1.asExpr() and
+    (node2.asExpr() = ma.getQualifier() or node2.asExpr() = ma)
+  )
+}
+
+/**
+ * Holds if `node1` to `node2` is a dataflow step creates `ExpressionCompiler`,
+ * i.e. `new ExpressionCompiler(tainted)`.
+ */
+predicate createExpressionCompilerStep(DataFlow::Node node1, DataFlow::Node node2) {
+  exists(ConstructorCall cc |
+    cc.getConstructedType() instanceof ExpressionCompiler and
+    (cc = node2.asExpr() or cc.getQualifier() = node2.asExpr()) and
+    cc.getArgument(0) = node1.asExpr()
+  )
+}
+
+/**
+ * Holds if `node1` to `node2` is a dataflow step that compiles a MVEL expression
+ * by calling `ExpressionCompiler.compile()`.
+ */
+predicate expressionCompilerCompileStep(DataFlow::Node node1, DataFlow::Node node2) {
+  exists(MethodAccess ma, Method m | ma.getMethod() = m |
+    m.getDeclaringType() instanceof ExpressionCompiler and
+    m.hasName("compile") and
+    ma = node2.asExpr() and
+    ma.getQualifier() = node1.asExpr()
+  )
+}
+
+/**
+ * Methods in the MVEL class that evaluate a MVEL expression.
+ */
+class MvelEvalMethod extends Method {
+  MvelEvalMethod() {
+    getDeclaringType() instanceof MVEL and
+    (
+      hasName("eval") or
+      hasName("executeExpression") or
+      hasName("evalToBoolean") or
+      hasName("evalToString") or
+      hasName("executeAllExpression") or
+      hasName("executeSetExpression")
+    )
+  }
+}
+
+/**
+ * Methods in `MVEL` class that compile a MVEL expression.
+ */
+class MvelCompileExpressionMethod extends Method {
+  MvelCompileExpressionMethod() {
+    getDeclaringType() instanceof MVEL and
+    (
+      hasName("compileExpression") or
+      hasName("compileGetExpression") or
+      hasName("compileSetExpression")
+    )
+  }
+}
+
+/**
+ * Methods in `ExecutableStatement` that trigger evaluating a MVEL expression.
+ */
+class ExecutableStatementEvaluationMethod extends Method {
+  ExecutableStatementEvaluationMethod() {
+    getDeclaringType() instanceof ExecutableStatement and
+    hasName("getValue")
+  }
+}
+
+class MVEL extends RefType {
+  MVEL() { hasQualifiedName("org.mvel2", "MVEL") }
+}
+
+class ExpressionCompiler extends RefType {
+  ExpressionCompiler() { hasQualifiedName("org.mvel2.compiler", "ExpressionCompiler") }
+}
+
+class ExecutableStatement extends RefType {
+  ExecutableStatement() { hasQualifiedName("org.mvel2.compiler", "ExecutableStatement") }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-094/UnsafeMvelExpressionEvaluation.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-094/UnsafeMvelExpressionEvaluation.java
@@ -1,0 +1,8 @@
+public void evaluate(Socket socket) throws IOException {
+  try (BufferedReader reader = new BufferedReader(
+    new InputStreamReader(socket.getInputStream()))) {
+  
+    String expression = reader.readLine();
+    MVEL.eval(expression);
+  }
+}

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,0 +1,15 @@
+edges
+| MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | MvelInjection.java:17:17:17:21 | input |
+| MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | MvelInjection.java:27:30:27:39 | expression |
+| MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | MvelInjection.java:38:7:38:15 | statement |
+nodes
+| MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:17:17:17:21 | input | semmle.label | input |
+| MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:27:30:27:39 | expression | semmle.label | expression |
+| MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:38:7:38:15 | statement | semmle.label | statement |
+#select
+| MvelInjection.java:17:17:17:21 | input | MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | MvelInjection.java:17:17:17:21 | input | MVEL injection from $@. | MvelInjection.java:13:27:13:49 | getInputStream(...) | this user input |
+| MvelInjection.java:27:30:27:39 | expression | MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | MvelInjection.java:27:30:27:39 | expression | MVEL injection from $@. | MvelInjection.java:22:27:22:49 | getInputStream(...) | this user input |
+| MvelInjection.java:38:7:38:15 | statement | MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | MvelInjection.java:38:7:38:15 | statement | MVEL injection from $@. | MvelInjection.java:32:27:32:49 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,19 +1,23 @@
 edges
-| MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | MvelInjection.java:18:17:18:21 | input |
-| MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | MvelInjection.java:28:30:28:39 | expression |
-| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:39:7:39:15 | statement |
-| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:16 | expression |
+| MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input |
+| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression |
+| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement |
+| MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | MvelInjection.java:52:7:52:16 | expression |
+| MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression |
 nodes
-| MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:18:17:18:21 | input | semmle.label | input |
-| MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:28:30:28:39 | expression | semmle.label | expression |
-| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:39:7:39:15 | statement | semmle.label | statement |
-| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:50:7:50:16 | expression | semmle.label | expression |
+| MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:20:17:20:21 | input | semmle.label | input |
+| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:30:30:30:39 | expression | semmle.label | expression |
+| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:41:7:41:15 | statement | semmle.label | statement |
+| MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:52:7:52:16 | expression | semmle.label | expression |
+| MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:62:7:62:16 | expression | semmle.label | expression |
 #select
-| MvelInjection.java:18:17:18:21 | input | MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | MvelInjection.java:18:17:18:21 | input | MVEL injection from $@. | MvelInjection.java:14:27:14:49 | getInputStream(...) | this user input |
-| MvelInjection.java:28:30:28:39 | expression | MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | MvelInjection.java:28:30:28:39 | expression | MVEL injection from $@. | MvelInjection.java:23:27:23:49 | getInputStream(...) | this user input |
-| MvelInjection.java:39:7:39:15 | statement | MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:39:7:39:15 | statement | MVEL injection from $@. | MvelInjection.java:33:27:33:49 | getInputStream(...) | this user input |
-| MvelInjection.java:50:7:50:16 | expression | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:16 | expression | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |
+| MvelInjection.java:20:17:20:21 | input | MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input | MVEL injection from $@. | MvelInjection.java:16:27:16:49 | getInputStream(...) | this user input |
+| MvelInjection.java:30:30:30:39 | expression | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression | MVEL injection from $@. | MvelInjection.java:25:27:25:49 | getInputStream(...) | this user input |
+| MvelInjection.java:41:7:41:15 | statement | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement | MVEL injection from $@. | MvelInjection.java:35:27:35:49 | getInputStream(...) | this user input |
+| MvelInjection.java:52:7:52:16 | expression | MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | MvelInjection.java:52:7:52:16 | expression | MVEL injection from $@. | MvelInjection.java:46:27:46:49 | getInputStream(...) | this user input |
+| MvelInjection.java:62:7:62:16 | expression | MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression | MVEL injection from $@. | MvelInjection.java:57:27:57:49 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,15 +1,19 @@
 edges
-| MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | MvelInjection.java:17:17:17:21 | input |
-| MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | MvelInjection.java:27:30:27:39 | expression |
-| MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | MvelInjection.java:38:7:38:15 | statement |
+| MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | MvelInjection.java:18:17:18:21 | input |
+| MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | MvelInjection.java:28:30:28:39 | expression |
+| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:39:7:39:15 | statement |
+| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:16 | expression |
 nodes
-| MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:17:17:17:21 | input | semmle.label | input |
-| MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:27:30:27:39 | expression | semmle.label | expression |
-| MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:38:7:38:15 | statement | semmle.label | statement |
+| MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:18:17:18:21 | input | semmle.label | input |
+| MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:28:30:28:39 | expression | semmle.label | expression |
+| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:39:7:39:15 | statement | semmle.label | statement |
+| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:50:7:50:16 | expression | semmle.label | expression |
 #select
-| MvelInjection.java:17:17:17:21 | input | MvelInjection.java:13:27:13:49 | getInputStream(...) : InputStream | MvelInjection.java:17:17:17:21 | input | MVEL injection from $@. | MvelInjection.java:13:27:13:49 | getInputStream(...) | this user input |
-| MvelInjection.java:27:30:27:39 | expression | MvelInjection.java:22:27:22:49 | getInputStream(...) : InputStream | MvelInjection.java:27:30:27:39 | expression | MVEL injection from $@. | MvelInjection.java:22:27:22:49 | getInputStream(...) | this user input |
-| MvelInjection.java:38:7:38:15 | statement | MvelInjection.java:32:27:32:49 | getInputStream(...) : InputStream | MvelInjection.java:38:7:38:15 | statement | MVEL injection from $@. | MvelInjection.java:32:27:32:49 | getInputStream(...) | this user input |
+| MvelInjection.java:18:17:18:21 | input | MvelInjection.java:14:27:14:49 | getInputStream(...) : InputStream | MvelInjection.java:18:17:18:21 | input | MVEL injection from $@. | MvelInjection.java:14:27:14:49 | getInputStream(...) | this user input |
+| MvelInjection.java:28:30:28:39 | expression | MvelInjection.java:23:27:23:49 | getInputStream(...) : InputStream | MvelInjection.java:28:30:28:39 | expression | MVEL injection from $@. | MvelInjection.java:23:27:23:49 | getInputStream(...) | this user input |
+| MvelInjection.java:39:7:39:15 | statement | MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:39:7:39:15 | statement | MVEL injection from $@. | MvelInjection.java:33:27:33:49 | getInputStream(...) | this user input |
+| MvelInjection.java:50:7:50:16 | expression | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:16 | expression | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -2,8 +2,9 @@ edges
 | MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input |
 | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression |
 | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement |
-| MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | MvelInjection.java:52:7:52:16 | expression |
-| MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression |
+| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:42:7:42:15 | statement |
+| MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | MvelInjection.java:53:7:53:16 | expression |
+| MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | MvelInjection.java:63:7:63:16 | expression |
 nodes
 | MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | MvelInjection.java:20:17:20:21 | input | semmle.label | input |
@@ -11,13 +12,15 @@ nodes
 | MvelInjection.java:30:30:30:39 | expression | semmle.label | expression |
 | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | MvelInjection.java:41:7:41:15 | statement | semmle.label | statement |
-| MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:52:7:52:16 | expression | semmle.label | expression |
-| MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:62:7:62:16 | expression | semmle.label | expression |
+| MvelInjection.java:42:7:42:15 | statement | semmle.label | statement |
+| MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:53:7:53:16 | expression | semmle.label | expression |
+| MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:63:7:63:16 | expression | semmle.label | expression |
 #select
 | MvelInjection.java:20:17:20:21 | input | MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input | MVEL injection from $@. | MvelInjection.java:16:27:16:49 | getInputStream(...) | this user input |
 | MvelInjection.java:30:30:30:39 | expression | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression | MVEL injection from $@. | MvelInjection.java:25:27:25:49 | getInputStream(...) | this user input |
 | MvelInjection.java:41:7:41:15 | statement | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement | MVEL injection from $@. | MvelInjection.java:35:27:35:49 | getInputStream(...) | this user input |
-| MvelInjection.java:52:7:52:16 | expression | MvelInjection.java:46:27:46:49 | getInputStream(...) : InputStream | MvelInjection.java:52:7:52:16 | expression | MVEL injection from $@. | MvelInjection.java:46:27:46:49 | getInputStream(...) | this user input |
-| MvelInjection.java:62:7:62:16 | expression | MvelInjection.java:57:27:57:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression | MVEL injection from $@. | MvelInjection.java:57:27:57:49 | getInputStream(...) | this user input |
+| MvelInjection.java:42:7:42:15 | statement | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:42:7:42:15 | statement | MVEL injection from $@. | MvelInjection.java:35:27:35:49 | getInputStream(...) | this user input |
+| MvelInjection.java:53:7:53:16 | expression | MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | MvelInjection.java:53:7:53:16 | expression | MVEL injection from $@. | MvelInjection.java:47:27:47:49 | getInputStream(...) | this user input |
+| MvelInjection.java:63:7:63:16 | expression | MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | MvelInjection.java:63:7:63:16 | expression | MVEL injection from $@. | MvelInjection.java:58:27:58:49 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,37 +1,49 @@
 edges
-| MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | MvelInjection.java:24:17:24:21 | input |
-| MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | MvelInjection.java:34:30:34:39 | expression |
-| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:45:7:45:15 | statement |
-| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:46:7:46:15 | statement |
-| MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | MvelInjection.java:57:7:57:16 | expression |
-| MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | MvelInjection.java:67:7:67:16 | expression |
-| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:80:5:80:18 | compiledScript |
-| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:83:21:83:26 | script |
-| MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | MvelInjection.java:97:5:97:10 | script |
+| MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | MvelInjection.java:28:17:28:21 | input |
+| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:38:30:38:39 | expression |
+| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:49:7:49:15 | statement |
+| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement |
+| MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | MvelInjection.java:61:7:61:16 | expression |
+| MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | MvelInjection.java:71:7:71:16 | expression |
+| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:84:5:84:18 | compiledScript |
+| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:87:21:87:26 | script |
+| MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | MvelInjection.java:101:5:101:10 | script |
+| MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | MvelInjection.java:111:26:111:30 | input |
+| MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | MvelInjection.java:121:29:121:67 | compileTemplate(...) |
+| MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | MvelInjection.java:132:54:132:71 | compile(...) |
 nodes
-| MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:24:17:24:21 | input | semmle.label | input |
-| MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:34:30:34:39 | expression | semmle.label | expression |
-| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:45:7:45:15 | statement | semmle.label | statement |
-| MvelInjection.java:46:7:46:15 | statement | semmle.label | statement |
-| MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:57:7:57:16 | expression | semmle.label | expression |
-| MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:67:7:67:16 | expression | semmle.label | expression |
-| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:80:5:80:18 | compiledScript | semmle.label | compiledScript |
-| MvelInjection.java:83:21:83:26 | script | semmle.label | script |
-| MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:97:5:97:10 | script | semmle.label | script |
+| MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:28:17:28:21 | input | semmle.label | input |
+| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:38:30:38:39 | expression | semmle.label | expression |
+| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:49:7:49:15 | statement | semmle.label | statement |
+| MvelInjection.java:50:7:50:15 | statement | semmle.label | statement |
+| MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:61:7:61:16 | expression | semmle.label | expression |
+| MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:71:7:71:16 | expression | semmle.label | expression |
+| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:84:5:84:18 | compiledScript | semmle.label | compiledScript |
+| MvelInjection.java:87:21:87:26 | script | semmle.label | script |
+| MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:101:5:101:10 | script | semmle.label | script |
+| MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:111:26:111:30 | input | semmle.label | input |
+| MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:121:29:121:67 | compileTemplate(...) | semmle.label | compileTemplate(...) |
+| MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:132:54:132:71 | compile(...) | semmle.label | compile(...) |
 #select
-| MvelInjection.java:24:17:24:21 | input | MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | MvelInjection.java:24:17:24:21 | input | MVEL injection from $@. | MvelInjection.java:20:27:20:49 | getInputStream(...) | this user input |
-| MvelInjection.java:34:30:34:39 | expression | MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | MvelInjection.java:34:30:34:39 | expression | MVEL injection from $@. | MvelInjection.java:29:27:29:49 | getInputStream(...) | this user input |
-| MvelInjection.java:45:7:45:15 | statement | MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:45:7:45:15 | statement | MVEL injection from $@. | MvelInjection.java:39:27:39:49 | getInputStream(...) | this user input |
-| MvelInjection.java:46:7:46:15 | statement | MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:46:7:46:15 | statement | MVEL injection from $@. | MvelInjection.java:39:27:39:49 | getInputStream(...) | this user input |
-| MvelInjection.java:57:7:57:16 | expression | MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | MvelInjection.java:57:7:57:16 | expression | MVEL injection from $@. | MvelInjection.java:51:27:51:49 | getInputStream(...) | this user input |
-| MvelInjection.java:67:7:67:16 | expression | MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | MvelInjection.java:67:7:67:16 | expression | MVEL injection from $@. | MvelInjection.java:62:27:62:49 | getInputStream(...) | this user input |
-| MvelInjection.java:80:5:80:18 | compiledScript | MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:80:5:80:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:72:22:72:44 | getInputStream(...) | this user input |
-| MvelInjection.java:83:21:83:26 | script | MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:83:21:83:26 | script | MVEL injection from $@. | MvelInjection.java:72:22:72:44 | getInputStream(...) | this user input |
-| MvelInjection.java:97:5:97:10 | script | MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | MvelInjection.java:97:5:97:10 | script | MVEL injection from $@. | MvelInjection.java:87:22:87:44 | getInputStream(...) | this user input |
+| MvelInjection.java:28:17:28:21 | input | MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | MvelInjection.java:28:17:28:21 | input | MVEL injection from $@. | MvelInjection.java:24:27:24:49 | getInputStream(...) | this user input |
+| MvelInjection.java:38:30:38:39 | expression | MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:38:30:38:39 | expression | MVEL injection from $@. | MvelInjection.java:33:27:33:49 | getInputStream(...) | this user input |
+| MvelInjection.java:49:7:49:15 | statement | MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:49:7:49:15 | statement | MVEL injection from $@. | MvelInjection.java:43:27:43:49 | getInputStream(...) | this user input |
+| MvelInjection.java:50:7:50:15 | statement | MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement | MVEL injection from $@. | MvelInjection.java:43:27:43:49 | getInputStream(...) | this user input |
+| MvelInjection.java:61:7:61:16 | expression | MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | MvelInjection.java:61:7:61:16 | expression | MVEL injection from $@. | MvelInjection.java:55:27:55:49 | getInputStream(...) | this user input |
+| MvelInjection.java:71:7:71:16 | expression | MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | MvelInjection.java:71:7:71:16 | expression | MVEL injection from $@. | MvelInjection.java:66:27:66:49 | getInputStream(...) | this user input |
+| MvelInjection.java:84:5:84:18 | compiledScript | MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:84:5:84:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:76:22:76:44 | getInputStream(...) | this user input |
+| MvelInjection.java:87:21:87:26 | script | MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:87:21:87:26 | script | MVEL injection from $@. | MvelInjection.java:76:22:76:44 | getInputStream(...) | this user input |
+| MvelInjection.java:101:5:101:10 | script | MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | MvelInjection.java:101:5:101:10 | script | MVEL injection from $@. | MvelInjection.java:91:22:91:44 | getInputStream(...) | this user input |
+| MvelInjection.java:111:26:111:30 | input | MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | MvelInjection.java:111:26:111:30 | input | MVEL injection from $@. | MvelInjection.java:105:22:105:44 | getInputStream(...) | this user input |
+| MvelInjection.java:121:29:121:67 | compileTemplate(...) | MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | MvelInjection.java:121:29:121:67 | compileTemplate(...) | MVEL injection from $@. | MvelInjection.java:115:22:115:44 | getInputStream(...) | this user input |
+| MvelInjection.java:132:54:132:71 | compile(...) | MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | MvelInjection.java:132:54:132:71 | compile(...) | MVEL injection from $@. | MvelInjection.java:125:22:125:44 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,49 +1,53 @@
 edges
-| MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | MvelInjection.java:28:17:28:21 | input |
-| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:38:30:38:39 | expression |
-| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:49:7:49:15 | statement |
-| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement |
-| MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | MvelInjection.java:61:7:61:16 | expression |
-| MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | MvelInjection.java:71:7:71:16 | expression |
-| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:84:5:84:18 | compiledScript |
-| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:87:21:87:26 | script |
-| MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | MvelInjection.java:101:5:101:10 | script |
-| MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | MvelInjection.java:111:26:111:30 | input |
-| MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | MvelInjection.java:121:29:121:67 | compileTemplate(...) |
-| MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | MvelInjection.java:132:54:132:71 | compile(...) |
+| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:29:17:29:21 | input |
+| MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | MvelInjection.java:39:30:39:39 | expression |
+| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement |
+| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:51:7:51:15 | statement |
+| MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression |
+| MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | MvelInjection.java:72:7:72:16 | expression |
+| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:85:5:85:18 | compiledScript |
+| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:88:21:88:26 | script |
+| MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | MvelInjection.java:102:5:102:10 | script |
+| MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | MvelInjection.java:112:26:112:30 | input |
+| MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | MvelInjection.java:122:29:122:67 | compileTemplate(...) |
+| MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | MvelInjection.java:133:54:133:71 | compile(...) |
+| MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | MvelInjection.java:145:32:145:41 | expression |
 nodes
-| MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:28:17:28:21 | input | semmle.label | input |
-| MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:38:30:38:39 | expression | semmle.label | expression |
-| MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:49:7:49:15 | statement | semmle.label | statement |
+| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:29:17:29:21 | input | semmle.label | input |
+| MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:39:30:39:39 | expression | semmle.label | expression |
+| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
 | MvelInjection.java:50:7:50:15 | statement | semmle.label | statement |
-| MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:61:7:61:16 | expression | semmle.label | expression |
-| MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:71:7:71:16 | expression | semmle.label | expression |
-| MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:84:5:84:18 | compiledScript | semmle.label | compiledScript |
-| MvelInjection.java:87:21:87:26 | script | semmle.label | script |
-| MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:101:5:101:10 | script | semmle.label | script |
-| MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:111:26:111:30 | input | semmle.label | input |
-| MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:121:29:121:67 | compileTemplate(...) | semmle.label | compileTemplate(...) |
-| MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:132:54:132:71 | compile(...) | semmle.label | compile(...) |
+| MvelInjection.java:51:7:51:15 | statement | semmle.label | statement |
+| MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:62:7:62:16 | expression | semmle.label | expression |
+| MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:72:7:72:16 | expression | semmle.label | expression |
+| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:85:5:85:18 | compiledScript | semmle.label | compiledScript |
+| MvelInjection.java:88:21:88:26 | script | semmle.label | script |
+| MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:102:5:102:10 | script | semmle.label | script |
+| MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:112:26:112:30 | input | semmle.label | input |
+| MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:122:29:122:67 | compileTemplate(...) | semmle.label | compileTemplate(...) |
+| MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:133:54:133:71 | compile(...) | semmle.label | compile(...) |
+| MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:145:32:145:41 | expression | semmle.label | expression |
 #select
-| MvelInjection.java:28:17:28:21 | input | MvelInjection.java:24:27:24:49 | getInputStream(...) : InputStream | MvelInjection.java:28:17:28:21 | input | MVEL injection from $@. | MvelInjection.java:24:27:24:49 | getInputStream(...) | this user input |
-| MvelInjection.java:38:30:38:39 | expression | MvelInjection.java:33:27:33:49 | getInputStream(...) : InputStream | MvelInjection.java:38:30:38:39 | expression | MVEL injection from $@. | MvelInjection.java:33:27:33:49 | getInputStream(...) | this user input |
-| MvelInjection.java:49:7:49:15 | statement | MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:49:7:49:15 | statement | MVEL injection from $@. | MvelInjection.java:43:27:43:49 | getInputStream(...) | this user input |
-| MvelInjection.java:50:7:50:15 | statement | MvelInjection.java:43:27:43:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement | MVEL injection from $@. | MvelInjection.java:43:27:43:49 | getInputStream(...) | this user input |
-| MvelInjection.java:61:7:61:16 | expression | MvelInjection.java:55:27:55:49 | getInputStream(...) : InputStream | MvelInjection.java:61:7:61:16 | expression | MVEL injection from $@. | MvelInjection.java:55:27:55:49 | getInputStream(...) | this user input |
-| MvelInjection.java:71:7:71:16 | expression | MvelInjection.java:66:27:66:49 | getInputStream(...) : InputStream | MvelInjection.java:71:7:71:16 | expression | MVEL injection from $@. | MvelInjection.java:66:27:66:49 | getInputStream(...) | this user input |
-| MvelInjection.java:84:5:84:18 | compiledScript | MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:84:5:84:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:76:22:76:44 | getInputStream(...) | this user input |
-| MvelInjection.java:87:21:87:26 | script | MvelInjection.java:76:22:76:44 | getInputStream(...) : InputStream | MvelInjection.java:87:21:87:26 | script | MVEL injection from $@. | MvelInjection.java:76:22:76:44 | getInputStream(...) | this user input |
-| MvelInjection.java:101:5:101:10 | script | MvelInjection.java:91:22:91:44 | getInputStream(...) : InputStream | MvelInjection.java:101:5:101:10 | script | MVEL injection from $@. | MvelInjection.java:91:22:91:44 | getInputStream(...) | this user input |
-| MvelInjection.java:111:26:111:30 | input | MvelInjection.java:105:22:105:44 | getInputStream(...) : InputStream | MvelInjection.java:111:26:111:30 | input | MVEL injection from $@. | MvelInjection.java:105:22:105:44 | getInputStream(...) | this user input |
-| MvelInjection.java:121:29:121:67 | compileTemplate(...) | MvelInjection.java:115:22:115:44 | getInputStream(...) : InputStream | MvelInjection.java:121:29:121:67 | compileTemplate(...) | MVEL injection from $@. | MvelInjection.java:115:22:115:44 | getInputStream(...) | this user input |
-| MvelInjection.java:132:54:132:71 | compile(...) | MvelInjection.java:125:22:125:44 | getInputStream(...) : InputStream | MvelInjection.java:132:54:132:71 | compile(...) | MVEL injection from $@. | MvelInjection.java:125:22:125:44 | getInputStream(...) | this user input |
+| MvelInjection.java:29:17:29:21 | input | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:29:17:29:21 | input | MVEL injection from $@. | MvelInjection.java:25:27:25:49 | getInputStream(...) | this user input |
+| MvelInjection.java:39:30:39:39 | expression | MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | MvelInjection.java:39:30:39:39 | expression | MVEL injection from $@. | MvelInjection.java:34:27:34:49 | getInputStream(...) | this user input |
+| MvelInjection.java:50:7:50:15 | statement | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |
+| MvelInjection.java:51:7:51:15 | statement | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:51:7:51:15 | statement | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |
+| MvelInjection.java:62:7:62:16 | expression | MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression | MVEL injection from $@. | MvelInjection.java:56:27:56:49 | getInputStream(...) | this user input |
+| MvelInjection.java:72:7:72:16 | expression | MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | MvelInjection.java:72:7:72:16 | expression | MVEL injection from $@. | MvelInjection.java:67:27:67:49 | getInputStream(...) | this user input |
+| MvelInjection.java:85:5:85:18 | compiledScript | MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:85:5:85:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:77:22:77:44 | getInputStream(...) | this user input |
+| MvelInjection.java:88:21:88:26 | script | MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:88:21:88:26 | script | MVEL injection from $@. | MvelInjection.java:77:22:77:44 | getInputStream(...) | this user input |
+| MvelInjection.java:102:5:102:10 | script | MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | MvelInjection.java:102:5:102:10 | script | MVEL injection from $@. | MvelInjection.java:92:22:92:44 | getInputStream(...) | this user input |
+| MvelInjection.java:112:26:112:30 | input | MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | MvelInjection.java:112:26:112:30 | input | MVEL injection from $@. | MvelInjection.java:106:22:106:44 | getInputStream(...) | this user input |
+| MvelInjection.java:122:29:122:67 | compileTemplate(...) | MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | MvelInjection.java:122:29:122:67 | compileTemplate(...) | MVEL injection from $@. | MvelInjection.java:116:22:116:44 | getInputStream(...) | this user input |
+| MvelInjection.java:133:54:133:71 | compile(...) | MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | MvelInjection.java:133:54:133:71 | compile(...) | MVEL injection from $@. | MvelInjection.java:126:22:126:44 | getInputStream(...) | this user input |
+| MvelInjection.java:145:32:145:41 | expression | MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | MvelInjection.java:145:32:145:41 | expression | MVEL injection from $@. | MvelInjection.java:137:22:137:44 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,53 +1,63 @@
 edges
-| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:29:17:29:21 | input |
-| MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | MvelInjection.java:39:30:39:39 | expression |
-| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement |
-| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:51:7:51:15 | statement |
-| MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression |
-| MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | MvelInjection.java:72:7:72:16 | expression |
-| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:85:5:85:18 | compiledScript |
-| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:88:21:88:26 | script |
-| MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | MvelInjection.java:102:5:102:10 | script |
-| MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | MvelInjection.java:112:26:112:30 | input |
-| MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | MvelInjection.java:122:29:122:67 | compileTemplate(...) |
-| MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | MvelInjection.java:133:54:133:71 | compile(...) |
-| MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | MvelInjection.java:145:32:145:41 | expression |
+| MvelInjection.java:29:54:29:65 | read(...) : String | MvelInjection.java:30:28:30:37 | expression |
+| MvelInjection.java:34:58:34:69 | read(...) : String | MvelInjection.java:36:5:36:13 | statement |
+| MvelInjection.java:34:58:34:69 | read(...) : String | MvelInjection.java:37:5:37:13 | statement |
+| MvelInjection.java:41:58:41:69 | read(...) : String | MvelInjection.java:43:5:43:14 | expression |
+| MvelInjection.java:48:7:48:18 | read(...) : String | MvelInjection.java:49:5:49:14 | expression |
+| MvelInjection.java:53:20:53:31 | read(...) : String | MvelInjection.java:57:5:57:18 | compiledScript |
+| MvelInjection.java:53:20:53:31 | read(...) : String | MvelInjection.java:60:21:60:26 | script |
+| MvelInjection.java:65:58:65:69 | read(...) : String | MvelInjection.java:68:5:68:10 | script |
+| MvelInjection.java:77:40:77:51 | read(...) : String | MvelInjection.java:77:7:77:52 | compileTemplate(...) |
+| MvelInjection.java:81:54:81:65 | read(...) : String | MvelInjection.java:82:29:82:46 | compile(...) |
+| MvelInjection.java:86:58:86:69 | read(...) : String | MvelInjection.java:88:32:88:41 | expression |
+| MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:95:14:95:36 | new String(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:25:15:25:26 | read(...) |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:29:54:29:65 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:34:58:34:69 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:41:58:41:69 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:48:7:48:18 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:53:20:53:31 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:65:58:65:69 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:72:26:72:37 | read(...) |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:77:40:77:51 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:81:54:81:65 | read(...) : String |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | MvelInjection.java:86:58:86:69 | read(...) : String |
 nodes
-| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:29:17:29:21 | input | semmle.label | input |
-| MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:39:30:39:39 | expression | semmle.label | expression |
-| MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:50:7:50:15 | statement | semmle.label | statement |
-| MvelInjection.java:51:7:51:15 | statement | semmle.label | statement |
-| MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:62:7:62:16 | expression | semmle.label | expression |
-| MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:72:7:72:16 | expression | semmle.label | expression |
-| MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:85:5:85:18 | compiledScript | semmle.label | compiledScript |
-| MvelInjection.java:88:21:88:26 | script | semmle.label | script |
-| MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:102:5:102:10 | script | semmle.label | script |
-| MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:112:26:112:30 | input | semmle.label | input |
-| MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:122:29:122:67 | compileTemplate(...) | semmle.label | compileTemplate(...) |
-| MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:133:54:133:71 | compile(...) | semmle.label | compile(...) |
-| MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:145:32:145:41 | expression | semmle.label | expression |
+| MvelInjection.java:25:15:25:26 | read(...) | semmle.label | read(...) |
+| MvelInjection.java:29:54:29:65 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:30:28:30:37 | expression | semmle.label | expression |
+| MvelInjection.java:34:58:34:69 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:36:5:36:13 | statement | semmle.label | statement |
+| MvelInjection.java:37:5:37:13 | statement | semmle.label | statement |
+| MvelInjection.java:41:58:41:69 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:43:5:43:14 | expression | semmle.label | expression |
+| MvelInjection.java:48:7:48:18 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:49:5:49:14 | expression | semmle.label | expression |
+| MvelInjection.java:53:20:53:31 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:57:5:57:18 | compiledScript | semmle.label | compiledScript |
+| MvelInjection.java:60:21:60:26 | script | semmle.label | script |
+| MvelInjection.java:65:58:65:69 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:68:5:68:10 | script | semmle.label | script |
+| MvelInjection.java:72:26:72:37 | read(...) | semmle.label | read(...) |
+| MvelInjection.java:77:7:77:52 | compileTemplate(...) | semmle.label | compileTemplate(...) |
+| MvelInjection.java:77:40:77:51 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:81:54:81:65 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:82:29:82:46 | compile(...) | semmle.label | compile(...) |
+| MvelInjection.java:86:58:86:69 | read(...) : String | semmle.label | read(...) : String |
+| MvelInjection.java:88:32:88:41 | expression | semmle.label | expression |
+| MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:95:14:95:36 | new String(...) : String | semmle.label | new String(...) : String |
 #select
-| MvelInjection.java:29:17:29:21 | input | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:29:17:29:21 | input | MVEL injection from $@. | MvelInjection.java:25:27:25:49 | getInputStream(...) | this user input |
-| MvelInjection.java:39:30:39:39 | expression | MvelInjection.java:34:27:34:49 | getInputStream(...) : InputStream | MvelInjection.java:39:30:39:39 | expression | MVEL injection from $@. | MvelInjection.java:34:27:34:49 | getInputStream(...) | this user input |
-| MvelInjection.java:50:7:50:15 | statement | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:50:7:50:15 | statement | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |
-| MvelInjection.java:51:7:51:15 | statement | MvelInjection.java:44:27:44:49 | getInputStream(...) : InputStream | MvelInjection.java:51:7:51:15 | statement | MVEL injection from $@. | MvelInjection.java:44:27:44:49 | getInputStream(...) | this user input |
-| MvelInjection.java:62:7:62:16 | expression | MvelInjection.java:56:27:56:49 | getInputStream(...) : InputStream | MvelInjection.java:62:7:62:16 | expression | MVEL injection from $@. | MvelInjection.java:56:27:56:49 | getInputStream(...) | this user input |
-| MvelInjection.java:72:7:72:16 | expression | MvelInjection.java:67:27:67:49 | getInputStream(...) : InputStream | MvelInjection.java:72:7:72:16 | expression | MVEL injection from $@. | MvelInjection.java:67:27:67:49 | getInputStream(...) | this user input |
-| MvelInjection.java:85:5:85:18 | compiledScript | MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:85:5:85:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:77:22:77:44 | getInputStream(...) | this user input |
-| MvelInjection.java:88:21:88:26 | script | MvelInjection.java:77:22:77:44 | getInputStream(...) : InputStream | MvelInjection.java:88:21:88:26 | script | MVEL injection from $@. | MvelInjection.java:77:22:77:44 | getInputStream(...) | this user input |
-| MvelInjection.java:102:5:102:10 | script | MvelInjection.java:92:22:92:44 | getInputStream(...) : InputStream | MvelInjection.java:102:5:102:10 | script | MVEL injection from $@. | MvelInjection.java:92:22:92:44 | getInputStream(...) | this user input |
-| MvelInjection.java:112:26:112:30 | input | MvelInjection.java:106:22:106:44 | getInputStream(...) : InputStream | MvelInjection.java:112:26:112:30 | input | MVEL injection from $@. | MvelInjection.java:106:22:106:44 | getInputStream(...) | this user input |
-| MvelInjection.java:122:29:122:67 | compileTemplate(...) | MvelInjection.java:116:22:116:44 | getInputStream(...) : InputStream | MvelInjection.java:122:29:122:67 | compileTemplate(...) | MVEL injection from $@. | MvelInjection.java:116:22:116:44 | getInputStream(...) | this user input |
-| MvelInjection.java:133:54:133:71 | compile(...) | MvelInjection.java:126:22:126:44 | getInputStream(...) : InputStream | MvelInjection.java:133:54:133:71 | compile(...) | MVEL injection from $@. | MvelInjection.java:126:22:126:44 | getInputStream(...) | this user input |
-| MvelInjection.java:145:32:145:41 | expression | MvelInjection.java:137:22:137:44 | getInputStream(...) : InputStream | MvelInjection.java:145:32:145:41 | expression | MVEL injection from $@. | MvelInjection.java:137:22:137:44 | getInputStream(...) | this user input |
+| MvelInjection.java:25:15:25:26 | read(...) | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:25:15:25:26 | read(...) | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:30:28:30:37 | expression | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:30:28:30:37 | expression | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:36:5:36:13 | statement | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:36:5:36:13 | statement | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:37:5:37:13 | statement | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:37:5:37:13 | statement | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:43:5:43:14 | expression | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:43:5:43:14 | expression | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:49:5:49:14 | expression | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:49:5:49:14 | expression | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:57:5:57:18 | compiledScript | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:57:5:57:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:60:21:60:26 | script | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:60:21:60:26 | script | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:68:5:68:10 | script | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:68:5:68:10 | script | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:72:26:72:37 | read(...) | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:72:26:72:37 | read(...) | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:77:7:77:52 | compileTemplate(...) | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:77:7:77:52 | compileTemplate(...) | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:82:29:82:46 | compile(...) | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:82:29:82:46 | compile(...) | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |
+| MvelInjection.java:88:32:88:41 | expression | MvelInjection.java:92:27:92:49 | getInputStream(...) : InputStream | MvelInjection.java:88:32:88:41 | expression | MVEL injection from $@. | MvelInjection.java:92:27:92:49 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.expected
@@ -1,26 +1,37 @@
 edges
-| MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input |
-| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression |
-| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement |
-| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:42:7:42:15 | statement |
-| MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | MvelInjection.java:53:7:53:16 | expression |
-| MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | MvelInjection.java:63:7:63:16 | expression |
+| MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | MvelInjection.java:24:17:24:21 | input |
+| MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | MvelInjection.java:34:30:34:39 | expression |
+| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:45:7:45:15 | statement |
+| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:46:7:46:15 | statement |
+| MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | MvelInjection.java:57:7:57:16 | expression |
+| MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | MvelInjection.java:67:7:67:16 | expression |
+| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:80:5:80:18 | compiledScript |
+| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:83:21:83:26 | script |
+| MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | MvelInjection.java:97:5:97:10 | script |
 nodes
-| MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:20:17:20:21 | input | semmle.label | input |
-| MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:30:30:30:39 | expression | semmle.label | expression |
-| MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:41:7:41:15 | statement | semmle.label | statement |
-| MvelInjection.java:42:7:42:15 | statement | semmle.label | statement |
-| MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:53:7:53:16 | expression | semmle.label | expression |
-| MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
-| MvelInjection.java:63:7:63:16 | expression | semmle.label | expression |
+| MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:24:17:24:21 | input | semmle.label | input |
+| MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:34:30:34:39 | expression | semmle.label | expression |
+| MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:45:7:45:15 | statement | semmle.label | statement |
+| MvelInjection.java:46:7:46:15 | statement | semmle.label | statement |
+| MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:57:7:57:16 | expression | semmle.label | expression |
+| MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:67:7:67:16 | expression | semmle.label | expression |
+| MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:80:5:80:18 | compiledScript | semmle.label | compiledScript |
+| MvelInjection.java:83:21:83:26 | script | semmle.label | script |
+| MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| MvelInjection.java:97:5:97:10 | script | semmle.label | script |
 #select
-| MvelInjection.java:20:17:20:21 | input | MvelInjection.java:16:27:16:49 | getInputStream(...) : InputStream | MvelInjection.java:20:17:20:21 | input | MVEL injection from $@. | MvelInjection.java:16:27:16:49 | getInputStream(...) | this user input |
-| MvelInjection.java:30:30:30:39 | expression | MvelInjection.java:25:27:25:49 | getInputStream(...) : InputStream | MvelInjection.java:30:30:30:39 | expression | MVEL injection from $@. | MvelInjection.java:25:27:25:49 | getInputStream(...) | this user input |
-| MvelInjection.java:41:7:41:15 | statement | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:41:7:41:15 | statement | MVEL injection from $@. | MvelInjection.java:35:27:35:49 | getInputStream(...) | this user input |
-| MvelInjection.java:42:7:42:15 | statement | MvelInjection.java:35:27:35:49 | getInputStream(...) : InputStream | MvelInjection.java:42:7:42:15 | statement | MVEL injection from $@. | MvelInjection.java:35:27:35:49 | getInputStream(...) | this user input |
-| MvelInjection.java:53:7:53:16 | expression | MvelInjection.java:47:27:47:49 | getInputStream(...) : InputStream | MvelInjection.java:53:7:53:16 | expression | MVEL injection from $@. | MvelInjection.java:47:27:47:49 | getInputStream(...) | this user input |
-| MvelInjection.java:63:7:63:16 | expression | MvelInjection.java:58:27:58:49 | getInputStream(...) : InputStream | MvelInjection.java:63:7:63:16 | expression | MVEL injection from $@. | MvelInjection.java:58:27:58:49 | getInputStream(...) | this user input |
+| MvelInjection.java:24:17:24:21 | input | MvelInjection.java:20:27:20:49 | getInputStream(...) : InputStream | MvelInjection.java:24:17:24:21 | input | MVEL injection from $@. | MvelInjection.java:20:27:20:49 | getInputStream(...) | this user input |
+| MvelInjection.java:34:30:34:39 | expression | MvelInjection.java:29:27:29:49 | getInputStream(...) : InputStream | MvelInjection.java:34:30:34:39 | expression | MVEL injection from $@. | MvelInjection.java:29:27:29:49 | getInputStream(...) | this user input |
+| MvelInjection.java:45:7:45:15 | statement | MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:45:7:45:15 | statement | MVEL injection from $@. | MvelInjection.java:39:27:39:49 | getInputStream(...) | this user input |
+| MvelInjection.java:46:7:46:15 | statement | MvelInjection.java:39:27:39:49 | getInputStream(...) : InputStream | MvelInjection.java:46:7:46:15 | statement | MVEL injection from $@. | MvelInjection.java:39:27:39:49 | getInputStream(...) | this user input |
+| MvelInjection.java:57:7:57:16 | expression | MvelInjection.java:51:27:51:49 | getInputStream(...) : InputStream | MvelInjection.java:57:7:57:16 | expression | MVEL injection from $@. | MvelInjection.java:51:27:51:49 | getInputStream(...) | this user input |
+| MvelInjection.java:67:7:67:16 | expression | MvelInjection.java:62:27:62:49 | getInputStream(...) : InputStream | MvelInjection.java:67:7:67:16 | expression | MVEL injection from $@. | MvelInjection.java:62:27:62:49 | getInputStream(...) | this user input |
+| MvelInjection.java:80:5:80:18 | compiledScript | MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:80:5:80:18 | compiledScript | MVEL injection from $@. | MvelInjection.java:72:22:72:44 | getInputStream(...) | this user input |
+| MvelInjection.java:83:21:83:26 | script | MvelInjection.java:72:22:72:44 | getInputStream(...) : InputStream | MvelInjection.java:83:21:83:26 | script | MVEL injection from $@. | MvelInjection.java:72:22:72:44 | getInputStream(...) | this user input |
+| MvelInjection.java:97:5:97:10 | script | MvelInjection.java:87:22:87:44 | getInputStream(...) : InputStream | MvelInjection.java:97:5:97:10 | script | MVEL injection from $@. | MvelInjection.java:87:22:87:44 | getInputStream(...) | this user input |

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -3,6 +3,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.Socket;
 import org.mvel2.MVEL;
+import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.compiler.ExpressionCompiler;
 import org.mvel2.integration.impl.ImmutableDefaultFactory;
@@ -36,6 +37,17 @@ public class MvelInjection {
       ExpressionCompiler compiler = new ExpressionCompiler(input);
       ExecutableStatement statement = compiler.compile();
       statement.getValue(new Object(), new ImmutableDefaultFactory());
+    }
+  }
+
+  public static void testWithCompiledExpressionGetDirectValue(Socket socket) throws IOException {
+    try (InputStream in = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = in.read(bytes);
+      String input = new String(bytes, 0, n);
+      ExpressionCompiler compiler = new ExpressionCompiler(input);
+      CompiledExpression expression = compiler.compile();
+      expression.getDirectValue(new Object(), new ImmutableDefaultFactory());
     }
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -2,6 +2,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.Socket;
+import java.util.HashMap;
 import javax.script.CompiledScript;
 import javax.script.SimpleScriptContext;
 import org.mvel2.MVEL;
@@ -13,6 +14,9 @@ import org.mvel2.compiler.ExpressionCompiler;
 import org.mvel2.integration.impl.ImmutableDefaultFactory;
 import org.mvel2.jsr223.MvelCompiledScript;
 import org.mvel2.jsr223.MvelScriptEngine;
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.TemplateCompiler;
+import org.mvel2.templates.TemplateRuntime;
 
 public class MvelInjection {
 
@@ -95,5 +99,36 @@ public class MvelInjection {
     ExecutableStatement statement = compiler.compile();
     MvelCompiledScript script = new MvelCompiledScript(engine, statement);
     script.eval(new SimpleScriptContext());
+  }
+
+  public static void testTemplateRuntimeEval(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    TemplateRuntime.eval(input, new HashMap());
+  }
+
+  public static void testTemplateRuntimeCompileTemplateAndExecute(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    TemplateRuntime.execute(TemplateCompiler.compileTemplate(input), new HashMap());
+  }
+
+  public static void testTemplateRuntimeCompileAndExecute(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    TemplateCompiler compiler = new TemplateCompiler(input);
+    String output = (String) TemplateRuntime.execute(compiler.compile(), new HashMap());
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -22,63 +22,35 @@ import org.mvel2.templates.TemplateRuntime;
 public class MvelInjection {
 
   public static void testWithMvelEval(Socket socket) throws IOException {
-    try (InputStream in = socket.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int n = in.read(bytes);
-      String input = new String(bytes, 0, n);
-      MVEL.eval(input);
-    }
+    MVEL.eval(read(socket));
   }
 
   public static void testWithMvelCompileAndExecute(Socket socket) throws IOException {
-    try (InputStream in = socket.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int n = in.read(bytes);
-      String input = new String(bytes, 0, n);
-      Serializable expression = MVEL.compileExpression(input);
-      MVEL.executeExpression(expression);
-    }
+    Serializable expression = MVEL.compileExpression(read(socket));
+    MVEL.executeExpression(expression);
   }
 
   public static void testWithExpressionCompiler(Socket socket) throws IOException {
-    try (InputStream in = socket.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int n = in.read(bytes);
-      String input = new String(bytes, 0, n);
-      ExpressionCompiler compiler = new ExpressionCompiler(input);
-      ExecutableStatement statement = compiler.compile();
-      statement.getValue(new Object(), new ImmutableDefaultFactory());
-      statement.getValue(new Object(), new Object(), new ImmutableDefaultFactory());
-    }
+    ExpressionCompiler compiler = new ExpressionCompiler(read(socket));
+    ExecutableStatement statement = compiler.compile();
+    statement.getValue(new Object(), new ImmutableDefaultFactory());
+    statement.getValue(new Object(), new Object(), new ImmutableDefaultFactory());
   }
 
   public static void testWithCompiledExpressionGetDirectValue(Socket socket) throws IOException {
-    try (InputStream in = socket.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int n = in.read(bytes);
-      String input = new String(bytes, 0, n);
-      ExpressionCompiler compiler = new ExpressionCompiler(input);
-      CompiledExpression expression = compiler.compile();
-      expression.getDirectValue(new Object(), new ImmutableDefaultFactory());
-    }
+    ExpressionCompiler compiler = new ExpressionCompiler(read(socket));
+    CompiledExpression expression = compiler.compile();
+    expression.getDirectValue(new Object(), new ImmutableDefaultFactory());
   }
 
   public static void testCompiledAccExpressionGetValue(Socket socket) throws IOException {
-    try (InputStream in = socket.getInputStream()) {
-      byte[] bytes = new byte[1024];
-      int n = in.read(bytes);
-      String input = new String(bytes, 0, n);
-      CompiledAccExpression expression = new CompiledAccExpression(input.toCharArray(), Object.class, new ParserContext());
-      expression.getValue(new Object(), new ImmutableDefaultFactory());
-    }
+    CompiledAccExpression expression = new CompiledAccExpression(
+      read(socket).toCharArray(), Object.class, new ParserContext());
+    expression.getValue(new Object(), new ImmutableDefaultFactory());
   }
 
   public static void testMvelScriptEngineCompileAndEvaluate(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
+    String input = read(socket);
 
     MvelScriptEngine engine = new MvelScriptEngine();
     CompiledScript compiledScript = engine.compile(input);
@@ -89,59 +61,38 @@ public class MvelInjection {
   }
 
   public static void testMvelCompiledScriptCompileAndEvaluate(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
-
     MvelScriptEngine engine = new MvelScriptEngine();
-    ExpressionCompiler compiler = new ExpressionCompiler(input);
+    ExpressionCompiler compiler = new ExpressionCompiler(read(socket));
     ExecutableStatement statement = compiler.compile();
     MvelCompiledScript script = new MvelCompiledScript(engine, statement);
     script.eval(new SimpleScriptContext());
   }
 
   public static void testTemplateRuntimeEval(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
-
-    TemplateRuntime.eval(input, new HashMap());
+    TemplateRuntime.eval(read(socket), new HashMap());
   }
 
   public static void testTemplateRuntimeCompileTemplateAndExecute(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
-
-    TemplateRuntime.execute(TemplateCompiler.compileTemplate(input), new HashMap());
+    TemplateRuntime.execute(
+      TemplateCompiler.compileTemplate(read(socket)), new HashMap());
   }
 
   public static void testTemplateRuntimeCompileAndExecute(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
-
-    TemplateCompiler compiler = new TemplateCompiler(input);
-    String output = (String) TemplateRuntime.execute(compiler.compile(), new HashMap());
+    TemplateCompiler compiler = new TemplateCompiler(read(socket));
+    TemplateRuntime.execute(compiler.compile(), new HashMap());
   }
 
   public static void testMvelRuntimeExecute(Socket socket) throws Exception {
-    InputStream in = socket.getInputStream();
-
-    byte[] bytes = new byte[1024];
-    int n = in.read(bytes);
-    String input = new String(bytes, 0, n);
-
-    ExpressionCompiler compiler = new ExpressionCompiler(input);
+    ExpressionCompiler compiler = new ExpressionCompiler(read(socket));
     CompiledExpression expression = compiler.compile();
     MVELRuntime.execute(false, expression, new Object(), new ImmutableDefaultFactory());
+  }
+
+  public static String read(Socket socket) throws IOException {
+    try (InputStream is = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = is.read(bytes);
+      return new String(bytes, 0, n);
+    }
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -3,6 +3,8 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.Socket;
 import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.CompiledAccExpression;
 import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.compiler.ExpressionCompiler;
@@ -48,6 +50,16 @@ public class MvelInjection {
       ExpressionCompiler compiler = new ExpressionCompiler(input);
       CompiledExpression expression = compiler.compile();
       expression.getDirectValue(new Object(), new ImmutableDefaultFactory());
+    }
+  }
+
+  public static void testCompiledAccExpressionGetValue(Socket socket) throws IOException {
+    try (InputStream in = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = in.read(bytes);
+      String input = new String(bytes, 0, n);
+      CompiledAccExpression expression = new CompiledAccExpression(input.toCharArray(), Object.class, new ParserContext());
+      expression.getValue(new Object(), new ImmutableDefaultFactory());
     }
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -1,0 +1,41 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.net.Socket;
+import org.mvel2.MVEL;
+import org.mvel2.compiler.ExecutableStatement;
+import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
+
+public class MvelInjection {
+
+  public static void testWithMvelEval(Socket socket) throws IOException {
+    try (InputStream in = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = in.read(bytes);
+      String input = new String(bytes, 0, n);
+      MVEL.eval(input);
+    }
+  }
+
+  public static void testWithMvelCompileAndExecute(Socket socket) throws IOException {
+    try (InputStream in = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = in.read(bytes);
+      String input = new String(bytes, 0, n);
+      Serializable expression = MVEL.compileExpression(input);
+      MVEL.executeExpression(expression);
+    }
+  }
+
+  public static void testWithExpressionCompiler(Socket socket) throws IOException {
+    try (InputStream in = socket.getInputStream()) {
+      byte[] bytes = new byte[1024];
+      int n = in.read(bytes);
+      String input = new String(bytes, 0, n);
+      ExpressionCompiler compiler = new ExpressionCompiler(input);
+      ExecutableStatement statement = compiler.compile();
+      statement.getValue(new Object(), new ImmutableDefaultFactory());
+    }
+  }
+}

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -39,6 +39,7 @@ public class MvelInjection {
       ExpressionCompiler compiler = new ExpressionCompiler(input);
       ExecutableStatement statement = compiler.compile();
       statement.getValue(new Object(), new ImmutableDefaultFactory());
+      statement.getValue(new Object(), new Object(), new ImmutableDefaultFactory());
     }
   }
 

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import javax.script.CompiledScript;
 import javax.script.SimpleScriptContext;
 import org.mvel2.MVEL;
+import org.mvel2.MVELRuntime;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.CompiledAccExpression;
 import org.mvel2.compiler.CompiledExpression;
@@ -130,5 +131,17 @@ public class MvelInjection {
 
     TemplateCompiler compiler = new TemplateCompiler(input);
     String output = (String) TemplateRuntime.execute(compiler.compile(), new HashMap());
+  }
+
+  public static void testMvelRuntimeExecute(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    ExpressionCompiler compiler = new ExpressionCompiler(input);
+    CompiledExpression expression = compiler.compile();
+    MVELRuntime.execute(false, expression, new Object(), new ImmutableDefaultFactory());
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.java
@@ -2,6 +2,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.Socket;
+import javax.script.CompiledScript;
+import javax.script.SimpleScriptContext;
 import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.CompiledAccExpression;
@@ -9,6 +11,8 @@ import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.compiler.ExpressionCompiler;
 import org.mvel2.integration.impl.ImmutableDefaultFactory;
+import org.mvel2.jsr223.MvelCompiledScript;
+import org.mvel2.jsr223.MvelScriptEngine;
 
 public class MvelInjection {
 
@@ -62,5 +66,34 @@ public class MvelInjection {
       CompiledAccExpression expression = new CompiledAccExpression(input.toCharArray(), Object.class, new ParserContext());
       expression.getValue(new Object(), new ImmutableDefaultFactory());
     }
+  }
+
+  public static void testMvelScriptEngineCompileAndEvaluate(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    MvelScriptEngine engine = new MvelScriptEngine();
+    CompiledScript compiledScript = engine.compile(input);
+    compiledScript.eval();
+
+    Serializable script = engine.compiledScript(input);
+    engine.evaluate(script, new SimpleScriptContext());
+  }
+
+  public static void testMvelCompiledScriptCompileAndEvaluate(Socket socket) throws Exception {
+    InputStream in = socket.getInputStream();
+
+    byte[] bytes = new byte[1024];
+    int n = in.read(bytes);
+    String input = new String(bytes, 0, n);
+
+    MvelScriptEngine engine = new MvelScriptEngine();
+    ExpressionCompiler compiler = new ExpressionCompiler(input);
+    ExecutableStatement statement = compiler.compile();
+    MvelCompiledScript script = new MvelCompiledScript(engine, statement);
+    script.eval(new SimpleScriptContext());
   }
 }

--- a/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.qlref
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/MvelInjection.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-094/MvelInjection.ql

--- a/java/ql/test/experimental/Security/CWE/CWE-094/options
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7:${testdir}/../../../../stubs/jsr223-api

--- a/java/ql/test/experimental/Security/CWE/CWE-094/options
+++ b/java/ql/test/experimental/Security/CWE/CWE-094/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/springframework-5.2.3:${testdir}/../../../../stubs/mvel2-2.4.7

--- a/java/ql/test/stubs/jsr223-api/javax/script/CompiledScript.java
+++ b/java/ql/test/stubs/jsr223-api/javax/script/CompiledScript.java
@@ -1,0 +1,5 @@
+package javax.script;
+
+public class CompiledScript {
+  public Object eval() throws ScriptException { return null; }
+}

--- a/java/ql/test/stubs/jsr223-api/javax/script/ScriptContext.java
+++ b/java/ql/test/stubs/jsr223-api/javax/script/ScriptContext.java
@@ -1,0 +1,3 @@
+package javax.script;
+
+public interface ScriptContext {}

--- a/java/ql/test/stubs/jsr223-api/javax/script/ScriptException.java
+++ b/java/ql/test/stubs/jsr223-api/javax/script/ScriptException.java
@@ -1,0 +1,3 @@
+package javax.script;
+
+public class ScriptException extends Exception {}

--- a/java/ql/test/stubs/jsr223-api/javax/script/SimpleScriptContext.java
+++ b/java/ql/test/stubs/jsr223-api/javax/script/SimpleScriptContext.java
@@ -1,0 +1,3 @@
+package javax.script;
+
+public class SimpleScriptContext implements ScriptContext {}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/MVEL.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/MVEL.java
@@ -1,0 +1,9 @@
+package org.mvel2;
+
+import java.io.Serializable;
+
+public class MVEL {
+  public static Object eval(String expression) { return null; }
+  public static Serializable compileExpression(String expression) { return null; }
+  public static Object executeExpression(Object compiledExpression) { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/MVELRuntime.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/MVELRuntime.java
@@ -1,0 +1,8 @@
+package org.mvel2;
+
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class MVELRuntime {
+  public static Object execute(boolean debugger, CompiledExpression expression, Object ctx, VariableResolverFactory variableFactory) { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/ParserContext.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/ParserContext.java
@@ -1,0 +1,3 @@
+package org.mvel2;
+
+public class ParserContext {}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/Accessor.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/Accessor.java
@@ -1,0 +1,7 @@
+package org.mvel2.compiler;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface Accessor {
+  public Object getValue(Object ctx, Object elCtx, VariableResolverFactory factory);
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledAccExpression.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledAccExpression.java
@@ -1,0 +1,10 @@
+package org.mvel2.compiler;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+
+public class CompiledAccExpression implements ExecutableStatement {
+  public CompiledAccExpression(char[] expression, Class ingressType, ParserContext context) {}
+  public Object getValue(Object staticContext, VariableResolverFactory factory) { return null; }
+  public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledExpression.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledExpression.java
@@ -1,0 +1,8 @@
+package org.mvel2.compiler;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public class CompiledExpression implements ExecutableStatement {
+  public Object getDirectValue(Object staticContext, VariableResolverFactory factory) { return null; }
+  public Object getValue(Object staticContext, VariableResolverFactory factory) { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledExpression.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/CompiledExpression.java
@@ -5,4 +5,5 @@ import org.mvel2.integration.VariableResolverFactory;
 public class CompiledExpression implements ExecutableStatement {
   public Object getDirectValue(Object staticContext, VariableResolverFactory factory) { return null; }
   public Object getValue(Object staticContext, VariableResolverFactory factory) { return null; }
+  public Object getValue(Object ctx, Object elCtx, VariableResolverFactory factory) { return null; }
 }

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
@@ -1,7 +1,8 @@
 package org.mvel2.compiler;
 
+import java.io.Serializable;
 import org.mvel2.integration.VariableResolverFactory;
 
-public interface ExecutableStatement extends Accessor {
+public interface ExecutableStatement extends Accessor, Serializable {
   public Object getValue(Object staticContext, VariableResolverFactory factory);
 }

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
@@ -2,6 +2,6 @@ package org.mvel2.compiler;
 
 import org.mvel2.integration.VariableResolverFactory;
 
-public interface ExecutableStatement {
+public interface ExecutableStatement extends Accessor {
   public Object getValue(Object staticContext, VariableResolverFactory factory);
 }

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
@@ -3,5 +3,5 @@ package org.mvel2.compiler;
 import org.mvel2.integration.VariableResolverFactory;
 
 public interface ExecutableStatement {
-    public Object getValue(Object staticContext, VariableResolverFactory factory);
+  public Object getValue(Object staticContext, VariableResolverFactory factory);
 }

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExecutableStatement.java
@@ -1,0 +1,7 @@
+package org.mvel2.compiler;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public interface ExecutableStatement {
+    public Object getValue(Object staticContext, VariableResolverFactory factory);
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExpressionCompiler.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExpressionCompiler.java
@@ -1,0 +1,6 @@
+package org.mvel2.compiler;
+
+public class ExpressionCompiler {
+  public ExpressionCompiler(String expression) {}
+  public ExecutableStatement compile() { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExpressionCompiler.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/compiler/ExpressionCompiler.java
@@ -2,5 +2,5 @@ package org.mvel2.compiler;
 
 public class ExpressionCompiler {
   public ExpressionCompiler(String expression) {}
-  public ExecutableStatement compile() { return null; }
+  public CompiledExpression compile() { return null; }
 }

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/integration/VariableResolverFactory.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/integration/VariableResolverFactory.java
@@ -1,0 +1,5 @@
+package org.mvel2.integration;
+
+import java.io.Serializable;
+
+public interface VariableResolverFactory extends Serializable {}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/integration/impl/ImmutableDefaultFactory.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/integration/impl/ImmutableDefaultFactory.java
@@ -1,0 +1,5 @@
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.VariableResolverFactory;
+
+public class ImmutableDefaultFactory implements VariableResolverFactory {}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/jsr223/MvelCompiledScript.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/jsr223/MvelCompiledScript.java
@@ -1,0 +1,11 @@
+package org.mvel2.jsr223;
+
+import java.io.Serializable;
+import javax.script.CompiledScript;
+import javax.script.ScriptContext;
+import javax.script.ScriptException;
+
+public class MvelCompiledScript extends CompiledScript {
+  public MvelCompiledScript(MvelScriptEngine engine, Serializable compiledScript) {}
+  public Object eval(ScriptContext context) throws ScriptException { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/jsr223/MvelScriptEngine.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/jsr223/MvelScriptEngine.java
@@ -1,0 +1,12 @@
+package org.mvel2.jsr223;
+
+import java.io.Serializable;
+import javax.script.CompiledScript;
+import javax.script.ScriptContext;
+import javax.script.ScriptException;
+
+public class MvelScriptEngine {
+  public CompiledScript compile(String script) throws ScriptException { return null; }
+  public Serializable compiledScript(String script) throws ScriptException { return null; }
+  public Object evaluate(Serializable expression, ScriptContext context) throws ScriptException { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/CompiledTemplate.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/CompiledTemplate.java
@@ -1,0 +1,3 @@
+package org.mvel2.templates;
+
+public class CompiledTemplate {}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/TemplateCompiler.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/TemplateCompiler.java
@@ -1,0 +1,7 @@
+package org.mvel2.templates;
+
+public class TemplateCompiler {
+  public TemplateCompiler(String template) {}
+  public static CompiledTemplate compileTemplate(String template) { return null; }
+  public CompiledTemplate compile() { return null; }
+}

--- a/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/TemplateRuntime.java
+++ b/java/ql/test/stubs/mvel2-2.4.7/org/mvel2/templates/TemplateRuntime.java
@@ -1,0 +1,8 @@
+package org.mvel2.templates;
+
+import java.util.Map;
+
+public class TemplateRuntime {
+  public static Object eval(String template, Map vars) { return null; }
+  public static Object execute(CompiledTemplate compiled, Map vars) { return null; }
+}


### PR DESCRIPTION
I'd like to add a query that looks for expression language injections with MVEL. Here is a list of main updates:

- Added `experimental/Security/CWE/CWE-094/MvelInjection.ql`.
- Added `experimental/Security/CWE/CWE-094/MvelInjectionLib.qll`.
- Added a qhelp file with an example of vulnerable code.
- Added tests and stubs for `mvel2-2.4.7`.

MVEL is a powerful expression language that allows, in particular, calling arbitrary methods. That may lead to arbitrary code execution. In past, there were several issues (not reported by myself) due to unsafe evaluation of MVEL expressions:

- CVE-2014-3120: RCE in Elasticsearch, see also this blog post
- CVE-2013-6468: RCE in Drools

Currently, the query doesn't find the CVEs above. To make it work, the query needs to be updated with additional taint propagation steps that take into account internal structure of Elasticsearch and Drools. This internal structure is not visible to users via public APIs. I didn't model this internal structure because I am not sure if the users can benefit from it.