### PR TITLE
Python: Refactor definitions query, add queries for ide search

### DIFF
--- a/python/ql/src/analysis/DefinitionTracking.qll
+++ b/python/ql/src/analysis/DefinitionTracking.qll
@@ -490,3 +490,24 @@ class NiceLocationExpr extends @py_expr {
         )
     }
 }
+
+/**
+ * Gets an element, of kind `kind`, that element `e` uses, if any.
+ */
+cached
+Definition definitionOf(NiceLocationExpr use, string kind) {
+  exists(string f, int l |
+    result = getUniqueDefinition(use) and
+    kind = "Definition" and
+    use.hasLocationInfo(f, l, _, _, _) and
+    // Ignore if the definition is on the same line as the use
+    not result.getLocation().hasLocationInfo(f, l, _, _, _))
+}
+
+/**
+ * Returns an appropriately encoded version of a filename `name`
+ * passed by the VS Code extension in order to coincide with the
+ * output of `.getFile()` on locatable entities.
+ */
+cached
+File getEncodedFile(string name) { result.getAbsolutePath().replaceAll(":", "_") = name }

--- a/python/ql/src/analysis/DefinitionTracking.qll
+++ b/python/ql/src/analysis/DefinitionTracking.qll
@@ -492,7 +492,7 @@ class NiceLocationExpr extends @py_expr {
 }
 
 /**
- * Gets an element, of kind `kind`, that element `e` uses, if any.
+ * Gets the definition (of kind `kind`) for the expression `use`, if one can be found.
  */
 cached
 Definition definitionOf(NiceLocationExpr use, string kind) {

--- a/python/ql/src/analysis/DefinitionTracking.qll
+++ b/python/ql/src/analysis/DefinitionTracking.qll
@@ -496,12 +496,13 @@ class NiceLocationExpr extends @py_expr {
  */
 cached
 Definition definitionOf(NiceLocationExpr use, string kind) {
-  exists(string f, int l |
-    result = getUniqueDefinition(use) and
-    kind = "Definition" and
-    use.hasLocationInfo(f, l, _, _, _) and
-    // Ignore if the definition is on the same line as the use
-    not result.getLocation().hasLocationInfo(f, l, _, _, _))
+    exists(string f, int l |
+        result = getUniqueDefinition(use) and
+        kind = "Definition" and
+        use.hasLocationInfo(f, l, _, _, _) and
+        // Ignore if the definition is on the same line as the use
+        not result.getLocation().hasLocationInfo(f, l, _, _, _)
+    )
 }
 
 /**

--- a/python/ql/src/analysis/Definitions.ql
+++ b/python/ql/src/analysis/Definitions.ql
@@ -8,11 +8,6 @@
 import python
 import DefinitionTracking
 
-from NiceLocationExpr use, Definition defn, string kind, string f, int l
-where
-    defn = getUniqueDefinition(use) and
-    kind = "Definition" and
-    use.hasLocationInfo(f, l, _, _, _) and
-    // Ignore if the definition is on the same line as the use
-    not defn.getLocation().hasLocationInfo(f, l, _, _, _)
+from NiceLocationExpr use, Definition defn, string kind
+where defn = definitionOf(use, kind)
 select use, defn, kind

--- a/python/ql/src/analysis/LocalDefinitions.ql
+++ b/python/ql/src/analysis/LocalDefinitions.ql
@@ -12,7 +12,8 @@ import DefinitionTracking
 
 external string selectedSourceFile();
 
-from NiceLocationExpr use, Definition defn, string kind
-where defn = definitionOf(use, kind) 
-and use.(Expr).getLocation().getFile() = getEncodedFile(selectedSourceFile())
+from NiceLocationExpr use, Definition defn, string kind, string f
+where defn = definitionOf(use, kind)
+and use.hasLocationInfo(f, _, _, _, _)
+and getEncodedFile(selectedSourceFile()).getAbsolutePath() = f
 select use, defn, kind

--- a/python/ql/src/analysis/LocalDefinitions.ql
+++ b/python/ql/src/analysis/LocalDefinitions.ql
@@ -1,0 +1,18 @@
+/**
+ * @name Jump-to-definition links
+ * @description Generates use-definition pairs that provide the data
+ *              for jump-to-definition in the code viewer.
+ * @kind definitions
+ * @id python/ide-jump-to-definition
+ * @tags ide-contextual-queries/local-definitions
+ */
+
+import python
+import DefinitionTracking
+
+external string selectedSourceFile();
+
+from NiceLocationExpr use, Definition defn, string kind
+where defn = definitionOf(use, kind) 
+and use.(Expr).getLocation().getFile() = getEncodedFile(selectedSourceFile())
+select use, defn, kind

--- a/python/ql/src/analysis/LocalReferences.ql
+++ b/python/ql/src/analysis/LocalReferences.ql
@@ -1,0 +1,18 @@
+/**
+ * @name Find-references links
+ * @description Generates use-definition pairs that provide the data
+ *              for find-references in the code viewer.
+ * @kind definitions
+ * @id python/ide-find-references
+ * @tags ide-contextual-queries/local-references
+ */
+
+import python
+import DefinitionTracking
+
+external string selectedSourceFile();
+
+from NiceLocationExpr use, Definition defn, string kind
+where defn = definitionOf(use, kind)
+and defn.getLocation().getFile() = getEncodedFile(selectedSourceFile())
+select use, defn, kind

--- a/python/ql/src/codeql-suites/python-lgtm-full.qls
+++ b/python/ql/src/codeql-suites/python-lgtm-full.qls
@@ -6,3 +6,4 @@
 - exclude:
     tags contain:
       - ide-contextual-queries/local-definitions
+      - ide-contextual-queries/local-references

--- a/python/ql/src/codeql-suites/python-lgtm-full.qls
+++ b/python/ql/src/codeql-suites/python-lgtm-full.qls
@@ -2,3 +2,7 @@
 - qlpack: codeql-python
 - apply: lgtm-selectors.yml
   from: codeql-suite-helpers
+# These are only for IDE use.
+- exclude:
+    tags contain:
+      - ide-contextual-queries/local-definitions


### PR DESCRIPTION
This enables jump-to-definition and find-references in the VS Code
extension, for python source archives.