### PR TITLE
Add guardsFlowFrom predicate to BarrierGuard

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -694,4 +694,7 @@ class BarrierGuard extends GuardCondition {
       this.controls(result.getExpr().getBasicBlock(), branch)
     )
   }
+
+  /** Holds if flow out from `node` is guarded by this guard. */
+  private predicate guardsFlowFrom(DataFlow::Node node) { none() }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -586,4 +586,7 @@ class BarrierGuard extends IRGuardCondition {
       this.controls(result.asInstruction().getBlock(), edge)
     )
   }
+
+  /** Holds if flow out from `node` is guarded by this guard. */
+  private predicate guardsFlowFrom(DataFlow::Node node) { none() }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -230,4 +230,7 @@ class BarrierGuard extends Guard {
       this.controlsNode(result.getControlFlowNode(), e, v)
     )
   }
+
+  /** Holds if flow out from `node` is guarded by this guard. */
+  private predicate guardsFlowFrom(DataFlow::Node node) { none() }
 }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -170,6 +170,11 @@ private predicate inBarrier(Node node, Configuration config) {
 private predicate outBarrier(Node node, Configuration config) {
   config.isBarrierOut(node) and
   config.isSink(node)
+  or
+  exists(BarrierGuard g |
+    config.isBarrierGuard(g) and
+    g.guardsFlowFrom(node)
+  )
 }
 
 private predicate fullBarrier(Node node, Configuration config) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -453,4 +453,7 @@ class BarrierGuard extends Guard {
       result.asExpr() = use
     )
   }
+
+  /** Holds if flow out from `node` is guarded by this guard. */
+  private predicate guardsFlowFrom(DataFlow::Node node) { none() }
 }


### PR DESCRIPTION
This is to facilitate phi edge barrier guards; see https://github.com/github/codeql-go/pull/110.

I've refrained from adding an `edgeBarrier` predicate to guard only a single edge, but if it seems like that would make more sense I can do that.