### PR TITLE
JS: Small performance improvements.

### DIFF
--- a/javascript/ql/src/semmle/javascript/CFG.qll
+++ b/javascript/ql/src/semmle/javascript/CFG.qll
@@ -379,8 +379,9 @@ class GuardControlFlowNode extends SyntheticControlFlowNode, @guard_node {
    * is known to hold at `bb`.
    */
   predicate dominates(ReachableBasicBlock bb) {
-    this = bb.getANode() or
-    dominates(bb.getImmediateDominator())
+    this = bb.getANode()
+    or
+    exists(ReachableBasicBlock prev | prev.strictlyDominates(bb) | this = prev.getANode())
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/src/semmle/javascript/InclusionTests.qll
@@ -71,8 +71,7 @@ module InclusionTest {
       count(this.getACallee()) = 1 and
       count(callee.getAReturnedExpr()) = 1 and
       not this.isImprecise() and
-      inner.getContainerNode().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
-      inner.getContainedNode().getALocalSource().getEnclosingExpr() = callee.getAParameter()
+      inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter())
     }
 
     override DataFlow::Node getContainerNode() {

--- a/javascript/ql/src/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/src/semmle/javascript/InclusionTests.qll
@@ -71,19 +71,20 @@ module InclusionTest {
       count(this.getACallee()) = 1 and
       count(callee.getAReturnedExpr()) = 1 and
       not this.isImprecise() and
+      inner.getContainedNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter()) and
       inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter())
     }
 
     override DataFlow::Node getContainerNode() {
       exists(int arg |
-        inner.getContainerNode().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+        inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getParameter(arg)) and
         result = this.getArgument(arg)
       )
     }
 
     override DataFlow::Node getContainedNode() {
       exists(int arg |
-        inner.getContainedNode().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+        inner.getContainedNode().getALocalSource() = DataFlow::parameterNode(callee.getParameter(arg)) and
         result = this.getArgument(arg)
       )
     }

--- a/javascript/ql/src/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/src/semmle/javascript/InclusionTests.qll
@@ -77,14 +77,16 @@ module InclusionTest {
 
     override DataFlow::Node getContainerNode() {
       exists(int arg |
-        inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getParameter(arg)) and
+        inner.getContainerNode().getALocalSource() =
+          DataFlow::parameterNode(callee.getParameter(arg)) and
         result = this.getArgument(arg)
       )
     }
 
     override DataFlow::Node getContainedNode() {
       exists(int arg |
-        inner.getContainedNode().getALocalSource() = DataFlow::parameterNode(callee.getParameter(arg)) and
+        inner.getContainedNode().getALocalSource() =
+          DataFlow::parameterNode(callee.getParameter(arg)) and
         result = this.getArgument(arg)
       )
     }

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -727,21 +727,6 @@ private predicate basicFlowStepNoBarrier(
 }
 
 /**
- * Holds if there is a flow step from `pred` to `succ` described by `summary`
- * under configuration `cfg`.
- *
- * Summary steps through function calls are not taken into account.
- */
-private predicate basicFlowStep(
-  DataFlow::Node pred, DataFlow::Node succ, PathSummary summary, DataFlow::Configuration cfg
-) {
-  basicFlowStepNoBarrier(pred, succ, summary, cfg) and
-  isRelevant(pred, cfg) and
-  not isLabeledBarrierEdge(cfg, pred, succ, summary.getStartLabel()) and
-  not isBarrierEdge(cfg, pred, succ)
-}
-
-/**
  * Holds if there is a flow step from `pred` to `succ` under configuration `cfg`,
  * including both basic flow steps and steps into/out of properties.
  *
@@ -1339,7 +1324,8 @@ private predicate flowStep(
   DataFlow::Node pred, DataFlow::Configuration cfg, DataFlow::Node succ, PathSummary summary
 ) {
   (
-    basicFlowStep(pred, succ, summary, cfg)
+    basicFlowStepNoBarrier(pred, succ, summary, cfg) and
+    isRelevant(pred, cfg)
     or
     // Flow through a function that returns a value that depends on one of its arguments
     // or a captured variable


### PR DESCRIPTION
I tried to figure out the performance regression in https://github.com/github/codeql/pull/3391, and that lead me to find some completely unrelated performance improvements. Which is why I'm opening a separate PR for these performance improvements. 

8716790 and f8de691 helps reduce the impact of https://github.com/github/codeql/pull/3391, and 6d05b40 just improves performance in general. 

An [evaluation on nightly](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1589190090216) shows about 5% performance improvement. 
(A [redo of the all the regressions](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1589195382488), and [yet another redo](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1589200162307) of just the worst offender). 

I have confirmed that each commit on its own improve performance, although the main impact seems to come from 6d05b40. 
Here is an evaluation where master is compared first with just 6d05b40 and with all 3 commits together: [link](https://docs.google.com/spreadsheets/d/1AlN78l0ukbBhS6yX0cRS0P2wfmrkBqzMv_A1YLKEHNA/edit#gid=0) (in a sheet because formatting [got weird](https://git.semmle.com/erik/dist-compare-reports/tree/erik-laptop_1589154083950) in the report). 

6d05b40 can cause some single queries to be slower, as it forces the `cached ReachableBasicBlock::strictlyDominates` predicate to be evaluated, and the query might not have needed that predicate without my change.   
But as `strictlyDominates` is a cached predicate, that performance penalty completely disappears when running many queries.

TODO: 
- [x] Big-apps evaluation