### PR TITLE
CodeQL docs: more updates to "Further reading" sections

### DIFF
--- a/docs/language/learn-ql/beginner/catch-the-fire-starter.rst
+++ b/docs/language/learn-ql/beginner/catch-the-fire-starter.rst
@@ -147,6 +147,4 @@ You have found the two fire starters! They are arrested and the villagers are on
 Further reading
 ---------------
 
--  Find out who will be the new ruler of the village in the :doc:`next tutorial <crown-the-rightful-heir>`.
--  Learn more about predicates and classes in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__.
--  Explore the libraries that help you get data about code in :doc:`Learning CodeQL <../../index>`.
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/beginner/cross-the-river.rst
+++ b/docs/language/learn-ql/beginner/cross-the-river.rst
@@ -263,3 +263,8 @@ Here are some more example queries that solve the river crossing puzzle:
      to model the situation, instead of defining everything as a subclass of ``string``.
 
      ➤ `See solution in the query console on LGTM.com <https://lgtm.com/query/7260748307619718263/>`__
+
+Further reading
+---------------
+
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/beginner/crown-the-rightful-heir.rst
+++ b/docs/language/learn-ql/beginner/crown-the-rightful-heir.rst
@@ -161,6 +161,4 @@ You could also try writing more of your own QL queries to find interesting facts
 Further reading
 ---------------
 
--  Learn more about recursion in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__.
--  Put your QL skills to the test and solve the :doc:`River crossing puzzle <cross-the-river>`.
--  Start using QL to analyze projects. See :doc:`Learning CodeQL <../../index>` for a summary of the available languages and resources.
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/beginner/find-the-thief.rst
+++ b/docs/language/learn-ql/beginner/find-the-thief.rst
@@ -292,6 +292,4 @@ Have you found the thief?
 Further reading
 ---------------
 
--  Help the villagers track down another criminal in the :doc:`next tutorial <catch-the-fire-starter>`.
--  Find out more about the concepts you discovered in this tutorial in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__.
--  Explore the libraries that help you get data about code in :doc:`Learning CodeQL <../../index>`.
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/intro-to-data-flow.rst
+++ b/docs/language/learn-ql/intro-to-data-flow.rst
@@ -79,8 +79,7 @@ However, since ``y`` is derived from ``x``, it is influenced by the untrusted or
 In QL, taint tracking extends data flow analysis by including steps in which the data values are not necessarily preserved, but the potentially insecure object is still propagated. 
 These flow steps are modeled in the taint-tracking library using predicates that hold if taint is propagated between nodes.
 
-What next?
-**********
+Further reading
+***************
 
-- Search for ``DataFlow`` and ``TaintTracking`` in the `standard CodeQL libraries <https://help.semmle.com/QL/ql-libraries.html>`__ to learn more about the technical implementation of data flow analysis for specific programming languages.
-- Visit `Learning CodeQL <https://help.semmle.com/QL/learn-ql/>`__ to find language-specific tutorials on data flow and other topics.
+- `Exploring data flow with path queries <https://help.semmle.com/codeql/codeql-for-vscode/procedures/exploring-paths.html>`__

--- a/docs/language/learn-ql/locations.rst
+++ b/docs/language/learn-ql/locations.rst
@@ -115,3 +115,8 @@ The ``toString()`` predicate
 ----------------------------
 
 All classes except those that extend primitive types, must provide a ``string toString()`` member predicate. The query compiler will complain if you don't. The uniqueness warning, noted above for locations, applies here too.
+
+Further reading
+---------------
+
+- `CodeQL repository <https://github.com/github/codeql>`__

--- a/docs/language/learn-ql/ql-training.rst
+++ b/docs/language/learn-ql/ql-training.rst
@@ -60,5 +60,4 @@ CodeQL and variant analysis for Java
 Further reading
 ~~~~~~~~~~~~~~~
 
-- If you are completely new to CodeQL, look at our introductory topics in :doc:`Learning CodeQL <index>`.
-- To see examples of CodeQL queries that have been used to find security vulnerabilities and bugs in open source software projects, visit the `GitHub Security Lab website <https://securitylab.github.com/research>`__ and the associated `repository <https://github.com/github/security-lab>`__.
+- `GitHub Security Lab <https://securitylab.github.com/research>`__

--- a/docs/language/learn-ql/writing-queries/debugging-queries.rst
+++ b/docs/language/learn-ql/writing-queries/debugging-queries.rst
@@ -148,7 +148,7 @@ However, as written it is difficult for the optimizer to pick out the best order
 
 Now the structure we want is clearer. We've separated out the easy part into its own predicate ``locInfo``, and the main predicate ``sameLoc`` is just a larger join.
 
-Further information
--------------------
+Further reading
+---------------
 
 .. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/writing-queries/debugging-queries.rst
+++ b/docs/language/learn-ql/writing-queries/debugging-queries.rst
@@ -151,4 +151,4 @@ Now the structure we want is clearer. We've separated out the easy part into its
 Further information
 -------------------
 
-- Find out more about QL in the `QL language reference <https://help.semmle.com/QL/ql-handbook/index.html>`__.
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/writing-queries/introduction-to-queries.rst
+++ b/docs/language/learn-ql/writing-queries/introduction-to-queries.rst
@@ -150,12 +150,3 @@ Query help files
 ****************
 
 When you write a custom query, we also recommend that you write a query help file to explain the purpose of the query to other users. For more information, see the `Query help style guide <https://github.com/github/codeql/blob/master/docs/query-help-style-guide.md>`__ on GitHub, and the :doc:`Query help files <query-help>`. 
