### PR TITLE
C#: Improve db consistency by removing assembly id

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
@@ -77,7 +77,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static Accessor Create(Context cx, IMethodSymbol symbol) =>
-            AccessorFactory.Instance.CreateEntity(cx, symbol);
+            AccessorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class AccessorFactory : ICachedEntityFactory<IMethodSymbol, Accessor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -104,7 +104,7 @@ namespace Semmle.Extraction.CSharp.Entities
             {
                 case MethodKind.StaticConstructor:
                 case MethodKind.Constructor:
-                    return ConstructorFactory.Instance.CreateEntity(cx, constructor);
+                    return ConstructorFactory.Instance.CreateEntityFromSymbol(cx, constructor);
                 default:
                     throw new InternalError(constructor, "Attempt to create a Constructor from a symbol that isn't a constructor");
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -114,7 +114,7 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             if (symbol.IsStatic) trapFile.Write("static");
             trapFile.WriteSubId(ContainingType);
-            AddParametersToId(Context, trapFile, symbol, symbol);
+            AddParametersToId(Context, trapFile, symbol);
             trapFile.Write(";constructor");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -114,7 +114,7 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             if (symbol.IsStatic) trapFile.Write("static");
             trapFile.WriteSubId(ContainingType);
-            AddParametersToId(Context, trapFile, symbol);
+            AddParametersToId(Context, trapFile, symbol, symbol);
             trapFile.Write(";constructor");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
@@ -11,7 +11,7 @@ namespace Semmle.Extraction.CSharp.Entities
             : base(cx, init) { }
 
         public new static Conversion Create(Context cx, IMethodSymbol symbol) =>
-            ConversionFactory.Instance.CreateEntity(cx, symbol);
+            ConversionFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static Destructor Create(Context cx, IMethodSymbol symbol) =>
-            DestructorFactory.Instance.CreateEntity(cx, symbol);
+            DestructorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class DestructorFactory : ICachedEntityFactory<IMethodSymbol, Destructor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
@@ -60,7 +60,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 TypeMention.Create(Context, syntaxType, this, type);
         }
 
-        public static Event Create(Context cx, IEventSymbol symbol) => EventFactory.Instance.CreateEntity(cx, symbol);
+        public static Event Create(Context cx, IEventSymbol symbol) => EventFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class EventFactory : ICachedEntityFactory<IEventSymbol, Event>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
@@ -53,7 +53,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static EventAccessor Create(Context cx, IMethodSymbol symbol) =>
-            EventAccessorFactory.Instance.CreateEntity(cx, symbol);
+            EventAccessorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class EventAccessorFactory : ICachedEntityFactory<IMethodSymbol, EventAccessor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.CSharp.Entities
             type = new Lazy<AnnotatedType>(() => Entities.Type.Create(cx, symbol.GetAnnotatedType()));
         }
 
-        public static Field Create(Context cx, IFieldSymbol field) => FieldFactory.Instance.CreateEntity(cx, field);
+        public static Field Create(Context cx, IFieldSymbol field) => FieldFactory.Instance.CreateEntityFromSymbol(cx, field);
 
         // Do not populate backing fields.
         // Populate Tuple fields.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
@@ -71,7 +71,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 TypeMention.Create(Context, syntax.Type, this, type);
         }
 
-        public static new Indexer Create(Context cx, IPropertySymbol prop) => IndexerFactory.Instance.CreateEntity(cx, prop);
+        public static new Indexer Create(Context cx, IPropertySymbol prop) => IndexerFactory.Instance.CreateEntityFromSymbol(cx, prop);
 
         public override void WriteId(TextWriter trapFile)
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.Write('*');
         }
 
-        public static new LocalFunction Create(Context cx, IMethodSymbol field) => LocalFunctionFactory.Instance.CreateEntity(cx, field);
+        public static new LocalFunction Create(Context cx, IMethodSymbol field) => LocalFunctionFactory.Instance.CreateEntityFromSymbol(cx, field);
 
         class LocalFunctionFactory : ICachedEntityFactory<IMethodSymbol, LocalFunction>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
@@ -43,7 +43,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static LocalVariable Create(Context cx, ISymbol local)
         {
-            return LocalVariableFactory.Instance.CreateEntity(cx, local);
+            return LocalVariableFactory.Instance.CreateEntityFromSymbol(cx, local);
         }
 
         void DefineConstantValue(TextWriter trapFile)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -201,10 +201,7 @@ namespace Semmle.Extraction.CSharp.Entities
         /// </summary>
         protected static void AddSignatureTypeToId(Context cx, TextWriter trapFile, IMethodSymbol method, ITypeSymbol type)
         {
-            if (type.ContainsTypeParameters(cx, method))
-                type.BuildTypeId(cx, trapFile, (cx0, tb0, type0) => AddSignatureTypeToId(cx, tb0, method, type0));
-            else
-                trapFile.WriteSubId(Type.Create(cx, type));
+            type.BuildTypeId(cx, trapFile, false, (cx0, tb0, type0) => AddSignatureTypeToId(cx, tb0, method, type0));
         }
 
         protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -134,7 +134,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 }
             }
 
-            AddParametersToId(m.Context, trapFile, m.symbol, m.symbol);
+            AddParametersToId(m.Context, trapFile, m.symbol);
             switch (m.symbol.MethodKind)
             {
                 case MethodKind.PropertyGet:
@@ -204,7 +204,7 @@ namespace Semmle.Extraction.CSharp.Entities
             type.BuildTypeId(cx, trapFile, false, symbolBeingDefined, (cx0, tb0, type0, g) => AddSignatureTypeToId(cx, tb0, method, type0, g));
         }
 
-        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method, ISymbol symbolBeingDefined)
+        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method)
         {
             trapFile.Write('(');
             int index = 0;
@@ -212,13 +212,13 @@ namespace Semmle.Extraction.CSharp.Entities
             if (method.MethodKind == MethodKind.ReducedExtension)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, symbolBeingDefined);
+                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, method);
             }
 
             foreach (var param in method.Parameters)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, param.Type, symbolBeingDefined);
