### PR TITLE
C++: Small tidy up

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScaling.ql
@@ -21,7 +21,7 @@ where
   destBase = baseType(destType) and
   destBase.getSize() != sourceBase.getSize() and
   not dest.isInMacroExpansion() and
-  // If the source type is a char* or void* then don't
+  // If the source type is a `char*` or `void*` then don't
   // produce a result, because it is likely to be a false
   // positive.
   not sourceBase instanceof CharType and

--- a/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/IncorrectPointerScalingChar.ql
@@ -21,7 +21,7 @@ where
   destBase = baseType(destType) and
   destBase.getSize() != sourceBase.getSize() and
   not dest.isInMacroExpansion() and
-  // If the source type is a char* or void* then don't
+  // If the source type is a `char*` or `void*` then don't
   // produce a result, because it is likely to be a false
   // positive.
   not sourceBase instanceof CharType and

--- a/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
+++ b/cpp/ql/src/Security/CWE/CWE-468/SuspiciousAddWithSizeof.ql
@@ -24,7 +24,7 @@ private predicate isCharSzPtrExpr(Expr e) {
 from Expr sizeofExpr, Expr e
 where
   // If we see an addWithSizeof then we expect the type of
-  // the pointer expression to be char* or void*. Otherwise it
+  // the pointer expression to be `char*` or `void*`. Otherwise it
   // is probably a mistake.
   addWithSizeof(e, sizeofExpr, _) and not isCharSzPtrExpr(e)
 select sizeofExpr,

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -282,25 +282,21 @@ class OperatorNewAllocationFunction extends AllocationFunction {
  * is `a * 2` and `sizeof` is `4`.
  */
 private predicate deconstructSizeExpr(Expr sizeExpr, Expr lengthExpr, int sizeof) {
-  if
-    sizeExpr instanceof MulExpr and
-    exists(SizeofOperator sizeofOp, Expr lengthOp |
-      sizeofOp = sizeExpr.(MulExpr).getAnOperand() and
-      lengthOp = sizeExpr.(MulExpr).getAnOperand() and
-      not lengthOp instanceof SizeofOperator and
-      exists(sizeofOp.getValue().toInt())
-    )
-  then
-    exists(SizeofOperator sizeofOp |
-      sizeofOp = sizeExpr.(MulExpr).getAnOperand() and
-      lengthExpr = sizeExpr.(MulExpr).getAnOperand() and
-      not lengthExpr instanceof SizeofOperator and
-      sizeof = sizeofOp.getValue().toInt()
-    )
-  else (
-    lengthExpr = sizeExpr and
-    sizeof = 1
+  exists(SizeofOperator sizeofOp |
+    sizeofOp = sizeExpr.(MulExpr).getAnOperand() and
+    lengthExpr = sizeExpr.(MulExpr).getAnOperand() and
+    not lengthExpr instanceof SizeofOperator and
+    sizeof = sizeofOp.getValue().toInt()
   )
+  or
+  not exists(SizeofOperator sizeofOp, Expr lengthOp |
+    sizeofOp = sizeExpr.(MulExpr).getAnOperand() and
+    lengthOp = sizeExpr.(MulExpr).getAnOperand() and
+    not lengthOp instanceof SizeofOperator and
+    exists(sizeofOp.getValue().toInt())
+  ) and
+  lengthExpr = sizeExpr and
+  sizeof = 1
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -271,12 +271,15 @@ class OperatorNewAllocationFunction extends AllocationFunction {
 }
 
 /**
- * The predicate analyzes a `sizeExpr`, which is an argument to an allocation
- * function like malloc, and tries to split it into an expression `lengthExpr`
- * that describes the length of the allocated array, and the size of the allocated
- * element type `sizeof`.
- * If this is not possible, the allocation is considered to be of size 1 and of
- * length `sizeExpr`.
+ * Holds if `sizeExpr` is an expression consisting of a subexpression
+ * `lengthExpr` multiplied by a constant `sizeof` that is the result of a
+ * `sizeof()` expression.  Alternatively if there isn't a suitable `sizeof()`
+ * expression, `lengthExpr = sizeExpr` and `sizeof = 1`.  For example:
+ * ```
+ * malloc(a * 2 * sizeof(char32_t));
+ * ```
+ * In this case if the `sizeExpr` is the argument to `malloc`, the `lengthExpr`
+ * is `a * 2` and `sizeof` is `4`.
  */
 private predicate deconstructSizeExpr(Expr sizeExpr, Expr lengthExpr, int sizeof) {
   if


### PR DESCRIPTION
A little bit of cleanup following https://github.com/Semmle/ql/pull/3326 (in particular, the QLDoc comment didn't conform to https://github.com/github/codeql/blob/master/docs/ql-style-guide.md#documentation).

Also fixed some random missing backticks in the `CWE-468` queries.