### PR TITLE
Update CODEOWNERS to use GitHub team identifiers after repo move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-/cpp/ @Semmle/cpp-analysis
-/csharp/ @Semmle/cs
-/java/ @Semmle/java
-/javascript/ @Semmle/js
-/python/ @Semmle/python
+/cpp/ @github/codeql-c-analysis
+/csharp/ @github/codeql-csharp
+/java/ @github/codeql-java
+/javascript/ @github/codeql-javascript
+/python/ @github/codeql-python
 /cpp/**/*.qhelp @hubwriter
 /csharp/**/*.qhelp @jf205
 /java/**/*.qhelp @felicitymay


### PR DESCRIPTION
The repository has now been moved to live under the `github` org: https://github.com/github/codeql. This PR updates the `CODEOWNERS` file to use the right team identifiers in the `github` org.

cc @p0 