### PR TITLE
JS: less spurious jQuery objects

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/jQuery.qll
@@ -37,19 +37,19 @@ private class OrdinaryJQueryObject extends JQueryObjectInternal {
   OrdinaryJQueryObject() {
     exists(JQuery::MethodCall jq |
       this.flow().getALocalSource() = jq and
-      returnsAJqueryObject(jq, jq.getMethodName())
+      returnsAJQueryObject(jq, jq.getMethodName())
     )
   }
 }
 
 /**
  * Holds if the jQuery method call `call`, with name `methodName`, returns a JQuery object.
- * 
- * The `call` parameter has type `DataFlow::CallNode` instead of `JQuery::MethodCall` to avoid non-monotonic recursion. 
- * The not is placed inside the predicate to avoid non-monotonic recursion. 
+ *
+ * The `call` parameter has type `DataFlow::CallNode` instead of `JQuery::MethodCall` to avoid non-monotonic recursion.
+ * The not is placed inside the predicate to avoid non-monotonic recursion.
  */
 bindingset[methodName, call]
-private predicate returnsAJqueryObject(DataFlow::CallNode call, string methodName) {
+private predicate returnsAJQueryObject(DataFlow::CallNode call, string methodName) {
   not (
     methodName = "val" // `jQuery.val()`
     or
@@ -70,7 +70,7 @@ private predicate returnsAJqueryObject(DataFlow::CallNode call, string methodNam
     or
     methodName = "trim" // $.trim()
     or
-    // `$.ajax`, and related methods. 
+    // `$.ajax`, and related methods.
     // note: there are 2 different `get` methods, and none of them return a jQuery object.
     methodName = ["ajax", "get", "getJSON", "getScript", "post", "load"]
   )

--- a/javascript/ql/test/library-tests/frameworks/jQuery/JQueryMethodCall.expected
+++ b/javascript/ql/test/library-tests/frameworks/jQuery/JQueryMethodCall.expected
@@ -17,3 +17,15 @@ WARNING: Type JQueryMethodCall has been deprecated and may be removed in future 
 | tst.js:5:1:5:15 | window.jQuery() | $ |
 | tst.js:6:1:6:32 | angular ... .attr() | attr |
 | tst.js:7:1:7:14 | $("<br>", doc) | $ |
+| tst.js:11:1:11:8 | $("foo") | $ |
+| tst.js:11:1:11:15 | $("foo").html() | html |
+| tst.js:12:1:12:8 | $("foo") | $ |
+| tst.js:12:1:12:20 | $("foo").html("foo") | html |
+| tst.js:12:1:12:31 | $("foo" ... query() | isJquery |
+| tst.js:13:1:13:8 | $("foo") | $ |
+| tst.js:13:1:13:17 | $("foo").data({}) | data |
+| tst.js:13:1:13:28 | $("foo" ... query() | isJquery |
+| tst.js:15:1:15:8 | $("foo") | $ |
+| tst.js:15:1:15:20 | $("foo").attr("bar") | attr |
+| tst.js:17:1:17:8 | $.trim() | trim |
+| tst.js:18:1:18:10 | $.ajax({}) | ajax |

--- a/javascript/ql/test/library-tests/frameworks/jQuery/interpretsArgumentAsHtml.expected
+++ b/javascript/ql/test/library-tests/frameworks/jQuery/interpretsArgumentAsHtml.expected
@@ -8,3 +8,8 @@ WARNING: Type JQueryMethodCall has been deprecated and may be removed in future 
 | tst2.js:2:1:2:7 | jq("a") | tst2.js:2:4:2:6 | "a" |
 | tst.js:3:1:3:9 | $("<a/>") | tst.js:3:3:3:8 | "<a/>" |
 | tst.js:7:1:7:14 | $("<br>", doc) | tst.js:7:3:7:8 | "<br>" |
+| tst.js:11:1:11:8 | $("foo") | tst.js:11:3:11:7 | "foo" |
+| tst.js:12:1:12:8 | $("foo") | tst.js:12:3:12:7 | "foo" |
+| tst.js:12:1:12:20 | $("foo").html("foo") | tst.js:12:15:12:19 | "foo" |
+| tst.js:13:1:13:8 | $("foo") | tst.js:13:3:13:7 | "foo" |
+| tst.js:15:1:15:8 | $("foo") | tst.js:15:3:15:7 | "foo" |

--- a/javascript/ql/test/library-tests/frameworks/jQuery/jquery-3.2.js
+++ b/javascript/ql/test/library-tests/frameworks/jQuery/jquery-3.2.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for jQuery 3.1
+ *
+ * Note that some functions use different return types depending on the number
+ * of parameters passed in. In these cases, you may need to annotate the type
+ * of the result in your code, so the JSCompiler understands which type you're
+ * expecting. For example:
+ *    <code>var elt = /** @type {Element} * / (foo.get(0));</code>
+ *
+ * @see http://api.jquery.com/
+ * @externs
+ */
+
+/**
+ * @typedef {(Window|Document|Element|Array<Element>|string|jQuery|
+ *     NodeList)}
+ */
+var jQuerySelector;
+
+/**
+ * @constructor
+ * @param {(jQuerySelector|Object|function())=} arg1
+ * @param {(Element|jQuery|Document|
+ *     Object<string, (string|function(!jQuery.Event))>)=} arg2
+ * @throws {Error} on invalid selector
+ * @return {!jQuery}
+ * @implements {Iterable}
+ */
+function jQuery(arg1, arg2) { };
+
+/**
+ * @const
+ */
+var $ = jQuery;
+
+/**
+ * @param {(string|jQueryAjaxSettings|Object<string,*>)} arg1
+ * @param {(jQueryAjaxSettings|Object<string, *>)=} settings
+ * @return {!jQuery.jqXHR}
+ */
+jQuery.ajax = function (arg1, settings) { };
+
+/**
+ * @param {string} str
+ * @return {string}
+ * @nosideeffects
+ */
+jQuery.trim = function (str) { };
+

--- a/javascript/ql/test/library-tests/frameworks/jQuery/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/jQuery/tst.js
@@ -5,3 +5,14 @@ window.$();
 window.jQuery();
 angular.element("<div/>").attr()
 $("<br>", doc);
+
+
+
+$("foo").html().doesNotReturnJquery();
+$("foo").html("foo").isJquery();
+$("foo").data({}).isJquery();
+
+$("foo").attr("bar").doesNotReturnJquery();
+
+$.trim().doesNotReturnJquery();
+$.ajax({}).doesNotReturnJquery()


### PR DESCRIPTION
Our JQuery model spuriously flag many objects as JQuery objects. 

Lots of examples among these results: https://lgtm.com/query/4125908389093061156/

Many of these can be alleviated by expanding the list of standard jQuery methods that does not return a jQuery object.

Any use of `JQuery::MethodCall` inside a `not` lead to non-monotonic recursion, which is why the design ended up as it did. 

This might improve performance a bit as we type-track less "JQuery" objects with this change. 