### PR TITLE
C++: Add a test of TOCTOUFilesystemRace.ql

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.expected
@@ -1,0 +1,3 @@
+| test.cpp:21:3:21:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:21:10:21:14 | file1 | filename | test.cpp:19:7:19:12 | call to rename | checked |
+| test.cpp:35:3:35:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:35:10:35:14 | file1 | filename | test.cpp:32:7:32:12 | call to rename | checked |
+| test.cpp:49:3:49:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:49:10:49:14 | file1 | filename | test.cpp:47:7:47:12 | call to rename | checked |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.expected
@@ -1,3 +1,1 @@
 | test.cpp:21:3:21:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:21:10:21:14 | file1 | filename | test.cpp:19:7:19:12 | call to rename | checked |
-| test.cpp:35:3:35:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:35:10:35:14 | file1 | filename | test.cpp:32:7:32:12 | call to rename | checked |
-| test.cpp:49:3:49:8 | call to remove | The $@ being operated upon was previously $@, but the underlying file may have been changed since then. | test.cpp:49:10:49:14 | file1 | filename | test.cpp:47:7:47:12 | call to rename | checked |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.qlref
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/TOCTOUFilesystemRace.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-367/TOCTOUFilesystemRace.ql

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/test.cpp
@@ -1,0 +1,51 @@
+
+class String
+{
+public:
+	String(const char *_s);
+	void set(const char *_s);
+};
+
+void create(const String &filename);
+bool rename(const String &from, const String &to);
+void remove(const String &filename);
+
+void test1()
+{
+	String file1 = "a.txt";
+	String file2 = "b.txt";
+
+	create(file1);
+	if (!rename(file1, file2))
+	{
+		remove(file1); // BAD
+	}
+}
+
+
+void test2()
+{
+	String file1 = "a.txt";
+	String file2 = "b.txt";
+
+	create(file1);
+	if (!rename(file1, file2))
+	{
+		file1.set("d.txt");
+		remove(file1); // GOOD [FALSE POSITIVE]
+	}
+}
+
+
+void test3()
+{
+	String file1 = "a.txt";
+	String file2 = "b.txt";
+	file1.set("d.txt");
+
+	create(file1);
+	if (!rename(file1, file2))
+	{
+		remove(file1); // BAD
+	}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-367/semmle/test.cpp
@@ -32,7 +32,7 @@ void test2()
 	if (!rename(file1, file2))
 	{
 		file1.set("d.txt");
-		remove(file1); // GOOD [FALSE POSITIVE]
+		remove(file1); // GOOD
 	}
 }
 
@@ -46,6 +46,6 @@ void test3()
 	create(file1);
 	if (!rename(file1, file2))
 	{
-		remove(file1); // BAD
+		remove(file1); // BAD [NOT DETECTED]
 	}
 }


### PR DESCRIPTION
Add a test of `TOCTOUFilesystemRace.ql`, which somehow didn't have a test in this repo.  The test is inspired by the recent regression in CPP-Differences, and I've included results both before and after https://github.com/github/codeql/pull/3382 which caused the difference.

On reflection though I don't actually think this is a regression - just a more cautious approach that's finding fewer correct results as well as fewer false positives.  We could probably get more _accurate_ results by converting this query to use a proper dataflow library.