### PR TITLE
C++: Refactor `PartialDefinition` charpred

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -299,7 +299,7 @@ private class PartialDefinitionNode extends PostUpdateNode, TPartialDefinitionNo
 
   override Node getPreUpdateNode() { result.asExpr() = pd.getDefinedExpr() }
 
-  override Location getLocation() { result = pd.getLocation() }
+  override Location getLocation() { result = pd.getActualLocation() }
 
   PartialDefinition getPartialDefinition() { result = pd }
 

--- a/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.ql
+++ b/cpp/ql/test/library-tests/dataflow/partialdefinitions/partialdefinitions.ql
@@ -1,4 +1,5 @@
 import semmle.code.cpp.dataflow.internal.FlowVar
 
 from PartialDefinition def
-select def, def.getDefinedExpr(), def.getSubBasicBlockStart()
+select def.getActualLocation().toString(), "partial def of " + def.toString(), def.getDefinedExpr(),
+  def.getSubBasicBlockStart()


### PR DESCRIPTION
This class used `newtype` for seemingly no reason. The new code is shorter and should be faster as well.

The purpose of this refactoring is to prepare for solving @lcartey's issue reported at https://github.slack.com/archives/CP0LHP150/p1587393520434500.