### PR TITLE
JS SSTI CWE-094

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -15,7 +15,7 @@ run arbitrary code on the application server.
 <p>
 Avoid including user input in any expression or template which may be dynamically rendered. 
 If user input must be included, use context-specific escaping before including it or run 
-render engine with sandbox options. 
+the rendering engine with sandbox options. 
 </p>
 </recommendation>
 

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -1,0 +1,41 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>
+Server Side Template Injection vulnerabilities occur when user input is embedded 
+in a template in an unsafe manner allowing attackers to access the template context and
+run arbitrary code on the application server.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Avoid including user input in any expression or template which may be dynamically rendered. 
+If user input must be included, use context-specific escaping before including it or run 
+render engine with sandbox options. 
+</p>
+</recommendation>
+
+<example>
+<p>
+The following example shows html page being rendered with user input allowing attackers to access the 
+template context and run arbitrary code on the application server. 
+</p>
+
+<sample src="examples/ServerSideTemplateInjection.js" />
+</example>
+
+<references>
+<li>
+OWASP:
+<a href="https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/18-Testing_for_Server_Side_Template_Injection">Server Side Template Injection</a>.
+</li>
+<li>
+PortSwigger Research Blog: 
+<a href="https://portswigger.net/research/server-side-template-injection">Server Side Template Injection</a>.
+</li>
+</references>
+</qhelp>

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -23,12 +23,11 @@ render engine with sandbox options.
 <p>
 The following example shows a page being rendered with user input allowing attackers to access the
 template context and run arbitrary code on the application server. 
-Pug template engine (and other template engines) provides Interpolation feature - insertion of variable values into a string of some kind.
-For example, `Hello #{user.username}!`, could be used for printing username from scoped variable user, but `user.username` expression will be executed as valid javascript code.
-Unsafe injection of user input provides attacker ability to inject conteqnt like #{some_js_expression}.
-Injection of `#{global.process.exit(1)}` leads to code execution of `global.process.exit(1)` by server.
-Working exploit (as curl command):
-curl -i -s -k -X $'POST' -H $'Host: 127.0.0.1:5061' -H $'Connection: close' -H $'Content-Length: 40' -H $'Content-Type: application/x-www-form-urlencoded' --data-binary $'name=%23%7Bglobal.process.exit%281%29%7D' $'http://127.0.0.1:5061/'
+The Pug template engine (and other template engines) provides an interpolation feature - insertion of variable values into a string of some kind.
+For example, <code>Hello #{user.username}!</code>, could be used for printing a username from a scoped variable user, 
+but the <code>user.username</code> expression will be executed as JavaScript.
+Unsafe injection of user input in a template therefore allows an attacker to inject arbitrary JavaScript code. 
+For example, a payload of <code>#{global.process.exit(1)}</code> will cause the server to crash.
 </p>
 
 <sample src="examples/ServerSideTemplateInjection.js" />

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -27,7 +27,7 @@ The Pug template engine (and other template engines) provides an interpolation f
 For example, <code>Hello #{user.username}!</code>, could be used for printing a username from a scoped variable user, 
 but the <code>user.username</code> expression will be executed as JavaScript.
 Unsafe injection of user input in a template therefore allows an attacker to inject arbitrary JavaScript code. 
-For example, a payload of <code>#{global.process.exit(1)}</code> will cause the server to crash.
+For example, a payload of <code>#{global.process.exit(1)}</code> will cause the below server to crash.
 </p>
 
 <sample src="examples/ServerSideTemplateInjection.js" />

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -5,7 +5,7 @@
 
 <overview>
 <p>
-Server-Side Template Injection vulnerabilities occur when user input is embedded 
+Server-Side Template Injection vulnerabilities occur when user input is embedded
 in a template in an unsafe manner allowing attackers to access the template context and
 run arbitrary code on the application server.
 </p>
@@ -21,11 +21,28 @@ render engine with sandbox options.
 
 <example>
 <p>
