### PR TITLE
C++: Allocation.qll: Provide getAllocatedElementType predicate for AllocationExprs. 

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -343,7 +343,8 @@ class CallAllocationExpr extends AllocationExpr, FunctionCall {
   override Expr getReallocPtr() { result = getArgument(target.getReallocPtrArg()) }
 
   override Type getAllocatedElementType() {
-    result = this.getFullyConverted().getUnderlyingType().(PointerType).getBaseType() and
+    result =
+      this.getFullyConverted().getType().stripTopLevelSpecifiers().(PointerType).getBaseType() and
     not result instanceof VoidType
   }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -342,6 +342,11 @@ class CallAllocationExpr extends AllocationExpr, FunctionCall {
 
   override Expr getReallocPtr() { result = getArgument(target.getReallocPtrArg()) }
 
+  override Type getAllocatedElementType() {
+    result = this.getFullyConverted().getUnderlyingType().(PointerType).getBaseType() and
+    not result instanceof VoidType
+  }
+
   override predicate requiresDealloc() { target.requiresDealloc() }
 }
 
@@ -352,6 +357,8 @@ class NewAllocationExpr extends AllocationExpr, NewExpr {
   NewAllocationExpr() { this instanceof NewExpr }
 
   override int getSizeBytes() { result = getAllocatedType().getSize() }
+
+  override Type getAllocatedElementType() { result = getAllocatedType() }
 
   override predicate requiresDealloc() { not exists(getPlacementPointer()) }
 }
@@ -372,6 +379,8 @@ class NewArrayAllocationExpr extends AllocationExpr, NewArrayExpr {
     exists(getExtent()) and
     result = getAllocatedElementType().getSize()
   }
+
+  override Type getAllocatedElementType() { result = NewArrayExpr.super.getAllocatedElementType() }
 
   override int getSizeBytes() { result = getAllocatedType().getSize() }
 

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/Allocation.qll
@@ -73,6 +73,11 @@ abstract class AllocationExpr extends Expr {
   Expr getReallocPtr() { none() }
 
   /**
+   * Gets the type of the elements that are allocated, if it can be determined.
+   */
+  Type getAllocatedElementType() { none() }
+
+  /**
    * Whether or not this allocation requires a corresponding deallocation of
    * some sort (most do, but `alloca` for example does not).  If it is unclear,
    * we default to no (for example a placement `new` allocation may or may not

--- a/cpp/ql/test/library-tests/allocators/allocators.cpp
+++ b/cpp/ql/test/library-tests/allocators/allocators.cpp
@@ -151,13 +151,14 @@ void directOperatorCall() {
 }
 
 void *malloc(size_t);
+typedef int* ptr_int;
 
 void testMalloc(size_t count) {
-  malloc(5);
-  malloc(5 * sizeof(int));
-  malloc(count);
-  malloc(count * sizeof(int));
-  malloc(count * sizeof(int) + 1);
-  malloc(((int) count) * sizeof(void *));
-  malloc(sizeof(void*) * sizeof(int));
+  const volatile int *i = (const volatile int *) malloc(5);
+  ptr_int i2 = (ptr_int) malloc(5 * sizeof(int));
+  volatile long *l = (long *) malloc(count);
+  l = (long *) malloc(count * sizeof(int));
+  const char* c = (const char *) malloc(count * sizeof(int) + 1);
+  void * v = (void *) malloc(((int) count) * sizeof(void *));
+  malloc(sizeof(void *) * sizeof(int));
 }

--- a/cpp/ql/test/library-tests/allocators/allocators.expected
+++ b/cpp/ql/test/library-tests/allocators/allocators.expected
@@ -86,7 +86,7 @@ allocationExprs
 | allocators.cpp:144:13:144:31 | new[] | getAllocatedElementType = char[30][30], getSizeExpr = x, getSizeMult = 900, requiresDealloc |
 | allocators.cpp:149:8:149:19 | call to operator new | getSizeBytes = 4, getSizeExpr = sizeof(int), getSizeMult = 1, requiresDealloc |
 | allocators.cpp:157:50:157:55 | call to malloc | getAllocatedElementType = const volatile int, getSizeBytes = 5, getSizeExpr = 5, getSizeMult = 1, requiresDealloc |
-| allocators.cpp:158:26:158:31 | call to malloc | getSizeBytes = 20, getSizeExpr = 5, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:158:26:158:31 | call to malloc | getAllocatedElementType = int, getSizeBytes = 20, getSizeExpr = 5, getSizeMult = 4, requiresDealloc |
 | allocators.cpp:159:31:159:36 | call to malloc | getAllocatedElementType = volatile long, getSizeExpr = count, getSizeMult = 1, requiresDealloc |
 | allocators.cpp:160:16:160:21 | call to malloc | getAllocatedElementType = volatile long, getSizeExpr = count, getSizeMult = 4, requiresDealloc |
 | allocators.cpp:161:34:161:39 | call to malloc | getAllocatedElementType = const char, getSizeExpr = ... + ..., getSizeMult = 1, requiresDealloc |

--- a/cpp/ql/test/library-tests/allocators/allocators.expected
+++ b/cpp/ql/test/library-tests/allocators/allocators.expected
@@ -85,13 +85,13 @@ allocationExprs
 | allocators.cpp:143:13:143:28 | new[] | getSizeBytes = 400, requiresDealloc |
 | allocators.cpp:144:13:144:31 | new[] | getSizeExpr = x, getSizeMult = 900, requiresDealloc |
 | allocators.cpp:149:8:149:19 | call to operator new | getSizeBytes = 4, getSizeExpr = sizeof(int), getSizeMult = 1, requiresDealloc |
-| allocators.cpp:156:3:156:8 | call to malloc | getSizeBytes = 5, getSizeExpr = 5, getSizeMult = 1, requiresDealloc |
-| allocators.cpp:157:3:157:8 | call to malloc | getSizeBytes = 20, getSizeExpr = 5, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:158:3:158:8 | call to malloc | getSizeExpr = count, getSizeMult = 1, requiresDealloc |
-| allocators.cpp:159:3:159:8 | call to malloc | getSizeExpr = count, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:160:3:160:8 | call to malloc | getSizeExpr = ... + ..., getSizeMult = 1, requiresDealloc |
-| allocators.cpp:161:3:161:8 | call to malloc | getSizeExpr = count, getSizeMult = 8, requiresDealloc |
-| allocators.cpp:162:3:162:8 | call to malloc | getSizeBytes = 32, getSizeExpr = ... * ..., getSizeMult = 1, requiresDealloc |
+| allocators.cpp:157:50:157:55 | call to malloc | getSizeBytes = 5, getSizeExpr = 5, getSizeMult = 1, requiresDealloc |
+| allocators.cpp:158:26:158:31 | call to malloc | getSizeBytes = 20, getSizeExpr = 5, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:159:31:159:36 | call to malloc | getSizeExpr = count, getSizeMult = 1, requiresDealloc |
+| allocators.cpp:160:16:160:21 | call to malloc | getSizeExpr = count, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:161:34:161:39 | call to malloc | getSizeExpr = ... + ..., getSizeMult = 1, requiresDealloc |
+| allocators.cpp:162:23:162:28 | call to malloc | getSizeExpr = count, getSizeMult = 8, requiresDealloc |
+| allocators.cpp:163:3:163:8 | call to malloc | getSizeBytes = 32, getSizeExpr = ... * ..., getSizeMult = 1, requiresDealloc |
 deallocationFunctions
 | allocators.cpp:11:6:11:20 | operator delete | getFreedArg = 0 |
 | allocators.cpp:12:6:12:22 | operator delete[] | getFreedArg = 0 |

--- a/cpp/ql/test/library-tests/allocators/allocators.expected
+++ b/cpp/ql/test/library-tests/allocators/allocators.expected
@@ -61,35 +61,35 @@ allocationFunctions
 | file://:0:0:0:0 | operator new[] | getSizeArg = 0, requiresDealloc |
 | file://:0:0:0:0 | operator new[] | getSizeArg = 0, requiresDealloc |
 allocationExprs
-| allocators.cpp:49:3:49:9 | new | getSizeBytes = 4, requiresDealloc |
-| allocators.cpp:50:3:50:15 | new | getSizeBytes = 4, requiresDealloc |
-| allocators.cpp:51:3:51:11 | new | getSizeBytes = 4, requiresDealloc |
-| allocators.cpp:52:3:52:14 | new | getSizeBytes = 8, requiresDealloc |
-| allocators.cpp:53:3:53:27 | new | getSizeBytes = 8, requiresDealloc |
-| allocators.cpp:54:3:54:17 | new | getSizeBytes = 256, requiresDealloc |
-| allocators.cpp:55:3:55:25 | new | getSizeBytes = 256, requiresDealloc |
-| allocators.cpp:68:3:68:12 | new[] | getSizeExpr = n, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:69:3:69:18 | new[] | getSizeExpr = n, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:70:3:70:15 | new[] | getSizeExpr = n, getSizeMult = 8, requiresDealloc |
-| allocators.cpp:71:3:71:20 | new[] | getSizeExpr = n, getSizeMult = 256, requiresDealloc |
-| allocators.cpp:72:3:72:16 | new[] | getSizeBytes = 80, requiresDealloc |
-| allocators.cpp:107:3:107:18 | new | getSizeBytes = 1, requiresDealloc |
-| allocators.cpp:108:3:108:19 | new[] | getSizeExpr = n, getSizeMult = 1, requiresDealloc |
-| allocators.cpp:109:3:109:35 | new | getSizeBytes = 128, requiresDealloc |
-| allocators.cpp:110:3:110:37 | new[] | getSizeBytes = 1280, requiresDealloc |
-| allocators.cpp:129:3:129:21 | new | getSizeBytes = 4 |
-| allocators.cpp:132:3:132:17 | new[] | getSizeBytes = 4 |
-| allocators.cpp:135:3:135:26 | new | getSizeBytes = 4, requiresDealloc |
-| allocators.cpp:136:3:136:26 | new[] | getSizeBytes = 8, requiresDealloc |
-| allocators.cpp:142:13:142:27 | new[] | getSizeExpr = x, getSizeMult = 10, requiresDealloc |
-| allocators.cpp:143:13:143:28 | new[] | getSizeBytes = 400, requiresDealloc |
-| allocators.cpp:144:13:144:31 | new[] | getSizeExpr = x, getSizeMult = 900, requiresDealloc |
+| allocators.cpp:49:3:49:9 | new | getAllocatedElementType = int, getSizeBytes = 4, requiresDealloc |
+| allocators.cpp:50:3:50:15 | new | getAllocatedElementType = int, getSizeBytes = 4, requiresDealloc |
+| allocators.cpp:51:3:51:11 | new | getAllocatedElementType = int, getSizeBytes = 4, requiresDealloc |
+| allocators.cpp:52:3:52:14 | new | getAllocatedElementType = String, getSizeBytes = 8, requiresDealloc |
+| allocators.cpp:53:3:53:27 | new | getAllocatedElementType = String, getSizeBytes = 8, requiresDealloc |
+| allocators.cpp:54:3:54:17 | new | getAllocatedElementType = Overaligned, getSizeBytes = 256, requiresDealloc |
+| allocators.cpp:55:3:55:25 | new | getAllocatedElementType = Overaligned, getSizeBytes = 256, requiresDealloc |
+| allocators.cpp:68:3:68:12 | new[] | getAllocatedElementType = int, getSizeExpr = n, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:69:3:69:18 | new[] | getAllocatedElementType = int, getSizeExpr = n, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:70:3:70:15 | new[] | getAllocatedElementType = String, getSizeExpr = n, getSizeMult = 8, requiresDealloc |
+| allocators.cpp:71:3:71:20 | new[] | getAllocatedElementType = Overaligned, getSizeExpr = n, getSizeMult = 256, requiresDealloc |
+| allocators.cpp:72:3:72:16 | new[] | getAllocatedElementType = String, getSizeBytes = 80, requiresDealloc |
+| allocators.cpp:107:3:107:18 | new | getAllocatedElementType = FailedInit, getSizeBytes = 1, requiresDealloc |
+| allocators.cpp:108:3:108:19 | new[] | getAllocatedElementType = FailedInit, getSizeExpr = n, getSizeMult = 1, requiresDealloc |
+| allocators.cpp:109:3:109:35 | new | getAllocatedElementType = FailedInitOveraligned, getSizeBytes = 128, requiresDealloc |
+| allocators.cpp:110:3:110:37 | new[] | getAllocatedElementType = FailedInitOveraligned, getSizeBytes = 1280, requiresDealloc |
+| allocators.cpp:129:3:129:21 | new | getAllocatedElementType = int, getSizeBytes = 4 |
+| allocators.cpp:132:3:132:17 | new[] | getAllocatedElementType = int, getSizeBytes = 4 |
+| allocators.cpp:135:3:135:26 | new | getAllocatedElementType = int, getSizeBytes = 4, requiresDealloc |
+| allocators.cpp:136:3:136:26 | new[] | getAllocatedElementType = int, getSizeBytes = 8, requiresDealloc |
+| allocators.cpp:142:13:142:27 | new[] | getAllocatedElementType = char[10], getSizeExpr = x, getSizeMult = 10, requiresDealloc |
+| allocators.cpp:143:13:143:28 | new[] | getAllocatedElementType = char[20], getSizeBytes = 400, requiresDealloc |
+| allocators.cpp:144:13:144:31 | new[] | getAllocatedElementType = char[30][30], getSizeExpr = x, getSizeMult = 900, requiresDealloc |
 | allocators.cpp:149:8:149:19 | call to operator new | getSizeBytes = 4, getSizeExpr = sizeof(int), getSizeMult = 1, requiresDealloc |
-| allocators.cpp:157:50:157:55 | call to malloc | getSizeBytes = 5, getSizeExpr = 5, getSizeMult = 1, requiresDealloc |
+| allocators.cpp:157:50:157:55 | call to malloc | getAllocatedElementType = const volatile int, getSizeBytes = 5, getSizeExpr = 5, getSizeMult = 1, requiresDealloc |
 | allocators.cpp:158:26:158:31 | call to malloc | getSizeBytes = 20, getSizeExpr = 5, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:159:31:159:36 | call to malloc | getSizeExpr = count, getSizeMult = 1, requiresDealloc |
-| allocators.cpp:160:16:160:21 | call to malloc | getSizeExpr = count, getSizeMult = 4, requiresDealloc |
-| allocators.cpp:161:34:161:39 | call to malloc | getSizeExpr = ... + ..., getSizeMult = 1, requiresDealloc |
+| allocators.cpp:159:31:159:36 | call to malloc | getAllocatedElementType = volatile long, getSizeExpr = count, getSizeMult = 1, requiresDealloc |
+| allocators.cpp:160:16:160:21 | call to malloc | getAllocatedElementType = volatile long, getSizeExpr = count, getSizeMult = 4, requiresDealloc |
+| allocators.cpp:161:34:161:39 | call to malloc | getAllocatedElementType = const char, getSizeExpr = ... + ..., getSizeMult = 1, requiresDealloc |
 | allocators.cpp:162:23:162:28 | call to malloc | getSizeExpr = count, getSizeMult = 8, requiresDealloc |
 | allocators.cpp:163:3:163:8 | call to malloc | getSizeBytes = 32, getSizeExpr = ... * ..., getSizeMult = 1, requiresDealloc |
 deallocationFunctions

--- a/cpp/ql/test/library-tests/allocators/allocators.ql
+++ b/cpp/ql/test/library-tests/allocators/allocators.ql
@@ -138,6 +138,8 @@ string describeAllocationExpr(AllocationExpr e) {
   or
   result = "getReallocPtr = " + e.getReallocPtr().toString()
   or
+  result = "getAllocatedElementType = " + e.getAllocatedElementType().toString()
+  or
   e.requiresDealloc() and
   result = "requiresDealloc"
 }


### PR DESCRIPTION
This predicate tries to determine the type of the allocated elements of an allocation expression.

This PR depends on #3326.

The biggest design decision here is to ignore void*-allocations of malloc and not report an allocated element type.
This is debatable, but as VoidType.getSize() yields 0, all downstream users that want to use the size of the allocated element would need to special case this.
Furthermore, talking about elements of type void seems weird.