### PR TITLE
JS: Performance tweaks in AMD, mayHaveStringValue, PropWrite

### DIFF
--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -290,6 +290,7 @@ private class AmdDependencyImport extends Import {
  * ```
  */
 class AmdModule extends Module {
+  cached
   AmdModule() { strictcount(AmdModuleDefinition def | amdModuleTopLevel(def, this)) = 1 }
 
   /** Gets the definition of this module. */

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -586,6 +586,7 @@ module DataFlow {
      * This predicate is undefined for spread properties, accessor
      * properties, and most uses of `Object.defineProperty`.
      */
+    pragma[nomagic]
     abstract Node getRhs();
 
     /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -118,7 +118,11 @@ module DataFlow {
     predicate accessesGlobal(string g) { globalVarRef(g).flowsTo(this) }
 
     /** Holds if this node may evaluate to the string `s`, possibly through local data flow. */
-    predicate mayHaveStringValue(string s) { getAPredecessor().mayHaveStringValue(s) }
+    predicate mayHaveStringValue(string s) {
+      getAPredecessor().mayHaveStringValue(s)
+      or
+      s = getStringValue()
+    }
 
     /** Gets the string value of this node, if it is a string literal or constant string concatenation. */
     string getStringValue() { result = asExpr().getStringValue() }
@@ -296,11 +300,6 @@ module DataFlow {
 
     /** Gets the expression or declaration this node corresponds to. */
     override AST::ValueNode getAstNode() { result = astNode }
-
-    override predicate mayHaveStringValue(string s) {
-      Node.super.mayHaveStringValue(s) or
-      astNode.(ConstantString).getStringValue() = s
-    }
 
     override BasicBlock getBasicBlock() { astNode = result.getANode() }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -647,25 +647,24 @@ module DataFlow {
    * writes to the corresponding property.
    */
   private class ObjectDefinePropertyAsPropWrite extends PropWrite, ValueNode {
-    CallToObjectDefineProperty odp;
+    override MethodCallExpr astNode;
 
-    ObjectDefinePropertyAsPropWrite() { odp = this }
-
-    override Node getBase() { result = odp.getBaseObject() }
-
-    override Expr getPropertyNameExpr() { result = odp.getArgument(1).asExpr() }
-
-    override string getPropertyName() { result = odp.getPropertyName() }
-
-    override Node getRhs() {
-      // not using `CallToObjectDefineProperty::getAPropertyAttribute` for performance reasons
-      exists(ObjectLiteralNode propdesc |
-        propdesc.flowsTo(odp.getPropertyDescriptor()) and
-        propdesc.hasPropertyWrite("value", result)
-      )
+    ObjectDefinePropertyAsPropWrite() {
+      astNode.getReceiver().(GlobalVarAccess).getName() = "Object" and
+      astNode.getMethodName() = "defineProperty"
     }
 
-    override ControlFlowNode getWriteNode() { result = odp.getAstNode() }
+    override Node getBase() { result = astNode.getArgument(0).flow() }
+
+    override Expr getPropertyNameExpr() { result = astNode.getArgument(1) }
+
+    override string getPropertyName() { result = astNode.getArgument(1).getStringValue() }
+
+    override Node getRhs() {
+      result = astNode.getArgument(2).(ObjectExpr).getPropertyByName("value").getInit().flow()
+    }
+
+    override ControlFlowNode getWriteNode() { result = astNode }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -156,6 +156,7 @@ class InvokeNode extends DataFlow::SourceNode {
    * Holds if the `i`th argument of this invocation is an object literal whose property
    * `name` is set to `result`.
    */
+  pragma[nomagic]
   DataFlow::ValueNode getOptionArgument(int i, string name) {
     getOptionsArgument(i).hasPropertyWrite(name, result)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -70,6 +70,7 @@ class SourceNode extends DataFlow::Node {
    * Holds if there is an assignment to property `propName` on this node,
    * and the right hand side of the assignment is `rhs`.
    */
+  pragma[nomagic]
   predicate hasPropertyWrite(string propName, DataFlow::Node rhs) {
     rhs = getAPropertyWrite(propName).getRhs()
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AngularJS/AngularJSCore.qll
@@ -461,6 +461,7 @@ class ComponentDirective extends CustomDirective, MkCustomComponent {
 
   override DataFlow::Node getDefinition() { result = comp }
 
+  pragma[nomagic]
   override DataFlow::ValueNode getMemberInit(string name) {
     comp.getConfig().hasPropertyWrite(name, result)
   }


### PR DESCRIPTION
- `mayHaveStringValue` used a recursion pattern through a super-call which the optimizer isn't handling very well. Switched to a more direct style.
- The above caused a bad join order in `AmdModuleDefinition.getFactoryNode()`, which can be avoided by caching AMD modules.
- It also caused bad join orders for uses of `PropWrite.getRhs()`, generally by putting `TValueNode` first in the join order. It turns out `getRhs` was actually recursive with `hasPropertyWrite` which I decided to fix, after which magic made it recursive again, which I fixed by adding `pragma[nomagic]` in a few key places.

Evaluations all show a speed-up of a few percent:
- [Full/nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/cache-amd_1588206175140)
- [XSS/big-apps](https://git.semmle.com/asger/dist-compare-reports/tree/js/cache-amd_1588111377483)
- [security/smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/cache-amd_1588033820564)

Based on some quick tuple counting, the second commit, and third+fourth commit, independently cause a speed-up, whereas the first commit is dependent on the others.