+                AddSignatureTypeToId(cx, trapFile, method, param.Type, method);
                 switch (param.RefKind)
                 {
                     case RefKind.Out:

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -204,7 +204,7 @@ namespace Semmle.Extraction.CSharp.Entities
             type.BuildTypeId(cx, trapFile, false, symbolBeingDefined, (cx0, tb0, type0, g) => AddSignatureTypeToId(cx, tb0, method, type0, g));
         }
 
-        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method, ISymbol generic)
+        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method, ISymbol symbolBeingDefined)
         {
             trapFile.Write('(');
             int index = 0;
@@ -212,13 +212,13 @@ namespace Semmle.Extraction.CSharp.Entities
             if (method.MethodKind == MethodKind.ReducedExtension)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, generic);
+                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, symbolBeingDefined);
             }
 
             foreach (var param in method.Parameters)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, param.Type, generic);
+                AddSignatureTypeToId(cx, trapFile, method, param.Type, symbolBeingDefined);
                 switch (param.RefKind)
                 {
                     case RefKind.Out:
@@ -241,9 +241,10 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static void AddExplicitInterfaceQualifierToId(Context cx, System.IO.TextWriter trapFile, IEnumerable<ISymbol> explicitInterfaceImplementations)
         {
-            if (explicitInterfaceImplementations.Any())
+            foreach (var i in explicitInterfaceImplementations)
             {
-                trapFile.AppendList(",", explicitInterfaceImplementations.Select(impl => cx.CreateEntity(impl.ContainingType)));
+                trapFile.Write(';');
+                i.ContainingType.BuildNestedTypeId(cx, trapFile, null);
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -129,12 +129,12 @@ namespace Semmle.Extraction.CSharp.Entities
                     // Type arguments with different nullability can result in 
                     // a constructed method with different nullability of its parameters and return type,
                     // so we need to create a distinct database entity for it.
-                    trapFile.BuildList(",", m.symbol.GetAnnotatedTypeArguments(), (ta, tb0) => { AddSignatureTypeToId(m.Context, tb0, m.symbol, ta.Symbol); trapFile.Write((int)ta.Nullability); });
+                    trapFile.BuildList(",", m.symbol.GetAnnotatedTypeArguments(), (ta, tb0) => { AddSignatureTypeToId(m.Context, tb0, m.symbol, ta.Symbol, m.symbol); trapFile.Write((int)ta.Nullability); });
                     trapFile.Write('>');
                 }
             }
 
-            AddParametersToId(m.Context, trapFile, m.symbol);
+            AddParametersToId(m.Context, trapFile, m.symbol, m.symbol);
             switch (m.symbol.MethodKind)
             {
                 case MethodKind.PropertyGet:
@@ -199,12 +199,12 @@ namespace Semmle.Extraction.CSharp.Entities
         /// to make the reference to <code>#3</code> in the label definition <code>#4</code> for
         /// <code>T</code> valid.
         /// </summary>
-        protected static void AddSignatureTypeToId(Context cx, TextWriter trapFile, IMethodSymbol method, ITypeSymbol type)
+        protected static void AddSignatureTypeToId(Context cx, TextWriter trapFile, IMethodSymbol method, ITypeSymbol type, ISymbol symbolBeingDefined)
         {
-            type.BuildTypeId(cx, trapFile, false, (cx0, tb0, type0) => AddSignatureTypeToId(cx, tb0, method, type0));
+            type.BuildTypeId(cx, trapFile, false, symbolBeingDefined, (cx0, tb0, type0, g) => AddSignatureTypeToId(cx, tb0, method, type0, g));
         }
 
-        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method)
+        protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method, ISymbol generic)
         {
             trapFile.Write('(');
             int index = 0;
@@ -212,13 +212,13 @@ namespace Semmle.Extraction.CSharp.Entities
             if (method.MethodKind == MethodKind.ReducedExtension)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType);
+                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, generic);
             }
 
             foreach (var param in method.Parameters)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, param.Type);
+                AddSignatureTypeToId(cx, trapFile, method, param.Type, generic);
                 switch (param.RefKind)
                 {
                     case RefKind.Out:

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -49,7 +49,7 @@ namespace Semmle.Extraction.CSharp.Entities
             ExtractCompilerGenerated(trapFile);
         }
 
-        public new static OrdinaryMethod Create(Context cx, IMethodSymbol method) => OrdinaryMethodFactory.Instance.CreateEntity(cx, method);
+        public new static OrdinaryMethod Create(Context cx, IMethodSymbol method) => OrdinaryMethodFactory.Instance.CreateEntityFromSymbol(cx, method);
 
         class OrdinaryMethodFactory : ICachedEntityFactory<IMethodSymbol, OrdinaryMethod>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -113,7 +113,7 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             bool isIndexer = prop.IsIndexer || prop.Parameters.Any();
 
-            return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntity(cx, prop);
+            return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntityFromSymbol(cx, prop);
         }
 
         public void VisitDeclaration(Context cx, PropertyDeclarationSyntax p)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
@@ -36,7 +36,7 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.Write(";type");
         }
 
-        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol) => ArrayTypeFactory.Instance.CreateEntity(cx, symbol);
+        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol) => ArrayTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class ArrayTypeFactory : ICachedEntityFactory<IArrayTypeSymbol, ArrayType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
@@ -9,7 +9,7 @@ namespace Semmle.Extraction.CSharp.Entities
         DynamicType(Context cx, IDynamicTypeSymbol init)
             : base(cx, init) { }
 
-        public static DynamicType Create(Context cx, IDynamicTypeSymbol type) => DynamicTypeFactory.Instance.CreateEntity(cx, type);
+        public static DynamicType Create(Context cx, IDynamicTypeSymbol type) => DynamicTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation => Context.Compilation.ObjectType.Locations.FirstOrDefault();
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -108,7 +108,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, true, symbol, (cx0, tb0, sub, g) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, true, symbol, (cx0, tb0, sub, _) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";type");
         }
 
@@ -174,11 +174,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            void WriteType(Context cx, TextWriter trapFile, ITypeSymbol symbol, ISymbol symbolBeingDefined)
-            {
-                symbol.BuildTypeId(cx, trapFile, false, symbolBeingDefined, WriteType);
-            }
-            WriteType(Context, trapFile, referencedType.symbol, referencedType.symbol);
+            referencedType.symbol.BuildNestedTypeId(Context, trapFile, referencedType.symbol);
             trapFile.Write(";typeRef");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -108,7 +108,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, true, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";type");
         }
 
