### PR TITLE
JS: model in-memory MongoDB libraries

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -6,6 +6,8 @@
   - [fstream](https://www.npmjs.com/package/fstream)
   - [jGrowl](https://github.com/stanlemon/jGrowl)
   - [jQuery](https://jquery.com/)
+  - [marsdb](https://www.npmjs.com/package/marsdb)
+  - [minimongo](https://www.npmjs.com/package/minimongo/)
 
 ## New queries
 

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -1,3 +1,6 @@
+| marsdb-flow-to.js:14:3:14:22 | db.myDoc.find(query) |
+| marsdb.js:16:3:16:17 | doc.find(query) |
+| minimongo.js:18:3:18:17 | doc.find(query) |
 | mongodb.js:18:7:18:21 | doc.find(query) |
 | mongodb.js:21:7:21:48 | doc.fin ... itle }) |
 | mongodb.js:24:7:24:53 | doc.fin ... r(1) }) |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -1,4 +1,25 @@
 nodes
+| marsdb-flow-to.js:10:9:10:18 | query |
+| marsdb-flow-to.js:10:17:10:18 | {} |
+| marsdb-flow-to.js:11:17:11:24 | req.body |
+| marsdb-flow-to.js:11:17:11:24 | req.body |
+| marsdb-flow-to.js:11:17:11:30 | req.body.title |
+| marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb.js:12:9:12:18 | query |
+| marsdb.js:12:17:12:18 | {} |
+| marsdb.js:13:17:13:24 | req.body |
+| marsdb.js:13:17:13:24 | req.body |
+| marsdb.js:13:17:13:30 | req.body.title |
+| marsdb.js:16:12:16:16 | query |
+| marsdb.js:16:12:16:16 | query |
+| minimongo.js:14:9:14:18 | query |
+| minimongo.js:14:17:14:18 | {} |
+| minimongo.js:15:17:15:24 | req.body |
+| minimongo.js:15:17:15:24 | req.body |
+| minimongo.js:15:17:15:30 | req.body.title |
+| minimongo.js:18:12:18:16 | query |
+| minimongo.js:18:12:18:16 | query |
 | mongodb.js:12:11:12:20 | query |
 | mongodb.js:12:19:12:20 | {} |
 | mongodb.js:13:19:13:26 | req.body |
@@ -150,6 +171,33 @@ nodes
 | tst.js:10:46:10:58 | req.params.id |
 | tst.js:10:46:10:58 | req.params.id |
 edges
+| marsdb-flow-to.js:10:9:10:18 | query | marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb-flow-to.js:10:9:10:18 | query | marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb-flow-to.js:10:17:10:18 | {} | marsdb-flow-to.js:10:9:10:18 | query |
+| marsdb-flow-to.js:11:17:11:24 | req.body | marsdb-flow-to.js:11:17:11:30 | req.body.title |
+| marsdb-flow-to.js:11:17:11:24 | req.body | marsdb-flow-to.js:11:17:11:30 | req.body.title |
+| marsdb-flow-to.js:11:17:11:30 | req.body.title | marsdb-flow-to.js:10:9:10:18 | query |
+| marsdb-flow-to.js:11:17:11:30 | req.body.title | marsdb-flow-to.js:10:17:10:18 | {} |
+| marsdb-flow-to.js:11:17:11:30 | req.body.title | marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb-flow-to.js:11:17:11:30 | req.body.title | marsdb-flow-to.js:14:17:14:21 | query |
+| marsdb.js:12:9:12:18 | query | marsdb.js:16:12:16:16 | query |
+| marsdb.js:12:9:12:18 | query | marsdb.js:16:12:16:16 | query |
+| marsdb.js:12:17:12:18 | {} | marsdb.js:12:9:12:18 | query |
+| marsdb.js:13:17:13:24 | req.body | marsdb.js:13:17:13:30 | req.body.title |
+| marsdb.js:13:17:13:24 | req.body | marsdb.js:13:17:13:30 | req.body.title |
+| marsdb.js:13:17:13:30 | req.body.title | marsdb.js:12:9:12:18 | query |
+| marsdb.js:13:17:13:30 | req.body.title | marsdb.js:12:17:12:18 | {} |
+| marsdb.js:13:17:13:30 | req.body.title | marsdb.js:16:12:16:16 | query |
+| marsdb.js:13:17:13:30 | req.body.title | marsdb.js:16:12:16:16 | query |
+| minimongo.js:14:9:14:18 | query | minimongo.js:18:12:18:16 | query |
+| minimongo.js:14:9:14:18 | query | minimongo.js:18:12:18:16 | query |
+| minimongo.js:14:17:14:18 | {} | minimongo.js:14:9:14:18 | query |
+| minimongo.js:15:17:15:24 | req.body | minimongo.js:15:17:15:30 | req.body.title |
+| minimongo.js:15:17:15:24 | req.body | minimongo.js:15:17:15:30 | req.body.title |
+| minimongo.js:15:17:15:30 | req.body.title | minimongo.js:14:9:14:18 | query |
+| minimongo.js:15:17:15:30 | req.body.title | minimongo.js:14:17:14:18 | {} |
+| minimongo.js:15:17:15:30 | req.body.title | minimongo.js:18:12:18:16 | query |
+| minimongo.js:15:17:15:30 | req.body.title | minimongo.js:18:12:18:16 | query |
 | mongodb.js:12:11:12:20 | query | mongodb.js:18:16:18:20 | query |
 | mongodb.js:12:11:12:20 | query | mongodb.js:18:16:18:20 | query |
 | mongodb.js:12:19:12:20 | {} | mongodb.js:12:11:12:20 | query |
@@ -371,6 +419,9 @@ edges
 | tst.js:10:46:10:58 | req.params.id | tst.js:10:10:10:64 | 'SELECT ... d + '"' |
 | tst.js:10:46:10:58 | req.params.id | tst.js:10:10:10:64 | 'SELECT ... d + '"' |
 #select
+| marsdb-flow-to.js:14:17:14:21 | query | marsdb-flow-to.js:11:17:11:24 | req.body | marsdb-flow-to.js:14:17:14:21 | query | This query depends on $@. | marsdb-flow-to.js:11:17:11:24 | req.body | a user-provided value |
+| marsdb.js:16:12:16:16 | query | marsdb.js:13:17:13:24 | req.body | marsdb.js:16:12:16:16 | query | This query depends on $@. | marsdb.js:13:17:13:24 | req.body | a user-provided value |
+| minimongo.js:18:12:18:16 | query | minimongo.js:15:17:15:24 | req.body | minimongo.js:18:12:18:16 | query | This query depends on $@. | minimongo.js:15:17:15:24 | req.body | a user-provided value |
 | mongodb.js:18:16:18:20 | query | mongodb.js:13:19:13:26 | req.body | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
 | mongodb.js:32:18:32:45 | { title ... itle) } | mongodb.js:26:19:26:26 | req.body | mongodb.js:32:18:32:45 | { title ... itle) } | This query depends on $@. | mongodb.js:26:19:26:26 | req.body | a user-provided value |
 | mongodb.js:54:16:54:20 | query | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query | This query depends on $@. | mongodb.js:49:19:49:33 | req.query.title | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb-flow-from.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb-flow-from.js
