### PR TITLE
Java: Added a query for unsafe TLS versions

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-327/SaferTLSVersion.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/SaferTLSVersion.java
@@ -1,0 +1,6 @@
+public SSLSocket connect(String host, int port)
+        throws NoSuchAlgorithmException, IOException {
+    
+    SSLContext context = SSLContext.getInstance("TLSv1.3");
+    return (SSLSocket) context.getSocketFactory().createSocket(host, port);
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-327/SslLib.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/SslLib.qll
@@ -1,0 +1,111 @@
+import java
+import semmle.code.java.security.Encryption
+import semmle.code.java.dataflow.TaintTracking
+import DataFlow
+import PathGraph
+
+/**
+ * A taint-tracking configuration for unsafe SSL and TLS versions.
+ */
+class UnsafeTlsVersionConfig extends TaintTracking::Configuration {
+  UnsafeTlsVersionConfig() { this = "UnsafeTlsVersion::UnsafeTlsVersionConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof UnsafeTlsVersion }
+
+  override predicate isSink(DataFlow::Node sink) {
+    sink instanceof SslContextGetInstanceSink or
+    sink instanceof CreateSslParametersSink or
+    sink instanceof SslParametersSetProtocolsSink or
+    sink instanceof SetEnabledProtocolsSink
+  }
+}
+
+/**
+ * A sink that sets protocol versions in `SSLContext`,
+ * i.e `SSLContext.getInstance(protocol)`.
+ */
+class SslContextGetInstanceSink extends DataFlow::ExprNode {
+  SslContextGetInstanceSink() {
+    exists(StaticMethodAccess ma, Method m | m = ma.getMethod() |
+      m.getDeclaringType() instanceof SSLContext and
+      m.hasName("getInstance") and
+      ma.getArgument(0) = asExpr()
+    )
+  }
+}
+
+/**
+ * A sink that creates `SSLParameters` with specified protocols,
+ * i.e. `new SSLParameters(ciphersuites, protocols)`.
+ */
+class CreateSslParametersSink extends DataFlow::ExprNode {
+  CreateSslParametersSink() {
+    exists(ConstructorCall cc | cc.getConstructedType() instanceof SSLParameters |
+      cc.getArgument(1) = asExpr()
+    )
+  }
+}
+
+/**
+ * A sink that sets protocol versions for `SSLParameters`,
+ * i.e. `parameters.setProtocols(versions)`.
+ */
+class SslParametersSetProtocolsSink extends DataFlow::ExprNode {
+  SslParametersSetProtocolsSink() {
+    exists(MethodAccess ma, Method m | m = ma.getMethod() |
+      m.getDeclaringType() instanceof SSLParameters and
+      m.hasName("setProtocols") and
+      ma.getArgument(0) = asExpr()
+    )
+  }
+}
+
+/**
+ * A sink that sets protocol versions fro `SSLSocket`, `SSLServerSocket` and `SSLEngine`,
+ * i.e. `socket.setEnabledProtocols(versions)` or `engine.setEnabledProtocols(versions)`.
+ */
+class SetEnabledProtocolsSink extends DataFlow::ExprNode {
+  SetEnabledProtocolsSink() {
+    exists(MethodAccess ma, Method m, RefType type |
+      m = ma.getMethod() and type = m.getDeclaringType()
+    |
+      (
+        type instanceof SSLSocket or
+        type instanceof SSLServerSocket or
+        type instanceof SSLEngine
+      ) and
+      m.hasName("setEnabledProtocols") and
+      ma.getArgument(0) = asExpr()
+    )
+  }
+}
+
+/**
+ * Insecure SSL and TLS versions supported by JSSE.
+ */
+class UnsafeTlsVersion extends StringLiteral {
+  UnsafeTlsVersion() {
+    getValue() = "SSL" or
+    getValue() = "SSLv2" or
+    getValue() = "SSLv3" or
+    getValue() = "TLS" or
+    getValue() = "TLSv1" or
+    getValue() = "TLSv1.1"
+  }
+}
+
+class SSLParameters extends RefType {
+  SSLParameters() { hasQualifiedName("javax.net.ssl", "SSLParameters") }
+}
+
+class SSLSocket extends RefType {
+  SSLSocket() { hasQualifiedName("javax.net.ssl", "SSLSocket") }
+}
+
+class SSLServerSocket extends RefType {
+  SSLServerSocket() { hasQualifiedName("javax.net.ssl", "SSLServerSocket") }
+}
+
+class SSLEngine extends RefType {
+  SSLEngine() { hasQualifiedName("javax.net.ssl", "SSLEngine") }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTLSVersion.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTLSVersion.java
@@ -1,0 +1,6 @@
+public SSLSocket connect(String host, int port)
+        throws NoSuchAlgorithmException, IOException {
+    
+    SSLContext context = SSLContext.getInstance("SSLv3");
+    return (SSLSocket) context.getSocketFactory().createSocket(host, port);
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.qhelp
@@ -1,0 +1,60 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Transport Layer Security (TLS) provides a number of security features such as 
+confidentiality, integrity, replay prevention and authenticatin. 
+There are several versions of TLS protocols. The latest is TLS 1.3.
+Unfortunately, older versions were found to be vulnerable to a number of attacks.</p>
+
+</overview>
+<recommendation>
+
+<p>An application should use TLS 1.3. Currenlty, TLS 1.2 is also considered acceptable.</p>
+
+</recommendation>
+<example>
+
+<p>The following example shows how a socket with an unsafe TLS version may be created:</p>
+
+<sample src="UnsafeTLSVersion.java" />
+
+<p>The next example creates a socket with the latest TLS version:</p>
+
+<sample src="SaferTLSVersion.java" />
+
+</example>
+<references>
+
+<li>
+  Wikipedia:
+  <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security">Transport Layer Security</a>
+</li>
+
+<li>
+  OWASP:
+  <a href="https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html">Transport Layer Protection Cheat Sheet</a>
+</li>
+
+<li>
+  Java SE Documentation:
+  <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html">Java Secure Socket Extension (JSSE) Reference Guide</a>
+</li>
+
+<li>
+  Java SE API Specification:
+  <a href="https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html">SSLContext</a>
+</li>
+
+<li>
+  Java SE API Specification:
+  <a href="https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLParameters.html">SSLParameters</a>
+</li>
+
+<li>
+  Java SE API Specification:
+  <a href="https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLSocket.html">SSLSocket</a>
+</li>
+
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Unsafe TLS version
+ * @description SSL and older TLS versions are known to be vulnerable.
+ *              TLS 1.3 or at least TLS 1.2 should be used.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/unsafe-tls-version
+ * @tags security
+ *       external/cwe/cwe-327
+ */
+
+import java
+import SslLib
+import DataFlow::PathGraph
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, UnsafeTlsVersionConfig conf
+where conf.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ is unsafe", source.getNode(),
+  source.getNode().asExpr().(StringLiteral).getValue()

--- a/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.expected
+++ b/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.expected
@@ -1,0 +1,150 @@
+edges
+| UnsafeTlsVersion.java:31:5:31:46 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] |
+| UnsafeTlsVersion.java:31:39:31:45 | "SSLv3" : String | UnsafeTlsVersion.java:31:5:31:46 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:32:5:32:44 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] |
+| UnsafeTlsVersion.java:32:39:32:43 | "TLS" : String | UnsafeTlsVersion.java:32:5:32:44 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:33:5:33:46 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] |
+| UnsafeTlsVersion.java:33:39:33:45 | "TLSv1" : String | UnsafeTlsVersion.java:33:5:33:46 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:34:5:34:48 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] |
+| UnsafeTlsVersion.java:34:39:34:47 | "TLSv1.1" : String | UnsafeTlsVersion.java:34:5:34:48 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:35:5:35:68 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] |
+| UnsafeTlsVersion.java:35:39:35:45 | "TLSv1" : String | UnsafeTlsVersion.java:35:5:35:68 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:35:48:35:56 | "TLSv1.1" : String | UnsafeTlsVersion.java:35:5:35:68 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] | UnsafeTlsVersion.java:44:44:44:52 | protocols |
+| UnsafeTlsVersion.java:50:53:50:59 | "SSLv3" : String | UnsafeTlsVersion.java:50:38:50:61 | new String[] |
+| UnsafeTlsVersion.java:51:53:51:57 | "TLS" : String | UnsafeTlsVersion.java:51:38:51:59 | new String[] |
+| UnsafeTlsVersion.java:52:53:52:59 | "TLSv1" : String | UnsafeTlsVersion.java:52:38:52:61 | new String[] |
+| UnsafeTlsVersion.java:53:53:53:61 | "TLSv1.1" : String | UnsafeTlsVersion.java:53:38:53:63 | new String[] |
+| UnsafeTlsVersion.java:56:44:56:52 | "TLSv1.1" : String | UnsafeTlsVersion.java:56:29:56:65 | new String[] |
+| UnsafeTlsVersion.java:68:5:68:28 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] |
+| UnsafeTlsVersion.java:68:21:68:27 | "SSLv3" : String | UnsafeTlsVersion.java:68:5:68:28 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:69:5:69:26 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] |
+| UnsafeTlsVersion.java:69:21:69:25 | "TLS" : String | UnsafeTlsVersion.java:69:5:69:26 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:70:5:70:28 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] |
+| UnsafeTlsVersion.java:70:21:70:27 | "TLSv1" : String | UnsafeTlsVersion.java:70:5:70:28 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:71:5:71:30 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] |
+| UnsafeTlsVersion.java:71:21:71:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:71:5:71:30 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:72:5:72:41 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] |
+| UnsafeTlsVersion.java:72:21:72:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:72:5:72:41 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] | UnsafeTlsVersion.java:81:32:81:40 | protocols |
+| UnsafeTlsVersion.java:88:5:88:34 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] |
+| UnsafeTlsVersion.java:88:27:88:33 | "SSLv3" : String | UnsafeTlsVersion.java:88:5:88:34 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:89:5:89:32 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] |
+| UnsafeTlsVersion.java:89:27:89:31 | "TLS" : String | UnsafeTlsVersion.java:89:5:89:32 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:90:5:90:34 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] |
+| UnsafeTlsVersion.java:90:27:90:33 | "TLSv1" : String | UnsafeTlsVersion.java:90:5:90:34 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:91:5:91:36 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] |
+| UnsafeTlsVersion.java:91:27:91:35 | "TLSv1.1" : String | UnsafeTlsVersion.java:91:5:91:36 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:92:5:92:47 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] |
+| UnsafeTlsVersion.java:92:27:92:35 | "TLSv1.1" : String | UnsafeTlsVersion.java:92:5:92:47 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] | UnsafeTlsVersion.java:101:32:101:40 | protocols |
+| UnsafeTlsVersion.java:108:5:108:28 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] |
+| UnsafeTlsVersion.java:108:21:108:27 | "SSLv3" : String | UnsafeTlsVersion.java:108:5:108:28 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:109:5:109:26 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] |
+| UnsafeTlsVersion.java:109:21:109:25 | "TLS" : String | UnsafeTlsVersion.java:109:5:109:26 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:110:5:110:28 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] |
+| UnsafeTlsVersion.java:110:21:110:27 | "TLSv1" : String | UnsafeTlsVersion.java:110:5:110:28 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:111:5:111:30 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] |
+| UnsafeTlsVersion.java:111:21:111:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:111:5:111:30 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:112:5:112:41 | new ..[] { .. } : String[] | UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] |
+| UnsafeTlsVersion.java:112:21:112:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:112:5:112:41 | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] | UnsafeTlsVersion.java:121:32:121:40 | protocols |
+nodes
+| UnsafeTlsVersion.java:16:28:16:32 | "SSL" | semmle.label | "SSL" |
+| UnsafeTlsVersion.java:17:28:17:34 | "SSLv2" | semmle.label | "SSLv2" |
+| UnsafeTlsVersion.java:18:28:18:34 | "SSLv3" | semmle.label | "SSLv3" |
+| UnsafeTlsVersion.java:19:28:19:32 | "TLS" | semmle.label | "TLS" |
+| UnsafeTlsVersion.java:20:28:20:34 | "TLSv1" | semmle.label | "TLSv1" |
+| UnsafeTlsVersion.java:21:28:21:36 | "TLSv1.1" | semmle.label | "TLSv1.1" |
+| UnsafeTlsVersion.java:31:5:31:46 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:31:39:31:45 | "SSLv3" : String | semmle.label | "SSLv3" : String |
+| UnsafeTlsVersion.java:32:5:32:44 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:32:39:32:43 | "TLS" : String | semmle.label | "TLS" : String |
+| UnsafeTlsVersion.java:33:5:33:46 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:33:39:33:45 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:34:5:34:48 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:34:39:34:47 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:35:5:35:68 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:35:39:35:45 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:35:48:35:56 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:43:74:43:92 | protocols : String[] | semmle.label | protocols : String[] |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | semmle.label | protocols |
+| UnsafeTlsVersion.java:50:38:50:61 | new String[] | semmle.label | new String[] |
+| UnsafeTlsVersion.java:50:53:50:59 | "SSLv3" : String | semmle.label | "SSLv3" : String |
+| UnsafeTlsVersion.java:51:38:51:59 | new String[] | semmle.label | new String[] |
+| UnsafeTlsVersion.java:51:53:51:57 | "TLS" : String | semmle.label | "TLS" : String |
+| UnsafeTlsVersion.java:52:38:52:61 | new String[] | semmle.label | new String[] |
+| UnsafeTlsVersion.java:52:53:52:59 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:53:38:53:63 | new String[] | semmle.label | new String[] |
+| UnsafeTlsVersion.java:53:53:53:61 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:56:29:56:65 | new String[] | semmle.label | new String[] |
+| UnsafeTlsVersion.java:56:44:56:52 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:68:5:68:28 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:68:21:68:27 | "SSLv3" : String | semmle.label | "SSLv3" : String |
+| UnsafeTlsVersion.java:69:5:69:26 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:69:21:69:25 | "TLS" : String | semmle.label | "TLS" : String |
+| UnsafeTlsVersion.java:70:5:70:28 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:70:21:70:27 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:71:5:71:30 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:71:21:71:29 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:72:5:72:41 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:72:21:72:29 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:79:43:79:61 | protocols : String[] | semmle.label | protocols : String[] |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | semmle.label | protocols |
+| UnsafeTlsVersion.java:88:5:88:34 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:88:27:88:33 | "SSLv3" : String | semmle.label | "SSLv3" : String |
+| UnsafeTlsVersion.java:89:5:89:32 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:89:27:89:31 | "TLS" : String | semmle.label | "TLS" : String |
+| UnsafeTlsVersion.java:90:5:90:34 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:90:27:90:33 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:91:5:91:36 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:91:27:91:35 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:92:5:92:47 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:92:27:92:35 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:99:55:99:73 | protocols : String[] | semmle.label | protocols : String[] |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | semmle.label | protocols |
+| UnsafeTlsVersion.java:108:5:108:28 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:108:21:108:27 | "SSLv3" : String | semmle.label | "SSLv3" : String |
+| UnsafeTlsVersion.java:109:5:109:26 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:109:21:109:25 | "TLS" : String | semmle.label | "TLS" : String |
+| UnsafeTlsVersion.java:110:5:110:28 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:110:21:110:27 | "TLSv1" : String | semmle.label | "TLSv1" : String |
+| UnsafeTlsVersion.java:111:5:111:30 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:111:21:111:29 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:112:5:112:41 | new ..[] { .. } : String[] | semmle.label | new ..[] { .. } : String[] |
+| UnsafeTlsVersion.java:112:21:112:29 | "TLSv1.1" : String | semmle.label | "TLSv1.1" : String |
+| UnsafeTlsVersion.java:119:43:119:61 | protocols : String[] | semmle.label | protocols : String[] |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | semmle.label | protocols |
+#select
+| UnsafeTlsVersion.java:16:28:16:32 | "SSL" | UnsafeTlsVersion.java:16:28:16:32 | "SSL" | UnsafeTlsVersion.java:16:28:16:32 | "SSL" | $@ is unsafe | UnsafeTlsVersion.java:16:28:16:32 | "SSL" | SSL |
+| UnsafeTlsVersion.java:17:28:17:34 | "SSLv2" | UnsafeTlsVersion.java:17:28:17:34 | "SSLv2" | UnsafeTlsVersion.java:17:28:17:34 | "SSLv2" | $@ is unsafe | UnsafeTlsVersion.java:17:28:17:34 | "SSLv2" | SSLv2 |
+| UnsafeTlsVersion.java:18:28:18:34 | "SSLv3" | UnsafeTlsVersion.java:18:28:18:34 | "SSLv3" | UnsafeTlsVersion.java:18:28:18:34 | "SSLv3" | $@ is unsafe | UnsafeTlsVersion.java:18:28:18:34 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:19:28:19:32 | "TLS" | UnsafeTlsVersion.java:19:28:19:32 | "TLS" | UnsafeTlsVersion.java:19:28:19:32 | "TLS" | $@ is unsafe | UnsafeTlsVersion.java:19:28:19:32 | "TLS" | TLS |
+| UnsafeTlsVersion.java:20:28:20:34 | "TLSv1" | UnsafeTlsVersion.java:20:28:20:34 | "TLSv1" | UnsafeTlsVersion.java:20:28:20:34 | "TLSv1" | $@ is unsafe | UnsafeTlsVersion.java:20:28:20:34 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:21:28:21:36 | "TLSv1.1" | UnsafeTlsVersion.java:21:28:21:36 | "TLSv1.1" | UnsafeTlsVersion.java:21:28:21:36 | "TLSv1.1" | $@ is unsafe | UnsafeTlsVersion.java:21:28:21:36 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:31:39:31:45 | "SSLv3" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:31:39:31:45 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:32:39:32:43 | "TLS" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:32:39:32:43 | "TLS" | TLS |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:33:39:33:45 | "TLSv1" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:33:39:33:45 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:34:39:34:47 | "TLSv1.1" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:34:39:34:47 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:35:39:35:45 | "TLSv1" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:35:39:35:45 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:44:44:44:52 | protocols | UnsafeTlsVersion.java:35:48:35:56 | "TLSv1.1" : String | UnsafeTlsVersion.java:44:44:44:52 | protocols | $@ is unsafe | UnsafeTlsVersion.java:35:48:35:56 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:50:38:50:61 | new String[] | UnsafeTlsVersion.java:50:53:50:59 | "SSLv3" : String | UnsafeTlsVersion.java:50:38:50:61 | new String[] | $@ is unsafe | UnsafeTlsVersion.java:50:53:50:59 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:51:38:51:59 | new String[] | UnsafeTlsVersion.java:51:53:51:57 | "TLS" : String | UnsafeTlsVersion.java:51:38:51:59 | new String[] | $@ is unsafe | UnsafeTlsVersion.java:51:53:51:57 | "TLS" | TLS |
+| UnsafeTlsVersion.java:52:38:52:61 | new String[] | UnsafeTlsVersion.java:52:53:52:59 | "TLSv1" : String | UnsafeTlsVersion.java:52:38:52:61 | new String[] | $@ is unsafe | UnsafeTlsVersion.java:52:53:52:59 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:53:38:53:63 | new String[] | UnsafeTlsVersion.java:53:53:53:61 | "TLSv1.1" : String | UnsafeTlsVersion.java:53:38:53:63 | new String[] | $@ is unsafe | UnsafeTlsVersion.java:53:53:53:61 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:56:29:56:65 | new String[] | UnsafeTlsVersion.java:56:44:56:52 | "TLSv1.1" : String | UnsafeTlsVersion.java:56:29:56:65 | new String[] | $@ is unsafe | UnsafeTlsVersion.java:56:44:56:52 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | UnsafeTlsVersion.java:68:21:68:27 | "SSLv3" : String | UnsafeTlsVersion.java:81:32:81:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:68:21:68:27 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | UnsafeTlsVersion.java:69:21:69:25 | "TLS" : String | UnsafeTlsVersion.java:81:32:81:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:69:21:69:25 | "TLS" | TLS |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | UnsafeTlsVersion.java:70:21:70:27 | "TLSv1" : String | UnsafeTlsVersion.java:81:32:81:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:70:21:70:27 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | UnsafeTlsVersion.java:71:21:71:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:81:32:81:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:71:21:71:29 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:81:32:81:40 | protocols | UnsafeTlsVersion.java:72:21:72:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:81:32:81:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:72:21:72:29 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | UnsafeTlsVersion.java:88:27:88:33 | "SSLv3" : String | UnsafeTlsVersion.java:101:32:101:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:88:27:88:33 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | UnsafeTlsVersion.java:89:27:89:31 | "TLS" : String | UnsafeTlsVersion.java:101:32:101:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:89:27:89:31 | "TLS" | TLS |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | UnsafeTlsVersion.java:90:27:90:33 | "TLSv1" : String | UnsafeTlsVersion.java:101:32:101:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:90:27:90:33 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | UnsafeTlsVersion.java:91:27:91:35 | "TLSv1.1" : String | UnsafeTlsVersion.java:101:32:101:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:91:27:91:35 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:101:32:101:40 | protocols | UnsafeTlsVersion.java:92:27:92:35 | "TLSv1.1" : String | UnsafeTlsVersion.java:101:32:101:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:92:27:92:35 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | UnsafeTlsVersion.java:108:21:108:27 | "SSLv3" : String | UnsafeTlsVersion.java:121:32:121:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:108:21:108:27 | "SSLv3" | SSLv3 |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | UnsafeTlsVersion.java:109:21:109:25 | "TLS" : String | UnsafeTlsVersion.java:121:32:121:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:109:21:109:25 | "TLS" | TLS |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | UnsafeTlsVersion.java:110:21:110:27 | "TLSv1" : String | UnsafeTlsVersion.java:121:32:121:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:110:21:110:27 | "TLSv1" | TLSv1 |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | UnsafeTlsVersion.java:111:21:111:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:121:32:121:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:111:21:111:29 | "TLSv1.1" | TLSv1.1 |
+| UnsafeTlsVersion.java:121:32:121:40 | protocols | UnsafeTlsVersion.java:112:21:112:29 | "TLSv1.1" : String | UnsafeTlsVersion.java:121:32:121:40 | protocols | $@ is unsafe | UnsafeTlsVersion.java:112:21:112:29 | "TLSv1.1" | TLSv1.1 |