-The following example shows a page being rendered with user input allowing attackers to access the 
+The following example shows a page being rendered with user input allowing attackers to access the
 template context and run arbitrary code on the application server. 
+Pug template engine (and other template engines) provides Interpolation feature - insertion of variable values into a string of some kind.
+For example, `Hello #{user.username}!`, could be used for printing username from scoped variable user, but `user.username` expression will be executed as valid javascript code.
+Unsafe injection of user input provides attacker ability to inject conteqnt like #{some_js_expression}.
+Injection of `#{global.process.exit(1)}` leads to code execution of `global.process.exit(1)` by server.
+Working exploit (as curl command):
+curl -i -s -k -X $'POST' -H $'Host: 127.0.0.1:5061' -H $'Connection: close' -H $'Content-Length: 40' -H $'Content-Type: application/x-www-form-urlencoded' --data-binary $'name=%23%7Bglobal.process.exit%281%29%7D' $'http://127.0.0.1:5061/'
 </p>
 
 <sample src="examples/ServerSideTemplateInjection.js" />
+</example>
+
+<example>
+<p>
+As the example of safe usage of rendering engine, please see example below.
+In opposite to first example, instead of concatenation of provided user input with the template
+it is possible to provide user input as a context - user input will be safely insterted
+and rendered inside correspondent placeholders.
+</p>
+
+<sample src="examples/ServerSideTemplateInjectionSafe.js" />
 </example>
 
 <references>
@@ -35,7 +52,7 @@ OWASP:
 </li>
 <li>
 PortSwigger Research Blog: 
-<a href="https://portswigger.net/research/server-side-template-injection">Server Side Template Injection</a>.
+<a href="https://portswigger.net/research/server-side-template-injection">Server-Side Template Injection</a>.
 </li>
 </references>
 </qhelp>

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.qhelp
@@ -36,10 +36,9 @@ curl -i -s -k -X $'POST' -H $'Host: 127.0.0.1:5061' -H $'Connection: close' -H $
 
 <example>
 <p>
-As the example of safe usage of rendering engine, please see example below.
-In opposite to first example, instead of concatenation of provided user input with the template
-it is possible to provide user input as a context - user input will be safely insterted
-and rendered inside correspondent placeholders.
+The example below provides an example of how to use a template engine without any risk of Server-Side Template Injection. 
+Instead of concatenating user input onto the template, the template uses a placeholder and safely inserts 
+the user input. 
 </p>
 
 <sample src="examples/ServerSideTemplateInjectionSafe.js" />

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -5,7 +5,7 @@
  * @kind path-problem
  * @problem.severity error
  * @precision high
