### PR TITLE
Add support for C++20's consteval specifier

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -103,6 +103,9 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
 
   /**
    * Holds if this function is declared to be `constexpr`.
+   *
+   * Note that this does not hold if the function has been declared
+   * `consteval`.
    */
   predicate isDeclaredConstexpr() { this.hasSpecifier("declared_constexpr") }
 
@@ -115,8 +118,15 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * template <typename T> constexpr int g(T x) { return f(x); }
    * ```
    * `g<int>` is declared constexpr, but is not constexpr.
+   *
+   * Will also hold if this function is `consteval`.
    */
   predicate isConstexpr() { this.hasSpecifier("is_constexpr") }
+
+  /**
+   * Holds if this function is declared to be `consteval`.
+   */
+  predicate isConsteval() { this.hasSpecifier("is_consteval") }
 
   /**
    * Holds if this function is declared with `__attribute__((naked))` or

--- a/cpp/ql/test/library-tests/clang_ms/element.expected
+++ b/cpp/ql/test/library-tests/clang_ms/element.expected
@@ -91,6 +91,7 @@
 | file://:0:0:0:0 | implicit_int |
 | file://:0:0:0:0 | inline |
 | file://:0:0:0:0 | int |
+| file://:0:0:0:0 | is_consteval |
 | file://:0:0:0:0 | is_constexpr |
 | file://:0:0:0:0 | is_thread_local |
 | file://:0:0:0:0 | long |

--- a/cpp/ql/test/library-tests/conditions/elements.expected
+++ b/cpp/ql/test/library-tests/conditions/elements.expected
@@ -66,6 +66,7 @@
 | file://:0:0:0:0 | initializer for <error> |
 | file://:0:0:0:0 | inline |
 | file://:0:0:0:0 | int |
+| file://:0:0:0:0 | is_consteval |
 | file://:0:0:0:0 | is_constexpr |
 | file://:0:0:0:0 | is_thread_local |
 | file://:0:0:0:0 | long |

--- a/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
+++ b/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
@@ -110,6 +110,7 @@
 | file://:0:0:0:0 | int |
 | file://:0:0:0:0 | int & |
 | file://:0:0:0:0 | int * |
+| file://:0:0:0:0 | is_consteval |
 | file://:0:0:0:0 | is_constexpr |
 | file://:0:0:0:0 | is_thread_local |
 | file://:0:0:0:0 | long |

--- a/cpp/ql/test/library-tests/unnamed/elements.expected
+++ b/cpp/ql/test/library-tests/unnamed/elements.expected
@@ -59,6 +59,7 @@
 | file://:0:0:0:0 | int | Other |
 | file://:0:0:0:0 | int * | Other |
 | file://:0:0:0:0 | int[0] | Other |
+| file://:0:0:0:0 | is_consteval | Other |
 | file://:0:0:0:0 | is_constexpr | Other |
 | file://:0:0:0:0 | is_thread_local | Other |
 | file://:0:0:0:0 | long | Other |


### PR DESCRIPTION
Internal extractor PR: https://git.semmle.com/Semmle/code/pull/36809
Issue: https://github.com/github/codeql-c-extractor-team/issues/49

This PR add support for the new `consteval` specifier in C++20.  See [p1073r3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1073r3.html) for the spec.

Will fail CPP tests as it requires an extractor change as well.

No DB Schema changes needed as it just outputs a new specifier string.  But the library is updated to recognise this new string.