### PR TITLE
JS: pruning load/store steps in the exploratory flow

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -834,7 +834,7 @@ private string getAPropertyUsedInLoadStore(DataFlow::Configuration cfg) {
  * Holds if there exists a store-step from `pred` to `succ` under configuration `cfg`,
  * and somewhere in the program there exists a load-step that could possibly read the stored value.
  */
-predicate exploratoryForwardStoreStep(
+private predicate exploratoryForwardStoreStep(
   DataFlow::Node pred, DataFlow::Node succ, DataFlow::Configuration cfg
 ) {
   exists(string prop |
@@ -867,7 +867,7 @@ private predicate exploratoryBackwardStoreStep(
  *
  * This private predicate is only used in `exploratoryBackwardStoreStep`, and exists as a separate predicate to give the compiler a hint about join-ordering.
  */
-string getABackwardsRelevantStoreProperty(DataFlow::Configuration cfg) {
+private string getABackwardsRelevantStoreProperty(DataFlow::Configuration cfg) {
   exists(DataFlow::Node mid | isRelevant(mid, cfg) |
     basicLoadStep(mid, _, result) or
     isAdditionalLoadStep(mid, _, result, cfg)
@@ -904,7 +904,7 @@ private predicate isRelevant(DataFlow::Node nd, DataFlow::Configuration cfg) {
 /**
  * Holds if there is backwards data-flow step from `mid` to `nd` under `cfg`.
  */
-predicate isRelevantBackStep(DataFlow::Node mid, DataFlow::Node nd, DataFlow::Configuration cfg) {
+private predicate isRelevantBackStep(DataFlow::Node mid, DataFlow::Node nd, DataFlow::Configuration cfg) {
   isRelevantForward(nd, cfg) and
   (
     exploratoryFlowStep(nd, mid, cfg) or

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -753,8 +753,7 @@ private predicate exploratoryFlowStep(
   DataFlow::Node pred, DataFlow::Node succ, DataFlow::Configuration cfg
 ) {
   basicFlowStepNoBarrier(pred, succ, _, cfg) or
-  basicStoreStep(pred, succ, _) or
-  isAdditionalStoreStep(pred, succ, _, cfg) or
+  exploratoryStoreStep(pred, succ, cfg) or
   exploratoryLoadStep(pred, succ, cfg) or
   isAdditionalLoadStoreStep(pred, succ, _, _, cfg) or
   // the following three disjuncts taken together over-approximate flow through
@@ -829,6 +828,23 @@ private string getAPropertyUsedInLoadStore(DataFlow::Configuration cfg) {
   or
   exists(string storeProp | not storeProp = result |
     isAdditionalLoadStoreStep(_, _, result, storeProp, cfg)
+  )
+}
+
+/**
+ * Holds if there exists a store-step from `pred` to `succ` under configuration `cfg`,
+ * and somewhere in the program there exists a load-step that could possibly read the stored value.
+ */
+predicate exploratoryStoreStep(
+  DataFlow::Node pred, DataFlow::Node succ, DataFlow::Configuration cfg
+) {
+  exists(string prop |
+    basicLoadStep(_, _, prop) or
+    isAdditionalLoadStep(_, _, prop, cfg) or
+    prop = getAPropertyUsedInLoadStore(cfg)
+  |
+    isAdditionalStoreStep(pred, succ, prop, cfg) or
+    basicStoreStep(pred, succ, prop)
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -821,12 +821,10 @@ private string getAForwardRelevantLoadProperty(DataFlow::Configuration cfg) {
  * The properties from this predicate are used as a white-list of properties for load/store steps that should always be considered in the exploratory flow.
  */
 private string getAPropertyUsedInLoadStore(DataFlow::Configuration cfg) {
-  exists(string loadProp | not loadProp = result |
-    isAdditionalLoadStoreStep(_, _, loadProp, result, cfg)
-  )
-  or
-  exists(string storeProp | not storeProp = result |
-    isAdditionalLoadStoreStep(_, _, result, storeProp, cfg)
+  exists(string loadProp, string storeProp |
+    isAdditionalLoadStoreStep(_, _, loadProp, storeProp, cfg) and
+    storeProp != loadProp and
+    result = [storeProp, loadProp]
   )
 }
 
@@ -904,7 +902,9 @@ private predicate isRelevant(DataFlow::Node nd, DataFlow::Configuration cfg) {
 /**
  * Holds if there is backwards data-flow step from `mid` to `nd` under `cfg`.
  */
-private predicate isRelevantBackStep(DataFlow::Node mid, DataFlow::Node nd, DataFlow::Configuration cfg) {
+private predicate isRelevantBackStep(
+  DataFlow::Node mid, DataFlow::Node nd, DataFlow::Configuration cfg
+) {
   isRelevantForward(nd, cfg) and
   (
     exploratoryFlowStep(nd, mid, cfg) or


### PR DESCRIPTION
This PR skips infeasible load/steps steps during the exploratory flow by looking at which load/store steps have been reached previously during the exploratory flow. 

For example: the forward exploratory flow only does a load-step involving a property `prop` if the forward exploratory flow has previously found a store-step that stores `prop`.   
This does not add any sensitivity to the exploratory flow, and there should therefore be no risk of the exploratory flow blowing up in complexity. 

I ended up splitting the implementation into a lot of different predicates, and a lot of `pragma` has been used. 
This was necessary to avoid a lot of catastrophic optimizations related to cartesian products.   
The refactorizations done of the existing predicates were done for the same reason.

Performance is definitely improved on average, and the performance improvement seem to average somewhere between 1-4%.   
There are definitely outliers, but the outliers seem to be mostly positive (see e.g. `vscode` in the first evaluation), and the negative outliers sometimes disappear on a redo (see `bwip-js` in the two evaluations). 

- [Evaluation on a small set of benchmarks](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1587761203162)
- [Evaluation on nightly](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-max.northeurope.cloudapp.azure.com_1587888660544). 


After this PR I think we should look into refactoring the exploratory flow predicates into another file.  