### PR TITLE
JS: introduce PropRef#mayHavePropertyName

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -538,6 +538,14 @@ module DataFlow {
     abstract Expr getPropertyNameExpr();
 
     /**
+     * Holds if this property reference may access a property named `propName`.
+     */
+    predicate mayHavePropertyName(string propName) {
+      propName = this.getPropertyName() or
+      this.getPropertyNameExpr().flow().mayHaveStringValue(propName)
+    }
+
+    /**
      * Gets the name of the property being read or written,
      * if it can be statically determined.
      *

--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -552,7 +552,7 @@ module JQuery {
       // Handle basic dynamic method dispatch (e.g. `$element[html ? 'html' : 'text'](content)`)
       exists(DataFlow::PropRead read | read = this.getCalleeNode() |
         read.getBase().getALocalSource() = [dollar(), objectRef()] and
-        read.getPropertyNameExpr().flow().mayHaveStringValue(name)
+        read.mayHavePropertyName(name)
       )
       or
       // Handle contributed JQuery objects that aren't source nodes (usually parameter uses)
@@ -616,10 +616,7 @@ module JQuery {
         )
       ) and
       plugin = write.getRhs() and
-      (
-        pluginName = write.getPropertyName() or
-        write.getPropertyNameExpr().flow().mayHaveStringValue(pluginName)
-      )
+      write.mayHavePropertyName(pluginName)
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDom.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/XssThroughDom.qll
@@ -81,10 +81,7 @@ module XssThroughDom {
     DOMTextSource() {
       exists(DataFlow::PropRead read | read = this |
         read.getBase().getALocalSource() = DOM::domValueRef() and
-        exists(string propName | propName = ["innerText", "textContent", "value", "name"] |
-          read.getPropertyName() = propName or
-          read.getPropertyNameExpr().flow().mayHaveStringValue(propName)
-        )
+        read.mayHavePropertyName(["innerText", "textContent", "value", "name"])
       )
       or
       exists(DataFlow::MethodCallNode mcn | mcn = this |


### PR DESCRIPTION
The same pattern of `name = read.getPropertyName() or read.getPropertyNameExpr().flow().mayHaveStringValue(name)` occurred a few times in our codebase. 

This PR introduces a new `mayHavePropertyName` predicate that describes that pattern. 

I did a small smoke-test evaluation trying what would happen if I replaced all `getPropertyName` with `mayHavePropertyName`, and it didn't really change anything. But such a change feels wrong to me. 