### PR TITLE
Python: Allow `runtime` scope to apply to "private" functions.

### DIFF
--- a/python/ql/src/semmle/python/pointsto/PointsToContext.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsToContext.qll
@@ -238,11 +238,9 @@ private predicate in_source(Scope s) { exists(s.getEnclosingModule().getFile().g
 /**
  * Holds if this scope can be executed in the default context.
  * All modules and classes executed at import time and
- * all "public" functions and methods, including those invoked by the VM.
+ * all functions and methods, including those invoked by the VM.
  */
 predicate executes_in_runtime_context(Function f) {
-    /* "Public" scope, i.e. functions whose name starts not with an underscore, or special methods */
-    (f.getName().charAt(0) != "_" or f.isSpecialMethod() or f.isInitMethod()) and
     in_source(f)
 }
 

--- a/python/ql/test/library-tests/PointsTo/new/PointsToUnknown.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToUnknown.expected
@@ -243,9 +243,13 @@
 | r_regressions.py:43 | ControlFlowNode for x() | 43 |
 | r_regressions.py:44 | ControlFlowNode for data | 43 |
 | r_regressions.py:52 | ControlFlowNode for msg | 51 |
+| r_regressions.py:62 | ControlFlowNode for obj | 61 |
 | r_regressions.py:64 | ControlFlowNode for do_validation | 64 |
 | r_regressions.py:64 | ControlFlowNode for do_validation() | 64 |
+| r_regressions.py:66 | ControlFlowNode for obj | 61 |
+| r_regressions.py:73 | ControlFlowNode for obj | 61 |
 | r_regressions.py:73 | ControlFlowNode for setattr() | 73 |
+| r_regressions.py:74 | ControlFlowNode for obj | 61 |
 | r_regressions.py:90 | ControlFlowNode for Attribute | 90 |
 | r_regressions.py:90 | ControlFlowNode for Attribute() | 90 |
 | r_regressions.py:102 | ControlFlowNode for unrelated_call | 102 |

--- a/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
@@ -262,16 +262,28 @@
 | g_class_init.py:9 | ControlFlowNode for FunctionExpr | Function _init | builtin-class function | 9 | import |
 | g_class_init.py:9 | ControlFlowNode for _init | Function _init | builtin-class function | 9 | import |
 | g_class_init.py:10 | ControlFlowNode for Attribute | int 2 | builtin-class int | 10 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:10 | ControlFlowNode for Attribute | int 2 | builtin-class int | 10 | runtime |
 | g_class_init.py:10 | ControlFlowNode for IntegerLiteral | int 2 | builtin-class int | 10 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:10 | ControlFlowNode for IntegerLiteral | int 2 | builtin-class int | 10 | runtime |
 | g_class_init.py:10 | ControlFlowNode for self | self | class C | 5 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:10 | ControlFlowNode for self | self | class C | 9 | runtime |
 | g_class_init.py:11 | ControlFlowNode for Attribute | Attribute | builtin-class method | 11 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:11 | ControlFlowNode for Attribute | Attribute | builtin-class method | 11 | runtime |
 | g_class_init.py:11 | ControlFlowNode for Attribute() | NoneType None | builtin-class NoneType | 13 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:11 | ControlFlowNode for Attribute() | NoneType None | builtin-class NoneType | 13 | runtime |
 | g_class_init.py:11 | ControlFlowNode for self | self | class C | 5 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:11 | ControlFlowNode for self | self | class C | 9 | runtime |
 | g_class_init.py:13 | ControlFlowNode for FunctionExpr | Function _init2 | builtin-class function | 13 | import |
 | g_class_init.py:13 | ControlFlowNode for _init2 | Function _init2 | builtin-class function | 13 | import |
 | g_class_init.py:14 | ControlFlowNode for Attribute | int 3 | builtin-class int | 14 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:14 | ControlFlowNode for Attribute | int 3 | builtin-class int | 14 | code/g_class_init.py:11 from runtime |
+| g_class_init.py:14 | ControlFlowNode for Attribute | int 3 | builtin-class int | 14 | runtime |
 | g_class_init.py:14 | ControlFlowNode for IntegerLiteral | int 3 | builtin-class int | 14 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:14 | ControlFlowNode for IntegerLiteral | int 3 | builtin-class int | 14 | code/g_class_init.py:11 from runtime |
+| g_class_init.py:14 | ControlFlowNode for IntegerLiteral | int 3 | builtin-class int | 14 | runtime |
 | g_class_init.py:14 | ControlFlowNode for self | self | class C | 5 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:14 | ControlFlowNode for self | self | class C | 9 | code/g_class_init.py:11 from runtime |
+| g_class_init.py:14 | ControlFlowNode for self | self | class C | 13 | runtime |
 | g_class_init.py:16 | ControlFlowNode for FunctionExpr | Function method | builtin-class function | 16 | import |
 | g_class_init.py:16 | ControlFlowNode for method | Function method | builtin-class function | 16 | import |
 | g_class_init.py:17 | ControlFlowNode for self | self | class C | 16 | runtime |
@@ -1069,11 +1081,17 @@
 | r_regressions.py:11 | ControlFlowNode for FunctionExpr | Function _after_fork | builtin-class function | 11 | import |
 | r_regressions.py:11 | ControlFlowNode for _after_fork | Function _after_fork | builtin-class function | 11 | import |
 | r_regressions.py:12 | ControlFlowNode for Attribute | bool False | builtin-class bool | 12 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:12 | ControlFlowNode for Attribute | bool False | builtin-class bool | 12 | runtime |
 | r_regressions.py:12 | ControlFlowNode for False | bool False | builtin-class bool | 12 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:12 | ControlFlowNode for False | bool False | builtin-class bool | 12 | runtime |
 | r_regressions.py:12 | ControlFlowNode for self | self | class Queue | 7 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:12 | ControlFlowNode for self | self | class Queue | 11 | runtime |
 | r_regressions.py:13 | ControlFlowNode for Attribute | NoneType None | builtin-class NoneType | 13 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:13 | ControlFlowNode for Attribute | NoneType None | builtin-class NoneType | 13 | runtime |
 | r_regressions.py:13 | ControlFlowNode for None | NoneType None | builtin-class NoneType | 13 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:13 | ControlFlowNode for None | NoneType None | builtin-class NoneType | 13 | runtime |
 | r_regressions.py:13 | ControlFlowNode for self | self | class Queue | 7 | code/r_regressions.py:9 from runtime |
+| r_regressions.py:13 | ControlFlowNode for self | self | class Queue | 11 | runtime |
 | r_regressions.py:15 | ControlFlowNode for FunctionExpr | Function close | builtin-class function | 15 | import |
 | r_regressions.py:15 | ControlFlowNode for close | Function close | builtin-class function | 15 | import |
 | r_regressions.py:16 | ControlFlowNode for Attribute | bool True | builtin-class bool | 16 | runtime |
@@ -1112,22 +1130,38 @@
 | r_regressions.py:61 | ControlFlowNode for FunctionExpr | Function _dec | builtin-class function | 61 | runtime |
 | r_regressions.py:61 | ControlFlowNode for _dec | Function _dec | builtin-class function | 61 | code/r_regressions.py:85 from import |
 | r_regressions.py:61 | ControlFlowNode for _dec | Function _dec | builtin-class function | 61 | runtime |
+| r_regressions.py:62 | ControlFlowNode for is_class | bool False | builtin-class bool | 62 | runtime |
 | r_regressions.py:62 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:62 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | runtime |
 | r_regressions.py:62 | ControlFlowNode for isinstance | Builtin-function isinstance | builtin-class builtin_function_or_method | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:62 | ControlFlowNode for isinstance | Builtin-function isinstance | builtin-class builtin_function_or_method | 62 | runtime |
+| r_regressions.py:62 | ControlFlowNode for isinstance() | bool False | builtin-class bool | 62 | runtime |
 | r_regressions.py:62 | ControlFlowNode for isinstance() | bool True | builtin-class bool | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:62 | ControlFlowNode for isinstance() | bool True | builtin-class bool | 62 | runtime |
 | r_regressions.py:62 | ControlFlowNode for obj | class TestFirst | builtin-class type | 86 | code/r_regressions.py:85 from import |
 | r_regressions.py:62 | ControlFlowNode for type | builtin-class type | builtin-class type | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:62 | ControlFlowNode for type | builtin-class type | builtin-class type | 62 | runtime |
+| r_regressions.py:63 | ControlFlowNode for is_class | bool False | builtin-class bool | 62 | runtime |
 | r_regressions.py:63 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:63 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | runtime |
 | r_regressions.py:68 | ControlFlowNode for FunctionExpr | Function _wrapper | builtin-class function | 68 | code/r_regressions.py:85 from import |
+| r_regressions.py:68 | ControlFlowNode for FunctionExpr | Function _wrapper | builtin-class function | 68 | runtime |
 | r_regressions.py:68 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 68 | code/r_regressions.py:85 from import |
+| r_regressions.py:68 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 68 | runtime |
 | r_regressions.py:68 | ControlFlowNode for args | args | builtin-class tuple | 68 | runtime |
 | r_regressions.py:68 | ControlFlowNode for kwargs | kwargs | builtin-class dict | 68 | runtime |
+| r_regressions.py:72 | ControlFlowNode for is_class | bool False | builtin-class bool | 62 | runtime |
 | r_regressions.py:72 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | code/r_regressions.py:85 from import |
+| r_regressions.py:72 | ControlFlowNode for is_class | bool True | builtin-class bool | 62 | runtime |
 | r_regressions.py:73 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 68 | code/r_regressions.py:85 from import |
+| r_regressions.py:73 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 68 | runtime |
 | r_regressions.py:73 | ControlFlowNode for obj | class TestFirst | builtin-class type | 86 | code/r_regressions.py:85 from import |
 | r_regressions.py:73 | ControlFlowNode for setattr | Builtin-function setattr | builtin-class builtin_function_or_method | 73 | code/r_regressions.py:85 from import |
+| r_regressions.py:73 | ControlFlowNode for setattr | Builtin-function setattr | builtin-class builtin_function_or_method | 73 | runtime |
 | r_regressions.py:73 | ControlFlowNode for setattr() | NoneType None | builtin-class NoneType | 73 | code/r_regressions.py:85 from import |
+| r_regressions.py:73 | ControlFlowNode for setattr() | NoneType None | builtin-class NoneType | 73 | runtime |
 | r_regressions.py:74 | ControlFlowNode for obj | class TestFirst | builtin-class type | 86 | code/r_regressions.py:85 from import |
+| r_regressions.py:76 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 68 | runtime |
 | r_regressions.py:78 | ControlFlowNode for _dec | Function _dec | builtin-class function | 61 | code/r_regressions.py:85 from import |
 | r_regressions.py:78 | ControlFlowNode for _dec | Function _dec | builtin-class function | 61 | runtime |
 | r_regressions.py:80 | ControlFlowNode for FunctionExpr | Function deco | builtin-class function | 80 | import |
@@ -1136,6 +1170,7 @@
 | r_regressions.py:81 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 81 | runtime |
 | r_regressions.py:81 | ControlFlowNode for args | args | builtin-class tuple | 81 | runtime |
 | r_regressions.py:81 | ControlFlowNode for kwargs | kwargs | builtin-class dict | 81 | runtime |
+| r_regressions.py:82 | ControlFlowNode for True | bool True | builtin-class bool | 82 | runtime |
 | r_regressions.py:83 | ControlFlowNode for _wrapper | Function _wrapper | builtin-class function | 81 | runtime |
 | r_regressions.py:85 | ControlFlowNode for Str | 'method' | builtin-class str | 85 | import |
 | r_regressions.py:85 | ControlFlowNode for deco | Function deco | builtin-class function | 80 | import |

--- a/python/ql/test/library-tests/PointsTo/new/PointsToWithType.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToWithType.expected
@@ -377,14 +377,18 @@
 | g_class_init.py:10 | ControlFlowNode for Attribute | int 2 | builtin-class int | 10 |
 | g_class_init.py:10 | ControlFlowNode for IntegerLiteral | int 2 | builtin-class int | 10 |
 | g_class_init.py:10 | ControlFlowNode for self | self | class C | 5 |
+| g_class_init.py:10 | ControlFlowNode for self | self | class C | 9 |
 | g_class_init.py:11 | ControlFlowNode for Attribute | Attribute | builtin-class method | 11 |
 | g_class_init.py:11 | ControlFlowNode for Attribute() | NoneType None | builtin-class NoneType | 13 |
 | g_class_init.py:11 | ControlFlowNode for self | self | class C | 5 |
+| g_class_init.py:11 | ControlFlowNode for self | self | class C | 9 |
 | g_class_init.py:13 | ControlFlowNode for FunctionExpr | Function _init2 | builtin-class function | 13 |
 | g_class_init.py:13 | ControlFlowNode for _init2 | Function _init2 | builtin-class function | 13 |
 | g_class_init.py:14 | ControlFlowNode for Attribute | int 3 | builtin-class int | 14 |
 | g_class_init.py:14 | ControlFlowNode for IntegerLiteral | int 3 | builtin-class int | 14 |
 | g_class_init.py:14 | ControlFlowNode for self | self | class C | 5 |
+| g_class_init.py:14 | ControlFlowNode for self | self | class C | 9 |
+| g_class_init.py:14 | ControlFlowNode for self | self | class C | 13 |
 | g_class_init.py:16 | ControlFlowNode for FunctionExpr | Function method | builtin-class function | 16 |
 | g_class_init.py:16 | ControlFlowNode for method | Function method | builtin-class function | 16 |
 | g_class_init.py:17 | ControlFlowNode for self | self | class C | 16 |

--- a/python/ql/test/library-tests/PointsTo/new/SsaAttr.expected
+++ b/python/ql/test/library-tests/PointsTo/new/SsaAttr.expected
@@ -13,11 +13,18 @@
 | g_class_init.py:7 | self_2 | y | AttributeAssignment 'x'(self_1) | int 2 | runtime |
 | g_class_init.py:7 | self_2 | z | AttributeAssignment 'x'(self_1) | int 3 | runtime |
 | g_class_init.py:10 | self_1 | y | AttributeAssignment 'y'(self_0) | int 2 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:10 | self_1 | y | AttributeAssignment 'y'(self_0) | int 2 | runtime |
 | g_class_init.py:11 | self_2 | y | SelfCallsiteRefinement(self_1) | int 2 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:11 | self_2 | y | SelfCallsiteRefinement(self_1) | int 2 | runtime |
 | g_class_init.py:11 | self_2 | z | SelfCallsiteRefinement(self_1) | int 3 | code/g_class_init.py:6 from runtime |
+| g_class_init.py:11 | self_2 | z | SelfCallsiteRefinement(self_1) | int 3 | runtime |
 | g_class_init.py:13 | self_0 | y | ParameterDefinition | int 2 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:13 | self_0 | y | ParameterDefinition | int 2 | code/g_class_init.py:11 from runtime |
 | g_class_init.py:14 | self_1 | y | AttributeAssignment 'z'(self_0) | int 2 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:14 | self_1 | y | AttributeAssignment 'z'(self_0) | int 2 | code/g_class_init.py:11 from runtime |
 | g_class_init.py:14 | self_1 | z | AttributeAssignment 'z'(self_0) | int 3 | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime |
+| g_class_init.py:14 | self_1 | z | AttributeAssignment 'z'(self_0) | int 3 | code/g_class_init.py:11 from runtime |
+| g_class_init.py:14 | self_1 | z | AttributeAssignment 'z'(self_0) | int 3 | runtime |
 | g_class_init.py:46 | self_3 | version | phi(self_1, self_2) | 'v2' | runtime |
 | g_class_init.py:46 | self_3 | version | phi(self_1, self_2) | 'v3' | runtime |
 | g_class_init.py:48 | self_1 | version | AttributeAssignment 'version'(self_0) | 'v2' | runtime |

--- a/python/ql/test/library-tests/PointsTo/new/Values.expected
+++ b/python/ql/test/library-tests/PointsTo/new/Values.expected
@@ -212,13 +212,22 @@
 | g_class_init.py:7 | ControlFlowNode for self | runtime | self instance of C | class C |
 | g_class_init.py:9 | ControlFlowNode for FunctionExpr | import | Function C._init | builtin-class function |
 | g_class_init.py:10 | ControlFlowNode for IntegerLiteral | code/g_class_init.py:6 from runtime | int 2 | builtin-class int |
+| g_class_init.py:10 | ControlFlowNode for IntegerLiteral | runtime | int 2 | builtin-class int |
 | g_class_init.py:10 | ControlFlowNode for self | code/g_class_init.py:6 from runtime | self instance of C | class C |
+| g_class_init.py:10 | ControlFlowNode for self | runtime | self instance of C | class C |
 | g_class_init.py:11 | ControlFlowNode for Attribute | code/g_class_init.py:6 from runtime | Method(Function C._init2, self instance of C) | builtin-class method |
+| g_class_init.py:11 | ControlFlowNode for Attribute | runtime | Method(Function C._init2, self instance of C) | builtin-class method |
 | g_class_init.py:11 | ControlFlowNode for Attribute() | code/g_class_init.py:6 from runtime | None | builtin-class NoneType |
+| g_class_init.py:11 | ControlFlowNode for Attribute() | runtime | None | builtin-class NoneType |
 | g_class_init.py:11 | ControlFlowNode for self | code/g_class_init.py:6 from runtime | self instance of C | class C |
+| g_class_init.py:11 | ControlFlowNode for self | runtime | self instance of C | class C |
 | g_class_init.py:13 | ControlFlowNode for FunctionExpr | import | Function C._init2 | builtin-class function |
 | g_class_init.py:14 | ControlFlowNode for IntegerLiteral | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime | int 3 | builtin-class int |
+| g_class_init.py:14 | ControlFlowNode for IntegerLiteral | code/g_class_init.py:11 from runtime | int 3 | builtin-class int |
+| g_class_init.py:14 | ControlFlowNode for IntegerLiteral | runtime | int 3 | builtin-class int |
 | g_class_init.py:14 | ControlFlowNode for self | code/g_class_init.py:11 from code/g_class_init.py:6 from runtime | self instance of C | class C |
+| g_class_init.py:14 | ControlFlowNode for self | code/g_class_init.py:11 from runtime | self instance of C | class C |
+| g_class_init.py:14 | ControlFlowNode for self | runtime | self instance of C | class C |
 | g_class_init.py:16 | ControlFlowNode for FunctionExpr | import | Function C.method | builtin-class function |
 | g_class_init.py:17 | ControlFlowNode for self | runtime | self instance of C | class C |
 | g_class_init.py:18 | ControlFlowNode for int | runtime | builtin-class int | builtin-class type |
@@ -860,9 +869,13 @@
 | r_regressions.py:9 | ControlFlowNode for self | runtime | self instance of Queue | class Queue |
 | r_regressions.py:11 | ControlFlowNode for FunctionExpr | import | Function Queue._after_fork | builtin-class function |
 | r_regressions.py:12 | ControlFlowNode for False | code/r_regressions.py:9 from runtime | bool False | builtin-class bool |
+| r_regressions.py:12 | ControlFlowNode for False | runtime | bool False | builtin-class bool |
 | r_regressions.py:12 | ControlFlowNode for self | code/r_regressions.py:9 from runtime | self instance of Queue | class Queue |
+| r_regressions.py:12 | ControlFlowNode for self | runtime | self instance of Queue | class Queue |
 | r_regressions.py:13 | ControlFlowNode for None | code/r_regressions.py:9 from runtime | None | builtin-class NoneType |
+| r_regressions.py:13 | ControlFlowNode for None | runtime | None | builtin-class NoneType |
 | r_regressions.py:13 | ControlFlowNode for self | code/r_regressions.py:9 from runtime | self instance of Queue | class Queue |
+| r_regressions.py:13 | ControlFlowNode for self | runtime | self instance of Queue | class Queue |
 | r_regressions.py:15 | ControlFlowNode for FunctionExpr | import | Function Queue.close | builtin-class function |
 | r_regressions.py:16 | ControlFlowNode for True | runtime | bool True | builtin-class bool |
 | r_regressions.py:16 | ControlFlowNode for self | runtime | self instance of Queue | class Queue |
@@ -891,21 +904,35 @@
 | r_regressions.py:61 | ControlFlowNode for FunctionExpr | code/r_regressions.py:85 from import | Function method_decorator._dec | builtin-class function |
 | r_regressions.py:61 | ControlFlowNode for FunctionExpr | runtime | Function method_decorator._dec | builtin-class function |
 | r_regressions.py:62 | ControlFlowNode for isinstance | code/r_regressions.py:85 from import | Builtin-function isinstance | builtin-class builtin_function_or_method |
+| r_regressions.py:62 | ControlFlowNode for isinstance | runtime | Builtin-function isinstance | builtin-class builtin_function_or_method |
 | r_regressions.py:62 | ControlFlowNode for isinstance() | code/r_regressions.py:85 from import | bool True | builtin-class bool |
+| r_regressions.py:62 | ControlFlowNode for isinstance() | runtime | bool False | builtin-class bool |
+| r_regressions.py:62 | ControlFlowNode for isinstance() | runtime | bool True | builtin-class bool |
 | r_regressions.py:62 | ControlFlowNode for obj | code/r_regressions.py:85 from import | class TestFirst | builtin-class type |
 | r_regressions.py:62 | ControlFlowNode for type | code/r_regressions.py:85 from import | builtin-class type | builtin-class type |
+| r_regressions.py:62 | ControlFlowNode for type | runtime | builtin-class type | builtin-class type |
 | r_regressions.py:63 | ControlFlowNode for is_class | code/r_regressions.py:85 from import | bool True | builtin-class bool |
+| r_regressions.py:63 | ControlFlowNode for is_class | runtime | bool False | builtin-class bool |
+| r_regressions.py:63 | ControlFlowNode for is_class | runtime | bool True | builtin-class bool |
 | r_regressions.py:68 | ControlFlowNode for FunctionExpr | code/r_regressions.py:85 from import | Function method_decorator._dec._wrapper | builtin-class function |
+| r_regressions.py:68 | ControlFlowNode for FunctionExpr | runtime | Function method_decorator._dec._wrapper | builtin-class function |
 | r_regressions.py:72 | ControlFlowNode for is_class | code/r_regressions.py:85 from import | bool True | builtin-class bool |
+| r_regressions.py:72 | ControlFlowNode for is_class | runtime | bool False | builtin-class bool |
+| r_regressions.py:72 | ControlFlowNode for is_class | runtime | bool True | builtin-class bool |
 | r_regressions.py:73 | ControlFlowNode for _wrapper | code/r_regressions.py:85 from import | Function method_decorator._dec._wrapper | builtin-class function |
+| r_regressions.py:73 | ControlFlowNode for _wrapper | runtime | Function method_decorator._dec._wrapper | builtin-class function |
 | r_regressions.py:73 | ControlFlowNode for obj | code/r_regressions.py:85 from import | class TestFirst | builtin-class type |
 | r_regressions.py:73 | ControlFlowNode for setattr | code/r_regressions.py:85 from import | Builtin-function setattr | builtin-class builtin_function_or_method |
+| r_regressions.py:73 | ControlFlowNode for setattr | runtime | Builtin-function setattr | builtin-class builtin_function_or_method |
 | r_regressions.py:73 | ControlFlowNode for setattr() | code/r_regressions.py:85 from import | None | builtin-class NoneType |
+| r_regressions.py:73 | ControlFlowNode for setattr() | runtime | None | builtin-class NoneType |
 | r_regressions.py:74 | ControlFlowNode for obj | code/r_regressions.py:85 from import | class TestFirst | builtin-class type |
+| r_regressions.py:76 | ControlFlowNode for _wrapper | runtime | Function method_decorator._dec._wrapper | builtin-class function |
 | r_regressions.py:78 | ControlFlowNode for _dec | code/r_regressions.py:85 from import | Function method_decorator._dec | builtin-class function |
 | r_regressions.py:78 | ControlFlowNode for _dec | runtime | Function method_decorator._dec | builtin-class function |
 | r_regressions.py:80 | ControlFlowNode for FunctionExpr | import | Function deco | builtin-class function |
 | r_regressions.py:81 | ControlFlowNode for FunctionExpr | runtime | Function deco._wrapper | builtin-class function |
+| r_regressions.py:82 | ControlFlowNode for True | runtime | bool True | builtin-class bool |
 | r_regressions.py:83 | ControlFlowNode for _wrapper | runtime | Function deco._wrapper | builtin-class function |
 | r_regressions.py:85 | ControlFlowNode for Str | import | 'method' | builtin-class str |
 | r_regressions.py:85 | ControlFlowNode for deco | import | Function deco | builtin-class function |

--- a/python/ql/test/library-tests/PointsTo/regressions/missing/uncalled-function/Test.expected
+++ b/python/ql/test/library-tests/PointsTo/regressions/missing/uncalled-function/Test.expected
@@ -1,2 +1,2 @@
-| test.py:10:11:10:14 | ControlFlowNode for open | <MISSING pointsTo()> |
+| test.py:10:11:10:14 | ControlFlowNode for open | Builtin-function open |
 | test.py:14:11:14:14 | ControlFlowNode for open | Builtin-function open |


### PR DESCRIPTION
Fixes the regression documented in #3300. 

As we are currently applying this scope to all non-"private" functions, I don't expect this to have a major impact on the accuracy of our analysis (apart from the obvious fact that we won't be ignoring all of the "private" functions!).

Still, we should run a performance test just to make sure.