@@ -174,7 +174,11 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            trapFile.WriteSubId(referencedType);
+            void WriteType(Context cx, TextWriter trapFile, ITypeSymbol symbol)
+            {
+                symbol.BuildTypeId(cx, trapFile, false, WriteType);
+            }
+            WriteType(Context, trapFile, referencedType.symbol);
             trapFile.Write(";typeRef");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -108,7 +108,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, true, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, true, symbol, (cx0, tb0, sub, g) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";type");
         }
 
@@ -174,11 +174,11 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            void WriteType(Context cx, TextWriter trapFile, ITypeSymbol symbol)
+            void WriteType(Context cx, TextWriter trapFile, ITypeSymbol symbol, ISymbol symbolBeingDefined)
             {
-                symbol.BuildTypeId(cx, trapFile, false, WriteType);
+                symbol.BuildTypeId(cx, trapFile, false, symbolBeingDefined, WriteType);
             }
-            WriteType(Context, trapFile, referencedType.symbol);
+            WriteType(Context, trapFile, referencedType.symbol, referencedType.symbol);
             trapFile.Write(";typeRef");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.CSharp.Entities
             typeArgumentsLazy = new Lazy<Type[]>(() => symbol.TypeArguments.Select(t => Create(cx, t)).ToArray());
         }
 
-        public static NamedType Create(Context cx, INamedTypeSymbol type) => NamedTypeFactory.Instance.CreateEntity(cx, type);
+        public static NamedType Create(Context cx, INamedTypeSymbol type) => NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
 
         public override bool NeedsPopulation => base.NeedsPopulation || symbol.TypeKind == TypeKind.Error;
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/PointerType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/PointerType.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public Type PointedAtType { get; private set; }
 
-        public static PointerType Create(Context cx, IPointerTypeSymbol symbol) => PointerTypeFactory.Instance.CreateEntity(cx, symbol);
+        public static PointerType Create(Context cx, IPointerTypeSymbol symbol) => PointerTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class PointerTypeFactory : ICachedEntityFactory<IPointerTypeSymbol, PointerType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -32,7 +32,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, false, symbol, (cx0, tb0, sub, g) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, false, symbol, (cx0, tb0, sub, _) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";tuple");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -32,7 +32,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, false, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, false, symbol, (cx0, tb0, sub, g) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";tuple");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -32,7 +32,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, false, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";tuple");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -13,7 +13,7 @@ namespace Semmle.Extraction.CSharp.Entities
     /// </summary>
     class TupleType : Type<INamedTypeSymbol>
     {
-        public static TupleType Create(Context cx, INamedTypeSymbol type) => TupleTypeFactory.Instance.CreateEntity(cx, type);
+        public static TupleType Create(Context cx, INamedTypeSymbol type) => TupleTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
 
         class TupleTypeFactory : ICachedEntityFactory<INamedTypeSymbol, TupleType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -324,6 +324,14 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as Type;
+            return other?.GetType() == GetType() && SymbolEqualityComparer.IncludeNullability.Equals(other.symbol, symbol);
+        }
+
+        public override int GetHashCode() => SymbolEqualityComparer.IncludeNullability.GetHashCode(symbol);
     }
 
     abstract class Type<T> : Type where T : ITypeSymbol

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
@@ -88,7 +88,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         static public TypeParameter Create(Context cx, ITypeParameterSymbol p) =>
-            TypeParameterFactory.Instance.CreateEntity(cx, p);
+            TypeParameterFactory.Instance.CreateEntityFromSymbol(cx, p);
 
         /// <summary>
         /// The variance of this type parameter.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -51,7 +51,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            AddSignatureTypeToId(Context, trapFile, symbol, symbol.ReturnType); // Needed for op_explicit(), which differs only by return type.
+            AddSignatureTypeToId(Context, trapFile, symbol, symbol.ReturnType, symbol); // Needed for op_explicit(), which differs only by return type.
             trapFile.Write(' ');
             BuildMethodId(this, trapFile);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -190,7 +190,7 @@ namespace Semmle.Extraction.CSharp.Entities
             return result;
         }
 
-        public new static UserOperator Create(Context cx, IMethodSymbol symbol) => UserOperatorFactory.Instance.CreateEntity(cx, symbol);
+        public new static UserOperator Create(Context cx, IMethodSymbol symbol) => UserOperatorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
 
         class UserOperatorFactory : ICachedEntityFactory<IMethodSymbol, UserOperator>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -51,7 +51,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            AddSignatureTypeToId(Context, trapFile, symbol, symbol.ReturnType, symbol); // Needed for op_explicit(), which differs only by return type.
+            symbol.ReturnType.BuildNestedTypeId(Context, trapFile, symbol); // Needed for op_explicit(), which differs only by return type.
             trapFile.Write(' ');
             BuildMethodId(this, trapFile);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -131,9 +131,9 @@ namespace Semmle.Extraction.CSharp
         /// <param name="cx">The extraction context.</param>
         /// <param name="trapFile">The trap builder used to store the result.</param>
         /// <param name="subTermAction">The action to apply to syntactic sub terms of this type.</param>