-
-What next?
-==========
-
-- See the queries used in real-life variant analysis on the `GitHub Security Lab website <https://securitylab.github.com/research>`__.
-- To learn more about writing path queries, see :doc:`Creating path queries <path-queries>`.
-- Take a look at the `built-in queries <https://help.semmle.com/wiki/display/QL/Built-in+queries>`__ to see examples of the queries included in CodeQL.
-- Explore the `query cookbooks <https://help.semmle.com/wiki/display/QL/QL+cookbooks>`__ to see how to access the basic language elements contained in the CodeQL libraries.
-- For a full list of resources to help you learn CodeQL, including beginner tutorials and language-specific examples, visit `Learning CodeQL <https://help.semmle.com/QL/learn-ql/>`__.

--- a/docs/language/learn-ql/writing-queries/path-queries.rst
+++ b/docs/language/learn-ql/writing-queries/path-queries.rst
@@ -189,9 +189,8 @@ The ``element`` that you select in the first column depends on the purpose of th
 
 The alert message defined in the final column in the ``select`` statement can be developed to give more detail about the alert or path found by the query using links and placeholders. For more information, see :doc:`Defining the results of a query <select-statement>`. 
 
-What next?
-**********
+Further reading
+***************
 
-- Take a look at the path queries for `C/C++ <https://help.semmle.com/wiki/label/CCPPOBJ/path-problem>`__, `C# <https://help.semmle.com/wiki/label/CSHARP/path-problem>`__, `Java <https://help.semmle.com/wiki/label/java/path-problem>`__, `JavaScript <https://help.semmle.com/wiki/label/js/path-problem>`__, and `Python <https://help.semmle.com/wiki/label/python/path-problem>`__ to see examples of these queries.
-- Explore the `query cookbooks <https://help.semmle.com/wiki/display/QL/QL+cookbooks>`__ to see how to access the basic language elements contained in the CodeQL libraries.
-- For a full list of resources to help you learn CodeQL, including beginner tutorials and language-specific examples, visit `Learning CodeQL <https://help.semmle.com/QL/learn-ql/>`__.
+- `Exploring data flow with path queries <https://help.semmle.com/codeql/codeql-for-vscode/procedures/exploring-paths.html>`__
+- `CodeQL repository <https://github.com/github/codeql>`__

--- a/docs/language/learn-ql/writing-queries/query-help.rst
+++ b/docs/language/learn-ql/writing-queries/query-help.rst
@@ -206,8 +206,3 @@ The included file, `ThreadUnsafeICryptoTransformOverview.qhelp <https://github.
       </fragment>
    </qhelp>
 
-Further information
-===================
-
-- To learn more about contributing to the standard CodeQL queries and libraries, see our `Contributing guidelines <https://github.com/github/codeql/blob/master/CONTRIBUTING.md>`__ on GitHub. 
-- To learn more about writing custom queries, and how to format your code for clarity and consistency, see `Writing CodeQL queries <https://help.semmle.com/QL/learn-ql/writing-queries/writing-queries.html>`__.

--- a/docs/language/learn-ql/writing-queries/query-metadata.rst
+++ b/docs/language/learn-ql/writing-queries/query-metadata.rst
@@ -99,7 +99,3 @@ Here is the metadata for one of the standard Java queries:
 .. |image0| image:: ../../images/query-metadata.png
 
 For more examples of query metadata, see the standard CodeQL queries in our `GitHub repository <https://github.com/github/codeql>`__.
-
-
-
-

--- a/docs/language/learn-ql/writing-queries/select-statement.rst
+++ b/docs/language/learn-ql/writing-queries/select-statement.rst
@@ -105,3 +105,8 @@ The new elements added here don't need to be clickable, so we added them directl
 .. image:: ../../images/ql-select-statement-similarity.png
    :alt: Results showing the extent of similarity
    :class: border
+
+Further reading
+---------------
+
+- `CodeQL repository <https://github.com/github/codeql>`__


### PR DESCRIPTION
Fixes some of https://github.com/github/semmle-docs/issues/68.

This PR updates the "Further reading" sections for topics in the CodeQL queries map topic.

### Summary of changes

- Headings unified. For example, "What's new" sections retitled to "Further reading"
- Links to articles in same map topic removed
- Superfluous text removed
- If the "Further reading" sections only contained links to content that were already heavily linked int he article, the whole section was removed.

### Previews

See the updated articles in these map topics:

- [CodeQL queries](http://docteam.internal.semmle.com/james/sd-68-2/learn-ql/writing-queries/writing-queries.html)
- [QL tutorials](http://docteam.internal.semmle.com/james/sd-68-2/learn-ql/beginner/ql-tutorials.html)
- [CodeQL training and variant analysis examples](http://docteam.internal.semmle.com/james/sd-68-2/learn-ql/ql-training.html) -- This is not a real map topic and the page may not be migrated, but it was a simple change so I did it anyway.

### Comment

At some point, we may want to add more links to the "Further reading" sections, specifically to CodeQL articles from different map topics. I could rather do that after the migration when the final structure is properly implemented.