### PR TITLE
JS: Recognize Express param value callback as RemoteFlowSource

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -3,6 +3,7 @@
 ## General improvements
 
 * Support for the following frameworks and libraries has been improved:
+  - [express](https://www.npmjs.com/package/express)
   - [fstream](https://www.npmjs.com/package/fstream)
   - [jGrowl](https://github.com/stanlemon/jGrowl)
   - [jQuery](https://jquery.com/)

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -58,7 +58,7 @@ module ConnectExpressShared {
     (
       sig.has("next")
       implies
-      function.getParameter(sig.getParameterIndex("next")).getName() = "next"
+      function.getParameter(sig.getParameterIndex("next")).getName() = ["next", "cb"]
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -42,9 +42,7 @@ module ConnectExpressShared {
     }
 
     /** Gets the signature corresonding to `(req, res, next) => {...}`. */
-    RouteHandlerSignature requestResponseNext() {
-      result = "request,response,next"
-    }
+    RouteHandlerSignature requestResponseNext() { result = "request,response,next" }
 
     /** Gets the signature corresonding to `(err, req, res, next) => {...}`. */
     RouteHandlerSignature errorRequestResponseNext() { result = "error,request,response,next" }

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -81,6 +81,7 @@ module ConnectExpressShared {
    *
    * `kind` is one of: "error", "request", "response", "next".
    */
+  pragma[inline]
   Parameter getRouteParameterHandlerParameter(Function routeHandler, string kind) {
     result =
       getRouteHandlerParameter(routeHandler, RouteHandlerSignature::requestResponseNextParameter(),
@@ -92,6 +93,7 @@ module ConnectExpressShared {
    *
    * `kind` is one of: "error", "request", "response", "next".
    */
+  pragma[inline]
   Parameter getRouteHandlerParameter(Function routeHandler, string kind) {
     if routeHandler.getNumParameter() = 4
     then

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -41,6 +41,11 @@ module ConnectExpressShared {
       result = "request,response,next,parameter"
     }
 
+    /** Gets the signature corresonding to `(req, res, next) => {...}`. */
+    RouteHandlerSignature requestResponseNext() {
+      result = "request,response,next"
+    }
+
     /** Gets the signature corresonding to `(err, req, res, next) => {...}`. */
     RouteHandlerSignature errorRequestResponseNext() { result = "error,request,response,next" }
   }
@@ -99,8 +104,7 @@ module ConnectExpressShared {
           kind)
     else
       result =
-        getRouteHandlerParameter(routeHandler,
-          RouteHandlerSignature::requestResponseNextParameter(), kind)
+        getRouteHandlerParameter(routeHandler, RouteHandlerSignature::requestResponseNext(), kind)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -17,9 +17,10 @@ module ConnectExpressShared {
    */
   private class RouteHandlerSignature extends string {
     RouteHandlerSignature() {
-      this =
-        ["request,response", "request,response,next", "request,response,next,parameter",
-            "error,request,response,next"]
+      this = "request,response" or
+      this = "request,response,next" or
+      this = "request,response,next,parameter" or
+      this = "error,request,response,next"
     }
 
     /** Gets the index of the parameter corresonding to the given `kind`, if any. */

--- a/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ConnectExpressShared.qll
@@ -8,23 +8,98 @@ import javascript
 
 module ConnectExpressShared {
   /**
+   * String representing the signature of a route handler, that is,
+   * the list of parameters taken by the route handler.
+   *
+   * Concretely this is a comma-separated list of parameter kinds, which can be either
+   * `request`, `response`, `next`, `error`, or `parameter`, but this is considered an
+   * implementation detail.
+   */
+  private class RouteHandlerSignature extends string {
+    RouteHandlerSignature() {
+      this =
+        ["request,response", "request,response,next", "request,response,next,parameter",
+            "error,request,response,next"]
+    }
+
+    /** Gets the index of the parameter corresonding to the given `kind`, if any. */
+    pragma[noinline]
+    int getParameterIndex(string kind) { this.splitAt(",", result) = kind }
+
+    /** Gets the number of parameters taken by this signature. */
+    pragma[noinline]
+    int getArity() { result = count(getParameterIndex(_)) }
+
+    /** Holds if this signature takes a parameter of the given kind. */
+    predicate has(string kind) { exists(getParameterIndex(kind)) }
+  }
+
+  private module RouteHandlerSignature {
+    /** Gets the signature corresonding to `(req, res, next, param) => {...}`. */
+    RouteHandlerSignature requestResponseNextParameter() {
+      result = "request,response,next,parameter"
+    }
+
+    /** Gets the signature corresonding to `(err, req, res, next) => {...}`. */
+    RouteHandlerSignature errorRequestResponseNext() { result = "error,request,response,next" }
+  }
+
+  /**
+   * Holds if `fun` appears to match the given signature based on parameter naming.
+   */
+  private predicate matchesSignature(Function function, RouteHandlerSignature sig) {
+    function.getNumParameter() = sig.getArity() and
+    function.getParameter(sig.getParameterIndex("request")).getName() = ["req", "request"] and
+    function.getParameter(sig.getParameterIndex("response")).getName() = ["res", "response"] and
+    (
+      sig.has("next")
+      implies
+      function.getParameter(sig.getParameterIndex("next")).getName() = "next"
+    )
+  }
+
+  /**
+   * Gets the parameter corresonding to the given `kind`, where `routeHandler` is interpreted as a
+   * route handler with the signature `sig`.
+   *
+   * This does not check if the function is actually a route handler or matches the signature in any way,
+   * so the caller should restrict the function accordingly.
+   */
+  pragma[inline]
+  private Parameter getRouteHandlerParameter(
+    Function routeHandler, RouteHandlerSignature sig, string kind
+  ) {
+    result = routeHandler.getParameter(sig.getParameterIndex(kind))
+  }
+
+  /**
+   * Gets the parameter of kind `kind` of a Connect/Express route parameter handler function.
+   *
+   * `kind` is one of: "error", "request", "response", "next".
+   */
+  Parameter getRouteParameterHandlerParameter(Function routeHandler, string kind) {
+    result =
+      getRouteHandlerParameter(routeHandler, RouteHandlerSignature::requestResponseNextParameter(),
+        kind)
+  }
+
+  /**
    * Gets the parameter of kind `kind` of a Connect/Express route handler function.
    *
    * `kind` is one of: "error", "request", "response", "next".
    */
-  SimpleParameter getRouteHandlerParameter(Function routeHandler, string kind) {
-    exists(int index, int offset |
-      result = routeHandler.getParameter(index + offset) and
-      (if routeHandler.getNumParameter() = 4 then offset = 0 else offset = -1)
-    |
-      kind = "error" and index = 0
-      or
-      kind = "request" and index = 1
-      or
-      kind = "response" and index = 2
-      or
-      kind = "next" and index = 3
-    )
+  Parameter getRouteHandlerParameter(Function routeHandler, string kind) {
+    if routeHandler.getNumParameter() = 4
+    then
+      // For arity 4 there is ambiguity between (err, req, res, next) and (req, res, next, param)
+      // This predicate favors the 'err' signature whereas getRouteParameterHandlerParameter favors the other.
+      result =
+        getRouteHandlerParameter(routeHandler, RouteHandlerSignature::errorRequestResponseNext(),
+          kind)
+    else
+      result =
+        getRouteHandlerParameter(routeHandler,
+          RouteHandlerSignature::requestResponseNextParameter(), kind)
   }
 
   /**
@@ -34,39 +109,16 @@ module ConnectExpressShared {
    */
   class RouteHandlerCandidate extends HTTP::RouteHandlerCandidate {
     RouteHandlerCandidate() {
-      exists(string request, string response, string next, string error |
-        (request = "request" or request = "req") and
-        (response = "response" or response = "res") and
-        next = "next" and
-        (error = "error" or error = "err")
-      |
-        // heuristic: parameter names match the documentation
-        astNode.getNumParameter() >= 2 and
-        getRouteHandlerParameter(astNode, "request").getName() = request and
-        getRouteHandlerParameter(astNode, "response").getName() = response and
-        (
-          astNode.getNumParameter() >= 3
-          implies
-          getRouteHandlerParameter(astNode, "next").getName() = next
-        ) and
-        (
-          astNode.getNumParameter() = 4
-          implies
-          getRouteHandlerParameter(astNode, "error").getName() = error
-        ) and
-        not (
-          // heuristic: max four parameters (the server will only supply four arguments)
-          astNode.getNumParameter() > 4
-          or
-          // heuristic: not a class method (the server invokes this with a function call)
-          astNode = any(MethodDefinition def).getBody()
-          or
-          // heuristic: does not return anything (the server will not use the return value)
-          exists(astNode.getAReturnStmt().getExpr())
-          or
-          // heuristic: is not invoked (the server invokes this at a call site we cannot reason precisely about)
-          exists(DataFlow::InvokeNode cs | cs.getACallee() = astNode)
-        )
+      matchesSignature(astNode, _) and
+      not (
+        // heuristic: not a class method (the server invokes this with a function call)
+        astNode = any(MethodDefinition def).getBody()
+        or
+        // heuristic: does not return anything (the server will not use the return value)
+        exists(astNode.getAReturnStmt().getExpr())
+        or
+        // heuristic: is not invoked (the server invokes this at a call site we cannot reason precisely about)
+        exists(DataFlow::InvokeNode cs | cs.getACallee() = astNode)
       )
     }
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -479,6 +479,13 @@ module Express {
       or
       kind = "body" and
       this.asExpr() = rh.getARequestBodyAccess()
+      or
+      // `value` in `router.param('foo', (req, res, next, value) => { ... })`
+      kind = "parameter" and
+      exists(RouteSetup setup | rh = setup.getARouteHandler() |
+        setup.getMethodName() = "param" and
+        this = rh.(DataFlow::FunctionNode).getParameter(3)
+      )
     }
 
     override RouteHandler getRouteHandler() { result = rh }

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -461,28 +461,21 @@ module Express {
     string kind;
 
     RequestInputAccess() {
-      exists(DataFlow::Node request | request = DataFlow::valueNode(rh.getARequestExpr()) |
+      exists(DataFlow::SourceNode request | request = rh.getARequestSource().ref() |
         kind = "parameter" and
         (
-          this.(DataFlow::MethodCallNode).calls(request, "param")
+          this = request.getAMethodCall("param")
           or
-          exists(DataFlow::PropRead base, string propName |
-            // `req.params.name` or `req.query.name`
-            base.accesses(request, propName) and
-            this = base.getAPropertyReference(_)
-          |
-            propName = "params" or
-            propName = "query"
-          )
+          this = request.getAPropertyRead(["params", "query"]).getAPropertyRead()
         )
         or
         // `req.originalUrl`
         kind = "url" and
-        this.(DataFlow::PropRef).accesses(request, "originalUrl")
+        this = request.getAPropertyRead("originalUrl")
         or
         // `req.cookies`
         kind = "cookie" and
-        this.(DataFlow::PropRef).accesses(request, "cookies")
+        this = request.getAPropertyRead("cookies")
       )
       or
       kind = "body" and

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -127,14 +127,14 @@ module Express {
     /**
      * Gets the HTTP request type this is registered for, if any.
      *
-     * Has no result for `use` and `all` calls.
+     * Has no result for `use`, `all`, or `param` calls.
      */
     HTTP::RequestMethodName getRequestMethod() { result.toLowerCase() = getMethodName() }
 
     /**
      * Holds if this registers a route for all request methods.
      */
-    predicate handlesAllRequestMethods() { getMethodName() = "use" or getMethodName() = "all" }
+    predicate handlesAllRequestMethods() { getMethodName() = ["use", "all", "param"] }
 
     /**
      * Holds if this route setup sets up a route for the same
@@ -146,6 +146,11 @@ module Express {
       that.handlesAllRequestMethods() or
       this.getRequestMethod() = that.getRequestMethod()
     }
+
+    /**
+     * Holds if this route setup is a parameter handler, such as `app.param("foo", ...)`.
+     */
+    predicate isParameterHandler() { getMethodName() = "param" }
   }
 
   /**
@@ -314,7 +319,7 @@ module Express {
     /**
      * Gets the parameter of kind `kind` of this route handler.
      *
-     * `kind` is one of: "error", "request", "response", "next".
+     * `kind` is one of: "error", "request", "response", "next", or "parameter".
      */
     abstract SimpleParameter getRouteHandlerParameter(string kind);
 
@@ -340,11 +345,14 @@ module Express {
   class StandardRouteHandler extends RouteHandler, HTTP::Servers::StandardRouteHandler,
     DataFlow::ValueNode {
     override Function astNode;
+    RouteSetup routeSetup;
 
-    StandardRouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
+    StandardRouteHandler() { this = routeSetup.getARouteHandler() }
 
     override SimpleParameter getRouteHandlerParameter(string kind) {
-      result = getRouteHandlerParameter(astNode, kind)
+      if routeSetup.isParameterHandler()
+      then result = getRouteParameterHandlerParameter(astNode, kind)
+      else result = getRouteHandlerParameter(astNode, kind)
     }
   }
 
@@ -483,8 +491,7 @@ module Express {
       // `value` in `router.param('foo', (req, res, next, value) => { ... })`
       kind = "parameter" and
       exists(RouteSetup setup | rh = setup.getARouteHandler() |
-        setup.getMethodName() = "param" and
-        this = rh.(DataFlow::FunctionNode).getParameter(3)
+        this = DataFlow::parameterNode(rh.getRouteHandlerParameter("parameter"))
       )
     }
 
@@ -855,10 +862,14 @@ module Express {
    */
   private class TrackedRouteHandlerCandidateWithSetup extends RouteHandler,
     HTTP::Servers::StandardRouteHandler, DataFlow::FunctionNode {
-    TrackedRouteHandlerCandidateWithSetup() { this = any(RouteSetup s).getARouteHandler() }
+    RouteSetup routeSetup;
+
+    TrackedRouteHandlerCandidateWithSetup() { this = routeSetup.getARouteHandler() }
 
     override SimpleParameter getRouteHandlerParameter(string kind) {
-      result = getRouteHandlerParameter(astNode, kind)
+      if routeSetup.isParameterHandler()
+      then result = getRouteParameterHandlerParameter(astNode, kind)
+      else result = getRouteHandlerParameter(astNode, kind)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
@@ -219,12 +219,14 @@ module Firebase {
      */
     private class RouteHandler extends Express::RouteHandler, HTTP::Servers::StandardRouteHandler,
       DataFlow::ValueNode {
+      override Function astNode;
+
       RouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
 
       override SimpleParameter getRouteHandlerParameter(string kind) {
-        kind = "request" and result = this.(DataFlow::FunctionNode).getParameter(0).getParameter()
+        kind = "request" and result = astNode.getParameter(0)
         or
-        kind = "response" and result = this.(DataFlow::FunctionNode).getParameter(1).getParameter()
+        kind = "response" and result = astNode.getParameter(1)
       }
     }
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -205,6 +205,24 @@ module HTTP {
     abstract HeaderDefinition getAResponseHeader(string name);
 
     /**
+     * Gets a request object originating from this route handler.
+     *
+     * Use `RequestSource.ref()` to get reference to this request object.
+     */
+    final Servers::RequestSource getARequestSource() {
+      result.getRouteHandler() = this
+    }
+
+    /**
+     * Gets a request object originating from this route handler.
+     *
+     * Use `RequestSource.ref()` to get reference to this request object.
+     */
+    final Servers::ResponseSource getAResponseSource() {
+      result.getRouteHandler() = this
+    }
+
+    /**
      * Gets an expression that contains a request object handled
      * by this handler.
      */
@@ -296,13 +314,20 @@ module HTTP {
        */
       abstract RouteHandler getRouteHandler();
 
-      predicate flowsTo(DataFlow::Node nd) { ref(DataFlow::TypeTracker::end()).flowsTo(nd) }
+      /** DEPRECATED. Use `ref().flowsTo()` instead. */
+      deprecated
+      predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
         result = this
         or
         exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
+      }
+
+      /** Gets a `SourceNode` that refers to this request object. */
+      DataFlow::SourceNode ref() {
+        result = ref(DataFlow::TypeTracker::end())
       }
     }
 
@@ -317,13 +342,19 @@ module HTTP {
        */
       abstract RouteHandler getRouteHandler();
 
-      predicate flowsTo(DataFlow::Node nd) { ref(DataFlow::TypeTracker::end()).flowsTo(nd) }
+      /** DEPRECATED. Use `ref().flowsTo()` instead. */
+      predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
         result = this
         or
         exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
+      }
+
+      /** Gets a `SourceNode` that refers to this response object. */
+      DataFlow::SourceNode ref() {
+        result = ref(DataFlow::TypeTracker::end())
       }
     }
 
@@ -333,7 +364,7 @@ module HTTP {
     class StandardRequestExpr extends RequestExpr {
       RequestSource src;
 
-      StandardRequestExpr() { src.flowsTo(DataFlow::valueNode(this)) }
+      StandardRequestExpr() { src.ref().flowsTo(DataFlow::valueNode(this)) }
 
       override RouteHandler getRouteHandler() { result = src.getRouteHandler() }
     }
@@ -344,7 +375,7 @@ module HTTP {
     class StandardResponseExpr extends ResponseExpr {
       ResponseSource src;
 
-      StandardResponseExpr() { src.flowsTo(DataFlow::valueNode(this)) }
+      StandardResponseExpr() { src.ref().flowsTo(DataFlow::valueNode(this)) }
 
       override RouteHandler getRouteHandler() { result = src.getRouteHandler() }
     }

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -370,6 +370,7 @@ module HTTP {
       /**
        * Gets a route handler that is defined by this setup.
        */
+      pragma[nomagic]
       abstract DataFlow::SourceNode getARouteHandler();
 
       /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -214,9 +214,9 @@ module HTTP {
     }
 
     /**
-     * Gets a request object originating from this route handler.
+     * Gets a response object originating from this route handler.
      *
-     * Use `RequestSource.ref()` to get reference to this request object.
+     * Use `ResponseSource.ref()` to get reference to this response object.
      */
     final Servers::ResponseSource getAResponseSource() {
       result.getRouteHandler() = this
@@ -343,6 +343,7 @@ module HTTP {
       abstract RouteHandler getRouteHandler();
 
       /** DEPRECATED. Use `ref().flowsTo()` instead. */
+      deprecated
       predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -209,18 +209,14 @@ module HTTP {
      *
      * Use `RequestSource.ref()` to get reference to this request object.
      */
-    final Servers::RequestSource getARequestSource() {
-      result.getRouteHandler() = this
-    }
+    final Servers::RequestSource getARequestSource() { result.getRouteHandler() = this }
 
     /**
      * Gets a response object originating from this route handler.
      *
      * Use `ResponseSource.ref()` to get reference to this response object.
      */
-    final Servers::ResponseSource getAResponseSource() {
-      result.getRouteHandler() = this
-    }
+    final Servers::ResponseSource getAResponseSource() { result.getRouteHandler() = this }
 
     /**
      * Gets an expression that contains a request object handled
@@ -315,8 +311,7 @@ module HTTP {
       abstract RouteHandler getRouteHandler();
 
       /** DEPRECATED. Use `ref().flowsTo()` instead. */
-      deprecated
-      predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
+      deprecated predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
@@ -326,9 +321,7 @@ module HTTP {
       }
 
       /** Gets a `SourceNode` that refers to this request object. */
-      DataFlow::SourceNode ref() {
-        result = ref(DataFlow::TypeTracker::end())
-      }
+      DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
     }
 
     /**
@@ -343,8 +336,7 @@ module HTTP {
       abstract RouteHandler getRouteHandler();
 
       /** DEPRECATED. Use `ref().flowsTo()` instead. */
-      deprecated
-      predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
+      deprecated predicate flowsTo(DataFlow::Node nd) { ref().flowsTo(nd) }
 
       private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
         t.start() and
@@ -354,9 +346,7 @@ module HTTP {
       }
 
       /** Gets a `SourceNode` that refers to this response object. */
-      DataFlow::SourceNode ref() {
-        result = ref(DataFlow::TypeTracker::end())
-      }
+      DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
     }
 
     /**

--- a/javascript/ql/test/library-tests/frameworks/Express/src/express4.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/express4.js
@@ -3,4 +3,7 @@ var app = express();
 
 app.get('/some/path', function(req, res) {
   let { foo, bar: baz } = req.query;
+  let dynamic1 = req.query[foo];
+  let dynamic2 = req.query[something()];
+  res.send(dynamic1);
 });

--- a/javascript/ql/test/library-tests/frameworks/Express/src/params.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/params.js
@@ -2,6 +2,8 @@ var express = require('express');
 var app = express();
 
 app.param('foo', (req, res, next, value) => {
+    console.log(req.query.xx);
+    console.log(req.body.xx);
     if (value) {
         res.send(value);
     } else {

--- a/javascript/ql/test/library-tests/frameworks/Express/src/params.js
+++ b/javascript/ql/test/library-tests/frameworks/Express/src/params.js
@@ -1,0 +1,14 @@
+var express = require('express');
+var app = express();
+
+app.param('foo', (req, res, next, value) => {
+    if (value) {
+        res.send(value);
+    } else {
+        next();
+    }
+});
+
+app.get('/hello/:foo', function(req, res) {
+  res.send("Hello");
+});

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -279,6 +279,8 @@ test_RequestInputAccess
 | src/express3.js:5:35:5:50 | req.param("val") | parameter | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express4.js:5:9:5:11 | foo | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:5:14:5:21 | bar: baz | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:6:18:6:31 | req.query[foo] | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:7:18:7:39 | req.que ... hing()] | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:5:16:5:34 | req.param("target") | parameter | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:26:6:44 | req.param("target") | parameter | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:23:3:23:10 | req.body | body | src/express.js:22:30:32:1 | functio ... ar');\\n} |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -13,8 +13,8 @@ test_RouteHandlerExpr_getBody
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -36,8 +36,8 @@ test_RouteSetup
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() | false |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() | false |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() | false |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() | false |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
@@ -68,8 +68,8 @@ test_RouteSetup_getLastRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -203,7 +203,8 @@ test_isRequest
 | src/express.js:49:3:49:5 | req |
 | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:7:2:7:4 | req |
-| src/params.js:6:9:6:11 | res |
+| src/params.js:5:17:5:19 | req |
+| src/params.js:6:17:6:19 | req |
 | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:17:5:17:7 | req |
 test_RouteSetup_getRouter
@@ -231,8 +232,8 @@ test_RouteSetup_getRouter
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -264,8 +265,8 @@ test_StandardRouteHandler
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:2:11:2:19 | express() | src/params.js:4:24:4:26 | res | src/params.js:4:29:4:32 | next |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:2:11:2:19 | express() | src/params.js:12:33:12:35 | req | src/params.js:12:38:12:40 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:2:11:2:19 | express() | src/params.js:4:19:4:21 | req | src/params.js:4:24:4:26 | res |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:2:11:2:19 | express() | src/params.js:14:33:14:35 | req | src/params.js:14:38:14:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |
@@ -291,7 +292,9 @@ test_RequestInputAccess
 | src/express.js:49:3:49:14 | req.hostname | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:32 | req.hea ... erName] | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:7:2:7:8 | req.url | url | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:35:4:39 | value | parameter | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:4:35:4:39 | value | parameter | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:5:17:5:28 | req.query.xx | parameter | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:6:17:6:24 | req.body | body | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/passport.js:28:2:28:9 | req.body | body | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 test_SetCookie
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -361,9 +364,10 @@ test_ResponseExpr
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/inheritedFromNode.js:5:2:5:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:6:2:6:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:8:9:8:12 | next | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:13:3:13:5 | res | src/params.js:12:24:14:1 | functio ... lo");\\n} |
-| src/params.js:13:3:13:19 | res.send("Hello") | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:8:9:8:11 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:8:9:8:23 | res.send(value) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:15:3:15:5 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
+| src/params.js:15:3:15:19 | res.send("Hello") | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:5:5:5:8 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:8:5:8:8 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:11:5:11:8 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -422,8 +426,8 @@ test_RouterDefinition_getARouteHandler
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:2:11:2:19 | express() | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:2:11:2:19 | express() | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:2:11:2:19 | express() | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:2:11:2:19 | express() | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -467,6 +471,7 @@ test_ExpressSession
 | src/express-session.js:7:1:9:2 | session ... -3"]\\n}) | secret | src/express-session.js:8:13:8:44 | ["secre ... key-3"] |
 test_RequestBodyAccess
 | src/express.js:23:3:23:10 | req.body |
+| src/params.js:6:17:6:24 | req.body |
 | src/passport.js:28:2:28:9 | req.body |
 test_RouteSetup_getServer
 | src/csurf-example.js:20:1:23:2 | app.get ... ) })\\n}) | src/csurf-example.js:7:11:7:19 | express() |
@@ -483,8 +488,8 @@ test_RouteSetup_getServer
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -525,8 +530,8 @@ test_RouteHandlerExpr
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:44:1:44:26 | app.use ... dler()) | false |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | true |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | true |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:1:10:2 | app.par ...    }\\n}) | true |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:1:14:2 | app.get ... o");\\n}) | true |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:1:12:2 | app.par ...    }\\n}) | true |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:1:16:2 | app.get ... o");\\n}) | true |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | true |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | true |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | true |
@@ -551,7 +556,9 @@ test_RouteSetup_handlesAllRequestMethods
 | src/express3.js:12:1:12:21 | app.use ... dler()) |
 | src/express.js:39:1:39:21 | app.use ... dler()) |
 | src/express.js:44:1:44:26 | app.use ... dler()) |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) |
 | src/route.js:4:1:5:39 | router. ... xt) {}) |
+| src/routesetups.js:3:1:4:14 | express ... ('', h) |
 | src/subrouter.js:4:1:4:26 | app.use ... rotect) |
 | src/subrouter.js:5:1:5:29 | app.use ... uter()) |
 test_RouterDefinition_getASubRouter
@@ -591,7 +598,7 @@ test_RouteSetup_getRequestMethod
 | src/express.js:34:1:34:53 | app.get ... andler) | GET |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | POST |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | POST |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | GET |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | GET |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | GET |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | GET |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | GET |
@@ -627,8 +634,8 @@ test_RouteExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -678,9 +685,10 @@ test_RouteHandler_getAResponseExpr
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:6:2:6:4 | res |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:8:9:8:12 | next |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:13:3:13:5 | res |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:13:3:13:19 | res.send("Hello") |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:11 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:5 | res |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:19 | res.send("Hello") |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:5:5:5:8 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:11:5:11:8 | res3 |
@@ -752,9 +760,10 @@ test_isResponse
 | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:6:2:6:4 | res |
-| src/params.js:8:9:8:12 | next |
-| src/params.js:13:3:13:5 | res |
-| src/params.js:13:3:13:19 | res.send("Hello") |
+| src/params.js:8:9:8:11 | res |
+| src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:15:3:15:5 | res |
+| src/params.js:15:3:15:19 | res.send("Hello") |
 | src/responseExprs.js:5:5:5:8 | res1 |
 | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:11:5:11:8 | res3 |
@@ -804,13 +813,15 @@ test_ResponseBody
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
-| src/params.js:13:12:13:18 | "Hello" | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:8:18:8:22 | value | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:15:12:15:18 | "Hello" | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 test_ResponseSendArgument
 | src/csurf-example.js:26:12:26:42 | 'csrf w ... t here' | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
-| src/params.js:13:12:13:18 | "Hello" | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:8:18:8:22 | value | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:15:12:15:18 | "Hello" | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 test_RouteSetup_getARouteHandler
 | src/auth.js:4:1:4:53 | app.use ... d' }})) | src/auth.js:4:9:4:52 | basicAu ... rd' }}) |
 | src/csurf-example.js:13:1:13:20 | app.use('/api', api) | src/csurf-example.js:10:11:10:27 | createApiRouter() |
@@ -841,8 +852,8 @@ test_RouteSetup_getARouteHandler
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -923,8 +934,8 @@ test_RouteSetup_getRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | 0 | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | 0 | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | 0 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | 0 | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | 0 | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | 0 | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | 0 | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | 0 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | 0 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | 0 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -960,6 +971,7 @@ test_RouterDefinition_RouterDefinition
 | src/subrouter.js:8:16:8:31 | express.Router() |
 test_RouteHandler_getARequestBodyAccess
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:23:3:23:10 | req.body |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:6:17:6:24 | req.body |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:28:2:28:9 | req.body |
 test_RouterDefinition_getMiddlewareStack
 | src/auth.js:1:13:1:32 | require('express')() | src/auth.js:4:9:4:52 | basicAu ... rd' }}) |
@@ -987,8 +999,8 @@ test_RouteHandler
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req | src/express.js:42:18:42:20 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res | src/params.js:4:29:4:32 | next |
-| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:33:12:35 | req | src/params.js:12:38:12:40 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req | src/params.js:4:24:4:26 | res |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:33:14:35 | req | src/params.js:14:38:14:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |
@@ -1020,8 +1032,8 @@ test_RouteSetup_getARouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
-| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:4:1:12:2 | app.par ...    }\\n}) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:1:16:2 | app.get ... o");\\n}) | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -1070,7 +1082,8 @@ test_RequestExpr
 | src/express.js:49:3:49:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:7:2:7:4 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
-| src/params.js:6:9:6:11 | res | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:5:17:5:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:6:17:6:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/passport.js:28:2:28:4 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 test_RequestExprStandalone
@@ -1104,6 +1117,7 @@ test_RouteHandler_getARequestExpr
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:49:3:49:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:7:2:7:4 | req |
-| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:6:9:6:11 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:5:17:5:19 | req |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:6:17:6:19 | req |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -7,7 +7,7 @@ test_RouteHandlerExpr_getBody
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:23:7:1 | functio ... al");\\n} |
-| src/express4.js:4:23:6:1 | functio ... uery;\\n} | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -30,7 +30,7 @@ test_RouteSetup
 | src/express2.js:3:1:3:56 | router. ...  res }) | src/express2.js:5:11:5:13 | e() | false |
 | src/express2.js:3:1:4:77 | router. ... sult }) | src/express2.js:5:11:5:13 | e() | false |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:2:11:2:19 | express() | false |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:2:11:2:19 | express() | false |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:2:11:2:19 | express() | false |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
@@ -59,7 +59,7 @@ test_RouteSetup_getLastRouteHandlerExpr
 | src/express2.js:6:1:6:15 | app.use(router) | src/express2.js:6:9:6:14 | router |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:12:9:12:20 | getHandler() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -188,6 +188,8 @@ test_isRequest
 | src/express3.js:5:14:5:16 | req |
 | src/express3.js:5:35:5:37 | req |
 | src/express4.js:5:27:5:29 | req |
+| src/express4.js:6:18:6:20 | req |
+| src/express4.js:7:18:7:20 | req |
 | src/express.js:5:16:5:18 | req |
 | src/express.js:6:26:6:28 | req |
 | src/express.js:23:3:23:5 | req |
@@ -223,7 +225,7 @@ test_RouteSetup_getRouter
 | src/express2.js:6:1:6:15 | app.use(router) | src/express2.js:5:11:5:13 | e() |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:2:11:2:19 | express() |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:2:11:2:19 | express() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:2:11:2:19 | express() |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:2:11:2:19 | express() |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
@@ -259,7 +261,7 @@ test_StandardRouteHandler
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:5:11:5:13 | e() | src/express2.js:3:34:3:36 | req | src/express2.js:3:39:3:41 | res |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:5:11:5:13 | e() | src/express2.js:4:41:4:47 | request | src/express2.js:4:50:4:55 | result |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:2:11:2:19 | express() | src/express3.js:4:32:4:34 | req | src/express3.js:4:37:4:39 | res |
-| src/express4.js:4:23:6:1 | functio ... uery;\\n} | src/express4.js:2:11:2:19 | express() | src/express4.js:4:32:4:34 | req | src/express4.js:4:37:4:39 | res |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:2:11:2:19 | express() | src/express4.js:4:32:4:34 | req | src/express4.js:4:37:4:39 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:2:11:2:19 | express() | src/express.js:4:32:4:34 | req | src/express.js:4:37:4:39 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:2:11:2:19 | express() | src/express.js:16:28:16:30 | req | src/express.js:16:33:16:35 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
@@ -275,8 +277,8 @@ test_StandardRouteHandler
 test_RequestInputAccess
 | src/express3.js:5:14:5:32 | req.param("header") | parameter | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:35:5:50 | req.param("val") | parameter | src/express3.js:4:23:7:1 | functio ... al");\\n} |
-| src/express4.js:5:9:5:11 | foo | parameter | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
-| src/express4.js:5:14:5:21 | bar: baz | parameter | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:5:9:5:11 | foo | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:5:14:5:21 | bar: baz | parameter | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:5:16:5:34 | req.param("target") | parameter | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:26:6:44 | req.param("target") | parameter | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:23:3:23:10 | req.body | body | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -350,6 +352,8 @@ test_ResponseExpr
 | src/express3.js:5:3:5:51 | res.hea ... "val")) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:6:3:6:5 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:6:3:6:17 | res.send("val") | src/express3.js:4:23:7:1 | functio ... al");\\n} |
+| src/express4.js:8:3:8:5 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:8:3:8:20 | res.send(dynamic1) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:5:3:5:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:3:6:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:3:6:45 | res.hea ... rget")) | src/express.js:4:23:9:1 | functio ... res);\\n} |
@@ -420,7 +424,7 @@ test_RouterDefinition_getARouteHandler
 | src/express2.js:2:14:2:23 | e.Router() | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:2:14:2:23 | e.Router() | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express3.js:2:11:2:19 | express() | src/express3.js:4:23:7:1 | functio ... al");\\n} |
-| src/express4.js:2:11:2:19 | express() | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:2:11:2:19 | express() | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -482,7 +486,7 @@ test_RouteSetup_getServer
 | src/express2.js:3:1:3:56 | router. ...  res }) | src/express2.js:5:11:5:13 | e() |
 | src/express2.js:3:1:4:77 | router. ... sult }) | src/express2.js:5:11:5:13 | e() |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:2:11:2:19 | express() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:2:11:2:19 | express() |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:2:11:2:19 | express() |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
@@ -521,7 +525,7 @@ test_RouteHandlerExpr
 | src/express2.js:6:9:6:14 | router | src/express2.js:6:1:6:15 | app.use(router) | false |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | true |
 | src/express3.js:12:9:12:20 | getHandler() | src/express3.js:12:1:12:21 | app.use ... dler()) | false |
-| src/express4.js:4:23:6:1 | functio ... uery;\\n} | src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | true |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | true |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:1:9:2 | app.get ... es);\\n}) | true |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:3:18:4 | router. ... );\\n  }) | true |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | true |
@@ -591,7 +595,7 @@ test_RouteSetup_getRequestMethod
 | src/express2.js:3:1:3:56 | router. ...  res }) | GET |
 | src/express2.js:3:1:4:77 | router. ... sult }) | POST |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | GET |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | GET |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | GET |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | GET |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | GET |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | POST |
@@ -625,7 +629,7 @@ test_RouteExpr
 | src/express2.js:6:1:6:15 | app.use(router) | src/express2.js:5:11:5:13 | e() |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:2:11:2:19 | express() |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:2:11:2:19 | express() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:2:11:2:19 | express() |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:2:11:2:19 | express() |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:2:11:2:19 | express() |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
@@ -671,6 +675,8 @@ test_RouteHandler_getAResponseExpr
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:3:5:51 | res.hea ... "val")) |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:6:3:6:5 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:6:3:6:17 | res.send("val") |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:5 | res |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:20 | res.send(dynamic1) |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:3:5:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:3:6:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:3:6:45 | res.hea ... rget")) |
@@ -746,6 +752,8 @@ test_isResponse
 | src/express3.js:5:3:5:51 | res.hea ... "val")) |
 | src/express3.js:6:3:6:5 | res |
 | src/express3.js:6:3:6:17 | res.send("val") |
+| src/express4.js:8:3:8:5 | res |
+| src/express4.js:8:3:8:20 | res.send(dynamic1) |
 | src/express.js:5:3:5:5 | res |
 | src/express.js:6:3:6:5 | res |
 | src/express.js:6:3:6:45 | res.hea ... rget")) |
@@ -812,6 +820,7 @@ test_ResponseBody
 | src/csurf-example.js:26:12:26:42 | 'csrf w ... t here' | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
+| src/express4.js:8:12:8:19 | dynamic1 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/params.js:8:18:8:22 | value | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:15:12:15:18 | "Hello" | src/params.js:14:24:16:1 | functio ... lo");\\n} |
@@ -819,6 +828,7 @@ test_ResponseSendArgument
 | src/csurf-example.js:26:12:26:42 | 'csrf w ... t here' | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
+| src/express4.js:8:12:8:19 | dynamic1 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/params.js:8:18:8:22 | value | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:15:12:15:18 | "Hello" | src/params.js:14:24:16:1 | functio ... lo");\\n} |
@@ -840,7 +850,7 @@ test_RouteSetup_getARouteHandler
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:10:12:10:32 | functio ...  res){} |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:12:9:12:20 | getHandler() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -925,7 +935,7 @@ test_RouteSetup_getRouteHandlerExpr
 | src/express2.js:6:1:6:15 | app.use(router) | 0 | src/express2.js:6:9:6:14 | router |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | 0 | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | 0 | src/express3.js:12:9:12:20 | getHandler() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | 0 | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | 0 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | 0 | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | 0 | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | 0 | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -991,7 +1001,7 @@ test_RouteHandler
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:41:4:47 | request | src/express2.js:4:50:4:55 | result |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:32:4:34 | req | src/express3.js:4:37:4:39 | res |
 | src/express3.js:10:12:10:32 | functio ...  res){} | src/express3.js:10:22:10:24 | req | src/express3.js:10:27:10:29 | res |
-| src/express4.js:4:23:6:1 | functio ... uery;\\n} | src/express4.js:4:32:4:34 | req | src/express4.js:4:37:4:39 | res |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:32:4:34 | req | src/express4.js:4:37:4:39 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:32:4:34 | req | src/express.js:4:37:4:39 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:28:16:30 | req | src/express.js:16:33:16:35 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
@@ -1023,7 +1033,7 @@ test_RouteSetup_getARouteHandlerExpr
 | src/express2.js:6:1:6:15 | app.use(router) | src/express2.js:6:9:6:14 | router |
 | src/express3.js:4:1:7:2 | app.get ... l");\\n}) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:12:1:12:21 | app.use ... dler()) | src/express3.js:12:9:12:20 | getHandler() |
-| src/express4.js:4:1:6:2 | app.get ... ery;\\n}) | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:4:1:9:2 | app.get ... c1);\\n}) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:4:1:9:2 | app.get ... es);\\n}) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:16:3:18:4 | router. ... );\\n  }) | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -1066,7 +1076,9 @@ test_RequestExpr
 | src/express2.js:4:60:4:66 | request | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express3.js:5:14:5:16 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:35:5:37 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
-| src/express4.js:5:27:5:29 | req | src/express4.js:4:23:6:1 | functio ... uery;\\n} |
+| src/express4.js:5:27:5:29 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:6:18:6:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express4.js:7:18:7:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express.js:5:16:5:18 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:26:6:28 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:23:3:23:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -1101,7 +1113,9 @@ test_RouteHandler_getARequestExpr
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:60:4:66 | request |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:14:5:16 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:35:5:37 | req |
-| src/express4.js:4:23:6:1 | functio ... uery;\\n} | src/express4.js:5:27:5:29 | req |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:5:27:5:29 | req |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:6:18:6:20 | req |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:7:18:7:20 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:16:5:18 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:26:6:28 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:23:3:23:5 | req |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -13,6 +13,8 @@ test_RouteHandlerExpr_getBody
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -34,6 +36,8 @@ test_RouteSetup
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() | false |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() | false |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() | false |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() | false |
@@ -64,6 +68,8 @@ test_RouteSetup_getLastRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -197,6 +203,7 @@ test_isRequest
 | src/express.js:49:3:49:5 | req |
 | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/params.js:6:9:6:11 | res |
 | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:17:5:17:7 | req |
 test_RouteSetup_getRouter
@@ -224,6 +231,8 @@ test_RouteSetup_getRouter
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -255,6 +264,8 @@ test_StandardRouteHandler
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:2:11:2:19 | express() | src/express.js:22:39:22:41 | req | src/express.js:22:44:22:46 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:2:11:2:19 | express() | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:2:11:2:19 | express() | src/params.js:4:24:4:26 | res | src/params.js:4:29:4:32 | next |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:2:11:2:19 | express() | src/params.js:12:33:12:35 | req | src/params.js:12:38:12:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |
@@ -280,6 +291,7 @@ test_RequestInputAccess
 | src/express.js:49:3:49:14 | req.hostname | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:32 | req.hea ... erName] | header | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:7:2:7:8 | req.url | url | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:35:4:39 | value | parameter | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
 | src/passport.js:28:2:28:9 | req.body | body | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 test_SetCookie
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -349,6 +361,9 @@ test_ResponseExpr
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/inheritedFromNode.js:5:2:5:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:6:2:6:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:8:9:8:12 | next | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:13:3:13:5 | res | src/params.js:12:24:14:1 | functio ... lo");\\n} |
+| src/params.js:13:3:13:19 | res.send("Hello") | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:5:5:5:8 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:8:5:8:8 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:11:5:11:8 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -407,6 +422,8 @@ test_RouterDefinition_getARouteHandler
 | src/express.js:2:11:2:19 | express() | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:2:11:2:19 | express() | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:2:11:2:19 | express() | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:2:11:2:19 | express() | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:2:11:2:19 | express() | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:2:11:2:19 | express() | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -466,6 +483,8 @@ test_RouteSetup_getServer
 | src/express.js:22:1:32:2 | app.pos ... r');\\n}) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -506,6 +525,8 @@ test_RouteHandlerExpr
 | src/express.js:44:9:44:25 | getArrowHandler() | src/express.js:44:1:44:26 | app.use ... dler()) | false |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | true |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | true |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:1:10:2 | app.par ...    }\\n}) | true |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:1:14:2 | app.get ... o");\\n}) | true |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | true |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | true |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | true |
@@ -550,6 +571,7 @@ test_appCreation
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:2:11:2:19 | express() |
 | src/routesetups.js:7:11:7:32 | express ... erver() |
 | src/subrouter.js:2:11:2:19 | express() |
@@ -569,6 +591,7 @@ test_RouteSetup_getRequestMethod
 | src/express.js:34:1:34:53 | app.get ... andler) | GET |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | POST |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | POST |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | GET |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | GET |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | GET |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | GET |
@@ -604,6 +627,8 @@ test_RouteExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:2:11:2:19 | express() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:2:11:2:19 | express() |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:2:11:2:19 | express() |
@@ -653,6 +678,9 @@ test_RouteHandler_getAResponseExpr
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:8:9:8:12 | next |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:13:3:13:5 | res |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:13:3:13:19 | res.send("Hello") |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:5:5:5:8 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:11:5:11:8 | res3 |
@@ -724,6 +752,9 @@ test_isResponse
 | src/express.js:31:3:31:26 | res.coo ...  'bar') |
 | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/params.js:8:9:8:12 | next |
+| src/params.js:13:3:13:5 | res |
+| src/params.js:13:3:13:19 | res.send("Hello") |
 | src/responseExprs.js:5:5:5:8 | res1 |
 | src/responseExprs.js:8:5:8:8 | res2 |
 | src/responseExprs.js:11:5:11:8 | res3 |
@@ -773,11 +804,13 @@ test_ResponseBody
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/params.js:13:12:13:18 | "Hello" | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 test_ResponseSendArgument
 | src/csurf-example.js:26:12:26:42 | 'csrf w ... t here' | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:33:14:33:34 | 'no csr ... t here' | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/express3.js:6:12:6:16 | "val" | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express.js:17:14:17:23 | "Go away." | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/params.js:13:12:13:18 | "Hello" | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 test_RouteSetup_getARouteHandler
 | src/auth.js:4:1:4:53 | app.use ... d' }})) | src/auth.js:4:9:4:52 | basicAu ... rd' }}) |
 | src/csurf-example.js:13:1:13:20 | app.use('/api', api) | src/csurf-example.js:10:11:10:27 | createApiRouter() |
@@ -808,6 +841,8 @@ test_RouteSetup_getARouteHandler
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -855,6 +890,7 @@ test_isRouterCreation
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:2:11:2:19 | express() |
 | src/route.js:2:14:2:29 | express.Router() |
 | src/routesetups.js:3:1:3:16 | express.Router() |
@@ -887,6 +923,8 @@ test_RouteSetup_getRouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | 0 | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | 0 | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | 0 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | 0 | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | 0 | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | 0 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | 0 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | 0 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -912,6 +950,7 @@ test_RouterDefinition_RouterDefinition
 | src/express4.js:2:11:2:19 | express() |
 | src/express.js:2:11:2:19 | express() |
 | src/inheritedFromNode.js:2:11:2:19 | express() |
+| src/params.js:2:11:2:19 | express() |
 | src/responseExprs.js:2:11:2:19 | express() |
 | src/route.js:2:14:2:29 | express.Router() |
 | src/routesetups.js:3:1:3:16 | express.Router() |
@@ -948,6 +987,8 @@ test_RouteHandler
 | src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req | src/express.js:42:18:42:20 | res |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req | src/express.js:46:36:46:38 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:29:4:31 | res |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res | src/params.js:4:29:4:32 | next |
+| src/params.js:12:24:14:1 | functio ... lo");\\n} | src/params.js:12:33:12:35 | req | src/params.js:12:38:12:40 | res |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:44:10:47 | res3 |
@@ -979,6 +1020,8 @@ test_RouteSetup_getARouteHandlerExpr
 | src/express.js:44:1:44:26 | app.use ... dler()) | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/express.js:46:1:51:2 | app.pos ... me];\\n}) | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:4:1:8:2 | app.pos ... url;\\n}) | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:1:10:2 | app.par ...    }\\n}) | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
+| src/params.js:12:1:14:2 | app.get ... o");\\n}) | src/params.js:12:24:14:1 | functio ... lo");\\n} |
 | src/responseExprs.js:4:1:6:2 | app.get ... res1\\n}) | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:7:1:9:2 | app.get ... es2;\\n}) | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:10:1:12:2 | app.get ... es3;\\n}) | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
@@ -1027,6 +1070,7 @@ test_RequestExpr
 | src/express.js:49:3:49:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/inheritedFromNode.js:7:2:7:4 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:6:9:6:11 | res | src/params.js:4:18:10:1 | (req, r ...     }\\n} |
 | src/passport.js:28:2:28:4 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 test_RequestExprStandalone
@@ -1060,5 +1104,6 @@ test_RouteHandler_getARequestExpr
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:49:3:49:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/params.js:4:18:10:1 | (req, r ...     }\\n} | src/params.js:6:9:6:11 | res |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:28:2:28:4 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |


### PR DESCRIPTION
A `param` route handler in Express takes the value of the parameter in the 4th argument as seen [here](https://gist.github.com/asgerf/f3da0abf24c90286c121034838e3f2e4). This PR adds it as a `RequestInputSource`.