@@ -1,0 +1,9 @@
+const MarsDB = require("marsdb");
+
+const myDoc = new MarsDB.Collection("myDoc");
+
+const db = {
+  myDoc
+};
+
+module.exports = db;

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb-flow-to.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb-flow-to.js
@@ -1,0 +1,15 @@
+const express = require("express"),
+      bodyParser = require("body-parser"),
+      db = require('./marsdb-flow-from');
+
+const app = express();
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+app.post("/documents/find", (req, res) => {
+  const query = {};
+  query.title = req.body.title;
+
+  // NOT OK: query is tainted by user-provided object value
+  db.myDoc.find(query);
+});

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/marsdb.js
@@ -1,0 +1,17 @@
+const express = require("express"),
+  MarsDB = require("marsdb"),
+  bodyParser = require("body-parser");
+
+let doc = new MarsDB.Collection("myDoc");
+
+const app = express();
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+app.post("/documents/find", (req, res) => {
+  const query = {};
+  query.title = req.body.title;
+
+  // NOT OK: query is tainted by user-provided object value
+  doc.find(query);
+});

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/minimongo.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/minimongo.js
@@ -1,0 +1,19 @@
+const express = require("express"),
+  minimongo = require("minimongo"),
+  bodyParser = require("body-parser");
+
+var LocalDb = minimongo.MemoryDb,
+  db = new LocalDb(),
+  doc = db.myDocs;
+
+const app = express();
+
+app.use(bodyParser.urlencoded({ extended: true }));
+
+app.post("/documents/find", (req, res) => {
+  const query = {};
+  query.title = req.body.title;
+
+  // NOT OK: query is tainted by user-provided object value
+  doc.find(query);
+});


### PR DESCRIPTION
Adds models for two in-memory ports of MongoDB. 

- Minimongo is used internally in <https://github.com/meteor/meteor>, but is also available as a standalone. 
- Marsdb is a port of Minimongo, and is relevant for <https://github.com/github/codeql/issues/3434>.

The marsdb model is enough to flag the following:

- https://github.com/bkimminich/juice-shop/blob/446718f47b2a49c7eb557e9152f7232eb459008e/routes/updateProductReviews.js#L15
- https://github.com/bkimminich/juice-shop/blob/446718f47b2a49c7eb557e9152f7232eb459008e/routes/likeProductReviews.js#L15
- https://github.com/bkimminich/juice-shop/blob/446718f47b2a49c7eb557e9152f7232eb459008e/routes/likeProductReviews.js#L19
- https://github.com/bkimminich/juice-shop/blob/446718f47b2a49c7eb557e9152f7232eb459008e/routes/likeProductReviews.js#L25
- https://github.com/bkimminich/juice-shop/blob/446718f47b2a49c7eb557e9152f7232eb459008e/routes/likeProductReviews.js#L36