-        public static void BuildTypeId(this ITypeSymbol type, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction)
+        public static void BuildTypeId(this ITypeSymbol type, Context cx, TextWriter trapFile, bool prefix, Action<Context, TextWriter, ITypeSymbol> subTermAction)
         {
-            if (type.SpecialType != SpecialType.None)
+            if (type.SpecialType != SpecialType.None && !(type is INamedTypeSymbol n && n.IsGenericType))
             {
                 /*
                  * Use the keyword ("int" etc) for the built-in types.
@@ -160,7 +160,7 @@ namespace Semmle.Extraction.CSharp
                     case TypeKind.Delegate:
                     case TypeKind.Error:
                         var named = (INamedTypeSymbol)type;
-                        named.BuildNamedTypeId(cx, trapFile, subTermAction);
+                        named.BuildNamedTypeId(cx, trapFile, prefix, subTermAction);
                         return;
                     case TypeKind.Pointer:
                         var ptr = (IPointerTypeSymbol)type;
@@ -211,9 +211,8 @@ namespace Semmle.Extraction.CSharp
             trapFile.Write("::");
         }
 
-        static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction)
+        static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, TextWriter trapFile, bool prefixAssembly, Action<Context, TextWriter, ITypeSymbol> subTermAction)
         {
-            bool prefixAssembly = true;
             if (named.ContainingAssembly is null) prefixAssembly = false;
 
             if (named.IsTupleType)

--- a/csharp/extractor/Semmle.Extraction/CommentProcessing.cs
+++ b/csharp/extractor/Semmle.Extraction/CommentProcessing.cs
@@ -35,7 +35,7 @@ namespace Semmle.Extraction.CommentProcessing
 
         class LocationComparer : IComparer<Location>
         {
-            public int Compare(Location l1, Location l2) => CommentProcessor.Compare(l1, l2);
+            int IComparer<Location>.Compare(Location? l1, Location? l2) => l1 is null ? (l2 is null ? 0 : -1) : l2 is null ? 1 : CommentProcessor.Compare(l1, l2);
         }
 
         /// <summary>

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -75,7 +75,7 @@ namespace Semmle.Extraction
             where Entity : ICachedEntity
             where Type: ISymbol
         {
-            return init == null ? CreateEntity2(factory, init) : CreateNonNullEntity(factory, init);
+            return init == null ? CreateEntity2(factory, init) : CreateNonNullEntity(factory, init, symbolEntityCache);
         }
 
         // A recursion guard against writing to the trap file whilst writing an id to the trap file.
@@ -161,11 +161,11 @@ namespace Semmle.Extraction
 
         public Entity CreateNonNullEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init)
             where Entity : ICachedEntity
+            where Type : notnull
             => CreateNonNullEntity(factory, init, objectEntityCache);
 
-        private Entity CreateNonNullEntity<Type, Src, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init, IDictionary<Src, ICachedEntity> dictionary)
+        private Entity CreateNonNullEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init, IDictionary<object, ICachedEntity> dictionary)
             where Entity : ICachedEntity
-            where Type : Src
         {
             if (init is null) throw new ArgumentException("Unexpected null value", nameof(init));
 
@@ -233,8 +233,18 @@ namespace Semmle.Extraction
         readonly Dictionary<string, ICachedEntity> idLabelCache = new Dictionary<string, ICachedEntity>();
 #endif
 
+        // Adaptor to convert IEqualityComparer<ISymbol> to IEqualityComparer<object>
+        class SymbolComparer : IEqualityComparer<object>
+        {
+            IEqualityComparer<ISymbol> comparer = SymbolEqualityComparer.IncludeNullability;
+
+            bool IEqualityComparer<object>.Equals(object? x, object? y) => comparer.Equals(x as ISymbol, y as ISymbol);
+
+            int IEqualityComparer<object>.GetHashCode(object obj) => comparer.GetHashCode((ISymbol)obj);
+        }
+
         readonly IDictionary<object, ICachedEntity> objectEntityCache = new Dictionary<object, ICachedEntity>();
-        readonly IDictionary<ISymbol, ICachedEntity> symbolEntityCache = new Dictionary<ISymbol, ICachedEntity>(10000, SymbolEqualityComparer.IncludeNullability);
+        readonly IDictionary<object, ICachedEntity> symbolEntityCache = new Dictionary<object, ICachedEntity>(10000, new SymbolComparer());
         readonly Dictionary<ICachedEntity, Label> entityLabelCache = new Dictionary<ICachedEntity, Label>();
         readonly HashSet<Label> extractedGenerics = new HashSet<Label>();
 

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -163,8 +163,9 @@ namespace Semmle.Extraction
             where Entity : ICachedEntity
             => CreateNonNullEntity(factory, init, objectEntityCache);
 
-
-        private Entity CreateNonNullEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init, IDictionary<object, ICachedEntity> dictionary) where Entity : ICachedEntity
+        private Entity CreateNonNullEntity<Type, Src, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init, IDictionary<Src, ICachedEntity> dictionary)
+            where Entity : ICachedEntity
+            where Type : Src
         {
             if (init is null) throw new ArgumentException("Unexpected null value", nameof(init));
 
@@ -231,17 +232,9 @@ namespace Semmle.Extraction
 #if DEBUG_LABELS
         readonly Dictionary<string, ICachedEntity> idLabelCache = new Dictionary<string, ICachedEntity>();
 #endif
-        class SymbolComparer : IEqualityComparer<object>
-        {
-            IEqualityComparer<ISymbol> comparer = SymbolEqualityComparer.IncludeNullability;
-
-            bool IEqualityComparer<object>.Equals(object x, object y) => comparer.Equals((ISymbol)x, (ISymbol)y);
-
-            int IEqualityComparer<object>.GetHashCode(object obj) => comparer.GetHashCode((ISymbol)obj);
-        }
 
         readonly IDictionary<object, ICachedEntity> objectEntityCache = new Dictionary<object, ICachedEntity>();
-        readonly IDictionary<object, ICachedEntity> symbolEntityCache = new Dictionary<object, ICachedEntity>(10000, new SymbolComparer());
+        readonly IDictionary<ISymbol, ICachedEntity> symbolEntityCache = new Dictionary<ISymbol, ICachedEntity>(10000, SymbolEqualityComparer.IncludeNullability);
         readonly Dictionary<ICachedEntity, Label> entityLabelCache = new Dictionary<ICachedEntity, Label>();
         readonly HashSet<Label> extractedGenerics = new HashSet<Label>();
 

--- a/csharp/extractor/Semmle.Extraction/Context.cs
+++ b/csharp/extractor/Semmle.Extraction/Context.cs
@@ -62,7 +62,7 @@ namespace Semmle.Extraction
         /// <returns>The new/existing entity.</returns>
         public Entity CreateNullableEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init) where Entity : ICachedEntity
         {
-            return init == null ? CreateEntity2(factory, init) : CreateNonNullEntity(factory, init);
+            return init == null ? CreateEntity2(factory, init) : CreateNonNullEntity(factory, init, objectEntityCache);
         }
 
         /// <summary>
@@ -161,10 +161,14 @@ namespace Semmle.Extraction
 
         public Entity CreateNonNullEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init)
             where Entity : ICachedEntity
+            => CreateNonNullEntity(factory, init, objectEntityCache);
+
+
+        private Entity CreateNonNullEntity<Type, Entity>(ICachedEntityFactory<Type, Entity> factory, Type init, IDictionary<object, ICachedEntity> dictionary) where Entity : ICachedEntity
         {
             if (init is null) throw new ArgumentException("Unexpected null value", nameof(init));
 
-            if (objectEntityCache.TryGetValue(init, out var cached))
+            if (dictionary.TryGetValue(init, out var cached))
                 return (Entity)cached;
 
             using (StackGuard)
@@ -173,7 +177,7 @@ namespace Semmle.Extraction
                 var entity = factory.Create(this, init);
                 entity.Label = label;
 
-                objectEntityCache[init] = entity;
+                dictionary[init] = entity;
 
                 DefineLabel(entity, TrapWriter.Writer, Extractor);
                 if (entity.NeedsPopulation)
@@ -227,7 +231,17 @@ namespace Semmle.Extraction
 #if DEBUG_LABELS
         readonly Dictionary<string, ICachedEntity> idLabelCache = new Dictionary<string, ICachedEntity>();
 #endif
-        readonly Dictionary<object, ICachedEntity> objectEntityCache = new Dictionary<object, ICachedEntity>();
+        class SymbolComparer : IEqualityComparer<object>
+        {
+            IEqualityComparer<ISymbol> comparer = SymbolEqualityComparer.IncludeNullability;
+
+            bool IEqualityComparer<object>.Equals(object x, object y) => comparer.Equals((ISymbol)x, (ISymbol)y);
+
+            int IEqualityComparer<object>.GetHashCode(object obj) => comparer.GetHashCode((ISymbol)obj);
+        }
+
+        readonly IDictionary<object, ICachedEntity> objectEntityCache = new Dictionary<object, ICachedEntity>();
+        readonly IDictionary<object, ICachedEntity> symbolEntityCache = new Dictionary<object, ICachedEntity>(10000, new SymbolComparer());
         readonly Dictionary<ICachedEntity, Label> entityLabelCache = new Dictionary<ICachedEntity, Label>();
         readonly HashSet<Label> extractedGenerics = new HashSet<Label>();
 

--- a/csharp/extractor/Semmle.Extraction/Entity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entity.cs
@@ -134,6 +134,19 @@ namespace Semmle.Extraction
             where Entity : ICachedEntity => cx.CreateNullableEntity(factory, init);
 
         /// <summary>
+        /// Creates and populates a new entity, or returns the existing one from the cache.
+        /// </summary>
+        /// <typeparam name="Type">The symbol type used to construct the entity.</typeparam>
+        /// <typeparam name="Entity">The type of the entity to create.</typeparam>
+        /// <param name="cx">The extractor context.</param>
+        /// <param name="factory">The factory used to construct the entity.</param>
+        /// <param name="init">The initializer for the entity, which may not be null.</param>
+        /// <returns>The entity.</returns>
+        public static Entity CreateEntityFromSymbol<Type, Entity>(this ICachedEntityFactory<Type, Entity> factory, Context cx, Type init)
+            where Entity : ICachedEntity
+            where Type : ISymbol => cx.CreateEntityFromSymbol(factory, init);
+
+        /// <summary>
         /// Creates and populates a new entity, but uses a different cache.
         /// </summary>
         /// <typeparam name="Type">The symbol type used to construct the entity.</typeparam>

--- a/csharp/ql/src/semmle/code/csharp/AnnotatedType.qll
+++ b/csharp/ql/src/semmle/code/csharp/AnnotatedType.qll
@@ -7,6 +7,7 @@
  */
 
 import csharp
+private import TypeRef
 
 private module Annotations {
   newtype TAnnotation =

--- a/csharp/ql/src/semmle/code/csharp/Attribute.qll
+++ b/csharp/ql/src/semmle/code/csharp/Attribute.qll
@@ -4,6 +4,7 @@
 
 import Type
 private import semmle.code.csharp.ExprOrStmtParent
+private import TypeRef
 
 /**
  * An element that can have attributes. Either an assembly (`Assembly`), a field (`Field`),

--- a/csharp/ql/src/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Callable.qll
@@ -3,13 +3,14 @@
  * such as methods and operators.
  */
 
-import Type
 import Member
 import Stmt
+import Type
 import exprs.Call
 private import dotnet
 private import semmle.code.csharp.ExprOrStmtParent
 private import semmle.code.csharp.metrics.Complexity
+private import TypeRef
 
 /**
  * An element that can be called.

--- a/csharp/ql/src/semmle/code/csharp/Event.qll
+++ b/csharp/ql/src/semmle/code/csharp/Event.qll
@@ -4,6 +4,7 @@
 
 import Member
 import Type
+private import TypeRef
 
 /**
  * An event, for example `E` on line 3 in

--- a/csharp/ql/src/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/src/semmle/code/csharp/Generics.qll
@@ -16,6 +16,7 @@
 import Location
 import Namespace
 private import dotnet
+private import TypeRef
 
 /**
  * A generic declaration. Either an unbound generic (`UnboundGeneric`) or a

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -1,11 +1,12 @@
 /** Provides classes relating to declarations and type members. */
 
-import Element
-import Variable
 import Callable
+import Element
 import Modifier
-private import Implements
+import Variable
 private import dotnet
+private import Implements
+private import TypeRef
 
 /**
  * A declaration.

--- a/csharp/ql/src/semmle/code/csharp/Property.qll
+++ b/csharp/ql/src/semmle/code/csharp/Property.qll
@@ -2,12 +2,13 @@
  * Provides classes for properties, indexers, and accessors.
  */
 
-import Type
 import Member
 import Stmt
-private import semmle.code.csharp.ExprOrStmtParent
-private import dotnet
+import Type
 private import cil
+private import dotnet
+private import semmle.code.csharp.ExprOrStmtParent
+private import TypeRef
 
 /**
  * A declaration that may have accessors. Either an event (`Event`), a property

--- a/csharp/ql/src/semmle/code/csharp/Stmt.qll
+++ b/csharp/ql/src/semmle/code/csharp/Stmt.qll
@@ -4,12 +4,13 @@
  * All statements have the common base class `Stmt`.
  */
 
-import Location
 import Element
+import Location
 import Member
 import exprs.Expr
 private import semmle.code.csharp.Enclosing::Internal
 private import semmle.code.csharp.frameworks.System
+private import TypeRef
 
 /**
  * A statement.

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -1000,8 +1000,7 @@ class TypeMention extends @type_mention {
 /**
  * Module for reasoning about typerefs.
  */
-// private 
-module TypeRefs {
+private module TypeRefs {
   /**
    * A typeref is a reference to a type in some assembly.
    * Often, a type can be present in multiple assemblies.
@@ -1026,14 +1025,14 @@ module TypeRefs {
   }
 
   /** Gets the location of a type. */
-  Location typeLocation(Type t) {
+  private Location typeLocation(Type t) {
     type_location(t, result)
     or
     exists(Type decl | constructed_generic(decl, t) and result = typeLocation(decl))
   }
 
   /** Gets a "canonical location" for a type. A type has only one canonical location. */
-  Location canonicalTypeLocation(Type t) {
+  private Location canonicalTypeLocation(Type t) {
     result = typeLocation(t) and
     not locationIsBetter(result, typeLocation(t))
   }
@@ -1044,10 +1043,11 @@ module TypeRefs {
     or
     typeLocation instanceof Assembly and betterLocation instanceof SourceLocation
     or
-    typeLocation.(SourceLocation).getFile().getAbsolutePath() < betterLocation.(SourceLocation).getFile().getAbsolutePath()
+    typeLocation.(SourceLocation).getFile().getAbsolutePath() <
+      betterLocation.(SourceLocation).getFile().getAbsolutePath()
   }
 
-  predicate isCanonicalType(Type type) {
+  private predicate isCanonicalType(Type type) {
     not exists(TypeRef tr |
       type = tr.getAType() and
       locationIsBetter(canonicalTypeLocation(type), canonicalTypeLocation(tr.getAType()))

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -1,14 +1,15 @@
 /** Provides classes for types. */
 
-import Location
-import Namespace
 import Callable
-import Property
 import Event
 import Generics
+import Location
+import Namespace
+import Property
 private import Conversion
-private import semmle.code.csharp.metrics.Coupling
 private import dotnet
+private import semmle.code.csharp.metrics.Coupling
+private import TypeRef
 
 /**
  * A type.
@@ -983,74 +984,4 @@ class TypeMention extends @type_mention {
 
   /** Gets the location of this type mention. */
   Location getLocation() { type_mention_location(this, result) }
-}
-
-/**
- * INTERNAL: Do not use.
- * Gets a type reference for a given type `type`.
- * This is used for extensionals that can be supplied
- * as either type references or types.
- */
-@type_or_ref getTypeRef(@type type) {
-  result = type
-  or
-  type = result.(TypeRefs::TypeRef).getCanonicalType()
-}
-
-/**
- * Module for reasoning about typerefs.
- */
-private module TypeRefs {
-  /**
-   * A typeref is a reference to a type in some assembly.
-   * Often, a type can be present in multiple assemblies.
-   */
-  class TypeRef extends @typeref {
-    string getName() { typerefs(this, result) }
-
-    string toString() { result = getName() }
-
-    Type getAType() { typeref_type(this, result) }
-
-    /**
-     * Gets the "canonical type" represented by a typeref.
-     * This is because a typeref can reference multiple types, or a type with the same
-     * fully qualified name can exist in multiple assemblies.
-     * The canonical type is an arbitrarily chosen type from the list of candidate types.
-     */
-    Type getCanonicalType() {
-      result = this.getAType() and
-      isCanonicalType(result)
-    }
-  }
-
-  /** Gets the location of a type. */
-  private Location typeLocation(Type t) {
-    type_location(t, result)
-    or
-    exists(Type decl | constructed_generic(decl, t) and result = typeLocation(decl))
-  }
-
-  /** Gets a "canonical location" for a type. A type has only one canonical location. */
-  private Location canonicalTypeLocation(Type t) {
-    result = typeLocation(t) and
-    not locationIsBetter(result, typeLocation(t))
-  }
-
-  pragma[inline]
-  private predicate locationIsBetter(Location typeLocation, Location betterLocation) {
-    typeLocation.(Assembly).getFullName() < betterLocation.(Assembly).getFullName()
-    or
-    typeLocation instanceof Assembly and betterLocation instanceof SourceLocation
-    or
-    typeLocation.(SourceLocation).getFile().getAbsolutePath() <
-      betterLocation.(SourceLocation).getFile().getAbsolutePath()
-  }
-
-  private predicate isCanonicalType(Type type) {
-    not exists(TypeRef tr |
-      type = tr.getAType() and
-      locationIsBetter(canonicalTypeLocation(type), canonicalTypeLocation(tr.getAType()))
-    )
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -994,5 +994,63 @@ class TypeMention extends @type_mention {
 @type_or_ref getTypeRef(@type type) {
   result = type
   or
-  typeref_type(result, type)
+  type = result.(TypeRefs::TypeRef).getCanonicalType()
+}
+
+/**
+ * Module for reasoning about typerefs.
+ */
+// private 
+module TypeRefs {
+  /**
+   * A typeref is a reference to a type in some assembly.
+   * Often, a type can be present in multiple assemblies.
+   */
+  class TypeRef extends @typeref {
+    string getName() { typerefs(this, result) }
+
+    string toString() { result = getName() }
+
+    Type getAType() { typeref_type(this, result) }
+
+    /**
+     * Gets the "canonical type" represented by a typeref.
+     * This is because a typeref can reference multiple types, or a type with the same
+     * fully qualified name can exist in multiple assemblies.
+     * The canonical type is an arbitrarily chosen type from the list of candidate types.
+     */
+    Type getCanonicalType() {
+      result = this.getAType() and
+      isCanonicalType(result)
+    }
+  }
+
+  /** Gets the location of a type. */
+  Location typeLocation(Type t) {
+    type_location(t, result)
+    or
+    exists(Type decl | constructed_generic(decl, t) and result = typeLocation(decl))
+  }
+
+  /** Gets a "canonical location" for a type. A type has only one canonical location. */
+  Location canonicalTypeLocation(Type t) {
+    result = typeLocation(t) and
+    not locationIsBetter(result, typeLocation(t))
+  }
+
+  pragma[inline]
+  private predicate locationIsBetter(Location typeLocation, Location betterLocation) {
+    typeLocation.(Assembly).getFullName() < betterLocation.(Assembly).getFullName()
+    or
+    typeLocation instanceof Assembly and betterLocation instanceof SourceLocation
+    or
+    typeLocation.(SourceLocation).getFile().getAbsolutePath() < betterLocation.(SourceLocation).getFile().getAbsolutePath()
+  }
+
+  predicate isCanonicalType(Type type) {
+    not exists(TypeRef tr |
+      type = tr.getAType() and
+      locationIsBetter(canonicalTypeLocation(type), canonicalTypeLocation(tr.getAType()))
+    )
+  }
 }

--- a/csharp/ql/src/semmle/code/csharp/TypeRef.qll
+++ b/csharp/ql/src/semmle/code/csharp/TypeRef.qll
@@ -11,6 +11,7 @@ import csharp
  * This is used for extensionals that can be supplied
  * as either type references or types.
  */
+cached
 @type_or_ref getTypeRef(@type type) {
   result = type
   or
@@ -37,7 +38,7 @@ private module TypeRefs {
      */
     Type getCanonicalType() {
       result = this.getAType() and
-      isCanonicalType(result)
+      not locationIsBetter(canonicalTypeLocation(result), canonicalTypeLocation(this.getAType()))
     }
   }
 
@@ -62,12 +63,5 @@ private module TypeRefs {
     or
     typeLocation.(SourceLocation).getFile().getAbsolutePath() <
       betterLocation.(SourceLocation).getFile().getAbsolutePath()
-  }
-
-  private predicate isCanonicalType(Type type) {
-    not exists(TypeRef tr |
-      type = tr.getAType() and
-      locationIsBetter(canonicalTypeLocation(type), canonicalTypeLocation(tr.getAType()))
-    )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/TypeRef.qll
+++ b/csharp/ql/src/semmle/code/csharp/TypeRef.qll
@@ -1,0 +1,73 @@
+/**
+ * INTERNAL: Do not use.
+ * Provides support for type-references.
+ */
+
+import csharp
+
+/**
+ * INTERNAL: Do not use.
+ * Gets a type reference for a given type `type`.
+ * This is used for extensionals that can be supplied
+ * as either type references or types.
+ */
+@type_or_ref getTypeRef(@type type) {
+  result = type
+  or
+  type = result.(TypeRefs::TypeRef).getCanonicalType()
+}
+
+private module TypeRefs {
+  /**
+   * A typeref is a reference to a type in some assembly.
+   * Often, a type can be present in multiple assemblies.
+   */
+  class TypeRef extends @typeref {
+    string getName() { typerefs(this, result) }
+
+    string toString() { result = getName() }
+
+    Type getAType() { typeref_type(this, result) }
+
+    /**
+     * Gets the "canonical type" represented by a typeref.
+     * This is because a typeref can reference multiple types, or a type with the same
+     * fully qualified name can exist in multiple assemblies.
+     * The canonical type is an arbitrarily chosen type from the list of candidate types.
+     */
+    Type getCanonicalType() {
+      result = this.getAType() and
+      isCanonicalType(result)
+    }
+  }
+
+  /** Gets a location of a type. */
+  private Location typeLocation(Type t) {
+    type_location(t, result)
+    or
+    exists(Type decl | constructed_generic(decl, t) and result = typeLocation(decl))
+  }
+
+  /** Gets the "canonical location" for a type. A type has only one canonical location. */
+  private Location canonicalTypeLocation(Type t) {
+    result = typeLocation(t) and
+    not locationIsBetter(result, typeLocation(t))
+  }
+
+  pragma[inline]
+  private predicate locationIsBetter(Location typeLocation, Location betterLocation) {
+    typeLocation.(Assembly).getFullName() < betterLocation.(Assembly).getFullName()
+    or
+    typeLocation instanceof Assembly and betterLocation instanceof SourceLocation
+    or
+    typeLocation.(SourceLocation).getFile().getAbsolutePath() <
+      betterLocation.(SourceLocation).getFile().getAbsolutePath()
+  }
+
+  private predicate isCanonicalType(Type type) {
+    not exists(TypeRef tr |
+      type = tr.getAType() and
+      locationIsBetter(canonicalTypeLocation(type), canonicalTypeLocation(tr.getAType()))
+    )
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/Using.qll
+++ b/csharp/ql/src/semmle/code/csharp/Using.qll
@@ -5,6 +5,7 @@
  */
 
 import Element
+private import TypeRef
 
 /**
  * A `using` directive. Either a namespace `using` directive

--- a/csharp/ql/src/semmle/code/csharp/Variable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Variable.qll
@@ -3,12 +3,13 @@
  * constants.
  */
 
-import Element
-import Callable
-import Type
 import Assignable
+import Callable
+import Element
+import Type
 private import dotnet
 private import semmle.code.csharp.ExprOrStmtParent
+private import TypeRef
 
 /**
  * A variable. Either a variable with local scope (`LocalScopeVariable`) or a field (`Field`).

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -738,7 +738,16 @@ private module Cached {
     or
     getATypeParameterSubType(t1) = getATypeParameterSubType(t2)
     or
-    getANonTypeParameterSubType(t1) = getANonTypeParameterSubType(t2)
+    t1 = getANonTypeParameterSubType(t2)
+    or
+    t2 = getANonTypeParameterSubType(t1)
+    or
+    exists(ValueOrRefType i1, ValueOrRefType i2 |
+      t1 = Gvn::getGlobalValueNumber(i1) and
+      t2 = Gvn::getGlobalValueNumber(i2) and
+      exists(ValueOrRefType common | i1 = common.getABaseType+() and i2 = common.getABaseType+()) and
+      (i1 instanceof Interface or i2 instanceof Interface)
+    )
   }
 
   cached

--- a/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
@@ -4,10 +4,6 @@
  * All expressions have the common base class `Expr`.
  */
 
-import semmle.code.csharp.Location
-import semmle.code.csharp.Stmt
-import semmle.code.csharp.Callable
-import semmle.code.csharp.Type
 import Access
 import ArithmeticOperation
 import Assignment
@@ -19,9 +15,14 @@ import Dynamic
 import Literal
 import LogicalOperation
 import semmle.code.csharp.controlflow.ControlFlowElement
+import semmle.code.csharp.Callable
+import semmle.code.csharp.Location
+import semmle.code.csharp.Stmt
+import semmle.code.csharp.Type
+private import dotnet
 private import semmle.code.csharp.Enclosing::Internal
 private import semmle.code.csharp.frameworks.System
-private import dotnet
+private import semmle.code.csharp.TypeRef
 
 /**
  * An expression. Either an access (`Access`), a call (`Call`), an object or

--- a/csharp/ql/test/library-tests/aliases/aliases2.expected
+++ b/csharp/ql/test/library-tests/aliases/aliases2.expected
@@ -1,9 +1,3 @@
-| Program.cs:18:21:18:22 | c1 | Assembly1.dll:0:0:0:0 | Class |
-| Program.cs:18:21:18:22 | c1 | Assembly2.dll:0:0:0:0 | Class |
 | Program.cs:18:21:18:22 | c1 | Program.cs:10:7:10:11 | Class |
-| Program.cs:19:21:19:22 | c2 | Assembly1.dll:0:0:0:0 | Class |
-| Program.cs:19:21:19:22 | c2 | Assembly2.dll:0:0:0:0 | Class |
 | Program.cs:19:21:19:22 | c2 | Program.cs:10:7:10:11 | Class |
-| Program.cs:20:15:20:16 | c3 | Assembly1.dll:0:0:0:0 | Class |
-| Program.cs:20:15:20:16 | c3 | Assembly2.dll:0:0:0:0 | Class |
 | Program.cs:20:15:20:16 | c3 | Program.cs:10:7:10:11 | Class |

--- a/csharp/ql/test/library-tests/aliases/aliases2.expected
+++ b/csharp/ql/test/library-tests/aliases/aliases2.expected
@@ -1,3 +1,9 @@
 | Program.cs:18:21:18:22 | c1 | Assembly1.dll:0:0:0:0 | Class |
+| Program.cs:18:21:18:22 | c1 | Assembly2.dll:0:0:0:0 | Class |
+| Program.cs:18:21:18:22 | c1 | Program.cs:10:7:10:11 | Class |
+| Program.cs:19:21:19:22 | c2 | Assembly1.dll:0:0:0:0 | Class |
 | Program.cs:19:21:19:22 | c2 | Assembly2.dll:0:0:0:0 | Class |
+| Program.cs:19:21:19:22 | c2 | Program.cs:10:7:10:11 | Class |
+| Program.cs:20:15:20:16 | c3 | Assembly1.dll:0:0:0:0 | Class |
+| Program.cs:20:15:20:16 | c3 | Assembly2.dll:0:0:0:0 | Class |
 | Program.cs:20:15:20:16 | c3 | Program.cs:10:7:10:11 | Class |

--- a/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
@@ -241,7 +241,7 @@ expressionTypes
 | NullableRefTypes.cs:17:29:17:32 | null | null |
 | NullableRefTypes.cs:18:31:18:34 | this access | MyClass! |
 | NullableRefTypes.cs:19:33:19:36 | this access | MyClass! |
-| NullableRefTypes.cs:26:44:26:53 | throw ... | MyClass?[]! |
+| NullableRefTypes.cs:26:44:26:53 | throw ... | MyClass![]! |
 | NullableRefTypes.cs:26:50:26:53 | null | null |
 | NullableRefTypes.cs:27:44:27:53 | throw ... | MyClass?[]! |
 | NullableRefTypes.cs:27:50:27:53 | null | null |

--- a/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
@@ -241,9 +241,9 @@ expressionTypes
 | NullableRefTypes.cs:17:29:17:32 | null | null |
 | NullableRefTypes.cs:18:31:18:34 | this access | MyClass! |
 | NullableRefTypes.cs:19:33:19:36 | this access | MyClass! |
-| NullableRefTypes.cs:26:44:26:53 | throw ... | MyClass![]! |
+| NullableRefTypes.cs:26:44:26:53 | throw ... | MyClass?[]! |
 | NullableRefTypes.cs:26:50:26:53 | null | null |
-| NullableRefTypes.cs:27:44:27:53 | throw ... | MyClass![]! |
+| NullableRefTypes.cs:27:44:27:53 | throw ... | MyClass?[]! |
 | NullableRefTypes.cs:27:50:27:53 | null | null |
 | NullableRefTypes.cs:30:21:30:24 | null | null |
 | NullableRefTypes.cs:31:20:31:23 | this access | MyClass! |


### PR DESCRIPTION
Improves database consistency and fixes unstable results.

Summary of changes:

* Reapply #2814 (only final 3 commits need to be reviewed)
* Fixes performance problems introduced in #2814, by ensuring that `getTypeRef` (that underlies predicates like `get_type_argument(n)`) has just a single type. This prevents certain predicates from blowing up.
* Removes additional assembly prefix on constructed types and method parameters.

In trap files, the identifiers for types are prefixed by their declaring assembly, in order to handle the same type name being used in different assemblies. This is because there can be several versions of the same type, or if the same type name is accidentally used in different assemblies, then it is useful to be able to distinguish them. This also prevents database errors if different versions of the same type name are incompatible.

However with .NET Core, the same type can be defined in different assemblies, for example `mscorlib`, `System.Private.CoreLib`, `netstandard` and `System.Runtime`. This causes database instability if an assembly is extracted against `netstandard` in one build thread, and `System.Runtime` in another build thread. Depending upon which extraction happened first, the identifiers in the trap file will reference either `System.Runtime` or `netstandard`.

The fix is to remove the assembly-id qualified from the trap file, so that the build order does not matter.