- * @id js/code-injection
+ * @id js/server-side-template-injection
  * @tags security
  *       external/cwe/cwe-094
  */

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -28,7 +28,7 @@ class SSTIPugSink extends ServerSideTemplateInjectionSink {
     exists(CallNode compile, ModuleImportNode renderImport |
       renderImport = moduleImport(["pug", "jade"]) and
       (
-        compile = renderImport.getAMemberCall("compile") and
+        compile = renderImport.getAMemberCall("compile")
         or
         compile = renderImport.getAMemberCall("render")
       ) and

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -25,11 +25,11 @@ abstract class ServerSideTemplateInjectionSink extends DataFlow::Node { }
 
 class SSTIPugSink extends ServerSideTemplateInjectionSink {
   SSTIPugSink() {
-    exists(CallNode compile, ModuleImportNode renderImport, Node sink |
+    exists(CallNode compile, ModuleImportNode renderImport |
       renderImport = moduleImport(["pug", "jade"]) and
       (
         compile = renderImport.getAMemberCall("compile") and
-        sink.getStartLine() != sink.getASuccessor().getStartLine()
+        exists(compile.getACall())
         or
         compile = renderImport.getAMemberCall("render")
       ) and

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -40,9 +40,9 @@ class SSTIPugSink extends ServerSideTemplateInjectionSink {
 
 class SSTIDotSink extends ServerSideTemplateInjectionSink {
   SSTIDotSink() {
-    exists(CallNode compile, Node sink |
+    exists(CallNode compile |
       compile = moduleImport("dot").getAMemberCall("template") and
-      sink.getStartLine() != sink.getASuccessor().getStartLine() and
+      exists(compile.getACall()) and
       this = compile.getArgument(0)
     )
   }

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Server Side Template Injection
+ * @description Rendering templates with unsanitized user input allows a malicious user arbitrary
+ *              code execution.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id js/code-injection
+ * @tags security
+ *       external/cwe/cwe-094
+ */
+
+import javascript
+import DataFlow
+
+class ServerSideTemplateInjectionConfiguration extends TaintTracking::Configuration {
+  ServerSideTemplateInjectionConfiguration() { this = "ServerSideTemplateInjectionConfiguration" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof ServerSideTemplateInjectionSink }
+}
+
+abstract class ServerSideTemplateInjectionSink extends DataFlow::Node { }
+
+class SSTIPugSink extends ServerSideTemplateInjectionSink {
+  SSTIPugSink() {
+    exists(CallNode compile, ModuleImportNode renderImport, Node sink |
+      (renderImport = moduleImport("pug") or renderImport = moduleImport("jade")) and
+      (
+        compile = renderImport.getAMemberCall("compile") and
+        compile.flowsTo(sink) and
+        sink.getStartLine() != sink.getASuccessor().getStartLine()
+        or
+        compile = renderImport.getAMemberCall("render") and compile.flowsTo(sink)
+      ) and
+      this = compile.getArgument(0)
+    )
+  }
+}
+
+class SSTIDotSink extends ServerSideTemplateInjectionSink {
+  SSTIDotSink() {
+    exists(CallNode compile, Node sink |
+      compile = moduleImport("dot").getAMemberCall("template") and
+      compile.flowsTo(sink) and
+      sink.getStartLine() != sink.getASuccessor().getStartLine() and
+      this = compile.getArgument(0)
+    )
+  }
+}
+
+class SSTIEjsSink extends ServerSideTemplateInjectionSink {
+  SSTIEjsSink() {
+    exists(CallNode compile, Node sink |
+      compile = moduleImport("ejs").getAMemberCall("render") and
+      compile.flowsTo(sink) and
+      this = compile.getArgument(0)
+    )
+  }
+}
+
+class SSTINunjucksSink extends ServerSideTemplateInjectionSink {
+  SSTINunjucksSink() {
+    exists(CallNode compile, Node sink |
+      compile = moduleImport("nunjucks").getAMemberCall("renderString") and
+      compile.flowsTo(sink) and
+      this = compile.getArgument(0)
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, ServerSideTemplateInjectionConfiguration c
+where c.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ flows to here and is used in an XPath expression.",
+  source.getNode(), "User-provided value"

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -29,7 +29,6 @@ class SSTIPugSink extends ServerSideTemplateInjectionSink {
       renderImport = moduleImport(["pug", "jade"]) and
       (
         compile = renderImport.getAMemberCall("compile") and
-        exists(compile.getACall())
         or
         compile = renderImport.getAMemberCall("render")
       ) and

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -12,6 +12,7 @@
 
 import javascript
 import DataFlow
+import DataFlow::PathGraph
 
 class ServerSideTemplateInjectionConfiguration extends TaintTracking::Configuration {
   ServerSideTemplateInjectionConfiguration() { this = "ServerSideTemplateInjectionConfiguration" }

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -41,7 +41,6 @@ class SSTIDotSink extends ServerSideTemplateInjectionSink {
   SSTIDotSink() {
     exists(CallNode compile |
       compile = moduleImport("dot").getAMemberCall("template") and
-      exists(compile.getACall()) and
       this = compile.getArgument(0)
     )
   }

--- a/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
+++ b/javascript/ql/src/experimental/Security/CWE-94/ServerSideTemplateInjection.ql
@@ -58,5 +58,6 @@ class SSTINunjucksSink extends ServerSideTemplateInjectionSink {
 
 from DataFlow::PathNode source, DataFlow::PathNode sink, ServerSideTemplateInjectionConfiguration c
 where c.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "$@ flows to here and unsafely used as part of rendered template",
-  source.getNode(), "User-provided value"
+select sink.getNode(), source, sink,
+  "$@ flows to here and unsafely used as part of rendered template", source.getNode(),
+  "User-provided value"

--- a/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjection.js
+++ b/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjection.js
@@ -31,3 +31,5 @@ app.post('/', (request, response) => {
     var html = getHTML(input)
     response.send(html);
 })
+
+app.listen(port, () => { console.log(`server is listening on ${port}`) })

--- a/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjection.js
+++ b/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjection.js
@@ -1,0 +1,33 @@
+const express = require('express')
+var bodyParser = require('body-parser');
+const app = express()
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+//Dependent of Templating engine
+var jade = require('pug');
+const port = 5061
+
+function getHTML(input) {
+    var template = `
+doctype
+html
+head
+    title= 'Hello world'
+body
+    form(action='/' method='post')
+        label(for='name') Name:
+            input#name.form-control(type='text', placeholder='' name='name')
+        button.btn.btn-primary(type='submit') Submit
+    p Hello `+ input
+    var fn = jade.compile(template);
+    var html = fn();
+    console.log(html);
+    return html;
+}
+
+app.post('/', (request, response) => {
+    var input = request.param('name', "")
+    var html = getHTML(input)
+    response.send(html);
+})

--- a/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjectionSafe.js
+++ b/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjectionSafe.js
@@ -31,9 +31,4 @@ app.post('/', (request, response) => {
     response.send(html);
 })
 
-app.listen(port, (err) => {
-    if (err) {
-        return console.log('something bad happened', err)
-    }
-    console.log(`server is listening on ${port}`)
-})
+app.listen(port, () => { console.log(`server is listening on ${port}`) })

--- a/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjectionSafe.js
+++ b/javascript/ql/src/experimental/Security/CWE-94/examples/ServerSideTemplateInjectionSafe.js
@@ -1,0 +1,39 @@
+const express = require('express')
+var bodyParser = require('body-parser');
+const app = express()
+app.use(bodyParser.urlencoded({ extended: true }));
+
+//Dependent of Templating engine
+var jade = require('pug');
+const port = 5061
+
+function getHTML(input) {
+    var template = `
+doctype
+html
+head
+    title= 'Hello world'
+body
+    form(action='/' method='post')
+        label(for='name') Name:
+            input#name.form-control(type='text', placeholder='' name='name')
+        button.btn.btn-primary(type='submit') Submit
+    p Hello #{username}`
+    var fn = jade.compile(template);
+    var html = fn({username: input});
+    console.log(html);
+    return html;
+}
+
+app.post('/', (request, response) => {
+    var input = request.param('name', "")
+    var html = getHTML(input)
+    response.send(html);
+})
+
+app.listen(port, (err) => {
+    if (err) {
+        return console.log('something bad happened', err)
+    }
+    console.log(`server is listening on ${port}`)
+})


### PR DESCRIPTION
CodeQL detection for Server Side Template Injection (SSTI) by following popular rendering engines and frameworks:
- jade/pug
`var jade = require('jade'); // var jade = require('pug');`
`var fn = jade.compile(template);`
`var html = fn({name:'aaaa'});`
- dot
`var dot = require('dot');`
`var tempFn = doT.template(template);`
`html = tempFn( { username: 'James' });`
- ejs
`var ejs = require('ejs');`
`var html =ejs.render(template,{ name: "Venus" })`
- nunjucks
`var nunjucks = require('nunjucks');`
`html = nunjucks.renderString(template, { username: 'James' });`
