### PR TITLE
C++: Remove an unneeded local-flow case

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -496,8 +496,6 @@ predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   // Expr -> Expr
   exprToExprStep_nocfg(nodeFrom.asExpr(), nodeTo.asExpr())
   or
-  exprToExprStep_nocfg(nodeFrom.(PostUpdateNode).getPreUpdateNode().asExpr(), nodeTo.asExpr())
-  or
   // Node -> FlowVar -> VariableAccess
   exists(FlowVar var |
     (

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow.expected
@@ -44,7 +44,6 @@
 | test.cpp:383:12:383:13 | 0 | test.cpp:384:33:384:35 | tmp |
 | test.cpp:383:12:383:13 | 0 | test.cpp:385:8:385:10 | tmp |
 | test.cpp:384:10:384:13 | & ... | test.cpp:384:3:384:8 | call to memcpy |
-| test.cpp:384:10:384:13 | ref arg & ... | test.cpp:384:3:384:8 | call to memcpy |
 | test.cpp:384:10:384:13 | ref arg & ... | test.cpp:384:33:384:35 | tmp |
 | test.cpp:384:10:384:13 | ref arg & ... | test.cpp:385:8:385:10 | tmp |
 | test.cpp:384:11:384:13 | tmp | test.cpp:384:10:384:13 | & ... |
@@ -59,7 +58,6 @@
 | test.cpp:389:12:389:13 | 0 | test.cpp:394:10:394:12 | tmp |
 | test.cpp:390:19:390:21 | tmp | test.cpp:390:18:390:21 | & ... |
 | test.cpp:391:10:391:13 | & ... | test.cpp:391:3:391:8 | call to memcpy |
-| test.cpp:391:10:391:13 | ref arg & ... | test.cpp:391:3:391:8 | call to memcpy |
 | test.cpp:391:10:391:13 | ref arg & ... | test.cpp:391:33:391:35 | tmp |
 | test.cpp:391:10:391:13 | ref arg & ... | test.cpp:392:8:392:10 | tmp |
 | test.cpp:391:10:391:13 | ref arg & ... | test.cpp:394:10:394:12 | tmp |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -299,7 +299,6 @@
 | taint.cpp:165:24:165:24 | 0 | taint.cpp:165:22:165:25 | {...} | TAINT |
 | taint.cpp:168:8:168:14 | ref arg tainted | taint.cpp:172:18:172:24 | tainted |  |
 | taint.cpp:170:10:170:15 | buffer | taint.cpp:170:3:170:8 | call to strcpy |  |
-| taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:170:3:170:8 | call to strcpy |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
@@ -309,7 +308,6 @@
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:172:10:172:15 | buffer | taint.cpp:172:3:172:8 | call to strcat |  |
 | taint.cpp:172:10:172:15 | buffer | taint.cpp:172:10:172:15 | ref arg buffer | TAINT |
-| taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:172:3:172:8 | call to strcat |  |
 | taint.cpp:172:10:172:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
 | taint.cpp:172:18:172:24 | tainted | taint.cpp:172:10:172:15 | ref arg buffer | TAINT |
 | taint.cpp:180:19:180:19 | p | taint.cpp:181:9:181:9 | p |  |
@@ -320,7 +318,6 @@
 | taint.cpp:193:6:193:6 | x | taint.cpp:194:10:194:10 | x |  |
 | taint.cpp:193:6:193:6 | x | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:9:194:10 | & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
-| taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... |  |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:2:194:7 | call to memcpy | TAINT |


### PR DESCRIPTION
> This case was added in dccc0f4db. The surrounding code has changed a lot since then, and the case no longer seems to have an effect except to create some dead ends and possibly cycles in the local flow graph.

Notice that the only affected tests are the ones that print every local data-flow step. The tests that go all the way from source to sink are not affected.