### PR TITLE
C++: Remove abstract keyword from a couple of AST classes

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -3,7 +3,7 @@ import semmle.code.cpp.Declaration
 import semmle.code.cpp.metrics.MetricFile
 
 /** A file or folder. */
-abstract class Container extends Locatable, @container {
+class Container extends Locatable, @container {
   /**
    * Gets the absolute, canonical path of this container, using forward slashes
    * as path separator.
@@ -28,7 +28,7 @@ abstract class Container extends Locatable, @container {
    * a bare root prefix, that is, the path has no path segments. A container
    * whose absolute path has no segments is always a `Folder`, not a `File`.
    */
-  abstract string getAbsolutePath();
+  string getAbsolutePath() { none() } // overridden by subclasses
 
   /**
    * DEPRECATED: Use `getLocation` instead.
@@ -36,7 +36,7 @@ abstract class Container extends Locatable, @container {
    *
    * For more information see [Providing URLs](https://help.semmle.com/QL/learn-ql/ql/locations.html#providing-urls).
    */
-  abstract deprecated string getURL();
+  deprecated string getURL() { none() } // overridden by subclasses
 
   /**
    * Gets the relative path of this file or folder from the root folder of the

--- a/cpp/ql/src/semmle/code/cpp/Namespace.qll
+++ b/cpp/ql/src/semmle/code/cpp/Namespace.qll
@@ -130,7 +130,7 @@ class NamespaceDeclarationEntry extends Locatable, @namespace_decl {
 /**
  * A C++ `using` directive or `using` declaration.
  */
-abstract class UsingEntry extends Locatable, @using {
+class UsingEntry extends Locatable, @using {
   override Location getLocation() { usings(underlyingElement(this), _, result) }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
@@ -34,10 +34,10 @@ abstract class Conversion extends Expr {
  * a `PointerBaseClassConversion`, or some other semantic conversion. Similarly,
  * a `PointerDerivedClassConversion` may also be a `CStyleCast` or a `StaticCast`.
  *
- * This is an abstract root QL class representing the different casts.  For
+ * This is a root QL class representing the different casts.  For
  * specific examples, consult the documentation for any of QL classes mentioned above.
  */
-abstract class Cast extends Conversion, @cast {
+class Cast extends Conversion, @cast {
   /**
    * Gets a string describing the semantic conversion operation being performed by
    * this cast.
@@ -699,7 +699,7 @@ class SizeofPackOperator extends Expr, @sizeof_pack {
 /**
  * A C/C++ sizeof expression.
  */
-abstract class SizeofOperator extends Expr, @runtime_sizeof {
+class SizeofOperator extends Expr, @runtime_sizeof {
   override int getPrecedence() { result = 16 }
 }
 
@@ -762,7 +762,7 @@ class SizeofTypeOperator extends SizeofOperator {
 /**
  * A C++11 `alignof` expression.
  */
-abstract class AlignofOperator extends Expr, @runtime_alignof {
+class AlignofOperator extends Expr, @runtime_alignof {
   override int getPrecedence() { result = 16 }
 }
 


### PR DESCRIPTION
The easy cases of https://github.com/github/codeql-c-analysis-team/issues/60 that did not require dbscheme changes.