--- a/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.java
+++ b/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.java
@@ -1,0 +1,124 @@
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+public class UnsafeTlsVersion {
+
+  public static void testSslContextWithProtocol() throws NoSuchAlgorithmException {
+
+    // unsafe
+    SSLContext.getInstance("SSL");
+    SSLContext.getInstance("SSLv2");
+    SSLContext.getInstance("SSLv3");
+    SSLContext.getInstance("TLS");
+    SSLContext.getInstance("TLSv1");
+    SSLContext.getInstance("TLSv1.1");
+
+    // safe
+    SSLContext.getInstance("TLSv1.2");
+    SSLContext.getInstance("TLSv1.3");
+  }
+
+  public static void testCreateSslParametersWithProtocol(String[] cipherSuites) {
+
+    // unsafe
+    createSslParameters(cipherSuites, "SSLv3");
+    createSslParameters(cipherSuites, "TLS");
+    createSslParameters(cipherSuites, "TLSv1");
+    createSslParameters(cipherSuites, "TLSv1.1");
+    createSslParameters(cipherSuites, "TLSv1", "TLSv1.1", "TLSv1.2");
+    createSslParameters(cipherSuites, "TLSv1.2");
+
+    // safe
+    createSslParameters(cipherSuites, "TLSv1.2");
+    createSslParameters(cipherSuites, "TLSv1.3");
+  }
+
+  public static SSLParameters createSslParameters(String[] cipherSuites, String... protocols) {
+    return new SSLParameters(cipherSuites, protocols);
+  }
+
+  public static void testSettingProtocolsForSslParameters() {
+
+    // unsafe
+    new SSLParameters().setProtocols(new String[] { "SSLv3" });
+    new SSLParameters().setProtocols(new String[] { "TLS" });
+    new SSLParameters().setProtocols(new String[] { "TLSv1" });
+    new SSLParameters().setProtocols(new String[] { "TLSv1.1" });
+
+    SSLParameters parameters = new SSLParameters();
+    parameters.setProtocols(new String[] { "TLSv1.1", "TLSv1.2" });
+
+    // safe
+    new SSLParameters().setProtocols(new String[] { "TLSv1.2" });
+
+    parameters = new SSLParameters();
+    parameters.setProtocols(new String[] { "TLSv1.2", "TLSv1.3" });
+  }
+
+  public static void testSettingProtocolForSslSocket() throws IOException {
+
+    // unsafe
+    createSslSocket("SSLv3");
+    createSslSocket("TLS");
+    createSslSocket("TLSv1");
+    createSslSocket("TLSv1.1");
+    createSslSocket("TLSv1.1", "TLSv1.2");
+
+    // safe
+    createSslSocket("TLSv1.2");
+    createSslSocket("TLSv1.3");
+  }
+
+  public static SSLSocket createSslSocket(String... protocols) throws IOException {
+    SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+    socket.setEnabledProtocols(protocols);
+    return socket;
+  }
+
+  public static void testSettingProtocolForSslServerSocket() throws IOException {
+
+    // unsafe
+    createSslServerSocket("SSLv3");
+    createSslServerSocket("TLS");
+    createSslServerSocket("TLSv1");
+    createSslServerSocket("TLSv1.1");
+    createSslServerSocket("TLSv1.1", "TLSv1.2");
+
+    // safe
+    createSslServerSocket("TLSv1.2");
+    createSslServerSocket("TLSv1.3");
+  }
+
+  public static SSLServerSocket createSslServerSocket(String... protocols) throws IOException {
+    SSLServerSocket socket = (SSLServerSocket) SSLServerSocketFactory.getDefault().createServerSocket();
+    socket.setEnabledProtocols(protocols);
+    return socket;
+  }
+
+  public static void testSettingProtocolForSslEngine() throws NoSuchAlgorithmException {
+
+    // unsafe
+    createSslEngine("SSLv3");
+    createSslEngine("TLS");
+    createSslEngine("TLSv1");
+    createSslEngine("TLSv1.1");
+    createSslEngine("TLSv1.1", "TLSv1.2");
+
+    // safe
+    createSslEngine("TLSv1.2");
+    createSslEngine("TLSv1.3");
+  }
+
+  public static SSLEngine createSslEngine(String... protocols) throws NoSuchAlgorithmException {
+    SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+    engine.setEnabledProtocols(protocols);
+    return engine;
+  }
+}

--- a/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.qlref
+++ b/java/ql/test/experimental/Security/CWE/CWE-327/UnsafeTlsVersion.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql


### PR DESCRIPTION
Here is a list of main updates:

- Added `experimental/Security/CWE/CWE-327/UnsafeTlsVersion.ql`. The query looks for calls to JSSE that ask to use one of the unsafe TLS versions.
- Added `SslLib.qll`.
- Added a qhelp file with examples.
- Added tests in `java/ql/test/experimental/Security/CWE/CWE-327`.

The query catches the following issue in Apache Geode that was recently found:

https://issues.apache.org/jira/browse/GEODE-8070