### PR TITLE
Update requirements for docs review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,9 +3,18 @@
 /java/ @github/codeql-java
 /javascript/ @github/codeql-javascript
 /python/ @github/codeql-python
+
+# Assign query help for docs review
 /cpp/**/*.qhelp @hubwriter
 /csharp/**/*.qhelp @jf205
 /java/**/*.qhelp @felicitymay
 /javascript/**/*.qhelp @mchammer01
 /python/**/*.qhelp @felicitymay
 /docs/language/ @shati-patel @jf205
+
+# Exclude help for experimental queries from docs review
+/cpp/**/experimental/**/*.qhelp @github/codeql-c-analysis
+/csharp/**/experimental/**/*.qhelp @github/codeql-csharp
+/java/**/experimental/**/*.qhelp @github/codeql-java
+/javascript/**/experimental/**/*.qhelp @github/codeql-javascript
+/python/**/experimental/**/*.qhelp @github/codeql-python

--- a/docs/supported-queries.md
+++ b/docs/supported-queries.md
@@ -77,3 +77,4 @@ The process must begin with the first step and must conclude with the final step
    - The structure of an `experimental` subdirectory mirrors the structure of its parent directory, so this step may just be a matter of removing the `experimental/` prefix of the query and test paths. Be sure to also edit any references to the query path in tests.
    - Add the query to one of the legacy suite files in `ql/<language>/config/suites/<language>/` if it exists. Note that there are separate suite directories for C and C++, `c` and `cpp` respectively, and the query should be added to one or both as appropriate.
    - Add a release note to `change-notes/<next-version>/analysis-<language>.md`.
+   - Your pull request will be flagged automatically for a review by the documentation team to ensure that the query help file is ready for wider use. 


### PR DESCRIPTION
Following discussions with the docs team and with the language teams, a docs review is necessary only for pull requests for documentation for supported queries and libraries.

This PR updates the `CODEOWNERS` and `supported-queries.md` files to reflect this decision.

@jbj - thanks for your suggestion that we update the information on supported queries. I'd forgotten about that.