### PR TITLE
JS: recognize reading/wrinting calls to fstream

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -3,6 +3,7 @@
 ## General improvements
 
 * Support for the following frameworks and libraries has been improved:
+  - [fstream](https://www.npmjs.com/package/fstream)
   - [jGrowl](https://github.com/stanlemon/jGrowl)
   - [jQuery](https://jquery.com/)
 

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlip.expected
@@ -16,6 +16,11 @@ nodes
 | ZipSlipBad.js:7:22:7:31 | entry.path |
 | ZipSlipBad.js:8:37:8:44 | fileName |
 | ZipSlipBad.js:8:37:8:44 | fileName |
+| ZipSlipBad.js:15:11:15:31 | fileName |
+| ZipSlipBad.js:15:22:15:31 | entry.path |
+| ZipSlipBad.js:15:22:15:31 | entry.path |
+| ZipSlipBad.js:16:30:16:37 | fileName |
+| ZipSlipBad.js:16:30:16:37 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path |
@@ -33,6 +38,10 @@ edges
 | ZipSlipBad.js:7:11:7:31 | fileName | ZipSlipBad.js:8:37:8:44 | fileName |
 | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:7:11:7:31 | fileName |
 | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:7:11:7:31 | fileName |
+| ZipSlipBad.js:15:11:15:31 | fileName | ZipSlipBad.js:16:30:16:37 | fileName |
+| ZipSlipBad.js:15:11:15:31 | fileName | ZipSlipBad.js:16:30:16:37 | fileName |
+| ZipSlipBad.js:15:22:15:31 | entry.path | ZipSlipBad.js:15:11:15:31 | fileName |
+| ZipSlipBad.js:15:22:15:31 | entry.path | ZipSlipBad.js:15:11:15:31 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:9:7:29 | fileName | ZipSlipBadUnzipper.js:8:37:8:44 | fileName |
 | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | ZipSlipBadUnzipper.js:7:9:7:29 | fileName |
@@ -42,4 +51,5 @@ edges
 | TarSlipBad.js:6:36:6:46 | header.name | TarSlipBad.js:6:36:6:46 | header.name | TarSlipBad.js:6:36:6:46 | header.name | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | TarSlipBad.js:6:36:6:46 | header.name | item path |
 | ZipSlipBad2.js:6:22:6:29 | fileName | ZipSlipBad2.js:5:37:5:46 | entry.path | ZipSlipBad2.js:6:22:6:29 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad2.js:5:37:5:46 | entry.path | item path |
 | ZipSlipBad.js:8:37:8:44 | fileName | ZipSlipBad.js:7:22:7:31 | entry.path | ZipSlipBad.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:7:22:7:31 | entry.path | item path |
+| ZipSlipBad.js:16:30:16:37 | fileName | ZipSlipBad.js:15:22:15:31 | entry.path | ZipSlipBad.js:16:30:16:37 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBad.js:15:22:15:31 | entry.path | item path |
 | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | ZipSlipBadUnzipper.js:8:37:8:44 | fileName | Unsanitized zip archive $@, which may contain '..', is used in a file system operation. | ZipSlipBadUnzipper.js:7:20:7:29 | entry.path | item path |

--- a/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/ZipSlip/ZipSlipBad.js
@@ -7,3 +7,11 @@ fs.createReadStream('archive.zip')
     const fileName = entry.path;
     entry.pipe(fs.createWriteStream(fileName));
   });
+
+var Writer = require('fstream').Writer;
+fs.createReadStream('archive.zip')
+  .pipe(unzip.Parse())
+  .on('entry', entry => {
+    const fileName = entry.path;
+    entry.pipe(Writer({path: fileName}));
+  });


### PR DESCRIPTION
Recognizes code like the below as a writing file-system call (and likewise for reading calls): 
```JavaScript
var Writer = require('fstream').Writer;
Writer({path: somePath});
```

This recognizes the sink in CVE-2018-1002203. 