### PR TITLE
C++/C#: Remove `UnmodeledUse` instruction

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -61,7 +61,6 @@ private newtype TOpcode =
   TReThrow() or
   TUnwind() or
   TUnmodeledDefinition() or
-  TUnmodeledUse() or
   TAliasedDefinition() or
   TInitializeNonLocal() or
   TAliasedUse() or
@@ -585,12 +584,6 @@ module Opcode {
     final override MemoryAccessKind getWriteMemoryAccess() {
       result instanceof UnmodeledMemoryAccess
     }
-  }
-
-  class UnmodeledUse extends Opcode, TUnmodeledUse {
-    final override string toString() { result = "UnmodeledUse" }
-
-    final override predicate hasOperandInternal(OperandTag tag) { none() }
   }
 
   class AliasedDefinition extends Opcode, TAliasedDefinition {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/Opcode.qll
@@ -590,9 +590,7 @@ module Opcode {
   class UnmodeledUse extends Opcode, TUnmodeledUse {
     final override string toString() { result = "UnmodeledUse" }
 
-    final override predicate hasOperandInternal(OperandTag tag) {
-      tag instanceof UnmodeledUseOperandTag
-    }
+    final override predicate hasOperandInternal(OperandTag tag) { none() }
   }
 
   class AliasedDefinition extends Opcode, TAliasedDefinition {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRBlock.qll
@@ -31,10 +31,14 @@ class IRBlockBase extends TIRBlock {
       config.shouldEvaluateDebugStringsForFunction(this.getEnclosingFunction())
     ) and
     this =
-      rank[result + 1](IRBlock funcBlock |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction()
+      rank[result + 1](IRBlock funcBlock, int sortOverride |
+        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        // Ensure that the block containing `EnterFunction` always comes first.
+        if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
+        then sortOverride = 0
+        else sortOverride = 1
       |
-        funcBlock order by funcBlock.getUniqueId()
+        funcBlock order by sortOverride, funcBlock.getUniqueId()
       )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
@@ -257,7 +257,6 @@ module InstructionConsistency {
     Operand useOperand, string message, IRFunction func, string funcText
   ) {
     exists(IRBlock useBlock, int useIndex, Instruction defInstr, IRBlock defBlock, int defIndex |
-      not useOperand.getUse() instanceof UnmodeledUseInstruction and
       not defInstr instanceof UnmodeledDefinitionInstruction and
       pointOfEvaluation(useOperand, useBlock, useIndex) and
       defInstr = useOperand.getAnyDef() and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRConsistency.qll
@@ -55,7 +55,6 @@ module InstructionConsistency {
           operand.getOperandTag() = tag
         ) and
       operandCount > 1 and
-      not tag instanceof UnmodeledUseOperandTag and
       message =
         "Instruction has " + operandCount + " operands with tag '" + tag.toString() + "'" +
           " in function '$@'." and
@@ -158,7 +157,6 @@ module InstructionConsistency {
   ) {
     exists(MemoryOperand operand, Instruction def |
       operand = instr.getAnOperand() and
-      not operand instanceof UnmodeledUseOperand and
       def = operand.getAnyDef() and
       not def.isResultModeled() and
       not def instanceof UnmodeledDefinitionInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/IRFunction.qll
@@ -45,11 +45,6 @@ class IRFunction extends TIRFunction {
     result.getEnclosingIRFunction() = this
   }
 
-  pragma[noinline]
-  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
-    result.getEnclosingIRFunction() = this
-  }
-
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -320,8 +320,7 @@ class Instruction extends Construction::TInstruction {
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
    * holds for a register result. For a memory result, a modeled result is
-   * connected to its actual uses. An unmodeled result is connected to the
-   * `UnmodeledUse` instruction.
+   * connected to its actual uses. An unmodeled result has no uses.
    *
    * For example:
    * ```
@@ -1246,12 +1245,6 @@ class AliasedDefinitionInstruction extends Instruction {
  */
 class AliasedUseInstruction extends Instruction {
   AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
-}
-
-class UnmodeledUseInstruction extends Instruction {
-  UnmodeledUseInstruction() { getOpcode() instanceof Opcode::UnmodeledUse }
-
-  override string getOperandsString() { result = "mu*" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -19,11 +19,7 @@ private newtype TOperand =
   ) {
     defInstr = Construction::getMemoryOperandDefinition(useInstr, tag, overlap) and
     not Construction::isInCycle(useInstr) and
-    (
-      strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
-      or
-      tag instanceof UnmodeledUseOperandTag
-    )
+    strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
   } or
   TPhiOperand(
     PhiInstruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
@@ -325,16 +321,6 @@ class ConditionOperand extends RegisterOperand {
   override ConditionOperandTag tag;
 
   override string toString() { result = "Condition" }
-}
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperand extends NonPhiMemoryOperand {
-  override UnmodeledUseOperandTag tag;
-
-  override string toString() { result = "UnmodeledUse" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -247,6 +247,10 @@ private predicate resultMayReachReturn(Instruction instr) { operandMayReachRetur
 private predicate resultEscapesNonReturn(Instruction instr) {
   // The result escapes if it has at least one use that escapes.
   operandEscapesNonReturn(instr.getAUse())
+  or
+  // The result also escapes if it is not modeled in SSA, because we do not know where it might be
+  // used.
+  not instr.isResultModeled()
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -128,23 +128,10 @@ private module Cached {
       oldOperand = oldInstruction.getAnOperand() and
       tag = oldOperand.getOperandTag() and
       (
-        (
-          if exists(Alias::getOperandMemoryLocation(oldOperand))
-          then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
-          else (
-            result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
-            overlap instanceof MustTotallyOverlap
-          )
-        )
-        or
-        // Connect any definitions that are not being modeled in SSA to the
-        // `UnmodeledUse` instruction.
-        exists(OldInstruction oldDefinition |
-          instruction instanceof UnmodeledUseInstruction and
-          tag instanceof UnmodeledUseOperandTag and
-          oldDefinition = oldOperand.getAnyDef() and
-          not exists(Alias::getResultMemoryLocation(oldDefinition)) and
-          result = getNewInstruction(oldDefinition) and
+        if exists(Alias::getOperandMemoryLocation(oldOperand))
+        then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
+        else (
+          result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
           overlap instanceof MustTotallyOverlap
         )
       )
@@ -153,13 +140,6 @@ private module Cached {
     instruction = Chi(getOldInstruction(result)) and
     tag instanceof ChiPartialOperandTag and
     overlap instanceof MustExactlyOverlap
-    or
-    exists(IRFunction f |
-      tag instanceof UnmodeledUseOperandTag and
-      result = f.getUnmodeledDefinitionInstruction() and
-      instruction = f.getUnmodeledUseInstruction() and
-      overlap instanceof MustTotallyOverlap
-    )
     or
     tag instanceof ChiTotalOperandTag and
     result = getChiInstructionTotalOperand(instruction) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -15,7 +15,6 @@ private newtype TOperandTag =
   TLeftOperand() or
   TRightOperand() or
   TConditionOperand() or
-  TUnmodeledUseOperand() or
   TCallTargetOperand() or
   TThisArgumentOperand() or
   TPositionalArgumentOperand(int argIndex) { Language::hasPositionalArgIndex(argIndex) } or
@@ -164,18 +163,6 @@ class ConditionOperandTag extends RegisterOperandTag, TConditionOperand {
 }
 
 ConditionOperandTag conditionOperand() { result = TConditionOperand() }
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperandTag extends MemoryOperandTag, TUnmodeledUseOperand {
-  final override string toString() { result = "UnmodeledUse" }
-
-  final override int getSortOrder() { result = 9 }
-}
-
-UnmodeledUseOperandTag unmodeledUseOperand() { result = TUnmodeledUseOperand() }
 
 /**
  * The operand representing the target function of an `Call` instruction.

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRBlock.qll
@@ -31,10 +31,14 @@ class IRBlockBase extends TIRBlock {
       config.shouldEvaluateDebugStringsForFunction(this.getEnclosingFunction())
     ) and
     this =
-      rank[result + 1](IRBlock funcBlock |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction()
+      rank[result + 1](IRBlock funcBlock, int sortOverride |
+        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        // Ensure that the block containing `EnterFunction` always comes first.
+        if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
+        then sortOverride = 0
+        else sortOverride = 1
       |
-        funcBlock order by funcBlock.getUniqueId()
+        funcBlock order by sortOverride, funcBlock.getUniqueId()
       )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
@@ -257,7 +257,6 @@ module InstructionConsistency {
     Operand useOperand, string message, IRFunction func, string funcText
   ) {
     exists(IRBlock useBlock, int useIndex, Instruction defInstr, IRBlock defBlock, int defIndex |
-      not useOperand.getUse() instanceof UnmodeledUseInstruction and
       not defInstr instanceof UnmodeledDefinitionInstruction and
       pointOfEvaluation(useOperand, useBlock, useIndex) and
       defInstr = useOperand.getAnyDef() and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRConsistency.qll
@@ -55,7 +55,6 @@ module InstructionConsistency {
           operand.getOperandTag() = tag
         ) and
       operandCount > 1 and
-      not tag instanceof UnmodeledUseOperandTag and
       message =
         "Instruction has " + operandCount + " operands with tag '" + tag.toString() + "'" +
           " in function '$@'." and
@@ -158,7 +157,6 @@ module InstructionConsistency {
   ) {
     exists(MemoryOperand operand, Instruction def |
       operand = instr.getAnOperand() and
-      not operand instanceof UnmodeledUseOperand and
       def = operand.getAnyDef() and
       not def.isResultModeled() and
       not def instanceof UnmodeledDefinitionInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/IRFunction.qll
@@ -45,11 +45,6 @@ class IRFunction extends TIRFunction {
     result.getEnclosingIRFunction() = this
   }
 
-  pragma[noinline]
-  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
-    result.getEnclosingIRFunction() = this
-  }
-
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -320,8 +320,7 @@ class Instruction extends Construction::TInstruction {
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
    * holds for a register result. For a memory result, a modeled result is
-   * connected to its actual uses. An unmodeled result is connected to the
-   * `UnmodeledUse` instruction.
+   * connected to its actual uses. An unmodeled result has no uses.
    *
    * For example:
    * ```
@@ -1246,12 +1245,6 @@ class AliasedDefinitionInstruction extends Instruction {
  */
 class AliasedUseInstruction extends Instruction {
   AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
-}
-
-class UnmodeledUseInstruction extends Instruction {
-  UnmodeledUseInstruction() { getOpcode() instanceof Opcode::UnmodeledUse }
-
-  override string getOperandsString() { result = "mu*" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -19,11 +19,7 @@ private newtype TOperand =
   ) {
     defInstr = Construction::getMemoryOperandDefinition(useInstr, tag, overlap) and
     not Construction::isInCycle(useInstr) and
-    (
-      strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
-      or
-      tag instanceof UnmodeledUseOperandTag
-    )
+    strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
   } or
   TPhiOperand(
     PhiInstruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
@@ -325,16 +321,6 @@ class ConditionOperand extends RegisterOperand {
   override ConditionOperandTag tag;
 
   override string toString() { result = "Condition" }
-}
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperand extends NonPhiMemoryOperand {
-  override UnmodeledUseOperandTag tag;
-
-  override string toString() { result = "UnmodeledUse" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/InstructionTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/InstructionTag.qll
@@ -29,7 +29,6 @@ newtype TInstructionTag =
   ReturnTag() or
   ExitFunctionTag() or
   UnmodeledDefinitionTag() or
-  UnmodeledUseTag() or
   AliasedDefinitionTag() or
   InitializeNonLocalTag() or
   AliasedUseTag() or
@@ -128,8 +127,6 @@ string getInstructionTagId(TInstructionTag tag) {
   tag = ExitFunctionTag() and result = "ExitFunc"
   or
   tag = UnmodeledDefinitionTag() and result = "UnmodeledDef"
-  or
-  tag = UnmodeledUseTag() and result = "UnmodeledUse"
   or
   tag = AliasedDefinitionTag() and result = "AliasedDef"
   or

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCondition.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedCondition.qll
@@ -182,7 +182,7 @@ class TranslatedValueCondition extends TranslatedCondition, TTranslatedValueCond
     )
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ValueConditionConditionalBranchTag() and
     operandTag instanceof ConditionOperandTag and
     result = getValueExpr().getResult()

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedDeclarationEntry.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedDeclarationEntry.qll
@@ -181,14 +181,11 @@ class TranslatedStaticLocalVariableDeclarationEntry extends TranslatedDeclaratio
     tag = DynamicInitializationFlagConstantTag() and result = "1"
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = DynamicInitializationFlagLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(DynamicInitializationFlagAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getTranslatedFunction(var.getFunction()).getUnmodeledDefinitionInstruction()
     )
     or
     tag = DynamicInitializationConditionalBranchTag() and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -736,12 +736,12 @@ abstract class TranslatedElement extends TTranslatedElement {
    * Gets the instruction whose result is consumed as an operand of the
    * instruction specified by `tag`, with the operand specified by `operandTag`.
    */
-  Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) { none() }
+  Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) { none() }
 
   /**
    * Gets the type of the memory operand specified by `operandTag` on the the instruction specified by `tag`.
    */
-  CppType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) { none() }
+  CppType getInstructionMemoryOperandType(InstructionTag tag, TypedOperandTag operandTag) { none() }
 
   /**
    * Gets the size of the memory operand specified by `operandTag` on the the instruction specified by `tag`.

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedExpr.qll
@@ -183,7 +183,7 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
     )
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ConditionValueTrueStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
@@ -206,9 +206,6 @@ class TranslatedConditionValue extends TranslatedCoreExpr, ConditionContext,
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(ConditionValueResultTempAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
   }
 
@@ -282,14 +279,11 @@ class TranslatedLoad extends TranslatedExpr, TTranslatedLoad {
 
   override Instruction getResult() { result = getInstruction(LoadTag()) }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = LoadTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getOperand().getResult()
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
   }
 
@@ -332,7 +326,7 @@ class TranslatedResultCopy extends TranslatedExpr, TTranslatedResultCopy {
 
   override Instruction getResult() { result = getInstruction(ResultCopyTag()) }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ResultCopyTag() and
     operandTag instanceof UnaryOperandTag and
     result = getOperand().getResult()
@@ -369,7 +363,9 @@ class TranslatedCommaExpr extends TranslatedNonConstantExpr {
     none()
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) { none() }
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    none()
+  }
 
   private TranslatedExpr getLeftOperand() {
     result = getTranslatedExpr(expr.getLeftOperand().getFullyConverted())
@@ -429,7 +425,7 @@ abstract class TranslatedCrementOperation extends TranslatedNonConstantExpr {
     resultType = getTypeForPRValue(expr.getType())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = CrementOpTag() and
     (
       operandTag instanceof LeftOperandTag and
@@ -580,7 +576,7 @@ class TranslatedArrayExpr extends TranslatedNonConstantExpr {
     resultType = getTypeForGLValue(expr.getType())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     (
       operandTag instanceof LeftOperandTag and
@@ -622,7 +618,7 @@ abstract class TranslatedTransparentExpr extends TranslatedNonConstantExpr {
 
   final override Instruction getResult() { result = getOperand().getResult() }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 
@@ -685,7 +681,7 @@ class TranslatedThisExpr extends TranslatedNonConstantExpr {
 
   final override Instruction getChildSuccessor(TranslatedElement child) { none() }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getInitializeThisInstruction()
@@ -729,7 +725,9 @@ class TranslatedNonFieldVariableAccess extends TranslatedVariableAccess {
     else result = getInstruction(OnlyInstructionTag())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) { none() }
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    none()
+  }
 
   override predicate hasInstruction(Opcode opcode, InstructionTag tag, CppType resultType) {
     tag = OnlyInstructionTag() and
@@ -748,7 +746,7 @@ class TranslatedFieldAccess extends TranslatedVariableAccess {
 
   override Instruction getFirstInstruction() { result = getQualifier().getFirstInstruction() }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getQualifier().getResult()
@@ -822,7 +820,7 @@ abstract class TranslatedConstantExpr extends TranslatedCoreExpr, TTranslatedVal
 
   final override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 
@@ -906,7 +904,7 @@ class TranslatedUnaryExpr extends TranslatedSingleInstructionExpr {
     child = getOperand() and result = getInstruction(OnlyInstructionTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     result = getOperand().getResult() and
     operandTag instanceof UnaryOperandTag
@@ -960,7 +958,7 @@ abstract class TranslatedSingleInstructionConversion extends TranslatedConversio
 
   override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getOperand().getResult()
@@ -1070,7 +1068,7 @@ class TranslatedBoolConversion extends TranslatedConversion {
 
   override Instruction getResult() { result = getInstruction(BoolConversionCompareTag()) }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = BoolConversionCompareTag() and
     (
       operandTag instanceof LeftOperandTag and
@@ -1172,7 +1170,7 @@ class TranslatedBinaryOperation extends TranslatedSingleInstructionExpr {
     id = 1 and result = getRightOperand()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     if swapOperandsOnOp()
     then (
@@ -1306,7 +1304,7 @@ class TranslatedAssignExpr extends TranslatedNonConstantExpr {
     resultType = getTypeForPRValue(expr.getType()) // Always a prvalue
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = AssignmentStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
@@ -1482,7 +1480,7 @@ class TranslatedAssignOperation extends TranslatedNonConstantExpr {
     result = getElementSize(expr.getType())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     leftOperandNeedsConversion() and
     tag = AssignOperationConvertLeftTag() and
     operandTag instanceof UnaryOperandTag and
@@ -1626,7 +1624,7 @@ class TranslatedNonConstantAllocationSize extends TranslatedAllocationSize {
     result = expr.getAllocatedElementType().getSize().toString()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = AllocationSizeTag() and
     (
       operandTag instanceof LeftOperandTag and result = getInstruction(AllocationExtentConvertTag())
@@ -1742,7 +1740,7 @@ class TranslatedDestructorFieldDestruction extends TranslatedNonConstantExpr, St
 
   final override Instruction getFirstInstruction() { result = getInstruction(OnlyInstructionTag()) }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getTranslatedFunction(expr.getEnclosingFunction()).getInitializeThisInstruction()
@@ -1832,7 +1830,7 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
     )
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     not resultIsVoid() and
     (
       not thenIsVoid() and
@@ -1859,9 +1857,6 @@ abstract class TranslatedConditionalExpr extends TranslatedNonConstantExpr {
       (
         operandTag instanceof AddressOperandTag and
         result = getInstruction(ConditionValueResultTempAddressTag())
-        or
-        operandTag instanceof LoadOperandTag and
-        result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
       )
     )
   }
@@ -2014,8 +2009,8 @@ class TranslatedBinaryConditionalExpr extends TranslatedConditionalExpr {
     )
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    result = super.getInstructionOperand(tag, operandTag)
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    result = super.getInstructionRegisterOperand(tag, operandTag)
     or
     tag = ValueConditionConditionalBranchTag() and
     operandTag instanceof ConditionOperandTag and
@@ -2093,20 +2088,19 @@ class TranslatedThrowValueExpr extends TranslatedThrowExpr, TranslatedVariableIn
     type = getTypeForPRValue(getExceptionType())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    result = TranslatedVariableInitialization.super.getInstructionOperand(tag, operandTag)
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    result = TranslatedVariableInitialization.super.getInstructionRegisterOperand(tag, operandTag)
     or
     tag = ThrowTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(InitializerVariableAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
   }
 
-  final override CppType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
+  final override CppType getInstructionMemoryOperandType(
+    InstructionTag tag, TypedOperandTag operandTag
+  ) {
     tag = ThrowTag() and
     operandTag instanceof LoadOperandTag and
     result = getTypeForPRValue(getExceptionType())
@@ -2191,7 +2185,7 @@ class TranslatedBuiltInOperation extends TranslatedNonConstantExpr {
     resultType = getResultType()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     exists(int index |
       operandTag = positionalArgumentOperand(index) and
@@ -2311,7 +2305,7 @@ class TranslatedVarArgsStart extends TranslatedNonConstantExpr {
     result = getEnclosingFunction().getEllipsisVariable()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsStartTag() and
     operandTag instanceof UnaryOperandTag and
     result = getInstruction(VarArgsStartEllipsisAddressTag())
@@ -2382,14 +2376,11 @@ class TranslatedVarArg extends TranslatedNonConstantExpr {
     result = getInstruction(VarArgsVAListLoadTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsVAListLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getVAList().getResult()
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
     or
     tag = VarArgsArgAddressTag() and
@@ -2442,7 +2433,7 @@ class TranslatedVarArgsEnd extends TranslatedNonConstantExpr {
     result = getInstruction(OnlyInstructionTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getVAList().getResult()
@@ -2503,14 +2494,11 @@ class TranslatedVarArgCopy extends TranslatedNonConstantExpr {
     result = getInstruction(VarArgsVAListStoreTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = VarArgsVAListLoadTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getSourceVAList().getResult()
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
     or
     tag = VarArgsVAListStoreTag() and
@@ -2560,7 +2548,7 @@ abstract class TranslatedNewOrNewArrayExpr extends TranslatedNonConstantExpr, In
     child = getInitialization() and result = getParent().getChildSuccessor(this)
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getAllocatorCall().getResult()
@@ -2623,7 +2611,7 @@ class TranslatedDeleteArrayExprPlaceHolder extends TranslatedSingleInstructionEx
     child = getOperand() and result = getInstruction(OnlyInstructionTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 
@@ -2657,7 +2645,7 @@ class TranslatedDeleteExprPlaceHolder extends TranslatedSingleInstructionExpr {
     child = getOperand() and result = getInstruction(OnlyInstructionTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 
@@ -2761,7 +2749,7 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
     resultType = getTypeForPRValue(expr.getType())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     operandTag instanceof AddressOperandTag and
     result = getInstruction(InitializerVariableAddressTag())
@@ -2770,9 +2758,6 @@ class TranslatedLambdaExpr extends TranslatedNonConstantExpr, InitializationCont
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(InitializerVariableAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
   }
 
@@ -2832,7 +2817,7 @@ class TranslatedStmtExpr extends TranslatedNonConstantExpr {
 
   override Instruction getResult() { result = getInstruction(OnlyInstructionTag()) }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag instanceof OnlyInstructionTag and
     operandTag instanceof UnaryOperandTag and
     result = getTranslatedExpr(expr.getResultExpr().getFullyConverted()).getResult()
@@ -2856,7 +2841,7 @@ class TranslatedErrorExpr extends TranslatedSingleInstructionExpr {
 
   final override Instruction getChildSuccessor(TranslatedElement child) { none() }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     none()
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
@@ -138,12 +138,9 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
       result = getInstruction(ReturnTag())
       or
       tag = ReturnTag() and
-      result = getInstruction(UnmodeledUseTag())
+      result = getInstruction(AliasedUseTag())
       or
       tag = UnwindTag() and
-      result = getInstruction(UnmodeledUseTag())
-      or
-      tag = UnmodeledUseTag() and
       result = getInstruction(AliasedUseTag())
       or
       tag = AliasedUseTag() and
@@ -220,10 +217,6 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
         exists(TryStmt try | try.getEnclosingFunction() = func) or
         exists(ThrowExpr throw | throw.getEnclosingFunction() = func)
       )
-      or
-      tag = UnmodeledUseTag() and
-      opcode instanceof Opcode::UnmodeledUse and
-      resultType = getVoidType()
       or
       tag = AliasedUseTag() and
       opcode instanceof Opcode::AliasedUse and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedFunction.qll
@@ -239,32 +239,18 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
     result = getInstruction(UnwindTag())
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = UnmodeledUseTag() and
-    operandTag instanceof UnmodeledUseOperandTag and
-    result.getEnclosingFunction() = func and
-    result.hasMemoryResult()
-    or
-    tag = UnmodeledUseTag() and
-    operandTag instanceof UnmodeledUseOperandTag and
-    result = getUnmodeledDefinitionInstruction()
-    or
-    tag = AliasedUseTag() and
-    operandTag instanceof SideEffectOperandTag and
-    result = getUnmodeledDefinitionInstruction()
-    or
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = ReturnTag() and
     hasReturnValue() and
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(ReturnValueAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getUnmodeledDefinitionInstruction()
     )
   }
 
-  final override CppType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
+  final override CppType getInstructionMemoryOperandType(
+    InstructionTag tag, TypedOperandTag operandTag
+  ) {
     tag = ReturnTag() and
     hasReturnValue() and
     operandTag instanceof LoadOperandTag and
@@ -445,7 +431,7 @@ abstract class TranslatedParameter extends TranslatedElement {
     result = getIRVariable()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
@@ -457,9 +443,6 @@ abstract class TranslatedParameter extends TranslatedElement {
     (
       operandTag instanceof AddressOperandTag and
       result = getInstruction(InitializerVariableAddressTag())
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getTranslatedFunction(getFunction()).getUnmodeledDefinitionInstruction()
     )
     or
     tag = InitializerIndirectStoreTag() and
@@ -734,17 +717,15 @@ class TranslatedReadEffect extends TranslatedElement, TTranslatedReadEffect {
     resultType = getVoidType()
   }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = OnlyInstructionTag() and
-    operandTag = sideEffectOperand() and
-    result = getTranslatedFunction(getFunction()).getUnmodeledDefinitionInstruction()
-    or
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag = addressOperand() and
     result = getTranslatedParameter(param).getInstruction(InitializerIndirectAddressTag())
   }
 
-  final override CppType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
+  final override CppType getInstructionMemoryOperandType(
+    InstructionTag tag, TypedOperandTag operandTag
+  ) {
     tag = OnlyInstructionTag() and
     operandTag = sideEffectOperand() and
     result = getUnknownType()

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedInitialization.qll
@@ -75,7 +75,7 @@ abstract class TranslatedVariableInitialization extends TranslatedElement, Initi
     child = getInitialization() and result = getInitializationSuccessor()
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     hasUninitializedInstruction() and
     tag = InitializerStoreTag() and
     operandTag instanceof AddressOperandTag and
@@ -262,7 +262,7 @@ class TranslatedSimpleDirectInitialization extends TranslatedDirectInitializatio
     child = getInitializer() and result = getInstruction(InitializerStoreTag())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerStoreTag() and
     (
       operandTag instanceof AddressOperandTag and
@@ -355,14 +355,11 @@ class TranslatedStringLiteralInitialization extends TranslatedDirectInitializati
     child = getInitializer() and result = getInstruction(InitializerLoadStringTag())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = InitializerLoadStringTag() and
     (
       operandTag instanceof AddressOperandTag and
       result = getInitializer().getResult()
-      or
-      operandTag instanceof LoadOperandTag and
-      result = getEnclosingFunction().getUnmodeledDefinitionInstruction()
     )
     or
     tag = InitializerStoreTag() and
@@ -461,7 +458,9 @@ class TranslatedConstructorInitialization extends TranslatedDirectInitialization
     child = getInitializer() and result = getParent().getChildSuccessor(this)
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) { none() }
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    none()
+  }
 
   override Instruction getReceiver() { result = getContext().getTargetAddress() }
 }
@@ -508,7 +507,7 @@ abstract class TranslatedFieldInitialization extends TranslatedElement {
     resultType = getTypeForGLValue(field.getType())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = getFieldAddressTag() and
     operandTag instanceof UnaryOperandTag and
     result = getParent().(InitializationContext).getTargetAddress()
@@ -599,8 +598,8 @@ class TranslatedFieldValueInitialization extends TranslatedFieldInitialization,
     result = getZeroValue(field.getUnspecifiedType())
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    result = TranslatedFieldInitialization.super.getInstructionOperand(tag, operandTag)
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    result = TranslatedFieldInitialization.super.getInstructionRegisterOperand(tag, operandTag)
     or
     tag = getFieldDefaultValueStoreTag() and
     (
@@ -656,7 +655,7 @@ abstract class TranslatedElementInitialization extends TranslatedElement {
     kind instanceof GotoEdge
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = getElementAddressTag() and
     (
       operandTag instanceof LeftOperandTag and
@@ -782,8 +781,8 @@ class TranslatedElementValueInitialization extends TranslatedElementInitializati
     result = elementCount * getElementType().getSize()
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    result = TranslatedElementInitialization.super.getInstructionOperand(tag, operandTag)
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
+    result = TranslatedElementInitialization.super.getInstructionRegisterOperand(tag, operandTag)
     or
     tag = getElementDefaultValueStoreTag() and
     (
@@ -861,7 +860,7 @@ abstract class TranslatedBaseStructorCall extends TranslatedStructorCallFromStru
 
   final override Instruction getReceiver() { result = getInstruction(OnlyInstructionTag()) }
 
-  final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  final override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = OnlyInstructionTag() and
     operandTag instanceof UnaryOperandTag and
     result = getTranslatedFunction(getFunction()).getInitializeThisInstruction()

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/TranslatedStmt.qll
@@ -713,7 +713,7 @@ class TranslatedSwitchStmt extends TranslatedStmt {
     resultType = getVoidType()
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     tag = SwitchBranchTag() and
     operandTag instanceof ConditionOperandTag and
     result = getExpr().getResult()
@@ -759,11 +759,7 @@ class TranslatedAsmStmt extends TranslatedStmt {
     resultType = getUnknownType()
   }
 
-  override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = AsmTag() and
-    operandTag instanceof SideEffectOperandTag and
-    result = getTranslatedFunction(stmt.getEnclosingFunction()).getUnmodeledDefinitionInstruction()
-    or
+  override Instruction getInstructionRegisterOperand(InstructionTag tag, OperandTag operandTag) {
     exists(int index |
       tag = AsmTag() and
       operandTag = asmOperand(index) and
@@ -771,7 +767,9 @@ class TranslatedAsmStmt extends TranslatedStmt {
     )
   }
 
-  final override CppType getInstructionOperandType(InstructionTag tag, TypedOperandTag operandTag) {
+  final override CppType getInstructionMemoryOperandType(
+    InstructionTag tag, TypedOperandTag operandTag
+  ) {
     tag = AsmTag() and
     operandTag instanceof SideEffectOperandTag and
     result = getUnknownType()

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -31,10 +31,14 @@ class IRBlockBase extends TIRBlock {
       config.shouldEvaluateDebugStringsForFunction(this.getEnclosingFunction())
     ) and
     this =
-      rank[result + 1](IRBlock funcBlock |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction()
+      rank[result + 1](IRBlock funcBlock, int sortOverride |
+        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        // Ensure that the block containing `EnterFunction` always comes first.
+        if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
+        then sortOverride = 0
+        else sortOverride = 1
       |
-        funcBlock order by funcBlock.getUniqueId()
+        funcBlock order by sortOverride, funcBlock.getUniqueId()
       )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -257,7 +257,6 @@ module InstructionConsistency {
     Operand useOperand, string message, IRFunction func, string funcText
   ) {
     exists(IRBlock useBlock, int useIndex, Instruction defInstr, IRBlock defBlock, int defIndex |
-      not useOperand.getUse() instanceof UnmodeledUseInstruction and
       not defInstr instanceof UnmodeledDefinitionInstruction and
       pointOfEvaluation(useOperand, useBlock, useIndex) and
       defInstr = useOperand.getAnyDef() and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -55,7 +55,6 @@ module InstructionConsistency {
           operand.getOperandTag() = tag
         ) and
       operandCount > 1 and
-      not tag instanceof UnmodeledUseOperandTag and
       message =
         "Instruction has " + operandCount + " operands with tag '" + tag.toString() + "'" +
           " in function '$@'." and
@@ -158,7 +157,6 @@ module InstructionConsistency {
   ) {
     exists(MemoryOperand operand, Instruction def |
       operand = instr.getAnOperand() and
-      not operand instanceof UnmodeledUseOperand and
       def = operand.getAnyDef() and
       not def.isResultModeled() and
       not def instanceof UnmodeledDefinitionInstruction and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/IRFunction.qll
@@ -45,11 +45,6 @@ class IRFunction extends TIRFunction {
     result.getEnclosingIRFunction() = this
   }
 
-  pragma[noinline]
-  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
-    result.getEnclosingIRFunction() = this
-  }
-
   /**
    * Gets the single return instruction for this function.
    */

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -320,8 +320,7 @@ class Instruction extends Construction::TInstruction {
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
    * holds for a register result. For a memory result, a modeled result is
-   * connected to its actual uses. An unmodeled result is connected to the
-   * `UnmodeledUse` instruction.
+   * connected to its actual uses. An unmodeled result has no uses.
    *
    * For example:
    * ```
@@ -1246,12 +1245,6 @@ class AliasedDefinitionInstruction extends Instruction {
  */
 class AliasedUseInstruction extends Instruction {
   AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
-}
-
-class UnmodeledUseInstruction extends Instruction {
-  UnmodeledUseInstruction() { getOpcode() instanceof Opcode::UnmodeledUse }
-
-  override string getOperandsString() { result = "mu*" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -19,11 +19,7 @@ private newtype TOperand =
   ) {
     defInstr = Construction::getMemoryOperandDefinition(useInstr, tag, overlap) and
     not Construction::isInCycle(useInstr) and
-    (
-      strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
-      or
-      tag instanceof UnmodeledUseOperandTag
-    )
+    strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
   } or
   TPhiOperand(
     PhiInstruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
@@ -325,16 +321,6 @@ class ConditionOperand extends RegisterOperand {
   override ConditionOperandTag tag;
 
   override string toString() { result = "Condition" }
-}
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperand extends NonPhiMemoryOperand {
-  override UnmodeledUseOperandTag tag;
-
-  override string toString() { result = "UnmodeledUse" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -247,6 +247,10 @@ private predicate resultMayReachReturn(Instruction instr) { operandMayReachRetur
 private predicate resultEscapesNonReturn(Instruction instr) {
   // The result escapes if it has at least one use that escapes.
   operandEscapesNonReturn(instr.getAUse())
+  or
+  // The result also escapes if it is not modeled in SSA, because we do not know where it might be
+  // used.
+  not instr.isResultModeled()
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -128,23 +128,10 @@ private module Cached {
       oldOperand = oldInstruction.getAnOperand() and
       tag = oldOperand.getOperandTag() and
       (
-        (
-          if exists(Alias::getOperandMemoryLocation(oldOperand))
-          then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
-          else (
-            result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
-            overlap instanceof MustTotallyOverlap
-          )
-        )
-        or
-        // Connect any definitions that are not being modeled in SSA to the
-        // `UnmodeledUse` instruction.
-        exists(OldInstruction oldDefinition |
-          instruction instanceof UnmodeledUseInstruction and
-          tag instanceof UnmodeledUseOperandTag and
-          oldDefinition = oldOperand.getAnyDef() and
-          not exists(Alias::getResultMemoryLocation(oldDefinition)) and
-          result = getNewInstruction(oldDefinition) and
+        if exists(Alias::getOperandMemoryLocation(oldOperand))
+        then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
+        else (
+          result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
           overlap instanceof MustTotallyOverlap
         )
       )
@@ -153,13 +140,6 @@ private module Cached {
     instruction = Chi(getOldInstruction(result)) and
     tag instanceof ChiPartialOperandTag and
     overlap instanceof MustExactlyOverlap
-    or
-    exists(IRFunction f |
-      tag instanceof UnmodeledUseOperandTag and
-      result = f.getUnmodeledDefinitionInstruction() and
-      instruction = f.getUnmodeledUseInstruction() and
-      overlap instanceof MustTotallyOverlap
-    )
     or
     tag instanceof ChiTotalOperandTag and
     result = getChiInstructionTotalOperand(instruction) and

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -20,9 +20,8 @@ bad_asts.cpp:
 #   10|     mu10_9(int)       = Store                    : &:r10_1, r10_8
 #    9|     r9_8(glval<int>)  = VariableAddress[#return] : 
 #    9|     v9_9(void)        = ReturnValue              : &:r9_8, ~mu9_4
-#    9|     v9_10(void)       = UnmodeledUse             : mu*
-#    9|     v9_11(void)       = AliasedUse               : ~mu9_4
-#    9|     v9_12(void)       = ExitFunction             : 
+#    9|     v9_10(void)       = AliasedUse               : ~mu9_4
+#    9|     v9_11(void)       = ExitFunction             : 
 
 #   14| void Bad::CallBadMemberFunction()
 #   14|   Block 0
@@ -44,9 +43,8 @@ bad_asts.cpp:
 #   16|     mu16_7(S)             = ^IndirectMayWriteSideEffect[-1] : &:r16_1
 #   17|     v17_1(void)           = NoOp                            : 
 #   14|     v14_5(void)           = ReturnVoid                      : 
-#   14|     v14_6(void)           = UnmodeledUse                    : mu*
-#   14|     v14_7(void)           = AliasedUse                      : ~mu14_4
-#   14|     v14_8(void)           = ExitFunction                    : 
+#   14|     v14_6(void)           = AliasedUse                      : ~mu14_4
+#   14|     v14_7(void)           = ExitFunction                    : 
 
 #   22| void Bad::Point::Point()
 #   22|   Block 0
@@ -57,9 +55,8 @@ bad_asts.cpp:
 #   22|     r22_5(glval<Point>) = InitializeThis      : 
 #   23|     v23_1(void)         = NoOp                : 
 #   22|     v22_6(void)         = ReturnVoid          : 
-#   22|     v22_7(void)         = UnmodeledUse        : mu*
-#   22|     v22_8(void)         = AliasedUse          : ~mu22_4
-#   22|     v22_9(void)         = ExitFunction        : 
+#   22|     v22_7(void)         = AliasedUse          : ~mu22_4
+#   22|     v22_8(void)         = ExitFunction        : 
 
 #   26| void Bad::CallCopyConstructor(Bad::Point const&)
 #   26|   Block 0
@@ -81,9 +78,8 @@ bad_asts.cpp:
 #   28|     v28_1(void)           = NoOp                     : 
 #   26|     v26_9(void)           = ReturnIndirection[a]     : &:r26_7, ~mu26_4
 #   26|     v26_10(void)          = ReturnVoid               : 
-#   26|     v26_11(void)          = UnmodeledUse             : mu*
-#   26|     v26_12(void)          = AliasedUse               : ~mu26_4
-#   26|     v26_13(void)          = ExitFunction             : 
+#   26|     v26_11(void)          = AliasedUse               : ~mu26_4
+#   26|     v26_12(void)          = ExitFunction             : 
 
 #   30| void Bad::errorExpr()
 #   30|   Block 0
@@ -103,9 +99,8 @@ bad_asts.cpp:
 #   33|     mu33_2(int)         = Store                   : &:r33_1, r0_2
 #   34|     v34_1(void)         = NoOp                    : 
 #   30|     v30_5(void)         = ReturnVoid              : 
-#   30|     v30_6(void)         = UnmodeledUse            : mu*
-#   30|     v30_7(void)         = AliasedUse              : ~mu30_4
-#   30|     v30_8(void)         = ExitFunction            : 
+#   30|     v30_6(void)         = AliasedUse              : ~mu30_4
+#   30|     v30_7(void)         = ExitFunction            : 
 
 clang.cpp:
 #    5| int* globalIntAddress()
@@ -120,9 +115,8 @@ clang.cpp:
 #    6|     mu6_4(int *)       = Store                      : &:r6_1, r6_3
 #    5|     r5_5(glval<int *>) = VariableAddress[#return]   : 
 #    5|     v5_6(void)         = ReturnValue                : &:r5_5, ~mu5_4
-#    5|     v5_7(void)         = UnmodeledUse               : mu*
-#    5|     v5_8(void)         = AliasedUse                 : ~mu5_4
-#    5|     v5_9(void)         = ExitFunction               : 
+#    5|     v5_7(void)         = AliasedUse                 : ~mu5_4
+#    5|     v5_8(void)         = ExitFunction               : 
 
 complex.c:
 #    1| void complex_literals()
@@ -168,9 +162,8 @@ complex.c:
 #   11|     mu11_4(_Imaginary long double)       = Store                : &:r11_1, r11_3
 #   12|     v12_1(void)                          = NoOp                 : 
 #    1|     v1_5(void)                           = ReturnVoid           : 
-#    1|     v1_6(void)                           = UnmodeledUse         : mu*
-#    1|     v1_7(void)                           = AliasedUse           : ~mu1_4
-#    1|     v1_8(void)                           = ExitFunction         : 
+#    1|     v1_6(void)                           = AliasedUse           : ~mu1_4
+#    1|     v1_7(void)                           = ExitFunction         : 
 
 #   14| void complex_arithmetic()
 #   14|   Block 0
@@ -338,9 +331,8 @@ complex.c:
 #   55|     mu55_7(_Imaginary float)       = Store                : &:r55_6, r55_5
 #   56|     v56_1(void)                    = NoOp                 : 
 #   14|     v14_5(void)                    = ReturnVoid           : 
-#   14|     v14_6(void)                    = UnmodeledUse         : mu*
-#   14|     v14_7(void)                    = AliasedUse           : ~mu14_4
-#   14|     v14_8(void)                    = ExitFunction         : 
+#   14|     v14_6(void)                    = AliasedUse           : ~mu14_4
+#   14|     v14_7(void)                    = ExitFunction         : 
 
 #   58| void complex_conversions()
 #   58|   Block 0
@@ -694,9 +686,8 @@ complex.c:
 #  144|     mu144_5(long double)                  = Store                : &:r144_4, r144_3
 #  145|     v145_1(void)                          = NoOp                 : 
 #   58|     v58_5(void)                           = ReturnVoid           : 
-#   58|     v58_6(void)                           = UnmodeledUse         : mu*
-#   58|     v58_7(void)                           = AliasedUse           : ~mu58_4
-#   58|     v58_8(void)                           = ExitFunction         : 
+#   58|     v58_6(void)                           = AliasedUse           : ~mu58_4
+#   58|     v58_7(void)                           = ExitFunction         : 
 
 ir.cpp:
 #    1| void Constants()
@@ -791,9 +782,8 @@ ir.cpp:
 #   40|     mu40_3(double)                   = Store                    : &:r40_1, r40_2
 #   41|     v41_1(void)                      = NoOp                     : 
 #    1|     v1_5(void)                       = ReturnVoid               : 
-#    1|     v1_6(void)                       = UnmodeledUse             : mu*
-#    1|     v1_7(void)                       = AliasedUse               : ~mu1_4
-#    1|     v1_8(void)                       = ExitFunction             : 
+#    1|     v1_6(void)                       = AliasedUse               : ~mu1_4
+#    1|     v1_7(void)                       = ExitFunction             : 
 
 #   43| void Foo()
 #   43|   Block 0
@@ -826,9 +816,8 @@ ir.cpp:
 #   47|     mu47_8(int)         = Store               : &:r47_7, r47_6
 #   48|     v48_1(void)         = NoOp                : 
 #   43|     v43_5(void)         = ReturnVoid          : 
-#   43|     v43_6(void)         = UnmodeledUse        : mu*
-#   43|     v43_7(void)         = AliasedUse          : ~mu43_4
-#   43|     v43_8(void)         = ExitFunction        : 
+#   43|     v43_6(void)         = AliasedUse          : ~mu43_4
+#   43|     v43_7(void)         = ExitFunction        : 
 
 #   50| void IntegerOps(int, int)
 #   50|   Block 0
@@ -1001,9 +990,8 @@ ir.cpp:
 #   84|     mu84_8(int)       = Store                  : &:r84_7, r84_6
 #   85|     v85_1(void)       = NoOp                   : 
 #   50|     v50_9(void)       = ReturnVoid             : 
-#   50|     v50_10(void)      = UnmodeledUse           : mu*
-#   50|     v50_11(void)      = AliasedUse             : ~mu50_4
-#   50|     v50_12(void)      = ExitFunction           : 
+#   50|     v50_10(void)      = AliasedUse             : ~mu50_4
+#   50|     v50_11(void)      = ExitFunction           : 
 
 #   87| void IntegerCompare(int, int)
 #   87|   Block 0
@@ -1061,9 +1049,8 @@ ir.cpp:
 #   95|     mu95_7(bool)       = Store                  : &:r95_6, r95_5
 #   96|     v96_1(void)        = NoOp                   : 
 #   87|     v87_9(void)        = ReturnVoid             : 
-#   87|     v87_10(void)       = UnmodeledUse           : mu*
-#   87|     v87_11(void)       = AliasedUse             : ~mu87_4
-#   87|     v87_12(void)       = ExitFunction           : 
+#   87|     v87_10(void)       = AliasedUse             : ~mu87_4
+#   87|     v87_11(void)       = ExitFunction           : 
 
 #   98| void IntegerCrement(int)
 #   98|   Block 0
@@ -1107,9 +1094,8 @@ ir.cpp:
 #  104|     mu104_8(int)       = Store                  : &:r104_7, r104_6
 #  105|     v105_1(void)       = NoOp                   : 
 #   98|     v98_7(void)        = ReturnVoid             : 
-#   98|     v98_8(void)        = UnmodeledUse           : mu*
-#   98|     v98_9(void)        = AliasedUse             : ~mu98_4
-#   98|     v98_10(void)       = ExitFunction           : 
+#   98|     v98_8(void)        = AliasedUse             : ~mu98_4
+#   98|     v98_9(void)        = ExitFunction           : 
 
 #  107| void IntegerCrement_LValue(int)
 #  107|   Block 0
@@ -1141,9 +1127,8 @@ ir.cpp:
 #  111|     mu111_9(int *)       = Store                  : &:r111_8, r111_7
 #  112|     v112_1(void)         = NoOp                   : 
 #  107|     v107_7(void)         = ReturnVoid             : 
-#  107|     v107_8(void)         = UnmodeledUse           : mu*
-#  107|     v107_9(void)         = AliasedUse             : ~mu107_4
-#  107|     v107_10(void)        = ExitFunction           : 
+#  107|     v107_8(void)         = AliasedUse             : ~mu107_4
+#  107|     v107_9(void)         = ExitFunction           : 
 
 #  114| void FloatOps(double, double)
 #  114|   Block 0
@@ -1225,9 +1210,8 @@ ir.cpp:
 #  130|     mu130_5(double)       = Store                  : &:r130_4, r130_3
 #  131|     v131_1(void)          = NoOp                   : 
 #  114|     v114_9(void)          = ReturnVoid             : 
-#  114|     v114_10(void)         = UnmodeledUse           : mu*
-#  114|     v114_11(void)         = AliasedUse             : ~mu114_4
-#  114|     v114_12(void)         = ExitFunction           : 
+#  114|     v114_10(void)         = AliasedUse             : ~mu114_4
+#  114|     v114_11(void)         = ExitFunction           : 
 
 #  133| void FloatCompare(double, double)
 #  133|   Block 0
@@ -1285,9 +1269,8 @@ ir.cpp:
 #  141|     mu141_7(bool)         = Store                  : &:r141_6, r141_5
 #  142|     v142_1(void)          = NoOp                   : 
 #  133|     v133_9(void)          = ReturnVoid             : 
-#  133|     v133_10(void)         = UnmodeledUse           : mu*
-#  133|     v133_11(void)         = AliasedUse             : ~mu133_4
-#  133|     v133_12(void)         = ExitFunction           : 
+#  133|     v133_10(void)         = AliasedUse             : ~mu133_4
+#  133|     v133_11(void)         = ExitFunction           : 
 
 #  144| void FloatCrement(float)
 #  144|   Block 0
@@ -1331,9 +1314,8 @@ ir.cpp:
 #  150|     mu150_8(float)       = Store                  : &:r150_7, r150_6
 #  151|     v151_1(void)         = NoOp                   : 
 #  144|     v144_7(void)         = ReturnVoid             : 
-#  144|     v144_8(void)         = UnmodeledUse           : mu*
-#  144|     v144_9(void)         = AliasedUse             : ~mu144_4
-#  144|     v144_10(void)        = ExitFunction           : 
+#  144|     v144_8(void)         = AliasedUse             : ~mu144_4
+#  144|     v144_9(void)         = ExitFunction           : 
 
 #  153| void PointerOps(int*, int)
 #  153|   Block 0
@@ -1412,9 +1394,8 @@ ir.cpp:
 #  169|     v169_1(void)         = NoOp                     : 
 #  153|     v153_11(void)        = ReturnIndirection[p]     : &:r153_7, ~mu153_4
 #  153|     v153_12(void)        = ReturnVoid               : 
-#  153|     v153_13(void)        = UnmodeledUse             : mu*
-#  153|     v153_14(void)        = AliasedUse               : ~mu153_4
-#  153|     v153_15(void)        = ExitFunction             : 
+#  153|     v153_13(void)        = AliasedUse               : ~mu153_4
+#  153|     v153_14(void)        = ExitFunction             : 
 
 #  171| void ArrayAccess(int*, int)
 #  171|   Block 0
@@ -1499,9 +1480,8 @@ ir.cpp:
 #  185|     v185_1(void)           = NoOp                     : 
 #  171|     v171_11(void)          = ReturnIndirection[p]     : &:r171_7, ~mu171_4
 #  171|     v171_12(void)          = ReturnVoid               : 
-#  171|     v171_13(void)          = UnmodeledUse             : mu*
-#  171|     v171_14(void)          = AliasedUse               : ~mu171_4
-#  171|     v171_15(void)          = ExitFunction             : 
+#  171|     v171_13(void)          = AliasedUse               : ~mu171_4
+#  171|     v171_14(void)          = ExitFunction             : 
 
 #  187| void StringLiteral(int)
 #  187|   Block 0
@@ -1534,9 +1514,8 @@ ir.cpp:
 #  190|     mu190_8(wchar_t)          = Store                  : &:r190_1, r190_7
 #  191|     v191_1(void)              = NoOp                   : 
 #  187|     v187_7(void)              = ReturnVoid             : 
-#  187|     v187_8(void)              = UnmodeledUse           : mu*
-#  187|     v187_9(void)              = AliasedUse             : ~mu187_4
-#  187|     v187_10(void)             = ExitFunction           : 
+#  187|     v187_8(void)              = AliasedUse             : ~mu187_4
+#  187|     v187_9(void)              = ExitFunction           : 
 
 #  193| void PointerCompare(int*, int*)
 #  193|   Block 0
@@ -1600,9 +1579,8 @@ ir.cpp:
 #  193|     v193_13(void)        = ReturnIndirection[p]     : &:r193_7, ~mu193_4
 #  193|     v193_14(void)        = ReturnIndirection[q]     : &:r193_11, ~mu193_4
 #  193|     v193_15(void)        = ReturnVoid               : 
-#  193|     v193_16(void)        = UnmodeledUse             : mu*
-#  193|     v193_17(void)        = AliasedUse               : ~mu193_4
-#  193|     v193_18(void)        = ExitFunction             : 
+#  193|     v193_16(void)        = AliasedUse               : ~mu193_4
+#  193|     v193_17(void)        = ExitFunction             : 
 
 #  204| void PointerCrement(int*)
 #  204|   Block 0
@@ -1649,9 +1627,8 @@ ir.cpp:
 #  211|     v211_1(void)         = NoOp                     : 
 #  204|     v204_9(void)         = ReturnIndirection[p]     : &:r204_7, ~mu204_4
 #  204|     v204_10(void)        = ReturnVoid               : 
-#  204|     v204_11(void)        = UnmodeledUse             : mu*
-#  204|     v204_12(void)        = AliasedUse               : ~mu204_4
-#  204|     v204_13(void)        = ExitFunction             : 
+#  204|     v204_11(void)        = AliasedUse               : ~mu204_4
+#  204|     v204_12(void)        = ExitFunction             : 
 
 #  213| void CompoundAssignment()
 #  213|   Block 0
@@ -1695,9 +1672,8 @@ ir.cpp:
 #  227|     mu227_7(long)        = Store               : &:r227_2, r227_6
 #  228|     v228_1(void)         = NoOp                : 
 #  213|     v213_5(void)         = ReturnVoid          : 
-#  213|     v213_6(void)         = UnmodeledUse        : mu*
-#  213|     v213_7(void)         = AliasedUse          : ~mu213_4
-#  213|     v213_8(void)         = ExitFunction        : 
+#  213|     v213_6(void)         = AliasedUse          : ~mu213_4
+#  213|     v213_7(void)         = ExitFunction        : 
 
 #  230| void UninitializedVariables()
 #  230|   Block 0
@@ -1713,9 +1689,8 @@ ir.cpp:
 #  232|     mu232_4(int)       = Store               : &:r232_1, r232_3
 #  233|     v233_1(void)       = NoOp                : 
 #  230|     v230_5(void)       = ReturnVoid          : 
-#  230|     v230_6(void)       = UnmodeledUse        : mu*
-#  230|     v230_7(void)       = AliasedUse          : ~mu230_4
-#  230|     v230_8(void)       = ExitFunction        : 
+#  230|     v230_6(void)       = AliasedUse          : ~mu230_4
+#  230|     v230_7(void)       = ExitFunction        : 
 
 #  235| int Parameters(int, int)
 #  235|   Block 0
@@ -1736,9 +1711,8 @@ ir.cpp:
 #  236|     mu236_7(int)       = Store                    : &:r236_1, r236_6
 #  235|     r235_9(glval<int>) = VariableAddress[#return] : 
 #  235|     v235_10(void)      = ReturnValue              : &:r235_9, ~mu235_4
-#  235|     v235_11(void)      = UnmodeledUse             : mu*
-#  235|     v235_12(void)      = AliasedUse               : ~mu235_4
-#  235|     v235_13(void)      = ExitFunction             : 
+#  235|     v235_11(void)      = AliasedUse               : ~mu235_4
+#  235|     v235_12(void)      = ExitFunction             : 
 
 #  239| void IfStatements(bool, int, int)
 #  239|   Block 0
@@ -1796,9 +1770,8 @@ ir.cpp:
 #  251|   Block 6
 #  251|     v251_1(void)  = NoOp         : 
 #  239|     v239_11(void) = ReturnVoid   : 
-#  239|     v239_12(void) = UnmodeledUse : mu*
-#  239|     v239_13(void) = AliasedUse   : ~mu239_4
-#  239|     v239_14(void) = ExitFunction : 
+#  239|     v239_12(void) = AliasedUse   : ~mu239_4
+#  239|     v239_13(void) = ExitFunction : 
 
 #  240|   Block 7
 #  240|     v240_4(void) = NoOp : 
@@ -1823,11 +1796,10 @@ ir.cpp:
 #-----|   Goto (back edge) -> Block 3
 
 #  257|   Block 2
-#  257|     v257_1(void)  = NoOp         : 
-#  253|     v253_7(void)  = ReturnVoid   : 
-#  253|     v253_8(void)  = UnmodeledUse : mu*
-#  253|     v253_9(void)  = AliasedUse   : ~mu253_4
-#  253|     v253_10(void) = ExitFunction : 
+#  257|     v257_1(void) = NoOp         : 
+#  253|     v253_7(void) = ReturnVoid   : 
+#  253|     v253_8(void) = AliasedUse   : ~mu253_4
+#  253|     v253_9(void) = ExitFunction : 
 
 #  254|   Block 3
 #  254|     r254_1(glval<int>) = VariableAddress[n] : 
@@ -1863,11 +1835,10 @@ ir.cpp:
 #-----|   True (back edge) -> Block 1
 
 #  263|   Block 2
-#  263|     v263_1(void)  = NoOp         : 
-#  259|     v259_7(void)  = ReturnVoid   : 
-#  259|     v259_8(void)  = UnmodeledUse : mu*
-#  259|     v259_9(void)  = AliasedUse   : ~mu259_4
-#  259|     v259_10(void) = ExitFunction : 
+#  263|     v263_1(void) = NoOp         : 
+#  259|     v259_7(void) = ReturnVoid   : 
+#  259|     v259_8(void) = AliasedUse   : ~mu259_4
+#  259|     v259_9(void) = ExitFunction : 
 
 #  265| void For_Empty()
 #  265|   Block 0
@@ -1881,9 +1852,8 @@ ir.cpp:
 
 #  265|   Block 1
 #  265|     v265_5(void) = ReturnVoid   : 
-#  265|     v265_6(void) = UnmodeledUse : mu*
-#  265|     v265_7(void) = AliasedUse   : ~mu265_4
-#  265|     v265_8(void) = ExitFunction : 
+#  265|     v265_6(void) = AliasedUse   : ~mu265_4
+#  265|     v265_7(void) = ExitFunction : 
 
 #  268|   Block 2
 #  268|     v268_1(void) = NoOp : 
@@ -1902,9 +1872,8 @@ ir.cpp:
 
 #  272|   Block 1
 #  272|     v272_5(void) = ReturnVoid   : 
-#  272|     v272_6(void) = UnmodeledUse : mu*
-#  272|     v272_7(void) = AliasedUse   : ~mu272_4
-#  272|     v272_8(void) = ExitFunction : 
+#  272|     v272_6(void) = AliasedUse   : ~mu272_4
+#  272|     v272_7(void) = ExitFunction : 
 
 #  274|   Block 2
 #  274|     v274_1(void) = NoOp : 
@@ -1937,9 +1906,8 @@ ir.cpp:
 #  283|   Block 3
 #  283|     v283_1(void) = NoOp         : 
 #  278|     v278_5(void) = ReturnVoid   : 
-#  278|     v278_6(void) = UnmodeledUse : mu*
-#  278|     v278_7(void) = AliasedUse   : ~mu278_4
-#  278|     v278_8(void) = ExitFunction : 
+#  278|     v278_6(void) = AliasedUse   : ~mu278_4
+#  278|     v278_7(void) = ExitFunction : 
 
 #  285| void For_Update()
 #  285|   Block 0
@@ -1954,9 +1922,8 @@ ir.cpp:
 
 #  285|   Block 1
 #  285|     v285_5(void) = ReturnVoid   : 
-#  285|     v285_6(void) = UnmodeledUse : mu*
-#  285|     v285_7(void) = AliasedUse   : ~mu285_4
-#  285|     v285_8(void) = ExitFunction : 
+#  285|     v285_6(void) = AliasedUse   : ~mu285_4
+#  285|     v285_7(void) = ExitFunction : 
 
 #  288|   Block 2
 #  288|     v288_1(void)       = NoOp               : 
@@ -1994,9 +1961,8 @@ ir.cpp:
 #  296|   Block 3
 #  296|     v296_1(void) = NoOp         : 
 #  292|     v292_5(void) = ReturnVoid   : 
-#  292|     v292_6(void) = UnmodeledUse : mu*
-#  292|     v292_7(void) = AliasedUse   : ~mu292_4
-#  292|     v292_8(void) = ExitFunction : 
+#  292|     v292_6(void) = AliasedUse   : ~mu292_4
+#  292|     v292_7(void) = ExitFunction : 
 
 #  298| void For_InitUpdate()
 #  298|   Block 0
@@ -2011,9 +1977,8 @@ ir.cpp:
 
 #  298|   Block 1
 #  298|     v298_5(void) = ReturnVoid   : 
-#  298|     v298_6(void) = UnmodeledUse : mu*
-#  298|     v298_7(void) = AliasedUse   : ~mu298_4
-#  298|     v298_8(void) = ExitFunction : 
+#  298|     v298_6(void) = AliasedUse   : ~mu298_4
+#  298|     v298_7(void) = ExitFunction : 
 
 #  300|   Block 2
 #  300|     v300_1(void)       = NoOp               : 
@@ -2056,9 +2021,8 @@ ir.cpp:
 #  309|   Block 3
 #  309|     v309_1(void) = NoOp         : 
 #  304|     v304_5(void) = ReturnVoid   : 
-#  304|     v304_6(void) = UnmodeledUse : mu*
-#  304|     v304_7(void) = AliasedUse   : ~mu304_4
-#  304|     v304_8(void) = ExitFunction : 
+#  304|     v304_6(void) = AliasedUse   : ~mu304_4
+#  304|     v304_7(void) = ExitFunction : 
 
 #  311| void For_InitConditionUpdate()
 #  311|   Block 0
@@ -2092,9 +2056,8 @@ ir.cpp:
 #  315|   Block 3
 #  315|     v315_1(void) = NoOp         : 
 #  311|     v311_5(void) = ReturnVoid   : 
-#  311|     v311_6(void) = UnmodeledUse : mu*
-#  311|     v311_7(void) = AliasedUse   : ~mu311_4
-#  311|     v311_8(void) = ExitFunction : 
+#  311|     v311_6(void) = AliasedUse   : ~mu311_4
+#  311|     v311_7(void) = ExitFunction : 
 
 #  317| void For_Break()
 #  317|   Block 0
@@ -2141,9 +2104,8 @@ ir.cpp:
 #  322|     v322_1(void) = NoOp         : 
 #  323|     v323_1(void) = NoOp         : 
 #  317|     v317_5(void) = ReturnVoid   : 
-#  317|     v317_6(void) = UnmodeledUse : mu*
-#  317|     v317_7(void) = AliasedUse   : ~mu317_4
-#  317|     v317_8(void) = ExitFunction : 
+#  317|     v317_6(void) = AliasedUse   : ~mu317_4
+#  317|     v317_7(void) = ExitFunction : 
 
 #  325| void For_Continue_Update()
 #  325|   Block 0
@@ -2190,9 +2152,8 @@ ir.cpp:
 #  331|   Block 5
 #  331|     v331_1(void) = NoOp         : 
 #  325|     v325_5(void) = ReturnVoid   : 
-#  325|     v325_6(void) = UnmodeledUse : mu*
-#  325|     v325_7(void) = AliasedUse   : ~mu325_4
-#  325|     v325_8(void) = ExitFunction : 
+#  325|     v325_6(void) = AliasedUse   : ~mu325_4
+#  325|     v325_7(void) = ExitFunction : 
 
 #  333| void For_Continue_NoUpdate()
 #  333|   Block 0
@@ -2234,9 +2195,8 @@ ir.cpp:
 #  339|   Block 5
 #  339|     v339_1(void) = NoOp         : 
 #  333|     v333_5(void) = ReturnVoid   : 
-#  333|     v333_6(void) = UnmodeledUse : mu*
-#  333|     v333_7(void) = AliasedUse   : ~mu333_4
-#  333|     v333_8(void) = ExitFunction : 
+#  333|     v333_6(void) = AliasedUse   : ~mu333_4
+#  333|     v333_7(void) = ExitFunction : 
 
 #  341| int Dereference(int*)
 #  341|   Block 0
@@ -2261,9 +2221,8 @@ ir.cpp:
 #  341|     v341_9(void)         = ReturnIndirection[p]     : &:r341_7, ~mu341_4
 #  341|     r341_10(glval<int>)  = VariableAddress[#return] : 
 #  341|     v341_11(void)        = ReturnValue              : &:r341_10, ~mu341_4
-#  341|     v341_12(void)        = UnmodeledUse             : mu*
-#  341|     v341_13(void)        = AliasedUse               : ~mu341_4
-#  341|     v341_14(void)        = ExitFunction             : 
+#  341|     v341_12(void)        = AliasedUse               : ~mu341_4
+#  341|     v341_13(void)        = ExitFunction             : 
 
 #  348| int* AddressOf()
 #  348|   Block 0
@@ -2277,9 +2236,8 @@ ir.cpp:
 #  349|     mu349_4(int *)       = Store                    : &:r349_1, r349_3
 #  348|     r348_5(glval<int *>) = VariableAddress[#return] : 
 #  348|     v348_6(void)         = ReturnValue              : &:r348_5, ~mu348_4
-#  348|     v348_7(void)         = UnmodeledUse             : mu*
-#  348|     v348_8(void)         = AliasedUse               : ~mu348_4
-#  348|     v348_9(void)         = ExitFunction             : 
+#  348|     v348_7(void)         = AliasedUse               : ~mu348_4
+#  348|     v348_8(void)         = ExitFunction             : 
 
 #  352| void Break(int)
 #  352|   Block 0
@@ -2313,12 +2271,11 @@ ir.cpp:
 #-----|   Goto (back edge) -> Block 5
 
 #  357|   Block 4
-#  357|     v357_1(void)  = NoOp         : 
-#  358|     v358_1(void)  = NoOp         : 
-#  352|     v352_7(void)  = ReturnVoid   : 
-#  352|     v352_8(void)  = UnmodeledUse : mu*
-#  352|     v352_9(void)  = AliasedUse   : ~mu352_4
-#  352|     v352_10(void) = ExitFunction : 
+#  357|     v357_1(void) = NoOp         : 
+#  358|     v358_1(void) = NoOp         : 
+#  352|     v352_7(void) = ReturnVoid   : 
+#  352|     v352_8(void) = AliasedUse   : ~mu352_4
+#  352|     v352_9(void) = ExitFunction : 
 
 #  353|   Block 5
 #  353|     r353_1(glval<int>) = VariableAddress[n] : 
@@ -2371,11 +2328,10 @@ ir.cpp:
 #-----|   True (back edge) -> Block 1
 
 #  367|   Block 5
-#  367|     v367_1(void)  = NoOp         : 
-#  360|     v360_7(void)  = ReturnVoid   : 
-#  360|     v360_8(void)  = UnmodeledUse : mu*
-#  360|     v360_9(void)  = AliasedUse   : ~mu360_4
-#  360|     v360_10(void) = ExitFunction : 
+#  367|     v367_1(void) = NoOp         : 
+#  360|     v360_7(void) = ReturnVoid   : 
+#  360|     v360_8(void) = AliasedUse   : ~mu360_4
+#  360|     v360_9(void) = ExitFunction : 
 
 #  372| void Call()
 #  372|   Block 0
@@ -2388,9 +2344,8 @@ ir.cpp:
 #  373|     mu373_3(unknown)       = ^CallSideEffect           : ~mu372_4
 #  374|     v374_1(void)           = NoOp                      : 
 #  372|     v372_5(void)           = ReturnVoid                : 
-#  372|     v372_6(void)           = UnmodeledUse              : mu*
-#  372|     v372_7(void)           = AliasedUse                : ~mu372_4
-#  372|     v372_8(void)           = ExitFunction              : 
+#  372|     v372_6(void)           = AliasedUse                : ~mu372_4
+#  372|     v372_7(void)           = ExitFunction              : 
 
 #  376| int CallAdd(int, int)
 #  376|   Block 0
@@ -2413,9 +2368,8 @@ ir.cpp:
 #  377|     mu377_9(int)           = Store                    : &:r377_1, r377_7
 #  376|     r376_9(glval<int>)     = VariableAddress[#return] : 
 #  376|     v376_10(void)          = ReturnValue              : &:r376_9, ~mu376_4
-#  376|     v376_11(void)          = UnmodeledUse             : mu*
-#  376|     v376_12(void)          = AliasedUse               : ~mu376_4
-#  376|     v376_13(void)          = ExitFunction             : 
+#  376|     v376_11(void)          = AliasedUse               : ~mu376_4
+#  376|     v376_12(void)          = ExitFunction             : 
 
 #  380| int Comma(int, int)
 #  380|   Block 0
@@ -2442,9 +2396,8 @@ ir.cpp:
 #  381|     mu381_13(int)          = Store                     : &:r381_1, r381_12
 #  380|     r380_9(glval<int>)     = VariableAddress[#return]  : 
 #  380|     v380_10(void)          = ReturnValue               : &:r380_9, ~mu380_4
-#  380|     v380_11(void)          = UnmodeledUse              : mu*
-#  380|     v380_12(void)          = AliasedUse                : ~mu380_4
-#  380|     v380_13(void)          = ExitFunction              : 
+#  380|     v380_11(void)          = AliasedUse                : ~mu380_4
+#  380|     v380_12(void)          = ExitFunction              : 
 
 #  384| void Switch(int)
 #  384|   Block 0
@@ -2522,12 +2475,11 @@ ir.cpp:
 #-----|   Goto -> Block 9
 
 #  409|   Block 9
-#  409|     v409_1(void)  = NoOp         : 
-#  410|     v410_1(void)  = NoOp         : 
-#  384|     v384_7(void)  = ReturnVoid   : 
-#  384|     v384_8(void)  = UnmodeledUse : mu*
-#  384|     v384_9(void)  = AliasedUse   : ~mu384_4
-#  384|     v384_10(void) = ExitFunction : 
+#  409|     v409_1(void) = NoOp         : 
+#  410|     v410_1(void) = NoOp         : 
+#  384|     v384_7(void) = ReturnVoid   : 
+#  384|     v384_8(void) = AliasedUse   : ~mu384_4
+#  384|     v384_9(void) = ExitFunction : 
 
 #  422| Point ReturnStruct(Point)
 #  422|   Block 0
@@ -2543,9 +2495,8 @@ ir.cpp:
 #  423|     mu423_4(Point)       = Store                    : &:r423_1, r423_3
 #  422|     r422_7(glval<Point>) = VariableAddress[#return] : 
 #  422|     v422_8(void)         = ReturnValue              : &:r422_7, ~mu422_4
-#  422|     v422_9(void)         = UnmodeledUse             : mu*
-#  422|     v422_10(void)        = AliasedUse               : ~mu422_4
-#  422|     v422_11(void)        = ExitFunction             : 
+#  422|     v422_9(void)         = AliasedUse               : ~mu422_4
+#  422|     v422_10(void)        = ExitFunction             : 
 
 #  426| void FieldAccess()
 #  426|   Block 0
@@ -2572,9 +2523,8 @@ ir.cpp:
 #  430|     mu430_5(int *)       = Store               : &:r430_1, r430_4
 #  431|     v431_1(void)         = NoOp                : 
 #  426|     v426_5(void)         = ReturnVoid          : 
-#  426|     v426_6(void)         = UnmodeledUse        : mu*
-#  426|     v426_7(void)         = AliasedUse          : ~mu426_4
-#  426|     v426_8(void)         = ExitFunction        : 
+#  426|     v426_6(void)         = AliasedUse          : ~mu426_4
+#  426|     v426_7(void)         = ExitFunction        : 
 
 #  433| void LogicalOr(bool, bool)
 #  433|   Block 0
@@ -2636,9 +2586,8 @@ ir.cpp:
 #  445|   Block 7
 #  445|     v445_1(void)  = NoOp         : 
 #  433|     v433_9(void)  = ReturnVoid   : 
-#  433|     v433_10(void) = UnmodeledUse : mu*
-#  433|     v433_11(void) = AliasedUse   : ~mu433_4
-#  433|     v433_12(void) = ExitFunction : 
+#  433|     v433_10(void) = AliasedUse   : ~mu433_4
+#  433|     v433_11(void) = ExitFunction : 
 
 #  447| void LogicalAnd(bool, bool)
 #  447|   Block 0
@@ -2700,9 +2649,8 @@ ir.cpp:
 #  459|   Block 7
 #  459|     v459_1(void)  = NoOp         : 
 #  447|     v447_9(void)  = ReturnVoid   : 
-#  447|     v447_10(void) = UnmodeledUse : mu*
-#  447|     v447_11(void) = AliasedUse   : ~mu447_4
-#  447|     v447_12(void) = ExitFunction : 
+#  447|     v447_10(void) = AliasedUse   : ~mu447_4
+#  447|     v447_11(void) = ExitFunction : 
 
 #  461| void LogicalNot(bool, bool)
 #  461|   Block 0
@@ -2757,9 +2705,8 @@ ir.cpp:
 #  473|   Block 6
 #  473|     v473_1(void)  = NoOp         : 
 #  461|     v461_9(void)  = ReturnVoid   : 
-#  461|     v461_10(void) = UnmodeledUse : mu*
-#  461|     v461_11(void) = AliasedUse   : ~mu461_4
-#  461|     v461_12(void) = ExitFunction : 
+#  461|     v461_10(void) = AliasedUse   : ~mu461_4
+#  461|     v461_11(void) = ExitFunction : 
 
 #  475| void ConditionValues(bool, bool)
 #  475|   Block 0
@@ -2830,9 +2777,8 @@ ir.cpp:
 #  479|     mu479_11(bool)       = Store                        : &:r479_10, r479_9
 #  480|     v480_1(void)         = NoOp                         : 
 #  475|     v475_9(void)         = ReturnVoid                   : 
-#  475|     v475_10(void)        = UnmodeledUse                 : mu*
-#  475|     v475_11(void)        = AliasedUse                   : ~mu475_4
-#  475|     v475_12(void)        = ExitFunction                 : 
+#  475|     v475_10(void)        = AliasedUse                   : ~mu475_4
+#  475|     v475_11(void)        = ExitFunction                 : 
 
 #  479|   Block 8
 #  479|     r479_12(glval<bool>) = VariableAddress[#temp479:11] : 
@@ -2909,9 +2855,8 @@ ir.cpp:
 #  483|     mu483_15(int)       = Store                        : &:r483_1, r483_14
 #  484|     v484_1(void)        = NoOp                         : 
 #  482|     v482_11(void)       = ReturnVoid                   : 
-#  482|     v482_12(void)       = UnmodeledUse                 : mu*
-#  482|     v482_13(void)       = AliasedUse                   : ~mu482_4
-#  482|     v482_14(void)       = ExitFunction                 : 
+#  482|     v482_12(void)       = AliasedUse                   : ~mu482_4
+#  482|     v482_13(void)       = ExitFunction                 : 
 
 #  486| void Conditional_LValue(bool)
 #  486|   Block 0
@@ -2938,9 +2883,8 @@ ir.cpp:
 #  489|     mu489_7(int)           = Store                       : &:r489_6, r489_1
 #  490|     v490_1(void)           = NoOp                        : 
 #  486|     v486_7(void)           = ReturnVoid                  : 
-#  486|     v486_8(void)           = UnmodeledUse                : mu*
-#  486|     v486_9(void)           = AliasedUse                  : ~mu486_4
-#  486|     v486_10(void)          = ExitFunction                : 
+#  486|     v486_8(void)           = AliasedUse                  : ~mu486_4
+#  486|     v486_9(void)           = ExitFunction                : 
 
 #  489|   Block 2
 #  489|     r489_8(glval<int>)     = VariableAddress[x]          : 
@@ -2975,11 +2919,10 @@ ir.cpp:
 #-----|   Goto -> Block 2
 
 #  494|   Block 2
-#  494|     v494_1(void)  = NoOp         : 
-#  492|     v492_7(void)  = ReturnVoid   : 
-#  492|     v492_8(void)  = UnmodeledUse : mu*
-#  492|     v492_9(void)  = AliasedUse   : ~mu492_4
-#  492|     v492_10(void) = ExitFunction : 
+#  494|     v494_1(void) = NoOp         : 
+#  492|     v492_7(void) = ReturnVoid   : 
+#  492|     v492_8(void) = AliasedUse   : ~mu492_4
+#  492|     v492_9(void) = ExitFunction : 
 
 #  493|   Block 3
 #  493|     r493_7(glval<unknown>) = FunctionAddress[VoidFunc] : 
@@ -3007,9 +2950,8 @@ ir.cpp:
 #  500|     mu500_3(int *)       = Store               : &:r500_2, r500_1
 #  501|     v501_1(void)         = NoOp                : 
 #  496|     v496_5(void)         = ReturnVoid          : 
-#  496|     v496_6(void)         = UnmodeledUse        : mu*
-#  496|     v496_7(void)         = AliasedUse          : ~mu496_4
-#  496|     v496_8(void)         = ExitFunction        : 
+#  496|     v496_6(void)         = AliasedUse          : ~mu496_4
+#  496|     v496_7(void)         = ExitFunction        : 
 
 #  503| void InitList(int, float)
 #  503|   Block 0
@@ -3057,9 +2999,8 @@ ir.cpp:
 #  509|     mu509_3(int)         = Store                  : &:r509_1, r509_2
 #  510|     v510_1(void)         = NoOp                   : 
 #  503|     v503_9(void)         = ReturnVoid             : 
-#  503|     v503_10(void)        = UnmodeledUse           : mu*
-#  503|     v503_11(void)        = AliasedUse             : ~mu503_4
-#  503|     v503_12(void)        = ExitFunction           : 
+#  503|     v503_10(void)        = AliasedUse             : ~mu503_4
+#  503|     v503_11(void)        = ExitFunction           : 
 
 #  512| void NestedInitList(int, float)
 #  512|   Block 0
@@ -3136,9 +3077,8 @@ ir.cpp:
 #  516|     mu516_18(int)         = Store                     : &:r516_16, r516_17
 #  517|     v517_1(void)          = NoOp                      : 
 #  512|     v512_9(void)          = ReturnVoid                : 
-#  512|     v512_10(void)         = UnmodeledUse              : mu*
-#  512|     v512_11(void)         = AliasedUse                : ~mu512_4
-#  512|     v512_12(void)         = ExitFunction              : 
+#  512|     v512_10(void)         = AliasedUse                : ~mu512_4
+#  512|     v512_11(void)         = ExitFunction              : 
 
 #  519| void ArrayInit(int, float)
 #  519|   Block 0
@@ -3186,9 +3126,8 @@ ir.cpp:
 #  522|     mu522_11(unknown[8])  = Store                  : &:r522_9, r522_10
 #  523|     v523_1(void)          = NoOp                   : 
 #  519|     v519_9(void)          = ReturnVoid             : 
-#  519|     v519_10(void)         = UnmodeledUse           : mu*
-#  519|     v519_11(void)         = AliasedUse             : ~mu519_4
-#  519|     v519_12(void)         = ExitFunction           : 
+#  519|     v519_10(void)         = AliasedUse             : ~mu519_4
+#  519|     v519_11(void)         = ExitFunction           : 
 
 #  530| void UnionInit(int, float)
 #  530|   Block 0
@@ -3209,9 +3148,8 @@ ir.cpp:
 #  531|     mu531_7(double)       = Store                  : &:r531_3, r531_6
 #  533|     v533_1(void)          = NoOp                   : 
 #  530|     v530_9(void)          = ReturnVoid             : 
-#  530|     v530_10(void)         = UnmodeledUse           : mu*
-#  530|     v530_11(void)         = AliasedUse             : ~mu530_4
-#  530|     v530_12(void)         = ExitFunction           : 
+#  530|     v530_10(void)         = AliasedUse             : ~mu530_4
+#  530|     v530_11(void)         = ExitFunction           : 
 
 #  535| void EarlyReturn(int, int)
 #  535|   Block 0
@@ -3234,9 +3172,8 @@ ir.cpp:
 
 #  535|   Block 1
 #  535|     v535_9(void)  = ReturnVoid   : 
-#  535|     v535_10(void) = UnmodeledUse : mu*
-#  535|     v535_11(void) = AliasedUse   : ~mu535_4
-#  535|     v535_12(void) = ExitFunction : 
+#  535|     v535_10(void) = AliasedUse   : ~mu535_4
+#  535|     v535_11(void) = ExitFunction : 
 
 #  537|   Block 2
 #  537|     v537_1(void) = NoOp : 
@@ -3272,9 +3209,8 @@ ir.cpp:
 #  543|   Block 1
 #  543|     r543_9(glval<int>) = VariableAddress[#return] : 
 #  543|     v543_10(void)      = ReturnValue              : &:r543_9, ~mu543_4
-#  543|     v543_11(void)      = UnmodeledUse             : mu*
-#  543|     v543_12(void)      = AliasedUse               : ~mu543_4
-#  543|     v543_13(void)      = ExitFunction             : 
+#  543|     v543_11(void)      = AliasedUse               : ~mu543_4
+#  543|     v543_12(void)      = ExitFunction             : 
 
 #  545|   Block 2
 #  545|     r545_1(glval<int>) = VariableAddress[#return] : 
@@ -3310,9 +3246,8 @@ ir.cpp:
 #  552|     mu552_7(int)             = Store                    : &:r552_1, r552_5
 #  551|     r551_7(glval<int>)       = VariableAddress[#return] : 
 #  551|     v551_8(void)             = ReturnValue              : &:r551_7, ~mu551_4
-#  551|     v551_9(void)             = UnmodeledUse             : mu*
-#  551|     v551_10(void)            = AliasedUse               : ~mu551_4
-#  551|     v551_11(void)            = ExitFunction             : 
+#  551|     v551_9(void)             = AliasedUse               : ~mu551_4
+#  551|     v551_10(void)            = ExitFunction             : 
 
 #  560| int EnumSwitch(E)
 #  560|   Block 0
@@ -3333,9 +3268,8 @@ ir.cpp:
 #  560|   Block 1
 #  560|     r560_7(glval<int>) = VariableAddress[#return] : 
 #  560|     v560_8(void)       = ReturnValue              : &:r560_7, ~mu560_4
-#  560|     v560_9(void)       = UnmodeledUse             : mu*
-#  560|     v560_10(void)      = AliasedUse               : ~mu560_4
-#  560|     v560_11(void)      = ExitFunction             : 
+#  560|     v560_9(void)       = AliasedUse               : ~mu560_4
+#  560|     v560_10(void)      = ExitFunction             : 
 
 #  564|   Block 2
 #  564|     v564_1(void)       = NoOp                     : 
@@ -3416,9 +3350,8 @@ ir.cpp:
 #  579|     mu579_10(unknown[2])    = Store                    : &:r579_8, r579_9
 #  580|     v580_1(void)            = NoOp                     : 
 #  571|     v571_5(void)            = ReturnVoid               : 
-#  571|     v571_6(void)            = UnmodeledUse             : mu*
-#  571|     v571_7(void)            = AliasedUse               : ~mu571_4
-#  571|     v571_8(void)            = ExitFunction             : 
+#  571|     v571_6(void)            = AliasedUse               : ~mu571_4
+#  571|     v571_7(void)            = ExitFunction             : 
 
 #  584| void VarArgs()
 #  584|   Block 0
@@ -3440,9 +3373,8 @@ ir.cpp:
 #  585|     mu585_12(unknown)      = ^BufferMayWriteSideEffect[2]    : &:r585_6
 #  586|     v586_1(void)           = NoOp                            : 
 #  584|     v584_5(void)           = ReturnVoid                      : 
-#  584|     v584_6(void)           = UnmodeledUse                    : mu*
-#  584|     v584_7(void)           = AliasedUse                      : ~mu584_4
-#  584|     v584_8(void)           = ExitFunction                    : 
+#  584|     v584_6(void)           = AliasedUse                      : ~mu584_4
+#  584|     v584_7(void)           = ExitFunction                    : 
 
 #  590| void SetFuncPtr()
 #  590|   Block 0
@@ -3470,9 +3402,8 @@ ir.cpp:
 #  594|     mu594_7(..(*)(..))       = Store                          : &:r594_6, r594_5
 #  595|     v595_1(void)             = NoOp                           : 
 #  590|     v590_5(void)             = ReturnVoid                     : 
-#  590|     v590_6(void)             = UnmodeledUse                   : mu*
-#  590|     v590_7(void)             = AliasedUse                     : ~mu590_4
-#  590|     v590_8(void)             = ExitFunction                   : 
+#  590|     v590_6(void)             = AliasedUse                     : ~mu590_4
+#  590|     v590_7(void)             = ExitFunction                   : 
 
 #  615| void DeclareObject()
 #  615|   Block 0
@@ -3513,9 +3444,8 @@ ir.cpp:
 #  619|     mu619_10(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r619_5
 #  620|     v620_1(void)           = NoOp                            : 
 #  615|     v615_5(void)           = ReturnVoid                      : 
-#  615|     v615_6(void)           = UnmodeledUse                    : mu*
-#  615|     v615_7(void)           = AliasedUse                      : ~mu615_4
-#  615|     v615_8(void)           = ExitFunction                    : 
+#  615|     v615_6(void)           = AliasedUse                      : ~mu615_4
+#  615|     v615_7(void)           = ExitFunction                    : 
 
 #  622| void CallMethods(String&, String*, String)
 #  622|   Block 0
@@ -3561,9 +3491,8 @@ ir.cpp:
 #  622|     v622_15(void)           = ReturnIndirection[r]            : &:r622_7, ~mu622_4
 #  622|     v622_16(void)           = ReturnIndirection[p]            : &:r622_11, ~mu622_4
 #  622|     v622_17(void)           = ReturnVoid                      : 
-#  622|     v622_18(void)           = UnmodeledUse                    : mu*
-#  622|     v622_19(void)           = AliasedUse                      : ~mu622_4
-#  622|     v622_20(void)           = ExitFunction                    : 
+#  622|     v622_18(void)           = AliasedUse                      : ~mu622_4
+#  622|     v622_19(void)           = ExitFunction                    : 
 
 #  628| void C::~C()
 #  628|   Block 0
@@ -3582,9 +3511,8 @@ ir.cpp:
 #  628|     v628_12(void)           = Call                     : func:r628_11, this:r628_10
 #  628|     mu628_13(unknown)       = ^CallSideEffect          : ~mu628_4
 #  628|     v628_14(void)           = ReturnVoid               : 
-#  628|     v628_15(void)           = UnmodeledUse             : mu*
-#  628|     v628_16(void)           = AliasedUse               : ~mu628_4
-#  628|     v628_17(void)           = ExitFunction             : 
+#  628|     v628_15(void)           = AliasedUse               : ~mu628_4
+#  628|     v628_16(void)           = ExitFunction             : 
 
 #  630| int C::StaticMemberFunction(int)
 #  630|   Block 0
@@ -3600,9 +3528,8 @@ ir.cpp:
 #  631|     mu631_4(int)       = Store                    : &:r631_1, r631_3
 #  630|     r630_7(glval<int>) = VariableAddress[#return] : 
 #  630|     v630_8(void)       = ReturnValue              : &:r630_7, ~mu630_4
-#  630|     v630_9(void)       = UnmodeledUse             : mu*
-#  630|     v630_10(void)      = AliasedUse               : ~mu630_4
-#  630|     v630_11(void)      = ExitFunction             : 
+#  630|     v630_9(void)       = AliasedUse               : ~mu630_4
+#  630|     v630_10(void)      = ExitFunction             : 
 
 #  634| int C::InstanceMemberFunction(int)
 #  634|   Block 0
@@ -3619,9 +3546,8 @@ ir.cpp:
 #  635|     mu635_4(int)       = Store                    : &:r635_1, r635_3
 #  634|     r634_8(glval<int>) = VariableAddress[#return] : 
 #  634|     v634_9(void)       = ReturnValue              : &:r634_8, ~mu634_4
-#  634|     v634_10(void)      = UnmodeledUse             : mu*
-#  634|     v634_11(void)      = AliasedUse               : ~mu634_4
-#  634|     v634_12(void)      = ExitFunction             : 
+#  634|     v634_10(void)      = AliasedUse               : ~mu634_4
+#  634|     v634_11(void)      = ExitFunction             : 
 
 #  638| int C::VirtualMemberFunction(int)
 #  638|   Block 0
@@ -3638,9 +3564,8 @@ ir.cpp:
 #  639|     mu639_4(int)       = Store                    : &:r639_1, r639_3
 #  638|     r638_8(glval<int>) = VariableAddress[#return] : 
 #  638|     v638_9(void)       = ReturnValue              : &:r638_8, ~mu638_4
-#  638|     v638_10(void)      = UnmodeledUse             : mu*
-#  638|     v638_11(void)      = AliasedUse               : ~mu638_4
-#  638|     v638_12(void)      = ExitFunction             : 
+#  638|     v638_10(void)      = AliasedUse               : ~mu638_4
+#  638|     v638_11(void)      = ExitFunction             : 
 
 #  642| void C::FieldAccess()
 #  642|   Block 0
@@ -3682,9 +3607,8 @@ ir.cpp:
 #  649|     mu649_4(int)       = Store               : &:r649_3, r649_2
 #  650|     v650_1(void)       = NoOp                : 
 #  642|     v642_6(void)       = ReturnVoid          : 
-#  642|     v642_7(void)       = UnmodeledUse        : mu*
-#  642|     v642_8(void)       = AliasedUse          : ~mu642_4
-#  642|     v642_9(void)       = ExitFunction        : 
+#  642|     v642_7(void)       = AliasedUse          : ~mu642_4
+#  642|     v642_8(void)       = ExitFunction        : 
 
 #  652| void C::MethodCalls()
 #  652|   Block 0
@@ -3717,9 +3641,8 @@ ir.cpp:
 #-----|     mu0_3(C)               = ^IndirectMayWriteSideEffect[-1]         : &:r0_1
 #  656|     v656_1(void)           = NoOp                                    : 
 #  652|     v652_6(void)           = ReturnVoid                              : 
-#  652|     v652_7(void)           = UnmodeledUse                            : mu*
-#  652|     v652_8(void)           = AliasedUse                              : ~mu652_4
-#  652|     v652_9(void)           = ExitFunction                            : 
+#  652|     v652_7(void)           = AliasedUse                              : ~mu652_4
+#  652|     v652_8(void)           = ExitFunction                            : 
 
 #  658| void C::C()
 #  658|   Block 0
@@ -3753,9 +3676,8 @@ ir.cpp:
 #  662|     mu662_9(unknown)       = ^BufferMayWriteSideEffect[0]    : &:r662_4
 #  664|     v664_1(void)           = NoOp                            : 
 #  658|     v658_6(void)           = ReturnVoid                      : 
-#  658|     v658_7(void)           = UnmodeledUse                    : mu*
-#  658|     v658_8(void)           = AliasedUse                      : ~mu658_4
-#  658|     v658_9(void)           = ExitFunction                    : 
+#  658|     v658_7(void)           = AliasedUse                      : ~mu658_4
+#  658|     v658_8(void)           = ExitFunction                    : 
 
 #  675| int DerefReference(int&)
 #  675|   Block 0
@@ -3775,9 +3697,8 @@ ir.cpp:
 #  675|     v675_9(void)         = ReturnIndirection[r]     : &:r675_7, ~mu675_4
 #  675|     r675_10(glval<int>)  = VariableAddress[#return] : 
 #  675|     v675_11(void)        = ReturnValue              : &:r675_10, ~mu675_4
-#  675|     v675_12(void)        = UnmodeledUse             : mu*
-#  675|     v675_13(void)        = AliasedUse               : ~mu675_4
-#  675|     v675_14(void)        = ExitFunction             : 
+#  675|     v675_12(void)        = AliasedUse               : ~mu675_4
+#  675|     v675_13(void)        = ExitFunction             : 
 
 #  679| int& TakeReference()
 #  679|   Block 0
@@ -3791,9 +3712,8 @@ ir.cpp:
 #  680|     mu680_4(int &)       = Store                    : &:r680_1, r680_3
 #  679|     r679_5(glval<int &>) = VariableAddress[#return] : 
 #  679|     v679_6(void)         = ReturnValue              : &:r679_5, ~mu679_4
-#  679|     v679_7(void)         = UnmodeledUse             : mu*
-#  679|     v679_8(void)         = AliasedUse               : ~mu679_4
-#  679|     v679_9(void)         = ExitFunction             : 
+#  679|     v679_7(void)         = AliasedUse               : ~mu679_4
+#  679|     v679_8(void)         = ExitFunction             : 
 
 #  685| void InitReference(int)
 #  685|   Block 0
@@ -3823,9 +3743,8 @@ ir.cpp:
 #  688|     mu688_8(String &)       = Store                            : &:r688_1, r688_7
 #  689|     v689_1(void)            = NoOp                             : 
 #  685|     v685_7(void)            = ReturnVoid                       : 
-#  685|     v685_8(void)            = UnmodeledUse                     : mu*
-#  685|     v685_9(void)            = AliasedUse                       : ~mu685_4
-#  685|     v685_10(void)           = ExitFunction                     : 
+#  685|     v685_8(void)            = AliasedUse                       : ~mu685_4
+#  685|     v685_9(void)            = ExitFunction                     : 
 
 #  691| void ArrayReferences()
 #  691|   Block 0
@@ -3850,9 +3769,8 @@ ir.cpp:
 #  694|     mu694_9(int)              = Store               : &:r694_1, r694_8
 #  695|     v695_1(void)              = NoOp                : 
 #  691|     v691_5(void)              = ReturnVoid          : 
-#  691|     v691_6(void)              = UnmodeledUse        : mu*
-#  691|     v691_7(void)              = AliasedUse          : ~mu691_4
-#  691|     v691_8(void)              = ExitFunction        : 
+#  691|     v691_6(void)              = AliasedUse          : ~mu691_4
+#  691|     v691_7(void)              = ExitFunction        : 
 
 #  697| void FunctionReferences()
 #  697|   Block 0
@@ -3877,9 +3795,8 @@ ir.cpp:
 #  700|     mu700_6(unknown)         = ^CallSideEffect                : ~mu697_4
 #  701|     v701_1(void)             = NoOp                           : 
 #  697|     v697_5(void)             = ReturnVoid                     : 
-#  697|     v697_6(void)             = UnmodeledUse                   : mu*
-#  697|     v697_7(void)             = AliasedUse                     : ~mu697_4
-#  697|     v697_8(void)             = ExitFunction                   : 
+#  697|     v697_6(void)             = AliasedUse                     : ~mu697_4
+#  697|     v697_7(void)             = ExitFunction                   : 
 
 #  704| int min<int>(int, int)
 #  704|   Block 0
@@ -3921,9 +3838,8 @@ ir.cpp:
 #  705|     mu705_18(int)       = Store                        : &:r705_1, r705_17
 #  704|     r704_9(glval<int>)  = VariableAddress[#return]     : 
 #  704|     v704_10(void)       = ReturnValue                  : &:r704_9, ~mu704_4
-#  704|     v704_11(void)       = UnmodeledUse                 : mu*
-#  704|     v704_12(void)       = AliasedUse                   : ~mu704_4
-#  704|     v704_13(void)       = ExitFunction                 : 
+#  704|     v704_11(void)       = AliasedUse                   : ~mu704_4
+#  704|     v704_12(void)       = ExitFunction                 : 
 
 #  708| int CallMin(int, int)
 #  708|   Block 0
@@ -3946,9 +3862,8 @@ ir.cpp:
 #  709|     mu709_9(int)           = Store                    : &:r709_1, r709_7
 #  708|     r708_9(glval<int>)     = VariableAddress[#return] : 
 #  708|     v708_10(void)          = ReturnValue              : &:r708_9, ~mu708_4
-#  708|     v708_11(void)          = UnmodeledUse             : mu*
-#  708|     v708_12(void)          = AliasedUse               : ~mu708_4
-#  708|     v708_13(void)          = ExitFunction             : 
+#  708|     v708_11(void)          = AliasedUse               : ~mu708_4
+#  708|     v708_12(void)          = ExitFunction             : 
 
 #  715| long Outer<long>::Func<void*, char>(void*, char)
 #  715|   Block 0
@@ -3968,9 +3883,8 @@ ir.cpp:
 #  715|     v715_11(void)         = ReturnIndirection[x]     : &:r715_7, ~mu715_4
 #  715|     r715_12(glval<long>)  = VariableAddress[#return] : 
 #  715|     v715_13(void)         = ReturnValue              : &:r715_12, ~mu715_4
-#  715|     v715_14(void)         = UnmodeledUse             : mu*
-#  715|     v715_15(void)         = AliasedUse               : ~mu715_4
-#  715|     v715_16(void)         = ExitFunction             : 
+#  715|     v715_14(void)         = AliasedUse               : ~mu715_4
+#  715|     v715_15(void)         = ExitFunction             : 
 
 #  720| double CallNestedTemplateFunc()
 #  720|   Block 0
@@ -3990,9 +3904,8 @@ ir.cpp:
 #  721|     mu721_10(double)       = Store                        : &:r721_1, r721_9
 #  720|     r720_5(glval<double>)  = VariableAddress[#return]     : 
 #  720|     v720_6(void)           = ReturnValue                  : &:r720_5, ~mu720_4
-#  720|     v720_7(void)           = UnmodeledUse                 : mu*
-#  720|     v720_8(void)           = AliasedUse                   : ~mu720_4
-#  720|     v720_9(void)           = ExitFunction                 : 
+#  720|     v720_7(void)           = AliasedUse                   : ~mu720_4
+#  720|     v720_8(void)           = ExitFunction                 : 
 
 #  724| void TryCatch(bool)
 #  724|   Block 0
@@ -4012,12 +3925,11 @@ ir.cpp:
 #-----|   True -> Block 3
 
 #  724|   Block 1
-#  724|     v724_7(void) = UnmodeledUse : mu*
-#  724|     v724_8(void) = AliasedUse   : ~mu724_4
-#  724|     v724_9(void) = ExitFunction : 
+#  724|     v724_7(void) = AliasedUse   : ~mu724_4
+#  724|     v724_8(void) = ExitFunction : 
 
 #  724|   Block 2
-#  724|     v724_10(void) = Unwind : 
+#  724|     v724_9(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #  728|   Block 3
@@ -4117,7 +4029,7 @@ ir.cpp:
 
 #  743|   Block 14
 #  743|     v743_1(void)  = NoOp       : 
-#  724|     v724_11(void) = ReturnVoid : 
+#  724|     v724_10(void) = ReturnVoid : 
 #-----|   Goto -> Block 1
 
 #  745| Base& Base::operator=(Base const&)
@@ -4155,9 +4067,8 @@ ir.cpp:
 #-----|     v0_23(void)            = ReturnIndirection[p#0]          : &:r0_3, ~mu745_4
 #  745|     r745_9(glval<Base &>)  = VariableAddress[#return]        : 
 #  745|     v745_10(void)          = ReturnValue                     : &:r745_9, ~mu745_4
-#  745|     v745_11(void)          = UnmodeledUse                    : mu*
-#  745|     v745_12(void)          = AliasedUse                      : ~mu745_4
-#  745|     v745_13(void)          = ExitFunction                    : 
+#  745|     v745_11(void)          = AliasedUse                      : ~mu745_4
+#  745|     v745_12(void)          = ExitFunction                    : 
 
 #  745| void Base::Base(Base const&)
 #  745|   Block 0
@@ -4178,9 +4089,8 @@ ir.cpp:
 #  745|     v745_11(void)          = NoOp                            : 
 #-----|     v0_5(void)             = ReturnIndirection[p#0]          : &:r0_3, ~mu745_4
 #  745|     v745_12(void)          = ReturnVoid                      : 
-#  745|     v745_13(void)          = UnmodeledUse                    : mu*
-#  745|     v745_14(void)          = AliasedUse                      : ~mu745_4
-#  745|     v745_15(void)          = ExitFunction                    : 
+#  745|     v745_13(void)          = AliasedUse                      : ~mu745_4
+#  745|     v745_14(void)          = ExitFunction                    : 
 
 #  748| void Base::Base()
 #  748|   Block 0
@@ -4196,9 +4106,8 @@ ir.cpp:
 #  748|     mu748_10(String)       = ^IndirectMayWriteSideEffect[-1] : &:r748_6
 #  749|     v749_1(void)           = NoOp                            : 
 #  748|     v748_11(void)          = ReturnVoid                      : 
-#  748|     v748_12(void)          = UnmodeledUse                    : mu*
-#  748|     v748_13(void)          = AliasedUse                      : ~mu748_4
-#  748|     v748_14(void)          = ExitFunction                    : 
+#  748|     v748_12(void)          = AliasedUse                      : ~mu748_4
+#  748|     v748_13(void)          = ExitFunction                    : 
 
 #  750| void Base::~Base()
 #  750|   Block 0
@@ -4213,9 +4122,8 @@ ir.cpp:
 #  751|     v751_4(void)           = Call                     : func:r751_3, this:r751_2
 #  751|     mu751_5(unknown)       = ^CallSideEffect          : ~mu750_4
 #  750|     v750_6(void)           = ReturnVoid               : 
-#  750|     v750_7(void)           = UnmodeledUse             : mu*
-#  750|     v750_8(void)           = AliasedUse               : ~mu750_4
-#  750|     v750_9(void)           = ExitFunction             : 
+#  750|     v750_7(void)           = AliasedUse               : ~mu750_4
+#  750|     v750_8(void)           = ExitFunction             : 
 
 #  754| Middle& Middle::operator=(Middle const&)
 #  754|   Block 0
@@ -4269,9 +4177,8 @@ ir.cpp:
 #-----|     v0_37(void)              = ReturnIndirection[p#0]                 : &:r0_3, ~mu754_4
 #  754|     r754_12(glval<Middle &>) = VariableAddress[#return]               : 
 #  754|     v754_13(void)            = ReturnValue                            : &:r754_12, ~mu754_4
-#  754|     v754_14(void)            = UnmodeledUse                           : mu*
-#  754|     v754_15(void)            = AliasedUse                             : ~mu754_4
-#  754|     v754_16(void)            = ExitFunction                           : 
+#  754|     v754_14(void)            = AliasedUse                             : ~mu754_4
+#  754|     v754_15(void)            = ExitFunction                           : 
 
 #  757| void Middle::Middle()
 #  757|   Block 0
@@ -4292,9 +4199,8 @@ ir.cpp:
 #  757|     mu757_15(String)        = ^IndirectMayWriteSideEffect[-1]        : &:r757_11
 #  758|     v758_1(void)            = NoOp                                   : 
 #  757|     v757_16(void)           = ReturnVoid                             : 
-#  757|     v757_17(void)           = UnmodeledUse                           : mu*
-#  757|     v757_18(void)           = AliasedUse                             : ~mu757_4
-#  757|     v757_19(void)           = ExitFunction                           : 
+#  757|     v757_17(void)           = AliasedUse                             : ~mu757_4
+#  757|     v757_18(void)           = ExitFunction                           : 
 
 #  759| void Middle::~Middle()
 #  759|   Block 0
@@ -4313,9 +4219,8 @@ ir.cpp:
 #  760|     v760_8(void)           = Call                                   : func:r760_7, this:r760_6
 #  760|     mu760_9(unknown)       = ^CallSideEffect                        : ~mu759_4
 #  759|     v759_6(void)           = ReturnVoid                             : 
-#  759|     v759_7(void)           = UnmodeledUse                           : mu*
-#  759|     v759_8(void)           = AliasedUse                             : ~mu759_4
-#  759|     v759_9(void)           = ExitFunction                           : 
+#  759|     v759_7(void)           = AliasedUse                             : ~mu759_4
+#  759|     v759_8(void)           = ExitFunction                           : 
 
 #  763| Derived& Derived::operator=(Derived const&)
 #  763|   Block 0
@@ -4369,9 +4274,8 @@ ir.cpp:
 #-----|     v0_37(void)               = ReturnIndirection[p#0]                    : &:r0_3, ~mu763_4
 #  763|     r763_12(glval<Derived &>) = VariableAddress[#return]                  : 
 #  763|     v763_13(void)             = ReturnValue                               : &:r763_12, ~mu763_4
-#  763|     v763_14(void)             = UnmodeledUse                              : mu*
-#  763|     v763_15(void)             = AliasedUse                                : ~mu763_4
-#  763|     v763_16(void)             = ExitFunction                              : 
+#  763|     v763_14(void)             = AliasedUse                                : ~mu763_4
+#  763|     v763_15(void)             = ExitFunction                              : 
 
 #  766| void Derived::Derived()
 #  766|   Block 0
@@ -4392,9 +4296,8 @@ ir.cpp:
 #  766|     mu766_15(String)        = ^IndirectMayWriteSideEffect[-1]           : &:r766_11
 #  767|     v767_1(void)            = NoOp                                      : 
 #  766|     v766_16(void)           = ReturnVoid                                : 
-#  766|     v766_17(void)           = UnmodeledUse                              : mu*
-#  766|     v766_18(void)           = AliasedUse                                : ~mu766_4
-#  766|     v766_19(void)           = ExitFunction                              : 
+#  766|     v766_17(void)           = AliasedUse                                : ~mu766_4
+#  766|     v766_18(void)           = ExitFunction                              : 
 
 #  768| void Derived::~Derived()
 #  768|   Block 0
@@ -4413,9 +4316,8 @@ ir.cpp:
 #  769|     v769_8(void)           = Call                                      : func:r769_7, this:r769_6
 #  769|     mu769_9(unknown)       = ^CallSideEffect                           : ~mu768_4
 #  768|     v768_6(void)           = ReturnVoid                                : 
-#  768|     v768_7(void)           = UnmodeledUse                              : mu*
-#  768|     v768_8(void)           = AliasedUse                                : ~mu768_4
-#  768|     v768_9(void)           = ExitFunction                              : 
+#  768|     v768_7(void)           = AliasedUse                                : ~mu768_4
+#  768|     v768_8(void)           = ExitFunction                              : 
 
 #  775| void MiddleVB1::MiddleVB1()
 #  775|   Block 0
@@ -4436,9 +4338,8 @@ ir.cpp:
 #  775|     mu775_15(String)         = ^IndirectMayWriteSideEffect[-1]           : &:r775_11
 #  776|     v776_1(void)             = NoOp                                      : 
 #  775|     v775_16(void)            = ReturnVoid                                : 
-#  775|     v775_17(void)            = UnmodeledUse                              : mu*
-#  775|     v775_18(void)            = AliasedUse                                : ~mu775_4
-#  775|     v775_19(void)            = ExitFunction                              : 
+#  775|     v775_17(void)            = AliasedUse                                : ~mu775_4
+#  775|     v775_18(void)            = ExitFunction                              : 
 
 #  777| void MiddleVB1::~MiddleVB1()
 #  777|   Block 0
@@ -4457,9 +4358,8 @@ ir.cpp:
 #  778|     v778_8(void)             = Call                                      : func:r778_7, this:r778_6
 #  778|     mu778_9(unknown)         = ^CallSideEffect                           : ~mu777_4
 #  777|     v777_6(void)             = ReturnVoid                                : 
-#  777|     v777_7(void)             = UnmodeledUse                              : mu*
-#  777|     v777_8(void)             = AliasedUse                                : ~mu777_4
-#  777|     v777_9(void)             = ExitFunction                              : 
+#  777|     v777_7(void)             = AliasedUse                                : ~mu777_4
+#  777|     v777_8(void)             = ExitFunction                              : 
 
 #  784| void MiddleVB2::MiddleVB2()
 #  784|   Block 0
@@ -4480,9 +4380,8 @@ ir.cpp:
 #  784|     mu784_15(String)         = ^IndirectMayWriteSideEffect[-1]           : &:r784_11
 #  785|     v785_1(void)             = NoOp                                      : 
 #  784|     v784_16(void)            = ReturnVoid                                : 
-#  784|     v784_17(void)            = UnmodeledUse                              : mu*
-#  784|     v784_18(void)            = AliasedUse                                : ~mu784_4
-#  784|     v784_19(void)            = ExitFunction                              : 
+#  784|     v784_17(void)            = AliasedUse                                : ~mu784_4
+#  784|     v784_18(void)            = ExitFunction                              : 
 
 #  786| void MiddleVB2::~MiddleVB2()
 #  786|   Block 0
@@ -4501,9 +4400,8 @@ ir.cpp:
 #  787|     v787_8(void)             = Call                                      : func:r787_7, this:r787_6
 #  787|     mu787_9(unknown)         = ^CallSideEffect                           : ~mu786_4
 #  786|     v786_6(void)             = ReturnVoid                                : 
-#  786|     v786_7(void)             = UnmodeledUse                              : mu*
-#  786|     v786_8(void)             = AliasedUse                                : ~mu786_4
-#  786|     v786_9(void)             = ExitFunction                              : 
+#  786|     v786_7(void)             = AliasedUse                                : ~mu786_4
+#  786|     v786_8(void)             = ExitFunction                              : 
 
 #  793| void DerivedVB::DerivedVB()
 #  793|   Block 0
@@ -4534,9 +4432,8 @@ ir.cpp:
 #  793|     mu793_25(String)          = ^IndirectMayWriteSideEffect[-1]                : &:r793_21
 #  794|     v794_1(void)              = NoOp                                           : 
 #  793|     v793_26(void)             = ReturnVoid                                     : 
-#  793|     v793_27(void)             = UnmodeledUse                                   : mu*
-#  793|     v793_28(void)             = AliasedUse                                     : ~mu793_4
-#  793|     v793_29(void)             = ExitFunction                                   : 
+#  793|     v793_27(void)             = AliasedUse                                     : ~mu793_4
+#  793|     v793_28(void)             = ExitFunction                                   : 
 
 #  795| void DerivedVB::~DerivedVB()
 #  795|   Block 0
@@ -4563,9 +4460,8 @@ ir.cpp:
 #  796|     v796_16(void)             = Call                                           : func:r796_15, this:r796_14
 #  796|     mu796_17(unknown)         = ^CallSideEffect                                : ~mu795_4
 #  795|     v795_6(void)              = ReturnVoid                                     : 
-#  795|     v795_7(void)              = UnmodeledUse                                   : mu*
-#  795|     v795_8(void)              = AliasedUse                                     : ~mu795_4
-#  795|     v795_9(void)              = ExitFunction                                   : 
+#  795|     v795_7(void)              = AliasedUse                                     : ~mu795_4
+#  795|     v795_8(void)              = ExitFunction                                   : 
 
 #  799| void HierarchyConversions()
 #  799|   Block 0
@@ -4857,9 +4753,8 @@ ir.cpp:
 #  839|     mu839_5(Base *)            = Store                                     : &:r839_4, r839_3
 #  840|     v840_1(void)               = NoOp                                      : 
 #  799|     v799_5(void)               = ReturnVoid                                : 
-#  799|     v799_6(void)               = UnmodeledUse                              : mu*
-#  799|     v799_7(void)               = AliasedUse                                : ~mu799_4
-#  799|     v799_8(void)               = ExitFunction                              : 
+#  799|     v799_6(void)               = AliasedUse                                : ~mu799_4
+#  799|     v799_7(void)               = ExitFunction                              : 
 
 #  842| void PolymorphicBase::PolymorphicBase()
 #  842|   Block 0
@@ -4870,9 +4765,8 @@ ir.cpp:
 #  842|     r842_5(glval<PolymorphicBase>) = InitializeThis      : 
 #  842|     v842_6(void)                   = NoOp                : 
 #  842|     v842_7(void)                   = ReturnVoid          : 
-#  842|     v842_8(void)                   = UnmodeledUse        : mu*
-#  842|     v842_9(void)                   = AliasedUse          : ~mu842_4
-#  842|     v842_10(void)                  = ExitFunction        : 
+#  842|     v842_8(void)                   = AliasedUse          : ~mu842_4
+#  842|     v842_9(void)                   = ExitFunction        : 
 
 #  846| void PolymorphicDerived::PolymorphicDerived()
 #  846|   Block 0
@@ -4888,9 +4782,8 @@ ir.cpp:
 #  846|     mu846_10(PolymorphicBase)         = ^IndirectMayWriteSideEffect[-1]                               : &:r846_6
 #  846|     v846_11(void)                     = NoOp                                                          : 
 #  846|     v846_12(void)                     = ReturnVoid                                                    : 
-#  846|     v846_13(void)                     = UnmodeledUse                                                  : mu*
-#  846|     v846_14(void)                     = AliasedUse                                                    : ~mu846_4
-#  846|     v846_15(void)                     = ExitFunction                                                  : 
+#  846|     v846_13(void)                     = AliasedUse                                                    : ~mu846_4
+#  846|     v846_14(void)                     = ExitFunction                                                  : 
 
 #  846| void PolymorphicDerived::~PolymorphicDerived()
 #  846|   Block 0
@@ -4905,9 +4798,8 @@ ir.cpp:
 #  846|     v846_8(void)                      = Call                                                          : func:r846_7, this:r846_6
 #  846|     mu846_9(unknown)                  = ^CallSideEffect                                               : ~mu846_4
 #  846|     v846_10(void)                     = ReturnVoid                                                    : 
-#  846|     v846_11(void)                     = UnmodeledUse                                                  : mu*
-#  846|     v846_12(void)                     = AliasedUse                                                    : ~mu846_4
-#  846|     v846_13(void)                     = ExitFunction                                                  : 
+#  846|     v846_11(void)                     = AliasedUse                                                    : ~mu846_4
+#  846|     v846_12(void)                     = ExitFunction                                                  : 
 
 #  849| void DynamicCast()
 #  849|   Block 0
@@ -4967,9 +4859,8 @@ ir.cpp:
 #  864|     mu864_5(void *)                     = Store                               : &:r864_1, r864_4
 #  865|     v865_1(void)                        = NoOp                                : 
 #  849|     v849_5(void)                        = ReturnVoid                          : 
-#  849|     v849_6(void)                        = UnmodeledUse                        : mu*
-#  849|     v849_7(void)                        = AliasedUse                          : ~mu849_4
-#  849|     v849_8(void)                        = ExitFunction                        : 
+#  849|     v849_6(void)                        = AliasedUse                          : ~mu849_4
+#  849|     v849_7(void)                        = ExitFunction                        : 
 
 #  867| void String::String()
 #  867|   Block 0
@@ -4988,9 +4879,8 @@ ir.cpp:
 #  868|     mu868_8(unknown)       = ^BufferMayWriteSideEffect[0]    : &:r868_3
 #  869|     v869_1(void)           = NoOp                            : 
 #  867|     v867_6(void)           = ReturnVoid                      : 
-#  867|     v867_7(void)           = UnmodeledUse                    : mu*
-#  867|     v867_8(void)           = AliasedUse                      : ~mu867_4
-#  867|     v867_9(void)           = ExitFunction                    : 
+#  867|     v867_7(void)           = AliasedUse                      : ~mu867_4
+#  867|     v867_8(void)           = ExitFunction                    : 
 
 #  871| void ArrayConversions()
 #  871|   Block 0
@@ -5043,9 +4933,8 @@ ir.cpp:
 #  880|     mu880_4(char(*)[5])       = Store                  : &:r880_3, r880_2
 #  881|     v881_1(void)              = NoOp                   : 
 #  871|     v871_5(void)              = ReturnVoid             : 
-#  871|     v871_6(void)              = UnmodeledUse           : mu*
-#  871|     v871_7(void)              = AliasedUse             : ~mu871_4
-#  871|     v871_8(void)              = ExitFunction           : 
+#  871|     v871_6(void)              = AliasedUse             : ~mu871_4
+#  871|     v871_7(void)              = ExitFunction           : 
 
 #  883| void FuncPtrConversions(int(*)(int), void*)
 #  883|   Block 0
@@ -5072,9 +4961,8 @@ ir.cpp:
 #  886|     v886_1(void)             = NoOp                     : 
 #  883|     v883_11(void)            = ReturnIndirection[p]     : &:r883_9, ~mu883_4
 #  883|     v883_12(void)            = ReturnVoid               : 
-#  883|     v883_13(void)            = UnmodeledUse             : mu*
-#  883|     v883_14(void)            = AliasedUse               : ~mu883_4
-#  883|     v883_15(void)            = ExitFunction             : 
+#  883|     v883_13(void)            = AliasedUse               : ~mu883_4
+#  883|     v883_14(void)            = ExitFunction             : 
 
 #  888| void VAListUsage(int, __va_list_tag[1])
 #  888|   Block 0
@@ -5121,9 +5009,8 @@ ir.cpp:
 #  894|     v894_1(void)                    = NoOp                        : 
 #  888|     v888_11(void)                   = ReturnIndirection[args]     : &:r888_9, ~mu888_4
 #  888|     v888_12(void)                   = ReturnVoid                  : 
-#  888|     v888_13(void)                   = UnmodeledUse                : mu*
-#  888|     v888_14(void)                   = AliasedUse                  : ~mu888_4
-#  888|     v888_15(void)                   = ExitFunction                : 
+#  888|     v888_13(void)                   = AliasedUse                  : ~mu888_4
+#  888|     v888_14(void)                   = ExitFunction                : 
 
 #  896| void VarArgUsage(int)
 #  896|   Block 0
@@ -5188,9 +5075,8 @@ ir.cpp:
 #  906|     v906_3(void)                    = VarArgsEnd                       : r906_2
 #  907|     v907_1(void)                    = NoOp                             : 
 #  896|     v896_11(void)                   = ReturnVoid                       : 
-#  896|     v896_12(void)                   = UnmodeledUse                     : mu*
-#  896|     v896_13(void)                   = AliasedUse                       : ~mu896_4
-#  896|     v896_14(void)                   = ExitFunction                     : 
+#  896|     v896_12(void)                   = AliasedUse                       : ~mu896_4
+#  896|     v896_13(void)                   = ExitFunction                     : 
 
 #  909| void CastToVoid(int)
 #  909|   Block 0
@@ -5204,9 +5090,8 @@ ir.cpp:
 #  910|     v910_2(void)       = Convert                : r910_1
 #  911|     v911_1(void)       = NoOp                   : 
 #  909|     v909_7(void)       = ReturnVoid             : 
-#  909|     v909_8(void)       = UnmodeledUse           : mu*
-#  909|     v909_9(void)       = AliasedUse             : ~mu909_4
-#  909|     v909_10(void)      = ExitFunction           : 
+#  909|     v909_8(void)       = AliasedUse             : ~mu909_4
+#  909|     v909_9(void)       = ExitFunction           : 
 
 #  913| void ConstantConditions(int)
 #  913|   Block 0
@@ -5231,9 +5116,8 @@ ir.cpp:
 #  915|     mu915_6(int)       = Store                        : &:r915_1, r915_5
 #  916|     v916_1(void)       = NoOp                         : 
 #  913|     v913_7(void)       = ReturnVoid                   : 
-#  913|     v913_8(void)       = UnmodeledUse                 : mu*
-#  913|     v913_9(void)       = AliasedUse                   : ~mu913_4
-#  913|     v913_10(void)      = ExitFunction                 : 
+#  913|     v913_8(void)       = AliasedUse                   : ~mu913_4
+#  913|     v913_9(void)       = ExitFunction                 : 
 
 #  915|   Block 2
 #  915|     r915_7(glval<int>) = VariableAddress[x]           : 
@@ -5320,9 +5204,8 @@ ir.cpp:
 #  956|     mu956_10(Overaligned)  = Store                           : &:r956_8, r956_9
 #  957|     v957_1(void)           = NoOp                            : 
 #  949|     v949_5(void)           = ReturnVoid                      : 
-#  949|     v949_6(void)           = UnmodeledUse                    : mu*
-#  949|     v949_7(void)           = AliasedUse                      : ~mu949_4
-#  949|     v949_8(void)           = ExitFunction                    : 
+#  949|     v949_6(void)           = AliasedUse                      : ~mu949_4
+#  949|     v949_7(void)           = ExitFunction                    : 
 
 #  959| void OperatorNewArray(int)
 #  959|   Block 0
@@ -5410,9 +5293,8 @@ ir.cpp:
 #  967|     r967_10(int *)                         = Convert                         : r967_7
 #  968|     v968_1(void)                           = NoOp                            : 
 #  959|     v959_7(void)                           = ReturnVoid                      : 
-#  959|     v959_8(void)                           = UnmodeledUse                    : mu*
-#  959|     v959_9(void)                           = AliasedUse                      : ~mu959_4
-#  959|     v959_10(void)                          = ExitFunction                    : 
+#  959|     v959_8(void)                           = AliasedUse                      : ~mu959_4
+#  959|     v959_9(void)                           = ExitFunction                    : 
 
 #  970| int designatedInit()
 #  970|   Block 0
@@ -5451,9 +5333,8 @@ ir.cpp:
 #  972|     mu972_7(int)             = Store                    : &:r972_1, r972_6
 #  970|     r970_5(glval<int>)       = VariableAddress[#return] : 
 #  970|     v970_6(void)             = ReturnValue              : &:r970_5, ~mu970_4
-#  970|     v970_7(void)             = UnmodeledUse             : mu*
-#  970|     v970_8(void)             = AliasedUse               : ~mu970_4
-#  970|     v970_9(void)             = ExitFunction             : 
+#  970|     v970_7(void)             = AliasedUse               : ~mu970_4
+#  970|     v970_8(void)             = ExitFunction             : 
 
 #  975| void IfStmtWithDeclaration(int, int)
 #  975|   Block 0
@@ -5533,9 +5414,8 @@ ir.cpp:
 #  985|   Block 6
 #  985|     v985_1(void)  = NoOp         : 
 #  975|     v975_9(void)  = ReturnVoid   : 
-#  975|     v975_10(void) = UnmodeledUse : mu*
-#  975|     v975_11(void) = AliasedUse   : ~mu975_4
-#  975|     v975_12(void) = ExitFunction : 
+#  975|     v975_10(void) = AliasedUse   : ~mu975_4
+#  975|     v975_11(void) = ExitFunction : 
 
 #  987| void WhileStmtWithDeclaration(int, int)
 #  987|   Block 0
@@ -5595,9 +5475,8 @@ ir.cpp:
 #  994|   Block 6
 #  994|     v994_1(void)  = NoOp         : 
 #  987|     v987_9(void)  = ReturnVoid   : 
-#  987|     v987_10(void) = UnmodeledUse : mu*
-#  987|     v987_11(void) = AliasedUse   : ~mu987_4
-#  987|     v987_12(void) = ExitFunction : 
+#  987|     v987_10(void) = AliasedUse   : ~mu987_4
+#  987|     v987_11(void) = ExitFunction : 
 
 #  988|   Block 7
 #  988|     r988_2(glval<bool>) = VariableAddress[b] : 
@@ -5642,9 +5521,8 @@ ir.cpp:
 #  996|     v996_11(void)            = ReturnIndirection[a]     : &:r996_7, ~mu996_4
 #  996|     r996_12(glval<int>)      = VariableAddress[#return] : 
 #  996|     v996_13(void)            = ReturnValue              : &:r996_12, ~mu996_4
-#  996|     v996_14(void)            = UnmodeledUse             : mu*
-#  996|     v996_15(void)            = AliasedUse               : ~mu996_4
-#  996|     v996_16(void)            = ExitFunction             : 
+#  996|     v996_14(void)            = AliasedUse               : ~mu996_4
+#  996|     v996_15(void)            = ExitFunction             : 
 
 # 1000| int ExprStmt(int, int, int)
 # 1000|   Block 0
@@ -5695,9 +5573,8 @@ ir.cpp:
 # 1011|     mu1011_5(int)        = Store                    : &:r1011_1, r1011_4
 # 1000|     r1000_11(glval<int>) = VariableAddress[#return] : 
 # 1000|     v1000_12(void)       = ReturnValue              : &:r1000_11, ~mu1000_4
-# 1000|     v1000_13(void)       = UnmodeledUse             : mu*
-# 1000|     v1000_14(void)       = AliasedUse               : ~mu1000_4
-# 1000|     v1000_15(void)       = ExitFunction             : 
+# 1000|     v1000_13(void)       = AliasedUse               : ~mu1000_4
+# 1000|     v1000_14(void)       = ExitFunction             : 
 
 # 1015| void OperatorDelete()
 # 1015|   Block 0
@@ -5717,9 +5594,8 @@ ir.cpp:
 # 1020|     v1020_2(void)              = NoOp                : 
 # 1021|     v1021_1(void)              = NoOp                : 
 # 1015|     v1015_5(void)              = ReturnVoid          : 
-# 1015|     v1015_6(void)              = UnmodeledUse        : mu*
-# 1015|     v1015_7(void)              = AliasedUse          : ~mu1015_4
-# 1015|     v1015_8(void)              = ExitFunction        : 
+# 1015|     v1015_6(void)              = AliasedUse          : ~mu1015_4
+# 1015|     v1015_7(void)              = ExitFunction        : 
 
 # 1024| void OperatorDeleteArray()
 # 1024|   Block 0
@@ -5739,9 +5615,8 @@ ir.cpp:
 # 1029|     v1029_2(void)              = NoOp                : 
 # 1030|     v1030_1(void)              = NoOp                : 
 # 1024|     v1024_5(void)              = ReturnVoid          : 
-# 1024|     v1024_6(void)              = UnmodeledUse        : mu*
-# 1024|     v1024_7(void)              = AliasedUse          : ~mu1024_4
-# 1024|     v1024_8(void)              = ExitFunction        : 
+# 1024|     v1024_6(void)              = AliasedUse          : ~mu1024_4
+# 1024|     v1024_7(void)              = ExitFunction        : 
 
 # 1034| void EmptyStructInit()
 # 1034|   Block 0
@@ -5753,9 +5628,8 @@ ir.cpp:
 # 1035|     mu1035_2(EmptyStruct)       = Uninitialized[s]    : &:r1035_1
 # 1036|     v1036_1(void)               = NoOp                : 
 # 1034|     v1034_5(void)               = ReturnVoid          : 
-# 1034|     v1034_6(void)               = UnmodeledUse        : mu*
-# 1034|     v1034_7(void)               = AliasedUse          : ~mu1034_4
-# 1034|     v1034_8(void)               = ExitFunction        : 
+# 1034|     v1034_6(void)               = AliasedUse          : ~mu1034_4
+# 1034|     v1034_7(void)               = ExitFunction        : 
 
 # 1038| void (lambda [] type at line 1038, col. 12)::operator()() const
 # 1038|   Block 0
@@ -5766,9 +5640,8 @@ ir.cpp:
 # 1038|     r1038_5(glval<decltype([...](...){...})>) = InitializeThis      : 
 # 1038|     v1038_6(void)                             = NoOp                : 
 # 1038|     v1038_7(void)                             = ReturnVoid          : 
-# 1038|     v1038_8(void)                             = UnmodeledUse        : mu*
-# 1038|     v1038_9(void)                             = AliasedUse          : ~mu1038_4
-# 1038|     v1038_10(void)                            = ExitFunction        : 
+# 1038|     v1038_8(void)                             = AliasedUse          : ~mu1038_4
+# 1038|     v1038_9(void)                             = ExitFunction        : 
 
 # 1038| void(* (lambda [] type at line 1038, col. 12)::operator void (*)()() const)()
 # 1038|   Block 0
@@ -5782,9 +5655,8 @@ ir.cpp:
 # 1038|     mu1038_8(..(*)(..))                       = Store                    : &:r1038_6, r1038_7
 # 1038|     r1038_9(glval<..(*)(..)>)                 = VariableAddress[#return] : 
 # 1038|     v1038_10(void)                            = ReturnValue              : &:r1038_9, ~mu1038_4
-# 1038|     v1038_11(void)                            = UnmodeledUse             : mu*
-# 1038|     v1038_12(void)                            = AliasedUse               : ~mu1038_4
-# 1038|     v1038_13(void)                            = ExitFunction             : 
+# 1038|     v1038_11(void)                            = AliasedUse               : ~mu1038_4
+# 1038|     v1038_12(void)                            = ExitFunction             : 
 
 # 1040| void Lambda(int, String const&)
 # 1040|   Block 0
@@ -5951,9 +5823,8 @@ ir.cpp:
 # 1056|     v1056_1(void)                             = NoOp                                   : 
 # 1040|     v1040_11(void)                            = ReturnIndirection[s]                   : &:r1040_9, ~mu1040_4
 # 1040|     v1040_12(void)                            = ReturnVoid                             : 
-# 1040|     v1040_13(void)                            = UnmodeledUse                           : mu*
-# 1040|     v1040_14(void)                            = AliasedUse                             : ~mu1040_4
-# 1040|     v1040_15(void)                            = ExitFunction                           : 
+# 1040|     v1040_13(void)                            = AliasedUse                             : ~mu1040_4
+# 1040|     v1040_14(void)                            = ExitFunction                           : 
 
 # 1041| char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator()(float) const
 # 1041|   Block 0
@@ -5969,9 +5840,8 @@ ir.cpp:
 # 1041|     mu1041_10(char)                           = Store                    : &:r1041_8, r1041_9
 # 1041|     r1041_11(glval<char>)                     = VariableAddress[#return] : 
 # 1041|     v1041_12(void)                            = ReturnValue              : &:r1041_11, ~mu1041_4
-# 1041|     v1041_13(void)                            = UnmodeledUse             : mu*
-# 1041|     v1041_14(void)                            = AliasedUse               : ~mu1041_4
-# 1041|     v1041_15(void)                            = ExitFunction             : 
+# 1041|     v1041_13(void)                            = AliasedUse               : ~mu1041_4
+# 1041|     v1041_14(void)                            = ExitFunction             : 
 
 # 1041| char(* (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator char (*)(float)() const)(float)
 # 1041|   Block 0
@@ -5985,9 +5855,8 @@ ir.cpp:
 # 1041|     mu1041_8(..(*)(..))                       = Store                    : &:r1041_6, r1041_7
 # 1041|     r1041_9(glval<..(*)(..)>)                 = VariableAddress[#return] : 
 # 1041|     v1041_10(void)                            = ReturnValue              : &:r1041_9, ~mu1041_4
-# 1041|     v1041_11(void)                            = UnmodeledUse             : mu*
-# 1041|     v1041_12(void)                            = AliasedUse               : ~mu1041_4
-# 1041|     v1041_13(void)                            = ExitFunction             : 
+# 1041|     v1041_11(void)                            = AliasedUse               : ~mu1041_4
+# 1041|     v1041_12(void)                            = ExitFunction             : 
 
 # 1043| char (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator()(float) const
 # 1043|   Block 0
@@ -6017,9 +5886,8 @@ ir.cpp:
 # 1043|     mu1043_18(char)                              = Store                           : &:r1043_8, r1043_17
 # 1043|     r1043_19(glval<char>)                        = VariableAddress[#return]        : 
 # 1043|     v1043_20(void)                               = ReturnValue                     : &:r1043_19, ~mu1043_4
-# 1043|     v1043_21(void)                               = UnmodeledUse                    : mu*
-# 1043|     v1043_22(void)                               = AliasedUse                      : ~mu1043_4
-# 1043|     v1043_23(void)                               = ExitFunction                    : 
+# 1043|     v1043_21(void)                               = AliasedUse                      : ~mu1043_4
+# 1043|     v1043_22(void)                               = ExitFunction                    : 
 
 # 1045| void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::~<unnamed>()
 # 1045|   Block 0
@@ -6034,9 +5902,8 @@ ir.cpp:
 # 1045|     v1045_8(void)                             = Call                     : func:r1045_7, this:r1045_6
 # 1045|     mu1045_9(unknown)                         = ^CallSideEffect          : ~mu1045_4
 # 1045|     v1045_10(void)                            = ReturnVoid               : 
-# 1045|     v1045_11(void)                            = UnmodeledUse             : mu*
-# 1045|     v1045_12(void)                            = AliasedUse               : ~mu1045_4
-# 1045|     v1045_13(void)                            = ExitFunction             : 
+# 1045|     v1045_11(void)                            = AliasedUse               : ~mu1045_4
+# 1045|     v1045_12(void)                            = ExitFunction             : 
 
 # 1045| char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator()(float) const
 # 1045|   Block 0
@@ -6063,9 +5930,8 @@ ir.cpp:
 # 1045|     mu1045_14(char)                              = Store                           : &:r1045_8, r1045_13
 # 1045|     r1045_15(glval<char>)                        = VariableAddress[#return]        : 
 # 1045|     v1045_16(void)                               = ReturnValue                     : &:r1045_15, ~mu1045_4
-# 1045|     v1045_17(void)                               = UnmodeledUse                    : mu*
-# 1045|     v1045_18(void)                               = AliasedUse                      : ~mu1045_4
-# 1045|     v1045_19(void)                               = ExitFunction                    : 
+# 1045|     v1045_17(void)                               = AliasedUse                      : ~mu1045_4
+# 1045|     v1045_18(void)                               = ExitFunction                    : 
 
 # 1047| char (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator()(float) const
 # 1047|   Block 0
@@ -6092,9 +5958,8 @@ ir.cpp:
 # 1047|     mu1047_18(char)                              = Store                           : &:r1047_8, r1047_17
 # 1047|     r1047_19(glval<char>)                        = VariableAddress[#return]        : 
 # 1047|     v1047_20(void)                               = ReturnValue                     : &:r1047_19, ~mu1047_4
-# 1047|     v1047_21(void)                               = UnmodeledUse                    : mu*
-# 1047|     v1047_22(void)                               = AliasedUse                      : ~mu1047_4
-# 1047|     v1047_23(void)                               = ExitFunction                    : 
+# 1047|     v1047_21(void)                               = AliasedUse                      : ~mu1047_4
+# 1047|     v1047_22(void)                               = ExitFunction                    : 
 
 # 1049| void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::~<unnamed>()
 # 1049|   Block 0
@@ -6109,9 +5974,8 @@ ir.cpp:
 # 1049|     v1049_8(void)                             = Call                     : func:r1049_7, this:r1049_6
 # 1049|     mu1049_9(unknown)                         = ^CallSideEffect          : ~mu1049_4
 # 1049|     v1049_10(void)                            = ReturnVoid               : 
-# 1049|     v1049_11(void)                            = UnmodeledUse             : mu*
-# 1049|     v1049_12(void)                            = AliasedUse               : ~mu1049_4
-# 1049|     v1049_13(void)                            = ExitFunction             : 
+# 1049|     v1049_11(void)                            = AliasedUse               : ~mu1049_4
+# 1049|     v1049_12(void)                            = ExitFunction             : 
 
 # 1049| char (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator()(float) const
 # 1049|   Block 0
@@ -6136,9 +6000,8 @@ ir.cpp:
 # 1049|     mu1049_15(char)                              = Store                           : &:r1049_8, r1049_14
 # 1049|     r1049_16(glval<char>)                        = VariableAddress[#return]        : 
 # 1049|     v1049_17(void)                               = ReturnValue                     : &:r1049_16, ~mu1049_4
-# 1049|     v1049_18(void)                               = UnmodeledUse                    : mu*
-# 1049|     v1049_19(void)                               = AliasedUse                      : ~mu1049_4
-# 1049|     v1049_20(void)                               = ExitFunction                    : 
+# 1049|     v1049_18(void)                               = AliasedUse                      : ~mu1049_4
+# 1049|     v1049_19(void)                               = ExitFunction                    : 
 
 # 1051| char (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator()(float) const
 # 1051|   Block 0
@@ -6167,9 +6030,8 @@ ir.cpp:
 # 1051|     mu1051_17(char)                              = Store                           : &:r1051_8, r1051_16
 # 1051|     r1051_18(glval<char>)                        = VariableAddress[#return]        : 
 # 1051|     v1051_19(void)                               = ReturnValue                     : &:r1051_18, ~mu1051_4
-# 1051|     v1051_20(void)                               = UnmodeledUse                    : mu*
-# 1051|     v1051_21(void)                               = AliasedUse                      : ~mu1051_4
-# 1051|     v1051_22(void)                               = ExitFunction                    : 
+# 1051|     v1051_20(void)                               = AliasedUse                      : ~mu1051_4
+# 1051|     v1051_21(void)                               = ExitFunction                    : 
 
 # 1054| char (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator()(float) const
 # 1054|   Block 0
@@ -6207,9 +6069,8 @@ ir.cpp:
 # 1054|     mu1054_24(char)                              = Store                           : &:r1054_8, r1054_23
 # 1054|     r1054_25(glval<char>)                        = VariableAddress[#return]        : 
 # 1054|     v1054_26(void)                               = ReturnValue                     : &:r1054_25, ~mu1054_4
-# 1054|     v1054_27(void)                               = UnmodeledUse                    : mu*
-# 1054|     v1054_28(void)                               = AliasedUse                      : ~mu1054_4
-# 1054|     v1054_29(void)                               = ExitFunction                    : 
+# 1054|     v1054_27(void)                               = AliasedUse                      : ~mu1054_4
+# 1054|     v1054_28(void)                               = ExitFunction                    : 
 
 # 1077| void RangeBasedFor(vector<int> const&)
 # 1077|   Block 0
@@ -6304,9 +6165,8 @@ ir.cpp:
 # 1089|     v1089_1(void)  = NoOp                 : 
 # 1077|     v1077_9(void)  = ReturnIndirection[v] : &:r1077_7, ~mu1077_4
 # 1077|     v1077_10(void) = ReturnVoid           : 
-# 1077|     v1077_11(void) = UnmodeledUse         : mu*
-# 1077|     v1077_12(void) = AliasedUse           : ~mu1077_4
-# 1077|     v1077_13(void) = ExitFunction         : 
+# 1077|     v1077_11(void) = AliasedUse           : ~mu1077_4
+# 1077|     v1077_12(void) = ExitFunction         : 
 
 #-----|   Block 6
 #-----|     r0_24(glval<iterator>)   = VariableAddress[(__begin)]      : 
@@ -6400,9 +6260,8 @@ ir.cpp:
 # 1110|     mu1110_4(int)       = Store                    : &:r1110_1, r1110_3
 # 1108|     r1108_7(glval<int>) = VariableAddress[#return] : 
 # 1108|     v1108_8(void)       = ReturnValue              : &:r1108_7, ~mu1108_4
-# 1108|     v1108_9(void)       = UnmodeledUse             : mu*
-# 1108|     v1108_10(void)      = AliasedUse               : ~mu1108_4
-# 1108|     v1108_11(void)      = ExitFunction             : 
+# 1108|     v1108_9(void)       = AliasedUse               : ~mu1108_4
+# 1108|     v1108_10(void)      = ExitFunction             : 
 
 # 1113| void AsmStmtWithOutputs(unsigned int&, unsigned int, unsigned int&, unsigned int)
 # 1113|   Block 0
@@ -6436,9 +6295,8 @@ ir.cpp:
 # 1113|     v1113_17(void)                  = ReturnIndirection[a]     : &:r1113_7, ~mu1113_4
 # 1113|     v1113_18(void)                  = ReturnIndirection[c]     : &:r1113_13, ~mu1113_4
 # 1113|     v1113_19(void)                  = ReturnVoid               : 
-# 1113|     v1113_20(void)                  = UnmodeledUse             : mu*
-# 1113|     v1113_21(void)                  = AliasedUse               : ~mu1113_4
-# 1113|     v1113_22(void)                  = ExitFunction             : 
+# 1113|     v1113_20(void)                  = AliasedUse               : ~mu1113_4
+# 1113|     v1113_21(void)                  = ExitFunction             : 
 
 # 1122| void ExternDeclarations()
 # 1122|   Block 0
@@ -6454,9 +6312,8 @@ ir.cpp:
 # 1127|     mu1127_2(int)       = Uninitialized[h]    : &:r1127_1
 # 1129|     v1129_1(void)       = NoOp                : 
 # 1122|     v1122_5(void)       = ReturnVoid          : 
-# 1122|     v1122_6(void)       = UnmodeledUse        : mu*
-# 1122|     v1122_7(void)       = AliasedUse          : ~mu1122_4
-# 1122|     v1122_8(void)       = ExitFunction        : 
+# 1122|     v1122_6(void)       = AliasedUse          : ~mu1122_4
+# 1122|     v1122_7(void)       = ExitFunction        : 
 
 # 1137| void ExternDeclarationsInMacro()
 # 1137|   Block 0
@@ -6490,9 +6347,8 @@ ir.cpp:
 # 1139|     v1139_14(void) = NoOp         : 
 # 1140|     v1140_1(void)  = NoOp         : 
 # 1137|     v1137_5(void)  = ReturnVoid   : 
-# 1137|     v1137_6(void)  = UnmodeledUse : mu*
-# 1137|     v1137_7(void)  = AliasedUse   : ~mu1137_4
-# 1137|     v1137_8(void)  = ExitFunction : 
+# 1137|     v1137_6(void)  = AliasedUse   : ~mu1137_4
+# 1137|     v1137_7(void)  = ExitFunction : 
 
 # 1142| void TryCatchNoCatchAny(bool)
 # 1142|   Block 0
@@ -6512,12 +6368,11 @@ ir.cpp:
 #-----|   True -> Block 3
 
 # 1142|   Block 1
-# 1142|     v1142_7(void) = UnmodeledUse : mu*
-# 1142|     v1142_8(void) = AliasedUse   : ~mu1142_4
-# 1142|     v1142_9(void) = ExitFunction : 
+# 1142|     v1142_7(void) = AliasedUse   : ~mu1142_4
+# 1142|     v1142_8(void) = ExitFunction : 
 
 # 1142|   Block 2
-# 1142|     v1142_10(void) = Unwind : 
+# 1142|     v1142_9(void) = Unwind : 
 #-----|   Goto -> Block 1
 
 # 1146|   Block 3
@@ -6612,7 +6467,7 @@ ir.cpp:
 
 # 1158|   Block 13
 # 1158|     v1158_1(void)  = NoOp       : 
-# 1142|     v1142_11(void) = ReturnVoid : 
+# 1142|     v1142_10(void) = ReturnVoid : 
 #-----|   Goto -> Block 1
 
 # 1162| void VectorTypes(int)
@@ -6675,9 +6530,8 @@ ir.cpp:
 # 1167|     mu1167_7(__attribute((vector_size(16UL))) int)       = Store                            : &:r1167_6, r1167_5
 # 1168|     v1168_1(void)                                        = NoOp                             : 
 # 1162|     v1162_7(void)                                        = ReturnVoid                       : 
-# 1162|     v1162_8(void)                                        = UnmodeledUse                     : mu*
-# 1162|     v1162_9(void)                                        = AliasedUse                       : ~mu1162_4
-# 1162|     v1162_10(void)                                       = ExitFunction                     : 
+# 1162|     v1162_8(void)                                        = AliasedUse                       : ~mu1162_4
+# 1162|     v1162_9(void)                                        = ExitFunction                     : 
 
 # 1172| int ModeledCallTarget(int)
 # 1172|   Block 0
@@ -6706,9 +6560,8 @@ ir.cpp:
 # 1175|     mu1175_4(int)           = Store                              : &:r1175_1, r1175_3
 # 1172|     r1172_7(glval<int>)     = VariableAddress[#return]           : 
 # 1172|     v1172_8(void)           = ReturnValue                        : &:r1172_7, ~mu1172_4
-# 1172|     v1172_9(void)           = UnmodeledUse                       : mu*
-# 1172|     v1172_10(void)          = AliasedUse                         : ~mu1172_4
-# 1172|     v1172_11(void)          = ExitFunction                       : 
+# 1172|     v1172_9(void)           = AliasedUse                         : ~mu1172_4
+# 1172|     v1172_10(void)          = ExitFunction                       : 
 
 # 1178| String ReturnObjectImpl()
 # 1178|   Block 0
@@ -6728,9 +6581,8 @@ ir.cpp:
 # 1179|     mu1179_10(unknown)      = ^BufferMayWriteSideEffect[0]    : &:r1179_5
 # 1178|     r1178_5(glval<String>)  = VariableAddress[#return]        : 
 # 1178|     v1178_6(void)           = ReturnValue                     : &:r1178_5, ~mu1178_4
-# 1178|     v1178_7(void)           = UnmodeledUse                    : mu*
-# 1178|     v1178_8(void)           = AliasedUse                      : ~mu1178_4
-# 1178|     v1178_9(void)           = ExitFunction                    : 
+# 1178|     v1178_7(void)           = AliasedUse                      : ~mu1178_4
+# 1178|     v1178_8(void)           = ExitFunction                    : 
 
 # 1182| void switch1Case(int)
 # 1182|   Block 0
@@ -6763,9 +6615,8 @@ ir.cpp:
 # 1188|     mu1188_4(int)       = Store              : &:r1188_1, r1188_3
 # 1189|     v1189_1(void)       = NoOp               : 
 # 1182|     v1182_7(void)       = ReturnVoid         : 
-# 1182|     v1182_8(void)       = UnmodeledUse       : mu*
-# 1182|     v1182_9(void)       = AliasedUse         : ~mu1182_4
-# 1182|     v1182_10(void)      = ExitFunction       : 
+# 1182|     v1182_8(void)       = AliasedUse         : ~mu1182_4
+# 1182|     v1182_9(void)       = ExitFunction       : 
 
 # 1191| void switch2Case_fallthrough(int)
 # 1191|   Block 0
@@ -6806,9 +6657,8 @@ ir.cpp:
 # 1199|     mu1199_4(int)       = Store              : &:r1199_1, r1199_3
 # 1200|     v1200_1(void)       = NoOp               : 
 # 1191|     v1191_7(void)       = ReturnVoid         : 
-# 1191|     v1191_8(void)       = UnmodeledUse       : mu*
-# 1191|     v1191_9(void)       = AliasedUse         : ~mu1191_4
-# 1191|     v1191_10(void)      = ExitFunction       : 
+# 1191|     v1191_8(void)       = AliasedUse         : ~mu1191_4
+# 1191|     v1191_9(void)       = ExitFunction       : 
 
 # 1202| void switch2Case(int)
 # 1202|   Block 0
@@ -6851,9 +6701,8 @@ ir.cpp:
 # 1211|     mu1211_4(int)       = Store              : &:r1211_1, r1211_3
 # 1212|     v1212_1(void)       = NoOp               : 
 # 1202|     v1202_7(void)       = ReturnVoid         : 
-# 1202|     v1202_8(void)       = UnmodeledUse       : mu*
-# 1202|     v1202_9(void)       = AliasedUse         : ~mu1202_4
-# 1202|     v1202_10(void)      = ExitFunction       : 
+# 1202|     v1202_8(void)       = AliasedUse         : ~mu1202_4
+# 1202|     v1202_9(void)       = ExitFunction       : 
 
 # 1214| void switch2Case_default(int)
 # 1214|   Block 0
@@ -6904,9 +6753,8 @@ ir.cpp:
 # 1228|     mu1228_4(int)       = Store              : &:r1228_1, r1228_3
 # 1229|     v1229_1(void)       = NoOp               : 
 # 1214|     v1214_7(void)       = ReturnVoid         : 
-# 1214|     v1214_8(void)       = UnmodeledUse       : mu*
-# 1214|     v1214_9(void)       = AliasedUse         : ~mu1214_4
-# 1214|     v1214_10(void)      = ExitFunction       : 
+# 1214|     v1214_8(void)       = AliasedUse         : ~mu1214_4
+# 1214|     v1214_9(void)       = ExitFunction       : 
 
 # 1231| int staticLocalInit(int)
 # 1231|   Block 0
@@ -6938,9 +6786,8 @@ ir.cpp:
 # 1237|     mu1237_13(int)       = Store                    : &:r1237_1, r1237_12
 # 1231|     r1231_7(glval<int>)  = VariableAddress[#return] : 
 # 1231|     v1231_8(void)        = ReturnValue              : &:r1231_7, ~mu1231_4
-# 1231|     v1231_9(void)        = UnmodeledUse             : mu*
-# 1231|     v1231_10(void)       = AliasedUse               : ~mu1231_4
-# 1231|     v1231_11(void)       = ExitFunction             : 
+# 1231|     v1231_9(void)        = AliasedUse               : ~mu1231_4
+# 1231|     v1231_10(void)       = ExitFunction             : 
 
 # 1234|   Block 2
 # 1234|     r1234_4(glval<int>) = VariableAddress[c] : 
@@ -7013,9 +6860,8 @@ ir.cpp:
 # 1244|     v1244_1(void)  = NoOp                       : 
 # 1240|     v1240_9(void)  = ReturnIndirection[dynamic] : &:r1240_7, ~mu1240_4
 # 1240|     v1240_10(void) = ReturnVoid                 : 
-# 1240|     v1240_11(void) = UnmodeledUse               : mu*
-# 1240|     v1240_12(void) = AliasedUse                 : ~mu1240_4
-# 1240|     v1240_13(void) = ExitFunction               : 
+# 1240|     v1240_11(void) = AliasedUse                 : ~mu1240_4
+# 1240|     v1240_12(void) = ExitFunction               : 
 
 # 1241|   Block 6
 # 1241|     r1241_4(glval<String>) = VariableAddress[a]              : 
@@ -7074,9 +6920,8 @@ ir.cpp:
 # 1251|     v1251_13(void)             = ReturnIndirection[s1]        : &:r1251_7, ~mu1251_4
 # 1251|     v1251_14(void)             = ReturnIndirection[s2]        : &:r1251_11, ~mu1251_4
 # 1251|     v1251_15(void)             = ReturnVoid                   : 
-# 1251|     v1251_16(void)             = UnmodeledUse                 : mu*
-# 1251|     v1251_17(void)             = AliasedUse                   : ~mu1251_4
-# 1251|     v1251_18(void)             = ExitFunction                 : 
+# 1251|     v1251_16(void)             = AliasedUse                   : ~mu1251_4
+# 1251|     v1251_17(void)             = ExitFunction                 : 
 
 # 1261| void A::static_member(A*, int)
 # 1261|   Block 0
@@ -7099,9 +6944,8 @@ ir.cpp:
 # 1263|     v1263_1(void)       = NoOp                     : 
 # 1261|     v1261_11(void)      = ReturnIndirection[a]     : &:r1261_7, ~mu1261_4
 # 1261|     v1261_12(void)      = ReturnVoid               : 
-# 1261|     v1261_13(void)      = UnmodeledUse             : mu*
-# 1261|     v1261_14(void)      = AliasedUse               : ~mu1261_4
-# 1261|     v1261_15(void)      = ExitFunction             : 
+# 1261|     v1261_13(void)      = AliasedUse               : ~mu1261_4
+# 1261|     v1261_14(void)      = ExitFunction             : 
 
 # 1270| void test_static_member_functions(int, A*)
 # 1270|   Block 0
@@ -7201,9 +7045,8 @@ ir.cpp:
 # 1287|     v1287_1(void)           = NoOp                                       : 
 # 1270|     v1270_11(void)          = ReturnIndirection[a_arg]                   : &:r1270_9, ~mu1270_4
 # 1270|     v1270_12(void)          = ReturnVoid                                 : 
-# 1270|     v1270_13(void)          = UnmodeledUse                               : mu*
-# 1270|     v1270_14(void)          = AliasedUse                                 : ~mu1270_4
-# 1270|     v1270_15(void)          = ExitFunction                               : 
+# 1270|     v1270_13(void)          = AliasedUse                                 : ~mu1270_4
+# 1270|     v1270_14(void)          = ExitFunction                               : 
 
 # 1289| int missingReturnValue(bool, int)
 # 1289|   Block 0
@@ -7231,9 +7074,8 @@ ir.cpp:
 # 1291|     mu1291_4(int)       = Store                    : &:r1291_1, r1291_3
 # 1289|     r1289_9(glval<int>) = VariableAddress[#return] : 
 # 1289|     v1289_10(void)      = ReturnValue              : &:r1289_9, ~mu1289_4
-# 1289|     v1289_11(void)      = UnmodeledUse             : mu*
-# 1289|     v1289_12(void)      = AliasedUse               : ~mu1289_4
-# 1289|     v1289_13(void)      = ExitFunction             : 
+# 1289|     v1289_11(void)      = AliasedUse               : ~mu1289_4
+# 1289|     v1289_12(void)      = ExitFunction             : 
 
 # 1295| void returnVoid(int, int)
 # 1295|   Block 0
@@ -7254,9 +7096,8 @@ ir.cpp:
 # 1296|     mu1296_7(unknown)       = ^CallSideEffect             : ~mu1295_4
 # 1296|     v1296_8(void)           = NoOp                        : 
 # 1295|     v1295_9(void)           = ReturnVoid                  : 
-# 1295|     v1295_10(void)          = UnmodeledUse                : mu*
-# 1295|     v1295_11(void)          = AliasedUse                  : ~mu1295_4
-# 1295|     v1295_12(void)          = ExitFunction                : 
+# 1295|     v1295_10(void)          = AliasedUse                  : ~mu1295_4
+# 1295|     v1295_11(void)          = ExitFunction                : 
 
 # 1299| void gccBinaryConditional(bool, int, long)
 # 1299|   Block 0
@@ -7440,9 +7281,8 @@ ir.cpp:
 # 1308|     mu1308_9(int)       = Store                        : &:r1308_8, r1308_7
 # 1309|     v1309_1(void)       = NoOp                         : 
 # 1299|     v1299_11(void)      = ReturnVoid                   : 
-# 1299|     v1299_12(void)      = UnmodeledUse                 : mu*
-# 1299|     v1299_13(void)      = AliasedUse                   : ~mu1299_4
-# 1299|     v1299_14(void)      = ExitFunction                 : 
+# 1299|     v1299_12(void)      = AliasedUse                   : ~mu1299_4
+# 1299|     v1299_13(void)      = ExitFunction                 : 
 
 # 1308|   Block 20
 # 1308|     r1308_10(glval<int>) = VariableAddress[#temp1308:9] : 
@@ -7537,9 +7377,8 @@ ir.cpp:
 # 1315|     mu1315_20(int)       = Store                         : &:r1315_1, r1315_19
 # 1314|     r1314_9(glval<int>)  = VariableAddress[#return]      : 
 # 1314|     v1314_10(void)       = ReturnValue                   : &:r1314_9, ~mu1314_4
-# 1314|     v1314_11(void)       = UnmodeledUse                  : mu*
-# 1314|     v1314_12(void)       = AliasedUse                    : ~mu1314_4
-# 1314|     v1314_13(void)       = ExitFunction                  : 
+# 1314|     v1314_11(void)       = AliasedUse                    : ~mu1314_4
+# 1314|     v1314_12(void)       = ExitFunction                  : 
 
 perf-regression.cpp:
 #    6| void Big::Big()
@@ -7556,9 +7395,8 @@ perf-regression.cpp:
 #    6|     mu6_10(unknown[1073741824])   = Store                : &:r6_8, r6_9
 #    6|     v6_11(void)                   = NoOp                 : 
 #    6|     v6_12(void)                   = ReturnVoid           : 
-#    6|     v6_13(void)                   = UnmodeledUse         : mu*
-#    6|     v6_14(void)                   = AliasedUse           : ~mu6_4
-#    6|     v6_15(void)                   = ExitFunction         : 
+#    6|     v6_13(void)                   = AliasedUse           : ~mu6_4
+#    6|     v6_14(void)                   = ExitFunction         : 
 
 #    9| int main()
 #    9|   Block 0
@@ -7583,9 +7421,8 @@ perf-regression.cpp:
 #   12|     mu12_3(int)           = Store                           : &:r12_1, r12_2
 #    9|     r9_5(glval<int>)      = VariableAddress[#return]        : 
 #    9|     v9_6(void)            = ReturnValue                     : &:r9_5, ~mu9_4
-#    9|     v9_7(void)            = UnmodeledUse                    : mu*
-#    9|     v9_8(void)            = AliasedUse                      : ~mu9_4
-#    9|     v9_9(void)            = ExitFunction                    : 
+#    9|     v9_7(void)            = AliasedUse                      : ~mu9_4
+#    9|     v9_8(void)            = ExitFunction                    : 
 
 struct_init.cpp:
 #   16| void let_info_escape(Info*)
@@ -7605,9 +7442,8 @@ struct_init.cpp:
 #   18|     v18_1(void)          = NoOp                            : 
 #   16|     v16_9(void)          = ReturnIndirection[info]         : &:r16_7, ~mu16_4
 #   16|     v16_10(void)         = ReturnVoid                      : 
-#   16|     v16_11(void)         = UnmodeledUse                    : mu*
-#   16|     v16_12(void)         = AliasedUse                      : ~mu16_4
-#   16|     v16_13(void)         = ExitFunction                    : 
+#   16|     v16_11(void)         = AliasedUse                      : ~mu16_4
+#   16|     v16_12(void)         = ExitFunction                    : 
 
 #   20| void declare_static_infos()
 #   20|   Block 0
@@ -7624,9 +7460,8 @@ struct_init.cpp:
 #   25|     mu25_7(unknown)       = ^BufferMayWriteSideEffect[0]     : &:r25_3
 #   26|     v26_1(void)           = NoOp                             : 
 #   20|     v20_5(void)           = ReturnVoid                       : 
-#   20|     v20_6(void)           = UnmodeledUse                     : mu*
-#   20|     v20_7(void)           = AliasedUse                       : ~mu20_4
-#   20|     v20_8(void)           = ExitFunction                     : 
+#   20|     v20_6(void)           = AliasedUse                       : ~mu20_4
+#   20|     v20_7(void)           = ExitFunction                     : 
 
 #   28| void declare_local_infos()
 #   28|   Block 0
@@ -7664,9 +7499,8 @@ struct_init.cpp:
 #   33|     mu33_7(unknown)         = ^BufferMayWriteSideEffect[0]     : &:r33_3
 #   34|     v34_1(void)             = NoOp                             : 
 #   28|     v28_5(void)             = ReturnVoid                       : 
-#   28|     v28_6(void)             = UnmodeledUse                     : mu*
-#   28|     v28_7(void)             = AliasedUse                       : ~mu28_4
-#   28|     v28_8(void)             = ExitFunction                     : 
+#   28|     v28_6(void)             = AliasedUse                       : ~mu28_4
+#   28|     v28_7(void)             = ExitFunction                     : 
 
 #   36| void declare_static_runtime_infos(char const*)
 #   36|   Block 0
@@ -7695,9 +7529,8 @@ struct_init.cpp:
 #   42|     v42_1(void)           = NoOp                             : 
 #   36|     v36_9(void)           = ReturnIndirection[name1]         : &:r36_7, ~mu36_4
 #   36|     v36_10(void)          = ReturnVoid                       : 
-#   36|     v36_11(void)          = UnmodeledUse                     : mu*
-#   36|     v36_12(void)          = AliasedUse                       : ~mu36_4
-#   36|     v36_13(void)          = ExitFunction                     : 
+#   36|     v36_11(void)          = AliasedUse                       : ~mu36_4
+#   36|     v36_12(void)          = ExitFunction                     : 
 
 #   37|   Block 2
 #   37|     r37_4(glval<Info[2]>)   = VariableAddress[static_infos] : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -92,9 +92,8 @@ ssa.cpp:
 #   13|     v13_14(void)          = ReturnIndirection[p]     : &:r13_8, m28_3
 #   13|     r13_15(glval<int>)    = VariableAddress[#return] : 
 #   13|     v13_16(void)          = ReturnValue              : &:r13_15, m28_14
-#   13|     v13_17(void)          = UnmodeledUse             : mu*
-#   13|     v13_18(void)          = AliasedUse               : m13_3
-#   13|     v13_19(void)          = ExitFunction             : 
+#   13|     v13_17(void)          = AliasedUse               : m13_3
+#   13|     v13_18(void)          = ExitFunction             : 
 
 #   31| int UnreachableViaGoto()
 #   31|   Block 0
@@ -110,9 +109,8 @@ ssa.cpp:
 #   35|     m35_3(int)        = Store                    : &:r35_1, r35_2
 #   31|     r31_6(glval<int>) = VariableAddress[#return] : 
 #   31|     v31_7(void)       = ReturnValue              : &:r31_6, m35_3
-#   31|     v31_8(void)       = UnmodeledUse             : mu*
-#   31|     v31_9(void)       = AliasedUse               : m31_3
-#   31|     v31_10(void)      = ExitFunction             : 
+#   31|     v31_8(void)       = AliasedUse               : m31_3
+#   31|     v31_9(void)       = ExitFunction             : 
 
 #   38| int UnreachableIf(bool)
 #   38|   Block 0
@@ -139,9 +137,8 @@ ssa.cpp:
 #   38|     m38_8(int)        = Phi                      : from 3:m46_3, from 5:m51_3
 #   38|     r38_9(glval<int>) = VariableAddress[#return] : 
 #   38|     v38_10(void)      = ReturnValue              : &:r38_9, m38_8
-#   38|     v38_11(void)      = UnmodeledUse             : mu*
-#   38|     v38_12(void)      = AliasedUse               : m38_3
-#   38|     v38_13(void)      = ExitFunction             : 
+#   38|     v38_11(void)      = AliasedUse               : m38_3
+#   38|     v38_12(void)      = ExitFunction             : 
 
 #   42|   Block 2
 #   42|     r42_1(glval<int>) = VariableAddress[x] : 
@@ -176,7 +173,7 @@ ssa.cpp:
 #-----|   Goto -> Block 1
 
 #   38|   Block 6
-#   38|     v38_14(void) = Unreached : 
+#   38|     v38_13(void) = Unreached : 
 
 #   59| int DoWhileFalse()
 #   59|   Block 0
@@ -205,12 +202,11 @@ ssa.cpp:
 #   65|     m65_4(int)        = Store                    : &:r65_1, r65_3
 #   59|     r59_6(glval<int>) = VariableAddress[#return] : 
 #   59|     v59_7(void)       = ReturnValue              : &:r59_6, m65_4
-#   59|     v59_8(void)       = UnmodeledUse             : mu*
-#   59|     v59_9(void)       = AliasedUse               : m59_3
-#   59|     v59_10(void)      = ExitFunction             : 
+#   59|     v59_8(void)       = AliasedUse               : m59_3
+#   59|     v59_9(void)       = ExitFunction             : 
 
 #   59|   Block 2
-#   59|     v59_11(void) = Unreached : 
+#   59|     v59_10(void) = Unreached : 
 
 #   68| void chiNodeAtEndOfLoop(int, char*)
 #   68|   Block 0
@@ -260,9 +256,8 @@ ssa.cpp:
 #   71|     v71_1(void)  = NoOp                 : 
 #   68|     v68_12(void) = ReturnIndirection[p] : &:r68_10, m68_11
 #   68|     v68_13(void) = ReturnVoid           : 
-#   68|     v68_14(void) = UnmodeledUse         : mu*
-#   68|     v68_15(void) = AliasedUse           : ~m69_3
-#   68|     v68_16(void) = ExitFunction         : 
+#   68|     v68_14(void) = AliasedUse           : ~m69_3
+#   68|     v68_15(void) = ExitFunction         : 
 
 #   75| void ScalarPhi(bool)
 #   75|   Block 0
@@ -320,9 +315,8 @@ ssa.cpp:
 #   88|     m88_4(int)        = Store                    : &:r88_1, r88_3
 #   89|     v89_1(void)       = NoOp                     : 
 #   75|     v75_8(void)       = ReturnVoid               : 
-#   75|     v75_9(void)       = UnmodeledUse             : mu*
-#   75|     v75_10(void)      = AliasedUse               : m75_3
-#   75|     v75_11(void)      = ExitFunction             : 
+#   75|     v75_9(void)       = AliasedUse               : m75_3
+#   75|     v75_10(void)      = ExitFunction             : 
 
 #   91| void MustExactlyOverlap(Point)
 #   91|   Block 0
@@ -339,9 +333,8 @@ ssa.cpp:
 #   92|     m92_4(Point)        = Store                  : &:r92_1, r92_3
 #   93|     v93_1(void)         = NoOp                   : 
 #   91|     v91_8(void)         = ReturnVoid             : 
-#   91|     v91_9(void)         = UnmodeledUse           : mu*
-#   91|     v91_10(void)        = AliasedUse             : m91_3
-#   91|     v91_11(void)        = ExitFunction           : 
+#   91|     v91_9(void)         = AliasedUse             : m91_3
+#   91|     v91_10(void)        = ExitFunction           : 
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
@@ -369,9 +362,8 @@ ssa.cpp:
 #   97|     m97_10(unknown)       = Chi                          : total:m97_7, partial:m97_9
 #   98|     v98_1(void)           = NoOp                         : 
 #   95|     v95_9(void)           = ReturnVoid                   : 
-#   95|     v95_10(void)          = UnmodeledUse                 : mu*
-#   95|     v95_11(void)          = AliasedUse                   : ~m97_7
-#   95|     v95_12(void)          = ExitFunction                 : 
+#   95|     v95_10(void)          = AliasedUse                   : ~m97_7
+#   95|     v95_11(void)          = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -394,9 +386,8 @@ ssa.cpp:
 #  102|     m102_5(int)          = Store                  : &:r102_1, r102_4
 #  103|     v103_1(void)         = NoOp                   : 
 #  100|     v100_8(void)         = ReturnVoid             : 
-#  100|     v100_9(void)         = UnmodeledUse           : mu*
-#  100|     v100_10(void)        = AliasedUse             : m100_3
-#  100|     v100_11(void)        = ExitFunction           : 
+#  100|     v100_9(void)         = AliasedUse             : m100_3
+#  100|     v100_10(void)        = ExitFunction           : 
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
@@ -430,9 +421,8 @@ ssa.cpp:
 #  108|     m108_10(unknown)       = Chi                          : total:m108_7, partial:m108_9
 #  109|     v109_1(void)           = NoOp                         : 
 #  105|     v105_9(void)           = ReturnVoid                   : 
-#  105|     v105_10(void)          = UnmodeledUse                 : mu*
-#  105|     v105_11(void)          = AliasedUse                   : ~m108_7
-#  105|     v105_12(void)          = ExitFunction                 : 
+#  105|     v105_10(void)          = AliasedUse                   : ~m108_7
+#  105|     v105_11(void)          = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -463,9 +453,8 @@ ssa.cpp:
 #  113|     m113_4(Point)        = Store                  : &:r113_1, r113_3
 #  114|     v114_1(void)         = NoOp                   : 
 #  111|     v111_10(void)        = ReturnVoid             : 
-#  111|     v111_11(void)        = UnmodeledUse           : mu*
-#  111|     v111_12(void)        = AliasedUse             : m111_3
-#  111|     v111_13(void)        = ExitFunction           : 
+#  111|     v111_11(void)        = AliasedUse             : m111_3
+#  111|     v111_12(void)        = ExitFunction           : 
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
@@ -507,9 +496,8 @@ ssa.cpp:
 #  119|     m119_10(unknown)       = Chi                          : total:m119_7, partial:m119_9
 #  120|     v120_1(void)           = NoOp                         : 
 #  116|     v116_10(void)          = ReturnVoid                   : 
-#  116|     v116_11(void)          = UnmodeledUse                 : mu*
-#  116|     v116_12(void)          = AliasedUse                   : ~m119_7
-#  116|     v116_13(void)          = ExitFunction                 : 
+#  116|     v116_11(void)          = AliasedUse                   : ~m119_7
+#  116|     v116_12(void)          = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -572,9 +560,8 @@ ssa.cpp:
 #  131|     m131_4(Point)        = Store              : &:r131_1, r131_3
 #  132|     v132_1(void)         = NoOp               : 
 #  122|     v122_12(void)        = ReturnVoid         : 
-#  122|     v122_13(void)        = UnmodeledUse       : mu*
-#  122|     v122_14(void)        = AliasedUse         : m122_3
-#  122|     v122_15(void)        = ExitFunction       : 
+#  122|     v122_13(void)        = AliasedUse         : m122_3
+#  122|     v122_14(void)        = ExitFunction       : 
 
 #  134| void MergeMustExactlyWithMustTotallyOverlap(bool, Point, int)
 #  134|   Block 0
@@ -631,9 +618,8 @@ ssa.cpp:
 #  142|     m142_7(int)          = Store              : &:r142_3, r142_6
 #  143|     v143_1(void)         = NoOp               : 
 #  134|     v134_12(void)        = ReturnVoid         : 
-#  134|     v134_13(void)        = UnmodeledUse       : mu*
-#  134|     v134_14(void)        = AliasedUse         : m134_3
-#  134|     v134_15(void)        = ExitFunction       : 
+#  134|     v134_13(void)        = AliasedUse         : m134_3
+#  134|     v134_14(void)        = ExitFunction       : 
 
 #  145| void MergeMustExactlyWithMayPartiallyOverlap(bool, Point, int)
 #  145|   Block 0
@@ -688,9 +674,8 @@ ssa.cpp:
 #  153|     m153_5(Point)        = Store              : &:r153_2, r153_4
 #  154|     v154_1(void)         = NoOp               : 
 #  145|     v145_12(void)        = ReturnVoid         : 
-#  145|     v145_13(void)        = UnmodeledUse       : mu*
-#  145|     v145_14(void)        = AliasedUse         : m145_3
-#  145|     v145_15(void)        = ExitFunction       : 
+#  145|     v145_13(void)        = AliasedUse         : m145_3
+#  145|     v145_14(void)        = ExitFunction       : 
 
 #  156| void MergeMustTotallyOverlapWithMayPartiallyOverlap(bool, Rect, int)
 #  156|   Block 0
@@ -747,9 +732,8 @@ ssa.cpp:
 #  164|     m164_6(Point)        = Store                 : &:r164_2, r164_5
 #  165|     v165_1(void)         = NoOp                  : 
 #  156|     v156_12(void)        = ReturnVoid            : 
-#  156|     v156_13(void)        = UnmodeledUse          : mu*
-#  156|     v156_14(void)        = AliasedUse            : m156_3
-#  156|     v156_15(void)        = ExitFunction          : 
+#  156|     v156_13(void)        = AliasedUse            : m156_3
+#  156|     v156_14(void)        = ExitFunction          : 
 
 #  171| void WrapperStruct(Wrapper)
 #  171|   Block 0
@@ -784,9 +768,8 @@ ssa.cpp:
 #  176|     m176_4(Wrapper)        = Store                  : &:r176_3, r176_2
 #  177|     v177_1(void)           = NoOp                   : 
 #  171|     v171_8(void)           = ReturnVoid             : 
-#  171|     v171_9(void)           = UnmodeledUse           : mu*
-#  171|     v171_10(void)          = AliasedUse             : m171_3
-#  171|     v171_11(void)          = ExitFunction           : 
+#  171|     v171_9(void)           = AliasedUse             : m171_3
+#  171|     v171_10(void)          = ExitFunction           : 
 
 #  179| int AsmStmt(int*)
 #  179|   Block 0
@@ -809,9 +792,8 @@ ssa.cpp:
 #  179|     v179_10(void)        = ReturnIndirection[p]     : &:r179_8, m179_9
 #  179|     r179_11(glval<int>)  = VariableAddress[#return] : 
 #  179|     v179_12(void)        = ReturnValue              : &:r179_11, m181_5
-#  179|     v179_13(void)        = UnmodeledUse             : mu*
-#  179|     v179_14(void)        = AliasedUse               : ~m180_2
-#  179|     v179_15(void)        = ExitFunction             : 
+#  179|     v179_13(void)        = AliasedUse               : ~m180_2
+#  179|     v179_14(void)        = ExitFunction             : 
 
 #  184| void AsmStmtWithOutputs(unsigned int&, unsigned int&, unsigned int&, unsigned int&)
 #  184|   Block 0
@@ -858,9 +840,8 @@ ssa.cpp:
 #  184|     v184_26(void)                  = ReturnIndirection[c]     : &:r184_18, m184_19
 #  184|     v184_27(void)                  = ReturnIndirection[d]     : &:r184_22, m184_23
 #  184|     v184_28(void)                  = ReturnVoid               : 
-#  184|     v184_29(void)                  = UnmodeledUse             : mu*
-#  184|     v184_30(void)                  = AliasedUse               : ~m186_2
-#  184|     v184_31(void)                  = ExitFunction             : 
+#  184|     v184_29(void)                  = AliasedUse               : ~m186_2
+#  184|     v184_30(void)                  = ExitFunction             : 
 
 #  198| int PureFunctions(char*, char*, int)
 #  198|   Block 0
@@ -917,9 +898,8 @@ ssa.cpp:
 #  198|     v198_17(void)          = ReturnIndirection[str2]     : &:r198_12, m198_13
 #  198|     r198_18(glval<int>)    = VariableAddress[#return]    : 
 #  198|     v198_19(void)          = ReturnValue                 : &:r198_18, m202_4
-#  198|     v198_20(void)          = UnmodeledUse                : mu*
-#  198|     v198_21(void)          = AliasedUse                  : m198_3
-#  198|     v198_22(void)          = ExitFunction                : 
+#  198|     v198_20(void)          = AliasedUse                  : m198_3
+#  198|     v198_21(void)          = ExitFunction                : 
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
@@ -952,9 +932,8 @@ ssa.cpp:
 #  210|     m210_4(int)            = Store                              : &:r210_1, r210_3
 #  207|     r207_9(glval<int>)     = VariableAddress[#return]           : 
 #  207|     v207_10(void)          = ReturnValue                        : &:r207_9, m210_4
-#  207|     v207_11(void)          = UnmodeledUse                       : mu*
-#  207|     v207_12(void)          = AliasedUse                         : m207_3
-#  207|     v207_13(void)          = ExitFunction                       : 
+#  207|     v207_11(void)          = AliasedUse                         : m207_3
+#  207|     v207_12(void)          = ExitFunction                       : 
 
 #  213| void InitArray()
 #  213|   Block 0
@@ -1021,9 +1000,8 @@ ssa.cpp:
 #  221|     m221_12(char[3])        = Chi                      : total:m221_7, partial:m221_11
 #  222|     v222_1(void)            = NoOp                     : 
 #  213|     v213_6(void)            = ReturnVoid               : 
-#  213|     v213_7(void)            = UnmodeledUse             : mu*
-#  213|     v213_8(void)            = AliasedUse               : m213_3
-#  213|     v213_9(void)            = ExitFunction             : 
+#  213|     v213_7(void)            = AliasedUse               : m213_3
+#  213|     v213_8(void)            = ExitFunction             : 
 
 #  226| char StringLiteralAliasing()
 #  226|   Block 0
@@ -1049,9 +1027,8 @@ ssa.cpp:
 #  230|     m230_7(char)           = Store                         : &:r230_1, r230_6
 #  226|     r226_6(glval<char>)    = VariableAddress[#return]      : 
 #  226|     v226_7(void)           = ReturnValue                   : &:r226_6, m230_7
-#  226|     v226_8(void)           = UnmodeledUse                  : mu*
-#  226|     v226_9(void)           = AliasedUse                    : ~m227_4
-#  226|     v226_10(void)          = ExitFunction                  : 
+#  226|     v226_8(void)           = AliasedUse                    : ~m227_4
+#  226|     v226_9(void)           = ExitFunction                  : 
 
 #  235| void Constructible::Constructible(int)
 #  235|   Block 0
@@ -1065,9 +1042,8 @@ ssa.cpp:
 #  235|     m235_8(int)                  = InitializeParameter[x] : &:r235_7
 #  235|     v235_9(void)                 = NoOp                   : 
 #  235|     v235_10(void)                = ReturnVoid             : 
-#  235|     v235_11(void)                = UnmodeledUse           : mu*
-#  235|     v235_12(void)                = AliasedUse             : m235_3
-#  235|     v235_13(void)                = ExitFunction           : 
+#  235|     v235_11(void)                = AliasedUse             : m235_3
+#  235|     v235_12(void)                = ExitFunction           : 
 
 #  236| void Constructible::g()
 #  236|   Block 0
@@ -1079,9 +1055,8 @@ ssa.cpp:
 #  236|     r236_6(glval<Constructible>) = InitializeThis      : 
 #  236|     v236_7(void)                 = NoOp                : 
 #  236|     v236_8(void)                 = ReturnVoid          : 
-#  236|     v236_9(void)                 = UnmodeledUse        : mu*
-#  236|     v236_10(void)                = AliasedUse          : m236_3
-#  236|     v236_11(void)                = ExitFunction        : 
+#  236|     v236_9(void)                 = AliasedUse          : m236_3
+#  236|     v236_10(void)                = ExitFunction        : 
 
 #  239| void ExplicitConstructorCalls()
 #  239|   Block 0
@@ -1134,9 +1109,8 @@ ssa.cpp:
 #  244|     m244_8(Constructible)        = Chi                             : total:m243_9, partial:m244_7
 #  245|     v245_1(void)                 = NoOp                            : 
 #  239|     v239_6(void)                 = ReturnVoid                      : 
-#  239|     v239_7(void)                 = UnmodeledUse                    : mu*
-#  239|     v239_8(void)                 = AliasedUse                      : ~m244_5
-#  239|     v239_9(void)                 = ExitFunction                    : 
+#  239|     v239_7(void)                 = AliasedUse                      : ~m244_5
+#  239|     v239_8(void)                 = ExitFunction                    : 
 
 #  247| char* VoidStarIndirectParameters(char*, int)
 #  247|   Block 0
@@ -1192,9 +1166,8 @@ ssa.cpp:
 #  247|     v247_13(void)          = ReturnIndirection[src]             : &:r247_8, ~m250_13
 #  247|     r247_14(glval<char *>) = VariableAddress[#return]           : 
 #  247|     v247_15(void)          = ReturnValue                        : &:r247_14, m251_4
-#  247|     v247_16(void)          = UnmodeledUse                       : mu*
-#  247|     v247_17(void)          = AliasedUse                         : ~m250_13
-#  247|     v247_18(void)          = ExitFunction                       : 
+#  247|     v247_16(void)          = AliasedUse                         : ~m250_13
+#  247|     v247_17(void)          = ExitFunction                       : 
 
 #  254| char StringLiteralAliasing2(bool)
 #  254|   Block 0
@@ -1240,9 +1213,8 @@ ssa.cpp:
 #  263|     m263_7(char)           = Store                     : &:r263_1, r263_6
 #  254|     r254_8(glval<char>)    = VariableAddress[#return]  : 
 #  254|     v254_9(void)           = ReturnValue               : &:r254_8, m263_7
-#  254|     v254_10(void)          = UnmodeledUse              : mu*
-#  254|     v254_11(void)          = AliasedUse                : ~m262_1
-#  254|     v254_12(void)          = ExitFunction              : 
+#  254|     v254_10(void)          = AliasedUse                : ~m262_1
+#  254|     v254_11(void)          = ExitFunction              : 
 
 #  268| void* MallocAliasing(void*, int)
 #  268|   Block 0
@@ -1286,9 +1258,8 @@ ssa.cpp:
 #  268|     v268_13(void)          = ReturnIndirection[s]               : &:r268_8, ~m270_11
 #  268|     r268_14(glval<void *>) = VariableAddress[#return]           : 
 #  268|     v268_15(void)          = ReturnValue                        : &:r268_14, m271_4
-#  268|     v268_16(void)          = UnmodeledUse                       : mu*
-#  268|     v268_17(void)          = AliasedUse                         : ~m270_11
-#  268|     v268_18(void)          = ExitFunction                       : 
+#  268|     v268_16(void)          = AliasedUse                         : ~m270_11
+#  268|     v268_17(void)          = ExitFunction                       : 
 
 #  275| void EscapedButNotConflated(bool, Point, int)
 #  275|   Block 0
@@ -1344,9 +1315,8 @@ ssa.cpp:
 #  281|     m281_7(int)          = Store              : &:r281_3, r281_6
 #  282|     v282_1(void)         = NoOp               : 
 #  275|     v275_12(void)        = ReturnVoid         : 
-#  275|     v275_13(void)        = UnmodeledUse       : mu*
-#  275|     v275_14(void)        = AliasedUse         : ~m281_2
-#  275|     v275_15(void)        = ExitFunction       : 
+#  275|     v275_13(void)        = AliasedUse         : ~m281_2
+#  275|     v275_14(void)        = ExitFunction       : 
 
 #  286| void A::A(int)
 #  286|   Block 0
@@ -1360,9 +1330,8 @@ ssa.cpp:
 #  286|     m286_8(int)        = InitializeParameter[x] : &:r286_7
 #  286|     v286_9(void)       = NoOp                   : 
 #  286|     v286_10(void)      = ReturnVoid             : 
-#  286|     v286_11(void)      = UnmodeledUse           : mu*
-#  286|     v286_12(void)      = AliasedUse             : m286_3
-#  286|     v286_13(void)      = ExitFunction           : 
+#  286|     v286_11(void)      = AliasedUse             : m286_3
+#  286|     v286_12(void)      = ExitFunction           : 
 
 #  287| void A::A(A*)
 #  287|   Block 0
@@ -1379,9 +1348,8 @@ ssa.cpp:
 #  287|     v287_11(void)      = NoOp                       : 
 #  287|     v287_12(void)      = ReturnIndirection[p#0]     : &:r287_9, m287_10
 #  287|     v287_13(void)      = ReturnVoid                 : 
-#  287|     v287_14(void)      = UnmodeledUse               : mu*
-#  287|     v287_15(void)      = AliasedUse                 : m287_3
-#  287|     v287_16(void)      = ExitFunction               : 
+#  287|     v287_14(void)      = AliasedUse                 : m287_3
+#  287|     v287_15(void)      = ExitFunction               : 
 
 #  288| void A::A()
 #  288|   Block 0
@@ -1393,9 +1361,8 @@ ssa.cpp:
 #  288|     r288_6(glval<A>) = InitializeThis      : 
 #  288|     v288_7(void)     = NoOp                : 
 #  288|     v288_8(void)     = ReturnVoid          : 
-#  288|     v288_9(void)     = UnmodeledUse        : mu*
-#  288|     v288_10(void)    = AliasedUse          : m288_3
-#  288|     v288_11(void)    = ExitFunction        : 
+#  288|     v288_9(void)     = AliasedUse          : m288_3
+#  288|     v288_10(void)    = ExitFunction        : 
 
 #  291| Point* NewAliasing(int)
 #  291|   Block 0
@@ -1480,9 +1447,8 @@ ssa.cpp:
 #  296|     m296_4(Point *)         = Store                           : &:r296_1, r296_3
 #  291|     r291_8(glval<Point *>)  = VariableAddress[#return]        : 
 #  291|     v291_9(void)            = ReturnValue                     : &:r291_8, m296_4
-#  291|     v291_10(void)           = UnmodeledUse                    : mu*
-#  291|     v291_11(void)           = AliasedUse                      : ~m295_12
-#  291|     v291_12(void)           = ExitFunction                    : 
+#  291|     v291_10(void)           = AliasedUse                      : ~m295_12
+#  291|     v291_11(void)           = ExitFunction                    : 
 
 #  301| int main(int, char**)
 #  301|   Block 0
@@ -1530,6 +1496,5 @@ ssa.cpp:
 #  301|     v301_13(void)          = ReturnIndirection[argv]          : &:r301_10, ~m303_11
 #  301|     r301_14(glval<int>)    = VariableAddress[#return]         : 
 #  301|     v301_15(void)          = ReturnValue                      : &:r301_14, m304_7
-#  301|     v301_16(void)          = UnmodeledUse                     : mu*
-#  301|     v301_17(void)          = AliasedUse                       : ~m303_11
-#  301|     v301_18(void)          = ExitFunction                     : 
+#  301|     v301_16(void)          = AliasedUse                       : ~m303_11
+#  301|     v301_17(void)          = ExitFunction                     : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
@@ -92,9 +92,8 @@ ssa.cpp:
 #   13|     v13_14(void)          = ReturnIndirection[p]     : &:r13_8, m28_3
 #   13|     r13_15(glval<int>)    = VariableAddress[#return] : 
 #   13|     v13_16(void)          = ReturnValue              : &:r13_15, m28_14
-#   13|     v13_17(void)          = UnmodeledUse             : mu*
-#   13|     v13_18(void)          = AliasedUse               : m13_3
-#   13|     v13_19(void)          = ExitFunction             : 
+#   13|     v13_17(void)          = AliasedUse               : m13_3
+#   13|     v13_18(void)          = ExitFunction             : 
 
 #   31| int UnreachableViaGoto()
 #   31|   Block 0
@@ -110,9 +109,8 @@ ssa.cpp:
 #   35|     m35_3(int)        = Store                    : &:r35_1, r35_2
 #   31|     r31_6(glval<int>) = VariableAddress[#return] : 
 #   31|     v31_7(void)       = ReturnValue              : &:r31_6, m35_3
-#   31|     v31_8(void)       = UnmodeledUse             : mu*
-#   31|     v31_9(void)       = AliasedUse               : m31_3
-#   31|     v31_10(void)      = ExitFunction             : 
+#   31|     v31_8(void)       = AliasedUse               : m31_3
+#   31|     v31_9(void)       = ExitFunction             : 
 
 #   38| int UnreachableIf(bool)
 #   38|   Block 0
@@ -139,9 +137,8 @@ ssa.cpp:
 #   38|     m38_8(int)        = Phi                      : from 3:m46_3, from 5:m51_3
 #   38|     r38_9(glval<int>) = VariableAddress[#return] : 
 #   38|     v38_10(void)      = ReturnValue              : &:r38_9, m38_8
-#   38|     v38_11(void)      = UnmodeledUse             : mu*
-#   38|     v38_12(void)      = AliasedUse               : m38_3
-#   38|     v38_13(void)      = ExitFunction             : 
+#   38|     v38_11(void)      = AliasedUse               : m38_3
+#   38|     v38_12(void)      = ExitFunction             : 
 
 #   42|   Block 2
 #   42|     r42_1(glval<int>) = VariableAddress[x] : 
@@ -176,7 +173,7 @@ ssa.cpp:
 #-----|   Goto -> Block 1
 
 #   38|   Block 6
-#   38|     v38_14(void) = Unreached : 
+#   38|     v38_13(void) = Unreached : 
 
 #   59| int DoWhileFalse()
 #   59|   Block 0
@@ -205,12 +202,11 @@ ssa.cpp:
 #   65|     m65_4(int)        = Store                    : &:r65_1, r65_3
 #   59|     r59_6(glval<int>) = VariableAddress[#return] : 
 #   59|     v59_7(void)       = ReturnValue              : &:r59_6, m65_4
-#   59|     v59_8(void)       = UnmodeledUse             : mu*
-#   59|     v59_9(void)       = AliasedUse               : m59_3
-#   59|     v59_10(void)      = ExitFunction             : 
+#   59|     v59_8(void)       = AliasedUse               : m59_3
+#   59|     v59_9(void)       = ExitFunction             : 
 
 #   59|   Block 2
-#   59|     v59_11(void) = Unreached : 
+#   59|     v59_10(void) = Unreached : 
 
 #   68| void chiNodeAtEndOfLoop(int, char*)
 #   68|   Block 0
@@ -260,9 +256,8 @@ ssa.cpp:
 #   71|     v71_1(void)  = NoOp                 : 
 #   68|     v68_12(void) = ReturnIndirection[p] : &:r68_10, m68_11
 #   68|     v68_13(void) = ReturnVoid           : 
-#   68|     v68_14(void) = UnmodeledUse         : mu*
-#   68|     v68_15(void) = AliasedUse           : ~m69_3
-#   68|     v68_16(void) = ExitFunction         : 
+#   68|     v68_14(void) = AliasedUse           : ~m69_3
+#   68|     v68_15(void) = ExitFunction         : 
 
 #   75| void ScalarPhi(bool)
 #   75|   Block 0
@@ -320,9 +315,8 @@ ssa.cpp:
 #   88|     m88_4(int)        = Store                    : &:r88_1, r88_3
 #   89|     v89_1(void)       = NoOp                     : 
 #   75|     v75_8(void)       = ReturnVoid               : 
-#   75|     v75_9(void)       = UnmodeledUse             : mu*
-#   75|     v75_10(void)      = AliasedUse               : m75_3
-#   75|     v75_11(void)      = ExitFunction             : 
+#   75|     v75_9(void)       = AliasedUse               : m75_3
+#   75|     v75_10(void)      = ExitFunction             : 
 
 #   91| void MustExactlyOverlap(Point)
 #   91|   Block 0
@@ -339,9 +333,8 @@ ssa.cpp:
 #   92|     m92_4(Point)        = Store                  : &:r92_1, r92_3
 #   93|     v93_1(void)         = NoOp                   : 
 #   91|     v91_8(void)         = ReturnVoid             : 
-#   91|     v91_9(void)         = UnmodeledUse           : mu*
-#   91|     v91_10(void)        = AliasedUse             : m91_3
-#   91|     v91_11(void)        = ExitFunction           : 
+#   91|     v91_9(void)         = AliasedUse             : m91_3
+#   91|     v91_10(void)        = ExitFunction           : 
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
@@ -368,9 +361,8 @@ ssa.cpp:
 #   97|     m97_10(Point)         = Chi                          : total:m95_7, partial:m97_9
 #   98|     v98_1(void)           = NoOp                         : 
 #   95|     v95_8(void)           = ReturnVoid                   : 
-#   95|     v95_9(void)           = UnmodeledUse                 : mu*
-#   95|     v95_10(void)          = AliasedUse                   : ~m97_7
-#   95|     v95_11(void)          = ExitFunction                 : 
+#   95|     v95_9(void)           = AliasedUse                   : ~m97_7
+#   95|     v95_10(void)          = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -393,9 +385,8 @@ ssa.cpp:
 #  102|     m102_5(int)          = Store                  : &:r102_1, r102_4
 #  103|     v103_1(void)         = NoOp                   : 
 #  100|     v100_8(void)         = ReturnVoid             : 
-#  100|     v100_9(void)         = UnmodeledUse           : mu*
-#  100|     v100_10(void)        = AliasedUse             : m100_3
-#  100|     v100_11(void)        = ExitFunction           : 
+#  100|     v100_9(void)         = AliasedUse             : m100_3
+#  100|     v100_10(void)        = ExitFunction           : 
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
@@ -428,9 +419,8 @@ ssa.cpp:
 #  108|     m108_10(Point)         = Chi                          : total:m105_7, partial:m108_9
 #  109|     v109_1(void)           = NoOp                         : 
 #  105|     v105_8(void)           = ReturnVoid                   : 
-#  105|     v105_9(void)           = UnmodeledUse                 : mu*
-#  105|     v105_10(void)          = AliasedUse                   : ~m108_7
-#  105|     v105_11(void)          = ExitFunction                 : 
+#  105|     v105_9(void)           = AliasedUse                   : ~m108_7
+#  105|     v105_10(void)          = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -461,9 +451,8 @@ ssa.cpp:
 #  113|     m113_4(Point)        = Store                  : &:r113_1, r113_3
 #  114|     v114_1(void)         = NoOp                   : 
 #  111|     v111_10(void)        = ReturnVoid             : 
-#  111|     v111_11(void)        = UnmodeledUse           : mu*
-#  111|     v111_12(void)        = AliasedUse             : m111_3
-#  111|     v111_13(void)        = ExitFunction           : 
+#  111|     v111_11(void)        = AliasedUse             : m111_3
+#  111|     v111_12(void)        = ExitFunction           : 
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
@@ -504,9 +493,8 @@ ssa.cpp:
 #  119|     m119_10(Point)         = Chi                          : total:m117_12, partial:m119_9
 #  120|     v120_1(void)           = NoOp                         : 
 #  116|     v116_10(void)          = ReturnVoid                   : 
-#  116|     v116_11(void)          = UnmodeledUse                 : mu*
-#  116|     v116_12(void)          = AliasedUse                   : ~m119_7
-#  116|     v116_13(void)          = ExitFunction                 : 
+#  116|     v116_11(void)          = AliasedUse                   : ~m119_7
+#  116|     v116_12(void)          = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -569,9 +557,8 @@ ssa.cpp:
 #  131|     m131_4(Point)        = Store              : &:r131_1, r131_3
 #  132|     v132_1(void)         = NoOp               : 
 #  122|     v122_12(void)        = ReturnVoid         : 
-#  122|     v122_13(void)        = UnmodeledUse       : mu*
-#  122|     v122_14(void)        = AliasedUse         : m122_3
-#  122|     v122_15(void)        = ExitFunction       : 
+#  122|     v122_13(void)        = AliasedUse         : m122_3
+#  122|     v122_14(void)        = ExitFunction       : 
 
 #  134| void MergeMustExactlyWithMustTotallyOverlap(bool, Point, int)
 #  134|   Block 0
@@ -628,9 +615,8 @@ ssa.cpp:
 #  142|     m142_7(int)          = Store              : &:r142_3, r142_6
 #  143|     v143_1(void)         = NoOp               : 
 #  134|     v134_12(void)        = ReturnVoid         : 
-#  134|     v134_13(void)        = UnmodeledUse       : mu*
-#  134|     v134_14(void)        = AliasedUse         : m134_3
-#  134|     v134_15(void)        = ExitFunction       : 
+#  134|     v134_13(void)        = AliasedUse         : m134_3
+#  134|     v134_14(void)        = ExitFunction       : 
 
 #  145| void MergeMustExactlyWithMayPartiallyOverlap(bool, Point, int)
 #  145|   Block 0
@@ -685,9 +671,8 @@ ssa.cpp:
 #  153|     m153_5(Point)        = Store              : &:r153_2, r153_4
 #  154|     v154_1(void)         = NoOp               : 
 #  145|     v145_12(void)        = ReturnVoid         : 
-#  145|     v145_13(void)        = UnmodeledUse       : mu*
-#  145|     v145_14(void)        = AliasedUse         : m145_3
-#  145|     v145_15(void)        = ExitFunction       : 
+#  145|     v145_13(void)        = AliasedUse         : m145_3
+#  145|     v145_14(void)        = ExitFunction       : 
 
 #  156| void MergeMustTotallyOverlapWithMayPartiallyOverlap(bool, Rect, int)
 #  156|   Block 0
@@ -744,9 +729,8 @@ ssa.cpp:
 #  164|     m164_6(Point)        = Store                 : &:r164_2, r164_5
 #  165|     v165_1(void)         = NoOp                  : 
 #  156|     v156_12(void)        = ReturnVoid            : 
-#  156|     v156_13(void)        = UnmodeledUse          : mu*
-#  156|     v156_14(void)        = AliasedUse            : m156_3
-#  156|     v156_15(void)        = ExitFunction          : 
+#  156|     v156_13(void)        = AliasedUse            : m156_3
+#  156|     v156_14(void)        = ExitFunction          : 
 
 #  171| void WrapperStruct(Wrapper)
 #  171|   Block 0
@@ -781,9 +765,8 @@ ssa.cpp:
 #  176|     m176_4(Wrapper)        = Store                  : &:r176_3, r176_2
 #  177|     v177_1(void)           = NoOp                   : 
 #  171|     v171_8(void)           = ReturnVoid             : 
-#  171|     v171_9(void)           = UnmodeledUse           : mu*
-#  171|     v171_10(void)          = AliasedUse             : m171_3
-#  171|     v171_11(void)          = ExitFunction           : 
+#  171|     v171_9(void)           = AliasedUse             : m171_3
+#  171|     v171_10(void)          = ExitFunction           : 
 
 #  179| int AsmStmt(int*)
 #  179|   Block 0
@@ -806,9 +789,8 @@ ssa.cpp:
 #  179|     v179_10(void)        = ReturnIndirection[p]     : &:r179_8, m179_9
 #  179|     r179_11(glval<int>)  = VariableAddress[#return] : 
 #  179|     v179_12(void)        = ReturnValue              : &:r179_11, m181_5
-#  179|     v179_13(void)        = UnmodeledUse             : mu*
-#  179|     v179_14(void)        = AliasedUse               : ~m180_2
-#  179|     v179_15(void)        = ExitFunction             : 
+#  179|     v179_13(void)        = AliasedUse               : ~m180_2
+#  179|     v179_14(void)        = ExitFunction             : 
 
 #  184| void AsmStmtWithOutputs(unsigned int&, unsigned int&, unsigned int&, unsigned int&)
 #  184|   Block 0
@@ -853,9 +835,8 @@ ssa.cpp:
 #  184|     v184_24(void)                  = ReturnIndirection[c]     : &:r184_16, m184_17
 #  184|     v184_25(void)                  = ReturnIndirection[d]     : &:r184_20, m184_21
 #  184|     v184_26(void)                  = ReturnVoid               : 
-#  184|     v184_27(void)                  = UnmodeledUse             : mu*
-#  184|     v184_28(void)                  = AliasedUse               : ~m186_2
-#  184|     v184_29(void)                  = ExitFunction             : 
+#  184|     v184_27(void)                  = AliasedUse               : ~m186_2
+#  184|     v184_28(void)                  = ExitFunction             : 
 
 #  198| int PureFunctions(char*, char*, int)
 #  198|   Block 0
@@ -912,9 +893,8 @@ ssa.cpp:
 #  198|     v198_17(void)          = ReturnIndirection[str2]     : &:r198_12, m198_13
 #  198|     r198_18(glval<int>)    = VariableAddress[#return]    : 
 #  198|     v198_19(void)          = ReturnValue                 : &:r198_18, m202_4
-#  198|     v198_20(void)          = UnmodeledUse                : mu*
-#  198|     v198_21(void)          = AliasedUse                  : m198_3
-#  198|     v198_22(void)          = ExitFunction                : 
+#  198|     v198_20(void)          = AliasedUse                  : m198_3
+#  198|     v198_21(void)          = ExitFunction                : 
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
@@ -945,9 +925,8 @@ ssa.cpp:
 #  210|     m210_4(int)            = Store                              : &:r210_1, r210_3
 #  207|     r207_8(glval<int>)     = VariableAddress[#return]           : 
 #  207|     v207_9(void)           = ReturnValue                        : &:r207_8, m210_4
-#  207|     v207_10(void)          = UnmodeledUse                       : mu*
-#  207|     v207_11(void)          = AliasedUse                         : m207_3
-#  207|     v207_12(void)          = ExitFunction                       : 
+#  207|     v207_10(void)          = AliasedUse                         : m207_3
+#  207|     v207_11(void)          = ExitFunction                       : 
 
 #  213| void InitArray()
 #  213|   Block 0
@@ -1014,9 +993,8 @@ ssa.cpp:
 #  221|     m221_12(char[3])        = Chi                      : total:m221_7, partial:m221_11
 #  222|     v222_1(void)            = NoOp                     : 
 #  213|     v213_6(void)            = ReturnVoid               : 
-#  213|     v213_7(void)            = UnmodeledUse             : mu*
-#  213|     v213_8(void)            = AliasedUse               : m213_3
-#  213|     v213_9(void)            = ExitFunction             : 
+#  213|     v213_7(void)            = AliasedUse               : m213_3
+#  213|     v213_8(void)            = ExitFunction             : 
 
 #  226| char StringLiteralAliasing()
 #  226|   Block 0
@@ -1042,9 +1020,8 @@ ssa.cpp:
 #  230|     m230_7(char)           = Store                         : &:r230_1, r230_6
 #  226|     r226_6(glval<char>)    = VariableAddress[#return]      : 
 #  226|     v226_7(void)           = ReturnValue                   : &:r226_6, m230_7
-#  226|     v226_8(void)           = UnmodeledUse                  : mu*
-#  226|     v226_9(void)           = AliasedUse                    : ~m227_4
-#  226|     v226_10(void)          = ExitFunction                  : 
+#  226|     v226_8(void)           = AliasedUse                    : ~m227_4
+#  226|     v226_9(void)           = ExitFunction                  : 
 
 #  235| void Constructible::Constructible(int)
 #  235|   Block 0
@@ -1058,9 +1035,8 @@ ssa.cpp:
 #  235|     m235_8(int)                  = InitializeParameter[x] : &:r235_7
 #  235|     v235_9(void)                 = NoOp                   : 
 #  235|     v235_10(void)                = ReturnVoid             : 
-#  235|     v235_11(void)                = UnmodeledUse           : mu*
-#  235|     v235_12(void)                = AliasedUse             : m235_3
-#  235|     v235_13(void)                = ExitFunction           : 
+#  235|     v235_11(void)                = AliasedUse             : m235_3
+#  235|     v235_12(void)                = ExitFunction           : 
 
 #  236| void Constructible::g()
 #  236|   Block 0
@@ -1072,9 +1048,8 @@ ssa.cpp:
 #  236|     r236_6(glval<Constructible>) = InitializeThis      : 
 #  236|     v236_7(void)                 = NoOp                : 
 #  236|     v236_8(void)                 = ReturnVoid          : 
-#  236|     v236_9(void)                 = UnmodeledUse        : mu*
-#  236|     v236_10(void)                = AliasedUse          : m236_3
-#  236|     v236_11(void)                = ExitFunction        : 
+#  236|     v236_9(void)                 = AliasedUse          : m236_3
+#  236|     v236_10(void)                = ExitFunction        : 
 
 #  239| void ExplicitConstructorCalls()
 #  239|   Block 0
@@ -1127,9 +1102,8 @@ ssa.cpp:
 #  244|     m244_8(Constructible)        = Chi                             : total:m243_9, partial:m244_7
 #  245|     v245_1(void)                 = NoOp                            : 
 #  239|     v239_6(void)                 = ReturnVoid                      : 
-#  239|     v239_7(void)                 = UnmodeledUse                    : mu*
-#  239|     v239_8(void)                 = AliasedUse                      : ~m244_5
-#  239|     v239_9(void)                 = ExitFunction                    : 
+#  239|     v239_7(void)                 = AliasedUse                      : ~m244_5
+#  239|     v239_8(void)                 = ExitFunction                    : 
 
 #  247| char* VoidStarIndirectParameters(char*, int)
 #  247|   Block 0
@@ -1183,9 +1157,8 @@ ssa.cpp:
 #  247|     v247_12(void)          = ReturnIndirection[src]             : &:r247_8, m249_6
 #  247|     r247_13(glval<char *>) = VariableAddress[#return]           : 
 #  247|     v247_14(void)          = ReturnValue                        : &:r247_13, m251_4
-#  247|     v247_15(void)          = UnmodeledUse                       : mu*
-#  247|     v247_16(void)          = AliasedUse                         : ~m248_10
-#  247|     v247_17(void)          = ExitFunction                       : 
+#  247|     v247_15(void)          = AliasedUse                         : ~m248_10
+#  247|     v247_16(void)          = ExitFunction                       : 
 
 #  254| char StringLiteralAliasing2(bool)
 #  254|   Block 0
@@ -1231,9 +1204,8 @@ ssa.cpp:
 #  263|     m263_7(char)           = Store                     : &:r263_1, r263_6
 #  254|     r254_8(glval<char>)    = VariableAddress[#return]  : 
 #  254|     v254_9(void)           = ReturnValue               : &:r254_8, m263_7
-#  254|     v254_10(void)          = UnmodeledUse              : mu*
-#  254|     v254_11(void)          = AliasedUse                : ~m262_1
-#  254|     v254_12(void)          = ExitFunction              : 
+#  254|     v254_10(void)          = AliasedUse                : ~m262_1
+#  254|     v254_11(void)          = ExitFunction              : 
 
 #  268| void* MallocAliasing(void*, int)
 #  268|   Block 0
@@ -1275,9 +1247,8 @@ ssa.cpp:
 #  268|     v268_12(void)          = ReturnIndirection[s]               : &:r268_8, m268_9
 #  268|     r268_13(glval<void *>) = VariableAddress[#return]           : 
 #  268|     v268_14(void)          = ReturnValue                        : &:r268_13, m271_4
-#  268|     v268_15(void)          = UnmodeledUse                       : mu*
-#  268|     v268_16(void)          = AliasedUse                         : ~m269_7
-#  268|     v268_17(void)          = ExitFunction                       : 
+#  268|     v268_15(void)          = AliasedUse                         : ~m269_7
+#  268|     v268_16(void)          = ExitFunction                       : 
 
 #  275| void EscapedButNotConflated(bool, Point, int)
 #  275|   Block 0
@@ -1332,9 +1303,8 @@ ssa.cpp:
 #  281|     m281_7(int)          = Store              : &:r281_3, r281_6
 #  282|     v282_1(void)         = NoOp               : 
 #  275|     v275_12(void)        = ReturnVoid         : 
-#  275|     v275_13(void)        = UnmodeledUse       : mu*
-#  275|     v275_14(void)        = AliasedUse         : ~m277_5
-#  275|     v275_15(void)        = ExitFunction       : 
+#  275|     v275_13(void)        = AliasedUse         : ~m277_5
+#  275|     v275_14(void)        = ExitFunction       : 
 
 #  286| void A::A(int)
 #  286|   Block 0
@@ -1348,9 +1318,8 @@ ssa.cpp:
 #  286|     m286_8(int)        = InitializeParameter[x] : &:r286_7
 #  286|     v286_9(void)       = NoOp                   : 
 #  286|     v286_10(void)      = ReturnVoid             : 
-#  286|     v286_11(void)      = UnmodeledUse           : mu*
-#  286|     v286_12(void)      = AliasedUse             : m286_3
-#  286|     v286_13(void)      = ExitFunction           : 
+#  286|     v286_11(void)      = AliasedUse             : m286_3
+#  286|     v286_12(void)      = ExitFunction           : 
 
 #  287| void A::A(A*)
 #  287|   Block 0
@@ -1367,9 +1336,8 @@ ssa.cpp:
 #  287|     v287_11(void)      = NoOp                       : 
 #  287|     v287_12(void)      = ReturnIndirection[p#0]     : &:r287_9, m287_10
 #  287|     v287_13(void)      = ReturnVoid                 : 
-#  287|     v287_14(void)      = UnmodeledUse               : mu*
-#  287|     v287_15(void)      = AliasedUse                 : m287_3
-#  287|     v287_16(void)      = ExitFunction               : 
+#  287|     v287_14(void)      = AliasedUse                 : m287_3
+#  287|     v287_15(void)      = ExitFunction               : 
 
 #  288| void A::A()
 #  288|   Block 0
@@ -1381,9 +1349,8 @@ ssa.cpp:
 #  288|     r288_6(glval<A>) = InitializeThis      : 
 #  288|     v288_7(void)     = NoOp                : 
 #  288|     v288_8(void)     = ReturnVoid          : 
-#  288|     v288_9(void)     = UnmodeledUse        : mu*
-#  288|     v288_10(void)    = AliasedUse          : m288_3
-#  288|     v288_11(void)    = ExitFunction        : 
+#  288|     v288_9(void)     = AliasedUse          : m288_3
+#  288|     v288_10(void)    = ExitFunction        : 
 
 #  291| Point* NewAliasing(int)
 #  291|   Block 0
@@ -1468,9 +1435,8 @@ ssa.cpp:
 #  296|     m296_4(Point *)         = Store                           : &:r296_1, r296_3
 #  291|     r291_8(glval<Point *>)  = VariableAddress[#return]        : 
 #  291|     v291_9(void)            = ReturnValue                     : &:r291_8, m296_4
-#  291|     v291_10(void)           = UnmodeledUse                    : mu*
-#  291|     v291_11(void)           = AliasedUse                      : ~m295_12
-#  291|     v291_12(void)           = ExitFunction                    : 
+#  291|     v291_10(void)           = AliasedUse                      : ~m295_12
+#  291|     v291_11(void)           = ExitFunction                    : 
 
 #  301| int main(int, char**)
 #  301|   Block 0
@@ -1517,6 +1483,5 @@ ssa.cpp:
 #  301|     v301_12(void)          = ReturnIndirection[argv]          : &:r301_10, ~m303_11, m303_11
 #  301|     r301_13(glval<int>)    = VariableAddress[#return]         : 
 #  301|     v301_14(void)          = ReturnValue                      : &:r301_13, m304_7
-#  301|     v301_15(void)          = UnmodeledUse                     : mu*
-#  301|     v301_16(void)          = AliasedUse                       : ~m303_8
-#  301|     v301_17(void)          = ExitFunction                     : 
+#  301|     v301_15(void)          = AliasedUse                       : ~m303_8
+#  301|     v301_16(void)          = ExitFunction                     : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -81,9 +81,8 @@ ssa.cpp:
 #   13|     v13_13(void)          = ReturnIndirection[p]     : &:r13_7, ~mu13_4
 #   13|     r13_14(glval<int>)    = VariableAddress[#return] : 
 #   13|     v13_15(void)          = ReturnValue              : &:r13_14, m28_11
-#   13|     v13_16(void)          = UnmodeledUse             : mu*
-#   13|     v13_17(void)          = AliasedUse               : ~mu13_4
-#   13|     v13_18(void)          = ExitFunction             : 
+#   13|     v13_16(void)          = AliasedUse               : ~mu13_4
+#   13|     v13_17(void)          = ExitFunction             : 
 
 #   31| int UnreachableViaGoto()
 #   31|   Block 0
@@ -98,9 +97,8 @@ ssa.cpp:
 #   35|     m35_3(int)        = Store                    : &:r35_1, r35_2
 #   31|     r31_5(glval<int>) = VariableAddress[#return] : 
 #   31|     v31_6(void)       = ReturnValue              : &:r31_5, m35_3
-#   31|     v31_7(void)       = UnmodeledUse             : mu*
-#   31|     v31_8(void)       = AliasedUse               : ~mu31_4
-#   31|     v31_9(void)       = ExitFunction             : 
+#   31|     v31_7(void)       = AliasedUse               : ~mu31_4
+#   31|     v31_8(void)       = ExitFunction             : 
 
 #   38| int UnreachableIf(bool)
 #   38|   Block 0
@@ -126,9 +124,8 @@ ssa.cpp:
 #   38|     m38_7(int)        = Phi                      : from 3:m43_3, from 4:m46_3, from 6:m51_3, from 7:m54_3
 #   38|     r38_8(glval<int>) = VariableAddress[#return] : 
 #   38|     v38_9(void)       = ReturnValue              : &:r38_8, m38_7
-#   38|     v38_10(void)      = UnmodeledUse             : mu*
-#   38|     v38_11(void)      = AliasedUse               : ~mu38_4
-#   38|     v38_12(void)      = ExitFunction             : 
+#   38|     v38_10(void)      = AliasedUse               : ~mu38_4
+#   38|     v38_11(void)      = ExitFunction             : 
 
 #   42|   Block 2
 #   42|     r42_1(glval<int>) = VariableAddress[x] : 
@@ -200,12 +197,11 @@ ssa.cpp:
 #   65|     m65_4(int)        = Store                    : &:r65_1, r65_3
 #   59|     r59_5(glval<int>) = VariableAddress[#return] : 
 #   59|     v59_6(void)       = ReturnValue              : &:r59_5, m65_4
-#   59|     v59_7(void)       = UnmodeledUse             : mu*
-#   59|     v59_8(void)       = AliasedUse               : ~mu59_4
-#   59|     v59_9(void)       = ExitFunction             : 
+#   59|     v59_7(void)       = AliasedUse               : ~mu59_4
+#   59|     v59_8(void)       = ExitFunction             : 
 
 #   59|   Block 2
-#   59|     v59_10(void) = Unreached : 
+#   59|     v59_9(void) = Unreached : 
 
 #   68| void chiNodeAtEndOfLoop(int, char*)
 #   68|   Block 0
@@ -252,9 +248,8 @@ ssa.cpp:
 #   71|     v71_1(void)  = NoOp                 : 
 #   68|     v68_11(void) = ReturnIndirection[p] : &:r68_9, ~mu68_4
 #   68|     v68_12(void) = ReturnVoid           : 
-#   68|     v68_13(void) = UnmodeledUse         : mu*
-#   68|     v68_14(void) = AliasedUse           : ~mu68_4
-#   68|     v68_15(void) = ExitFunction         : 
+#   68|     v68_13(void) = AliasedUse           : ~mu68_4
+#   68|     v68_14(void) = ExitFunction         : 
 
 #   75| void ScalarPhi(bool)
 #   75|   Block 0
@@ -311,9 +306,8 @@ ssa.cpp:
 #   88|     m88_4(int)        = Store                    : &:r88_1, r88_3
 #   89|     v89_1(void)       = NoOp                     : 
 #   75|     v75_7(void)       = ReturnVoid               : 
-#   75|     v75_8(void)       = UnmodeledUse             : mu*
-#   75|     v75_9(void)       = AliasedUse               : ~mu75_4
-#   75|     v75_10(void)      = ExitFunction             : 
+#   75|     v75_8(void)       = AliasedUse               : ~mu75_4
+#   75|     v75_9(void)       = ExitFunction             : 
 
 #   91| void MustExactlyOverlap(Point)
 #   91|   Block 0
@@ -329,9 +323,8 @@ ssa.cpp:
 #   92|     m92_4(Point)        = Store                  : &:r92_1, r92_3
 #   93|     v93_1(void)         = NoOp                   : 
 #   91|     v91_7(void)         = ReturnVoid             : 
-#   91|     v91_8(void)         = UnmodeledUse           : mu*
-#   91|     v91_9(void)         = AliasedUse             : ~mu91_4
-#   91|     v91_10(void)        = ExitFunction           : 
+#   91|     v91_8(void)         = AliasedUse             : ~mu91_4
+#   91|     v91_9(void)         = ExitFunction           : 
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
@@ -355,9 +348,8 @@ ssa.cpp:
 #   97|     mu97_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r97_4
 #   98|     v98_1(void)           = NoOp                         : 
 #   95|     v95_7(void)           = ReturnVoid                   : 
-#   95|     v95_8(void)           = UnmodeledUse                 : mu*
-#   95|     v95_9(void)           = AliasedUse                   : ~mu95_4
-#   95|     v95_10(void)          = ExitFunction                 : 
+#   95|     v95_8(void)           = AliasedUse                   : ~mu95_4
+#   95|     v95_9(void)           = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -379,9 +371,8 @@ ssa.cpp:
 #  102|     m102_5(int)          = Store                  : &:r102_1, r102_4
 #  103|     v103_1(void)         = NoOp                   : 
 #  100|     v100_7(void)         = ReturnVoid             : 
-#  100|     v100_8(void)         = UnmodeledUse           : mu*
-#  100|     v100_9(void)         = AliasedUse             : ~mu100_4
-#  100|     v100_10(void)        = ExitFunction           : 
+#  100|     v100_8(void)         = AliasedUse             : ~mu100_4
+#  100|     v100_9(void)         = ExitFunction           : 
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
@@ -411,9 +402,8 @@ ssa.cpp:
 #  108|     mu108_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r108_4
 #  109|     v109_1(void)           = NoOp                         : 
 #  105|     v105_7(void)           = ReturnVoid                   : 
-#  105|     v105_8(void)           = UnmodeledUse                 : mu*
-#  105|     v105_9(void)           = AliasedUse                   : ~mu105_4
-#  105|     v105_10(void)          = ExitFunction                 : 
+#  105|     v105_8(void)           = AliasedUse                   : ~mu105_4
+#  105|     v105_9(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -441,9 +431,8 @@ ssa.cpp:
 #  113|     m113_4(Point)        = Store                  : &:r113_1, r113_3
 #  114|     v114_1(void)         = NoOp                   : 
 #  111|     v111_9(void)         = ReturnVoid             : 
-#  111|     v111_10(void)        = UnmodeledUse           : mu*
-#  111|     v111_11(void)        = AliasedUse             : ~mu111_4
-#  111|     v111_12(void)        = ExitFunction           : 
+#  111|     v111_10(void)        = AliasedUse             : ~mu111_4
+#  111|     v111_11(void)        = ExitFunction           : 
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
@@ -479,9 +468,8 @@ ssa.cpp:
 #  119|     mu119_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r119_4
 #  120|     v120_1(void)           = NoOp                         : 
 #  116|     v116_9(void)           = ReturnVoid                   : 
-#  116|     v116_10(void)          = UnmodeledUse                 : mu*
-#  116|     v116_11(void)          = AliasedUse                   : ~mu116_4
-#  116|     v116_12(void)          = ExitFunction                 : 
+#  116|     v116_10(void)          = AliasedUse                   : ~mu116_4
+#  116|     v116_11(void)          = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -537,9 +525,8 @@ ssa.cpp:
 #  131|     m131_4(Point)        = Store              : &:r131_1, r131_3
 #  132|     v132_1(void)         = NoOp               : 
 #  122|     v122_11(void)        = ReturnVoid         : 
-#  122|     v122_12(void)        = UnmodeledUse       : mu*
-#  122|     v122_13(void)        = AliasedUse         : ~mu122_4
-#  122|     v122_14(void)        = ExitFunction       : 
+#  122|     v122_12(void)        = AliasedUse         : ~mu122_4
+#  122|     v122_13(void)        = ExitFunction       : 
 
 #  134| void MergeMustExactlyWithMustTotallyOverlap(bool, Point, int)
 #  134|   Block 0
@@ -590,9 +577,8 @@ ssa.cpp:
 #  142|     m142_5(int)          = Store              : &:r142_1, r142_4
 #  143|     v143_1(void)         = NoOp               : 
 #  134|     v134_11(void)        = ReturnVoid         : 
-#  134|     v134_12(void)        = UnmodeledUse       : mu*
-#  134|     v134_13(void)        = AliasedUse         : ~mu134_4
-#  134|     v134_14(void)        = ExitFunction       : 
+#  134|     v134_12(void)        = AliasedUse         : ~mu134_4
+#  134|     v134_13(void)        = ExitFunction       : 
 
 #  145| void MergeMustExactlyWithMayPartiallyOverlap(bool, Point, int)
 #  145|   Block 0
@@ -642,9 +628,8 @@ ssa.cpp:
 #  153|     m153_4(Point)        = Store              : &:r153_1, r153_3
 #  154|     v154_1(void)         = NoOp               : 
 #  145|     v145_11(void)        = ReturnVoid         : 
-#  145|     v145_12(void)        = UnmodeledUse       : mu*
-#  145|     v145_13(void)        = AliasedUse         : ~mu145_4
-#  145|     v145_14(void)        = ExitFunction       : 
+#  145|     v145_12(void)        = AliasedUse         : ~mu145_4
+#  145|     v145_13(void)        = ExitFunction       : 
 
 #  156| void MergeMustTotallyOverlapWithMayPartiallyOverlap(bool, Rect, int)
 #  156|   Block 0
@@ -696,9 +681,8 @@ ssa.cpp:
 #  164|     m164_5(Point)        = Store                 : &:r164_1, r164_4
 #  165|     v165_1(void)         = NoOp                  : 
 #  156|     v156_11(void)        = ReturnVoid            : 
-#  156|     v156_12(void)        = UnmodeledUse          : mu*
-#  156|     v156_13(void)        = AliasedUse            : ~mu156_4
-#  156|     v156_14(void)        = ExitFunction          : 
+#  156|     v156_12(void)        = AliasedUse            : ~mu156_4
+#  156|     v156_13(void)        = ExitFunction          : 
 
 #  171| void WrapperStruct(Wrapper)
 #  171|   Block 0
@@ -732,9 +716,8 @@ ssa.cpp:
 #  176|     m176_4(Wrapper)        = Store                  : &:r176_3, r176_2
 #  177|     v177_1(void)           = NoOp                   : 
 #  171|     v171_7(void)           = ReturnVoid             : 
-#  171|     v171_8(void)           = UnmodeledUse           : mu*
-#  171|     v171_9(void)           = AliasedUse             : ~mu171_4
-#  171|     v171_10(void)          = ExitFunction           : 
+#  171|     v171_8(void)           = AliasedUse             : ~mu171_4
+#  171|     v171_9(void)           = ExitFunction           : 
 
 #  179| int AsmStmt(int*)
 #  179|   Block 0
@@ -755,9 +738,8 @@ ssa.cpp:
 #  179|     v179_9(void)         = ReturnIndirection[p]     : &:r179_7, ~mu179_4
 #  179|     r179_10(glval<int>)  = VariableAddress[#return] : 
 #  179|     v179_11(void)        = ReturnValue              : &:r179_10, m181_5
-#  179|     v179_12(void)        = UnmodeledUse             : mu*
-#  179|     v179_13(void)        = AliasedUse               : ~mu179_4
-#  179|     v179_14(void)        = ExitFunction             : 
+#  179|     v179_12(void)        = AliasedUse               : ~mu179_4
+#  179|     v179_13(void)        = ExitFunction             : 
 
 #  184| void AsmStmtWithOutputs(unsigned int&, unsigned int&, unsigned int&, unsigned int&)
 #  184|   Block 0
@@ -800,9 +782,8 @@ ssa.cpp:
 #  184|     v184_23(void)                  = ReturnIndirection[c]     : &:r184_15, ~mu184_4
 #  184|     v184_24(void)                  = ReturnIndirection[d]     : &:r184_19, ~mu184_4
 #  184|     v184_25(void)                  = ReturnVoid               : 
-#  184|     v184_26(void)                  = UnmodeledUse             : mu*
-#  184|     v184_27(void)                  = AliasedUse               : ~mu184_4
-#  184|     v184_28(void)                  = ExitFunction             : 
+#  184|     v184_26(void)                  = AliasedUse               : ~mu184_4
+#  184|     v184_27(void)                  = ExitFunction             : 
 
 #  198| int PureFunctions(char*, char*, int)
 #  198|   Block 0
@@ -858,9 +839,8 @@ ssa.cpp:
 #  198|     v198_16(void)          = ReturnIndirection[str2]     : &:r198_11, ~mu198_4
 #  198|     r198_17(glval<int>)    = VariableAddress[#return]    : 
 #  198|     v198_18(void)          = ReturnValue                 : &:r198_17, m202_4
-#  198|     v198_19(void)          = UnmodeledUse                : mu*
-#  198|     v198_20(void)          = AliasedUse                  : ~mu198_4
-#  198|     v198_21(void)          = ExitFunction                : 
+#  198|     v198_19(void)          = AliasedUse                  : ~mu198_4
+#  198|     v198_20(void)          = ExitFunction                : 
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
@@ -889,9 +869,8 @@ ssa.cpp:
 #  210|     m210_4(int)            = Store                              : &:r210_1, r210_3
 #  207|     r207_7(glval<int>)     = VariableAddress[#return]           : 
 #  207|     v207_8(void)           = ReturnValue                        : &:r207_7, m210_4
-#  207|     v207_9(void)           = UnmodeledUse                       : mu*
-#  207|     v207_10(void)          = AliasedUse                         : ~mu207_4
-#  207|     v207_11(void)          = ExitFunction                       : 
+#  207|     v207_9(void)           = AliasedUse                         : ~mu207_4
+#  207|     v207_10(void)          = ExitFunction                       : 
 
 #  213| void InitArray()
 #  213|   Block 0
@@ -951,9 +930,8 @@ ssa.cpp:
 #  221|     mu221_10(unknown[2])    = Store                    : &:r221_8, r221_9
 #  222|     v222_1(void)            = NoOp                     : 
 #  213|     v213_5(void)            = ReturnVoid               : 
-#  213|     v213_6(void)            = UnmodeledUse             : mu*
-#  213|     v213_7(void)            = AliasedUse               : ~mu213_4
-#  213|     v213_8(void)            = ExitFunction             : 
+#  213|     v213_6(void)            = AliasedUse               : ~mu213_4
+#  213|     v213_7(void)            = ExitFunction             : 
 
 #  226| char StringLiteralAliasing()
 #  226|   Block 0
@@ -977,9 +955,8 @@ ssa.cpp:
 #  230|     m230_7(char)           = Store                         : &:r230_1, r230_6
 #  226|     r226_5(glval<char>)    = VariableAddress[#return]      : 
 #  226|     v226_6(void)           = ReturnValue                   : &:r226_5, m230_7
-#  226|     v226_7(void)           = UnmodeledUse                  : mu*
-#  226|     v226_8(void)           = AliasedUse                    : ~mu226_4
-#  226|     v226_9(void)           = ExitFunction                  : 
+#  226|     v226_7(void)           = AliasedUse                    : ~mu226_4
+#  226|     v226_8(void)           = ExitFunction                  : 
 
 #  235| void Constructible::Constructible(int)
 #  235|   Block 0
@@ -992,9 +969,8 @@ ssa.cpp:
 #  235|     m235_7(int)                  = InitializeParameter[x] : &:r235_6
 #  235|     v235_8(void)                 = NoOp                   : 
 #  235|     v235_9(void)                 = ReturnVoid             : 
-#  235|     v235_10(void)                = UnmodeledUse           : mu*
-#  235|     v235_11(void)                = AliasedUse             : ~mu235_4
-#  235|     v235_12(void)                = ExitFunction           : 
+#  235|     v235_10(void)                = AliasedUse             : ~mu235_4
+#  235|     v235_11(void)                = ExitFunction           : 
 
 #  236| void Constructible::g()
 #  236|   Block 0
@@ -1005,9 +981,8 @@ ssa.cpp:
 #  236|     r236_5(glval<Constructible>) = InitializeThis      : 
 #  236|     v236_6(void)                 = NoOp                : 
 #  236|     v236_7(void)                 = ReturnVoid          : 
-#  236|     v236_8(void)                 = UnmodeledUse        : mu*
-#  236|     v236_9(void)                 = AliasedUse          : ~mu236_4
-#  236|     v236_10(void)                = ExitFunction        : 
+#  236|     v236_8(void)                 = AliasedUse          : ~mu236_4
+#  236|     v236_9(void)                 = ExitFunction        : 
 
 #  239| void ExplicitConstructorCalls()
 #  239|   Block 0
@@ -1049,9 +1024,8 @@ ssa.cpp:
 #  244|     mu244_6(Constructible)       = ^IndirectMayWriteSideEffect[-1] : &:r244_1
 #  245|     v245_1(void)                 = NoOp                            : 
 #  239|     v239_5(void)                 = ReturnVoid                      : 
-#  239|     v239_6(void)                 = UnmodeledUse                    : mu*
-#  239|     v239_7(void)                 = AliasedUse                      : ~mu239_4
-#  239|     v239_8(void)                 = ExitFunction                    : 
+#  239|     v239_6(void)                 = AliasedUse                      : ~mu239_4
+#  239|     v239_7(void)                 = ExitFunction                    : 
 
 #  247| char* VoidStarIndirectParameters(char*, int)
 #  247|   Block 0
@@ -1101,9 +1075,8 @@ ssa.cpp:
 #  247|     v247_11(void)          = ReturnIndirection[src]             : &:r247_7, ~mu247_4
 #  247|     r247_12(glval<char *>) = VariableAddress[#return]           : 
 #  247|     v247_13(void)          = ReturnValue                        : &:r247_12, m251_4
-#  247|     v247_14(void)          = UnmodeledUse                       : mu*
-#  247|     v247_15(void)          = AliasedUse                         : ~mu247_4
-#  247|     v247_16(void)          = ExitFunction                       : 
+#  247|     v247_14(void)          = AliasedUse                         : ~mu247_4
+#  247|     v247_15(void)          = ExitFunction                       : 
 
 #  254| char StringLiteralAliasing2(bool)
 #  254|   Block 0
@@ -1145,9 +1118,8 @@ ssa.cpp:
 #  263|     m263_7(char)           = Store                     : &:r263_1, r263_6
 #  254|     r254_7(glval<char>)    = VariableAddress[#return]  : 
 #  254|     v254_8(void)           = ReturnValue               : &:r254_7, m263_7
-#  254|     v254_9(void)           = UnmodeledUse              : mu*
-#  254|     v254_10(void)          = AliasedUse                : ~mu254_4
-#  254|     v254_11(void)          = ExitFunction              : 
+#  254|     v254_9(void)           = AliasedUse                : ~mu254_4
+#  254|     v254_10(void)          = ExitFunction              : 
 
 #  268| void* MallocAliasing(void*, int)
 #  268|   Block 0
@@ -1186,9 +1158,8 @@ ssa.cpp:
 #  268|     v268_11(void)          = ReturnIndirection[s]               : &:r268_7, ~mu268_4
 #  268|     r268_12(glval<void *>) = VariableAddress[#return]           : 
 #  268|     v268_13(void)          = ReturnValue                        : &:r268_12, m271_4
-#  268|     v268_14(void)          = UnmodeledUse                       : mu*
-#  268|     v268_15(void)          = AliasedUse                         : ~mu268_4
-#  268|     v268_16(void)          = ExitFunction                       : 
+#  268|     v268_14(void)          = AliasedUse                         : ~mu268_4
+#  268|     v268_15(void)          = ExitFunction                       : 
 
 #  275| void EscapedButNotConflated(bool, Point, int)
 #  275|   Block 0
@@ -1236,9 +1207,8 @@ ssa.cpp:
 #  281|     m281_5(int)          = Store              : &:r281_1, r281_4
 #  282|     v282_1(void)         = NoOp               : 
 #  275|     v275_11(void)        = ReturnVoid         : 
-#  275|     v275_12(void)        = UnmodeledUse       : mu*
-#  275|     v275_13(void)        = AliasedUse         : ~mu275_4
-#  275|     v275_14(void)        = ExitFunction       : 
+#  275|     v275_12(void)        = AliasedUse         : ~mu275_4
+#  275|     v275_13(void)        = ExitFunction       : 
 
 #  286| void A::A(int)
 #  286|   Block 0
@@ -1251,9 +1221,8 @@ ssa.cpp:
 #  286|     m286_7(int)        = InitializeParameter[x] : &:r286_6
 #  286|     v286_8(void)       = NoOp                   : 
 #  286|     v286_9(void)       = ReturnVoid             : 
-#  286|     v286_10(void)      = UnmodeledUse           : mu*
-#  286|     v286_11(void)      = AliasedUse             : ~mu286_4
-#  286|     v286_12(void)      = ExitFunction           : 
+#  286|     v286_10(void)      = AliasedUse             : ~mu286_4
+#  286|     v286_11(void)      = ExitFunction           : 
 
 #  287| void A::A(A*)
 #  287|   Block 0
@@ -1269,9 +1238,8 @@ ssa.cpp:
 #  287|     v287_10(void)      = NoOp                       : 
 #  287|     v287_11(void)      = ReturnIndirection[p#0]     : &:r287_8, ~mu287_4
 #  287|     v287_12(void)      = ReturnVoid                 : 
-#  287|     v287_13(void)      = UnmodeledUse               : mu*
-#  287|     v287_14(void)      = AliasedUse                 : ~mu287_4
-#  287|     v287_15(void)      = ExitFunction               : 
+#  287|     v287_13(void)      = AliasedUse                 : ~mu287_4
+#  287|     v287_14(void)      = ExitFunction               : 
 
 #  288| void A::A()
 #  288|   Block 0
@@ -1282,9 +1250,8 @@ ssa.cpp:
 #  288|     r288_5(glval<A>) = InitializeThis      : 
 #  288|     v288_6(void)     = NoOp                : 
 #  288|     v288_7(void)     = ReturnVoid          : 
-#  288|     v288_8(void)     = UnmodeledUse        : mu*
-#  288|     v288_9(void)     = AliasedUse          : ~mu288_4
-#  288|     v288_10(void)    = ExitFunction        : 
+#  288|     v288_8(void)     = AliasedUse          : ~mu288_4
+#  288|     v288_9(void)     = ExitFunction        : 
 
 #  291| Point* NewAliasing(int)
 #  291|   Block 0
@@ -1356,9 +1323,8 @@ ssa.cpp:
 #  296|     m296_4(Point *)         = Store                           : &:r296_1, r296_3
 #  291|     r291_7(glval<Point *>)  = VariableAddress[#return]        : 
 #  291|     v291_8(void)            = ReturnValue                     : &:r291_7, m296_4
-#  291|     v291_9(void)            = UnmodeledUse                    : mu*
-#  291|     v291_10(void)           = AliasedUse                      : ~mu291_4
-#  291|     v291_11(void)           = ExitFunction                    : 
+#  291|     v291_9(void)            = AliasedUse                      : ~mu291_4
+#  291|     v291_10(void)           = ExitFunction                    : 
 
 #  301| int main(int, char**)
 #  301|   Block 0
@@ -1400,6 +1366,5 @@ ssa.cpp:
 #  301|     v301_11(void)          = ReturnIndirection[argv]          : &:r301_9, ~mu301_4
 #  301|     r301_12(glval<int>)    = VariableAddress[#return]         : 
 #  301|     v301_13(void)          = ReturnValue                      : &:r301_12, m304_7
-#  301|     v301_14(void)          = UnmodeledUse                     : mu*
-#  301|     v301_15(void)          = AliasedUse                       : ~mu301_4
-#  301|     v301_16(void)          = ExitFunction                     : 
+#  301|     v301_14(void)          = AliasedUse                       : ~mu301_4
+#  301|     v301_15(void)          = ExitFunction                     : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
@@ -81,9 +81,8 @@ ssa.cpp:
 #   13|     v13_13(void)          = ReturnIndirection[p]     : &:r13_7, ~mu13_4
 #   13|     r13_14(glval<int>)    = VariableAddress[#return] : 
 #   13|     v13_15(void)          = ReturnValue              : &:r13_14, m28_11
-#   13|     v13_16(void)          = UnmodeledUse             : mu*
-#   13|     v13_17(void)          = AliasedUse               : ~mu13_4
-#   13|     v13_18(void)          = ExitFunction             : 
+#   13|     v13_16(void)          = AliasedUse               : ~mu13_4
+#   13|     v13_17(void)          = ExitFunction             : 
 
 #   31| int UnreachableViaGoto()
 #   31|   Block 0
@@ -98,9 +97,8 @@ ssa.cpp:
 #   35|     m35_3(int)        = Store                    : &:r35_1, r35_2
 #   31|     r31_5(glval<int>) = VariableAddress[#return] : 
 #   31|     v31_6(void)       = ReturnValue              : &:r31_5, m35_3
-#   31|     v31_7(void)       = UnmodeledUse             : mu*
-#   31|     v31_8(void)       = AliasedUse               : ~mu31_4
-#   31|     v31_9(void)       = ExitFunction             : 
+#   31|     v31_7(void)       = AliasedUse               : ~mu31_4
+#   31|     v31_8(void)       = ExitFunction             : 
 
 #   38| int UnreachableIf(bool)
 #   38|   Block 0
@@ -126,9 +124,8 @@ ssa.cpp:
 #   38|     m38_7(int)        = Phi                      : from 3:m43_3, from 4:m46_3, from 6:m51_3, from 7:m54_3
 #   38|     r38_8(glval<int>) = VariableAddress[#return] : 
 #   38|     v38_9(void)       = ReturnValue              : &:r38_8, m38_7
-#   38|     v38_10(void)      = UnmodeledUse             : mu*
-#   38|     v38_11(void)      = AliasedUse               : ~mu38_4
-#   38|     v38_12(void)      = ExitFunction             : 
+#   38|     v38_10(void)      = AliasedUse               : ~mu38_4
+#   38|     v38_11(void)      = ExitFunction             : 
 
 #   42|   Block 2
 #   42|     r42_1(glval<int>) = VariableAddress[x] : 
@@ -200,12 +197,11 @@ ssa.cpp:
 #   65|     m65_4(int)        = Store                    : &:r65_1, r65_3
 #   59|     r59_5(glval<int>) = VariableAddress[#return] : 
 #   59|     v59_6(void)       = ReturnValue              : &:r59_5, m65_4
-#   59|     v59_7(void)       = UnmodeledUse             : mu*
-#   59|     v59_8(void)       = AliasedUse               : ~mu59_4
-#   59|     v59_9(void)       = ExitFunction             : 
+#   59|     v59_7(void)       = AliasedUse               : ~mu59_4
+#   59|     v59_8(void)       = ExitFunction             : 
 
 #   59|   Block 2
-#   59|     v59_10(void) = Unreached : 
+#   59|     v59_9(void) = Unreached : 
 
 #   68| void chiNodeAtEndOfLoop(int, char*)
 #   68|   Block 0
@@ -252,9 +248,8 @@ ssa.cpp:
 #   71|     v71_1(void)  = NoOp                 : 
 #   68|     v68_11(void) = ReturnIndirection[p] : &:r68_9, ~mu68_4
 #   68|     v68_12(void) = ReturnVoid           : 
-#   68|     v68_13(void) = UnmodeledUse         : mu*
-#   68|     v68_14(void) = AliasedUse           : ~mu68_4
-#   68|     v68_15(void) = ExitFunction         : 
+#   68|     v68_13(void) = AliasedUse           : ~mu68_4
+#   68|     v68_14(void) = ExitFunction         : 
 
 #   75| void ScalarPhi(bool)
 #   75|   Block 0
@@ -311,9 +306,8 @@ ssa.cpp:
 #   88|     m88_4(int)        = Store                    : &:r88_1, r88_3
 #   89|     v89_1(void)       = NoOp                     : 
 #   75|     v75_7(void)       = ReturnVoid               : 
-#   75|     v75_8(void)       = UnmodeledUse             : mu*
-#   75|     v75_9(void)       = AliasedUse               : ~mu75_4
-#   75|     v75_10(void)      = ExitFunction             : 
+#   75|     v75_8(void)       = AliasedUse               : ~mu75_4
+#   75|     v75_9(void)       = ExitFunction             : 
 
 #   91| void MustExactlyOverlap(Point)
 #   91|   Block 0
@@ -329,9 +323,8 @@ ssa.cpp:
 #   92|     m92_4(Point)        = Store                  : &:r92_1, r92_3
 #   93|     v93_1(void)         = NoOp                   : 
 #   91|     v91_7(void)         = ReturnVoid             : 
-#   91|     v91_8(void)         = UnmodeledUse           : mu*
-#   91|     v91_9(void)         = AliasedUse             : ~mu91_4
-#   91|     v91_10(void)        = ExitFunction           : 
+#   91|     v91_8(void)         = AliasedUse             : ~mu91_4
+#   91|     v91_9(void)         = ExitFunction           : 
 
 #   95| void MustExactlyOverlapEscaped(Point)
 #   95|   Block 0
@@ -355,9 +348,8 @@ ssa.cpp:
 #   97|     mu97_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r97_4
 #   98|     v98_1(void)           = NoOp                         : 
 #   95|     v95_7(void)           = ReturnVoid                   : 
-#   95|     v95_8(void)           = UnmodeledUse                 : mu*
-#   95|     v95_9(void)           = AliasedUse                   : ~mu95_4
-#   95|     v95_10(void)          = ExitFunction                 : 
+#   95|     v95_8(void)           = AliasedUse                   : ~mu95_4
+#   95|     v95_9(void)           = ExitFunction                 : 
 
 #  100| void MustTotallyOverlap(Point)
 #  100|   Block 0
@@ -379,9 +371,8 @@ ssa.cpp:
 #  102|     m102_5(int)          = Store                  : &:r102_1, r102_4
 #  103|     v103_1(void)         = NoOp                   : 
 #  100|     v100_7(void)         = ReturnVoid             : 
-#  100|     v100_8(void)         = UnmodeledUse           : mu*
-#  100|     v100_9(void)         = AliasedUse             : ~mu100_4
-#  100|     v100_10(void)        = ExitFunction           : 
+#  100|     v100_8(void)         = AliasedUse             : ~mu100_4
+#  100|     v100_9(void)         = ExitFunction           : 
 
 #  105| void MustTotallyOverlapEscaped(Point)
 #  105|   Block 0
@@ -411,9 +402,8 @@ ssa.cpp:
 #  108|     mu108_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r108_4
 #  109|     v109_1(void)           = NoOp                         : 
 #  105|     v105_7(void)           = ReturnVoid                   : 
-#  105|     v105_8(void)           = UnmodeledUse                 : mu*
-#  105|     v105_9(void)           = AliasedUse                   : ~mu105_4
-#  105|     v105_10(void)          = ExitFunction                 : 
+#  105|     v105_8(void)           = AliasedUse                   : ~mu105_4
+#  105|     v105_9(void)           = ExitFunction                 : 
 
 #  111| void MayPartiallyOverlap(int, int)
 #  111|   Block 0
@@ -441,9 +431,8 @@ ssa.cpp:
 #  113|     m113_4(Point)        = Store                  : &:r113_1, r113_3
 #  114|     v114_1(void)         = NoOp                   : 
 #  111|     v111_9(void)         = ReturnVoid             : 
-#  111|     v111_10(void)        = UnmodeledUse           : mu*
-#  111|     v111_11(void)        = AliasedUse             : ~mu111_4
-#  111|     v111_12(void)        = ExitFunction           : 
+#  111|     v111_10(void)        = AliasedUse             : ~mu111_4
+#  111|     v111_11(void)        = ExitFunction           : 
 
 #  116| void MayPartiallyOverlapEscaped(int, int)
 #  116|   Block 0
@@ -479,9 +468,8 @@ ssa.cpp:
 #  119|     mu119_8(unknown)       = ^BufferMayWriteSideEffect[0] : &:r119_4
 #  120|     v120_1(void)           = NoOp                         : 
 #  116|     v116_9(void)           = ReturnVoid                   : 
-#  116|     v116_10(void)          = UnmodeledUse                 : mu*
-#  116|     v116_11(void)          = AliasedUse                   : ~mu116_4
-#  116|     v116_12(void)          = ExitFunction                 : 
+#  116|     v116_10(void)          = AliasedUse                   : ~mu116_4
+#  116|     v116_11(void)          = ExitFunction                 : 
 
 #  122| void MergeMustExactlyOverlap(bool, int, int)
 #  122|   Block 0
@@ -537,9 +525,8 @@ ssa.cpp:
 #  131|     m131_4(Point)        = Store              : &:r131_1, r131_3
 #  132|     v132_1(void)         = NoOp               : 
 #  122|     v122_11(void)        = ReturnVoid         : 
-#  122|     v122_12(void)        = UnmodeledUse       : mu*
-#  122|     v122_13(void)        = AliasedUse         : ~mu122_4
-#  122|     v122_14(void)        = ExitFunction       : 
+#  122|     v122_12(void)        = AliasedUse         : ~mu122_4
+#  122|     v122_13(void)        = ExitFunction       : 
 
 #  134| void MergeMustExactlyWithMustTotallyOverlap(bool, Point, int)
 #  134|   Block 0
@@ -590,9 +577,8 @@ ssa.cpp:
 #  142|     m142_5(int)          = Store              : &:r142_1, r142_4
 #  143|     v143_1(void)         = NoOp               : 
 #  134|     v134_11(void)        = ReturnVoid         : 
-#  134|     v134_12(void)        = UnmodeledUse       : mu*
-#  134|     v134_13(void)        = AliasedUse         : ~mu134_4
-#  134|     v134_14(void)        = ExitFunction       : 
+#  134|     v134_12(void)        = AliasedUse         : ~mu134_4
+#  134|     v134_13(void)        = ExitFunction       : 
 
 #  145| void MergeMustExactlyWithMayPartiallyOverlap(bool, Point, int)
 #  145|   Block 0
@@ -642,9 +628,8 @@ ssa.cpp:
 #  153|     m153_4(Point)        = Store              : &:r153_1, r153_3
 #  154|     v154_1(void)         = NoOp               : 
 #  145|     v145_11(void)        = ReturnVoid         : 
-#  145|     v145_12(void)        = UnmodeledUse       : mu*
-#  145|     v145_13(void)        = AliasedUse         : ~mu145_4
-#  145|     v145_14(void)        = ExitFunction       : 
+#  145|     v145_12(void)        = AliasedUse         : ~mu145_4
+#  145|     v145_13(void)        = ExitFunction       : 
 
 #  156| void MergeMustTotallyOverlapWithMayPartiallyOverlap(bool, Rect, int)
 #  156|   Block 0
@@ -696,9 +681,8 @@ ssa.cpp:
 #  164|     m164_5(Point)        = Store                 : &:r164_1, r164_4
 #  165|     v165_1(void)         = NoOp                  : 
 #  156|     v156_11(void)        = ReturnVoid            : 
-#  156|     v156_12(void)        = UnmodeledUse          : mu*
-#  156|     v156_13(void)        = AliasedUse            : ~mu156_4
-#  156|     v156_14(void)        = ExitFunction          : 
+#  156|     v156_12(void)        = AliasedUse            : ~mu156_4
+#  156|     v156_13(void)        = ExitFunction          : 
 
 #  171| void WrapperStruct(Wrapper)
 #  171|   Block 0
@@ -732,9 +716,8 @@ ssa.cpp:
 #  176|     m176_4(Wrapper)        = Store                  : &:r176_3, r176_2
 #  177|     v177_1(void)           = NoOp                   : 
 #  171|     v171_7(void)           = ReturnVoid             : 
-#  171|     v171_8(void)           = UnmodeledUse           : mu*
-#  171|     v171_9(void)           = AliasedUse             : ~mu171_4
-#  171|     v171_10(void)          = ExitFunction           : 
+#  171|     v171_8(void)           = AliasedUse             : ~mu171_4
+#  171|     v171_9(void)           = ExitFunction           : 
 
 #  179| int AsmStmt(int*)
 #  179|   Block 0
@@ -755,9 +738,8 @@ ssa.cpp:
 #  179|     v179_9(void)         = ReturnIndirection[p]     : &:r179_7, ~mu179_4
 #  179|     r179_10(glval<int>)  = VariableAddress[#return] : 
 #  179|     v179_11(void)        = ReturnValue              : &:r179_10, m181_5
-#  179|     v179_12(void)        = UnmodeledUse             : mu*
-#  179|     v179_13(void)        = AliasedUse               : ~mu179_4
-#  179|     v179_14(void)        = ExitFunction             : 
+#  179|     v179_12(void)        = AliasedUse               : ~mu179_4
+#  179|     v179_13(void)        = ExitFunction             : 
 
 #  184| void AsmStmtWithOutputs(unsigned int&, unsigned int&, unsigned int&, unsigned int&)
 #  184|   Block 0
@@ -800,9 +782,8 @@ ssa.cpp:
 #  184|     v184_23(void)                  = ReturnIndirection[c]     : &:r184_15, ~mu184_4
 #  184|     v184_24(void)                  = ReturnIndirection[d]     : &:r184_19, ~mu184_4
 #  184|     v184_25(void)                  = ReturnVoid               : 
-#  184|     v184_26(void)                  = UnmodeledUse             : mu*
-#  184|     v184_27(void)                  = AliasedUse               : ~mu184_4
-#  184|     v184_28(void)                  = ExitFunction             : 
+#  184|     v184_26(void)                  = AliasedUse               : ~mu184_4
+#  184|     v184_27(void)                  = ExitFunction             : 
 
 #  198| int PureFunctions(char*, char*, int)
 #  198|   Block 0
@@ -858,9 +839,8 @@ ssa.cpp:
 #  198|     v198_16(void)          = ReturnIndirection[str2]     : &:r198_11, ~mu198_4
 #  198|     r198_17(glval<int>)    = VariableAddress[#return]    : 
 #  198|     v198_18(void)          = ReturnValue                 : &:r198_17, m202_4
-#  198|     v198_19(void)          = UnmodeledUse                : mu*
-#  198|     v198_20(void)          = AliasedUse                  : ~mu198_4
-#  198|     v198_21(void)          = ExitFunction                : 
+#  198|     v198_19(void)          = AliasedUse                  : ~mu198_4
+#  198|     v198_20(void)          = ExitFunction                : 
 
 #  207| int ModeledCallTarget(int)
 #  207|   Block 0
@@ -889,9 +869,8 @@ ssa.cpp:
 #  210|     m210_4(int)            = Store                              : &:r210_1, r210_3
 #  207|     r207_7(glval<int>)     = VariableAddress[#return]           : 
 #  207|     v207_8(void)           = ReturnValue                        : &:r207_7, m210_4
-#  207|     v207_9(void)           = UnmodeledUse                       : mu*
-#  207|     v207_10(void)          = AliasedUse                         : ~mu207_4
-#  207|     v207_11(void)          = ExitFunction                       : 
+#  207|     v207_9(void)           = AliasedUse                         : ~mu207_4
+#  207|     v207_10(void)          = ExitFunction                       : 
 
 #  213| void InitArray()
 #  213|   Block 0
@@ -951,9 +930,8 @@ ssa.cpp:
 #  221|     mu221_10(unknown[2])    = Store                    : &:r221_8, r221_9
 #  222|     v222_1(void)            = NoOp                     : 
 #  213|     v213_5(void)            = ReturnVoid               : 
-#  213|     v213_6(void)            = UnmodeledUse             : mu*
-#  213|     v213_7(void)            = AliasedUse               : ~mu213_4
-#  213|     v213_8(void)            = ExitFunction             : 
+#  213|     v213_6(void)            = AliasedUse               : ~mu213_4
+#  213|     v213_7(void)            = ExitFunction             : 
 
 #  226| char StringLiteralAliasing()
 #  226|   Block 0
@@ -977,9 +955,8 @@ ssa.cpp:
 #  230|     m230_7(char)           = Store                         : &:r230_1, r230_6
 #  226|     r226_5(glval<char>)    = VariableAddress[#return]      : 
 #  226|     v226_6(void)           = ReturnValue                   : &:r226_5, m230_7
-#  226|     v226_7(void)           = UnmodeledUse                  : mu*
-#  226|     v226_8(void)           = AliasedUse                    : ~mu226_4
-#  226|     v226_9(void)           = ExitFunction                  : 
+#  226|     v226_7(void)           = AliasedUse                    : ~mu226_4
+#  226|     v226_8(void)           = ExitFunction                  : 
 
 #  235| void Constructible::Constructible(int)
 #  235|   Block 0
@@ -992,9 +969,8 @@ ssa.cpp:
 #  235|     m235_7(int)                  = InitializeParameter[x] : &:r235_6
 #  235|     v235_8(void)                 = NoOp                   : 
 #  235|     v235_9(void)                 = ReturnVoid             : 
-#  235|     v235_10(void)                = UnmodeledUse           : mu*
-#  235|     v235_11(void)                = AliasedUse             : ~mu235_4
-#  235|     v235_12(void)                = ExitFunction           : 
+#  235|     v235_10(void)                = AliasedUse             : ~mu235_4
+#  235|     v235_11(void)                = ExitFunction           : 
 
 #  236| void Constructible::g()
 #  236|   Block 0
@@ -1005,9 +981,8 @@ ssa.cpp:
 #  236|     r236_5(glval<Constructible>) = InitializeThis      : 
 #  236|     v236_6(void)                 = NoOp                : 
 #  236|     v236_7(void)                 = ReturnVoid          : 
-#  236|     v236_8(void)                 = UnmodeledUse        : mu*
-#  236|     v236_9(void)                 = AliasedUse          : ~mu236_4
-#  236|     v236_10(void)                = ExitFunction        : 
+#  236|     v236_8(void)                 = AliasedUse          : ~mu236_4
+#  236|     v236_9(void)                 = ExitFunction        : 
 
 #  239| void ExplicitConstructorCalls()
 #  239|   Block 0
@@ -1049,9 +1024,8 @@ ssa.cpp:
 #  244|     mu244_6(Constructible)       = ^IndirectMayWriteSideEffect[-1] : &:r244_1
 #  245|     v245_1(void)                 = NoOp                            : 
 #  239|     v239_5(void)                 = ReturnVoid                      : 
-#  239|     v239_6(void)                 = UnmodeledUse                    : mu*
-#  239|     v239_7(void)                 = AliasedUse                      : ~mu239_4
-#  239|     v239_8(void)                 = ExitFunction                    : 
+#  239|     v239_6(void)                 = AliasedUse                      : ~mu239_4
+#  239|     v239_7(void)                 = ExitFunction                    : 
 
 #  247| char* VoidStarIndirectParameters(char*, int)
 #  247|   Block 0
@@ -1101,9 +1075,8 @@ ssa.cpp:
 #  247|     v247_11(void)          = ReturnIndirection[src]             : &:r247_7, ~mu247_4
 #  247|     r247_12(glval<char *>) = VariableAddress[#return]           : 
 #  247|     v247_13(void)          = ReturnValue                        : &:r247_12, m251_4
-#  247|     v247_14(void)          = UnmodeledUse                       : mu*
-#  247|     v247_15(void)          = AliasedUse                         : ~mu247_4
-#  247|     v247_16(void)          = ExitFunction                       : 
+#  247|     v247_14(void)          = AliasedUse                         : ~mu247_4
+#  247|     v247_15(void)          = ExitFunction                       : 
 
 #  254| char StringLiteralAliasing2(bool)
 #  254|   Block 0
@@ -1145,9 +1118,8 @@ ssa.cpp:
 #  263|     m263_7(char)           = Store                     : &:r263_1, r263_6
 #  254|     r254_7(glval<char>)    = VariableAddress[#return]  : 
 #  254|     v254_8(void)           = ReturnValue               : &:r254_7, m263_7
-#  254|     v254_9(void)           = UnmodeledUse              : mu*
-#  254|     v254_10(void)          = AliasedUse                : ~mu254_4
-#  254|     v254_11(void)          = ExitFunction              : 
+#  254|     v254_9(void)           = AliasedUse                : ~mu254_4
+#  254|     v254_10(void)          = ExitFunction              : 
 
 #  268| void* MallocAliasing(void*, int)
 #  268|   Block 0
@@ -1186,9 +1158,8 @@ ssa.cpp:
 #  268|     v268_11(void)          = ReturnIndirection[s]               : &:r268_7, ~mu268_4
 #  268|     r268_12(glval<void *>) = VariableAddress[#return]           : 
 #  268|     v268_13(void)          = ReturnValue                        : &:r268_12, m271_4
-#  268|     v268_14(void)          = UnmodeledUse                       : mu*
-#  268|     v268_15(void)          = AliasedUse                         : ~mu268_4
-#  268|     v268_16(void)          = ExitFunction                       : 
+#  268|     v268_14(void)          = AliasedUse                         : ~mu268_4
+#  268|     v268_15(void)          = ExitFunction                       : 
 
 #  275| void EscapedButNotConflated(bool, Point, int)
 #  275|   Block 0
@@ -1236,9 +1207,8 @@ ssa.cpp:
 #  281|     m281_5(int)          = Store              : &:r281_1, r281_4
 #  282|     v282_1(void)         = NoOp               : 
 #  275|     v275_11(void)        = ReturnVoid         : 
-#  275|     v275_12(void)        = UnmodeledUse       : mu*
-#  275|     v275_13(void)        = AliasedUse         : ~mu275_4
-#  275|     v275_14(void)        = ExitFunction       : 
+#  275|     v275_12(void)        = AliasedUse         : ~mu275_4
+#  275|     v275_13(void)        = ExitFunction       : 
 
 #  286| void A::A(int)
 #  286|   Block 0
@@ -1251,9 +1221,8 @@ ssa.cpp:
 #  286|     m286_7(int)        = InitializeParameter[x] : &:r286_6
 #  286|     v286_8(void)       = NoOp                   : 
 #  286|     v286_9(void)       = ReturnVoid             : 
-#  286|     v286_10(void)      = UnmodeledUse           : mu*
-#  286|     v286_11(void)      = AliasedUse             : ~mu286_4
-#  286|     v286_12(void)      = ExitFunction           : 
+#  286|     v286_10(void)      = AliasedUse             : ~mu286_4
+#  286|     v286_11(void)      = ExitFunction           : 
 
 #  287| void A::A(A*)
 #  287|   Block 0
@@ -1269,9 +1238,8 @@ ssa.cpp:
 #  287|     v287_10(void)      = NoOp                       : 
 #  287|     v287_11(void)      = ReturnIndirection[p#0]     : &:r287_8, ~mu287_4
 #  287|     v287_12(void)      = ReturnVoid                 : 
-#  287|     v287_13(void)      = UnmodeledUse               : mu*
-#  287|     v287_14(void)      = AliasedUse                 : ~mu287_4
-#  287|     v287_15(void)      = ExitFunction               : 
+#  287|     v287_13(void)      = AliasedUse                 : ~mu287_4
+#  287|     v287_14(void)      = ExitFunction               : 
 
 #  288| void A::A()
 #  288|   Block 0
@@ -1282,9 +1250,8 @@ ssa.cpp:
 #  288|     r288_5(glval<A>) = InitializeThis      : 
 #  288|     v288_6(void)     = NoOp                : 
 #  288|     v288_7(void)     = ReturnVoid          : 
-#  288|     v288_8(void)     = UnmodeledUse        : mu*
-#  288|     v288_9(void)     = AliasedUse          : ~mu288_4
-#  288|     v288_10(void)    = ExitFunction        : 
+#  288|     v288_8(void)     = AliasedUse          : ~mu288_4
+#  288|     v288_9(void)     = ExitFunction        : 
 
 #  291| Point* NewAliasing(int)
 #  291|   Block 0
@@ -1356,9 +1323,8 @@ ssa.cpp:
 #  296|     m296_4(Point *)         = Store                           : &:r296_1, r296_3
 #  291|     r291_7(glval<Point *>)  = VariableAddress[#return]        : 
 #  291|     v291_8(void)            = ReturnValue                     : &:r291_7, m296_4
-#  291|     v291_9(void)            = UnmodeledUse                    : mu*
-#  291|     v291_10(void)           = AliasedUse                      : ~mu291_4
-#  291|     v291_11(void)           = ExitFunction                    : 
+#  291|     v291_9(void)            = AliasedUse                      : ~mu291_4
+#  291|     v291_10(void)           = ExitFunction                    : 
 
 #  301| int main(int, char**)
 #  301|   Block 0
@@ -1400,6 +1366,5 @@ ssa.cpp:
 #  301|     v301_11(void)          = ReturnIndirection[argv]          : &:r301_9, ~mu301_4
 #  301|     r301_12(glval<int>)    = VariableAddress[#return]         : 
 #  301|     v301_13(void)          = ReturnValue                      : &:r301_12, m304_7
-#  301|     v301_14(void)          = UnmodeledUse                     : mu*
-#  301|     v301_15(void)          = AliasedUse                       : ~mu301_4
-#  301|     v301_16(void)          = ExitFunction                     : 
+#  301|     v301_14(void)          = AliasedUse                       : ~mu301_4
+#  301|     v301_15(void)          = ExitFunction                     : 

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -11,7 +11,6 @@ uniqueNodeLocation
 | aggregateinitializer.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | aggregateinitializer.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | aggregateinitializer.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| aggregateinitializer.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | aggregateinitializer.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | allocators.cpp:14:5:14:8 | AliasedDefinition | Node should have one location but has 4. |
 | allocators.cpp:14:5:14:8 | AliasedUse | Node should have one location but has 4. |
@@ -23,7 +22,6 @@ uniqueNodeLocation
 | allocators.cpp:14:5:14:8 | Phi | Node should have one location but has 4. |
 | allocators.cpp:14:5:14:8 | ReturnValue | Node should have one location but has 4. |
 | allocators.cpp:14:5:14:8 | UnmodeledDefinition | Node should have one location but has 4. |
-| allocators.cpp:14:5:14:8 | UnmodeledUse | Node should have one location but has 4. |
 | allocators.cpp:14:5:14:8 | VariableAddress | Node should have one location but has 4. |
 | array_delete.cpp:5:6:5:6 | AliasedDefinition | Node should have one location but has 14. |
 | array_delete.cpp:5:6:5:6 | AliasedUse | Node should have one location but has 14. |
@@ -34,7 +32,6 @@ uniqueNodeLocation
 | array_delete.cpp:5:6:5:6 | Phi | Node should have one location but has 14. |
 | array_delete.cpp:5:6:5:6 | ReturnVoid | Node should have one location but has 14. |
 | array_delete.cpp:5:6:5:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| array_delete.cpp:5:6:5:6 | UnmodeledUse | Node should have one location but has 14. |
 | assignexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
 | assignexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
 | assignexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
@@ -44,7 +41,6 @@ uniqueNodeLocation
 | assignexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | assignexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | assignexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| assignexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | break_labels.c:2:5:2:5 | AliasedDefinition | Node should have one location but has 20. |
 | break_labels.c:2:5:2:5 | AliasedUse | Node should have one location but has 20. |
 | break_labels.c:2:5:2:5 | Chi | Node should have one location but has 20. |
@@ -54,7 +50,6 @@ uniqueNodeLocation
 | break_labels.c:2:5:2:5 | Phi | Node should have one location but has 20. |
 | break_labels.c:2:5:2:5 | ReturnVoid | Node should have one location but has 20. |
 | break_labels.c:2:5:2:5 | UnmodeledDefinition | Node should have one location but has 20. |
-| break_labels.c:2:5:2:5 | UnmodeledUse | Node should have one location but has 20. |
 | break_labels.c:2:5:2:5 | Unreached | Node should have one location but has 20. |
 | break_labels.c:2:11:2:11 | VariableAddress | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
@@ -70,7 +65,6 @@ uniqueNodeLocation
 | conditional_destructors.cpp:29:6:29:7 | Phi | Node should have one location but has 2. |
 | conditional_destructors.cpp:29:6:29:7 | ReturnVoid | Node should have one location but has 2. |
 | conditional_destructors.cpp:29:6:29:7 | UnmodeledDefinition | Node should have one location but has 2. |
-| conditional_destructors.cpp:29:6:29:7 | UnmodeledUse | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | AliasedDefinition | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | AliasedUse | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | Chi | Node should have one location but has 2. |
@@ -80,7 +74,6 @@ uniqueNodeLocation
 | conditional_destructors.cpp:38:6:38:7 | Phi | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | ReturnVoid | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | UnmodeledDefinition | Node should have one location but has 2. |
-| conditional_destructors.cpp:38:6:38:7 | UnmodeledUse | Node should have one location but has 2. |
 | conditional_destructors.cpp:38:6:38:7 | Unreached | Node should have one location but has 2. |
 | constmemberaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
 | constmemberaccess.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
@@ -92,7 +85,6 @@ uniqueNodeLocation
 | constmemberaccess.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | constmemberaccess.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | constmemberaccess.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| constmemberaccess.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | constructorinitializer.cpp:3:9:3:9 | i | Node should have one location but has 2. |
 | constructorinitializer.cpp:3:9:3:9 | x | Node should have one location but has 2. |
 | constructorinitializer.cpp:3:16:3:16 | j | Node should have one location but has 2. |
@@ -106,7 +98,6 @@ uniqueNodeLocation
 | constructorinitializer.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | constructorinitializer.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | constructorinitializer.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| constructorinitializer.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | defconstructornewexpr.cpp:3:6:3:6 | AliasedDefinition | Node should have one location but has 14. |
 | defconstructornewexpr.cpp:3:6:3:6 | AliasedUse | Node should have one location but has 14. |
 | defconstructornewexpr.cpp:3:6:3:6 | Chi | Node should have one location but has 14. |
@@ -116,7 +107,6 @@ uniqueNodeLocation
 | defconstructornewexpr.cpp:3:6:3:6 | Phi | Node should have one location but has 14. |
 | defconstructornewexpr.cpp:3:6:3:6 | ReturnVoid | Node should have one location but has 14. |
 | defconstructornewexpr.cpp:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| defconstructornewexpr.cpp:3:6:3:6 | UnmodeledUse | Node should have one location but has 14. |
 | defdestructordeleteexpr.cpp:3:6:3:6 | AliasedDefinition | Node should have one location but has 14. |
 | defdestructordeleteexpr.cpp:3:6:3:6 | AliasedUse | Node should have one location but has 14. |
 | defdestructordeleteexpr.cpp:3:6:3:6 | Chi | Node should have one location but has 14. |
@@ -126,7 +116,6 @@ uniqueNodeLocation
 | defdestructordeleteexpr.cpp:3:6:3:6 | Phi | Node should have one location but has 14. |
 | defdestructordeleteexpr.cpp:3:6:3:6 | ReturnVoid | Node should have one location but has 14. |
 | defdestructordeleteexpr.cpp:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| defdestructordeleteexpr.cpp:3:6:3:6 | UnmodeledUse | Node should have one location but has 14. |
 | deleteexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
 | deleteexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
 | deleteexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
@@ -136,7 +125,6 @@ uniqueNodeLocation
 | deleteexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | deleteexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | deleteexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| deleteexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | dostmt.c:8:6:8:18 | AliasedDefinition | Node should have one location but has 4. |
 | dostmt.c:8:6:8:18 | AliasedUse | Node should have one location but has 4. |
 | dostmt.c:8:6:8:18 | Chi | Node should have one location but has 4. |
@@ -145,7 +133,6 @@ uniqueNodeLocation
 | dostmt.c:8:6:8:18 | InitializeNonLocal | Node should have one location but has 4. |
 | dostmt.c:8:6:8:18 | ReturnVoid | Node should have one location but has 4. |
 | dostmt.c:8:6:8:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| dostmt.c:8:6:8:18 | UnmodeledUse | Node should have one location but has 4. |
 | dostmt.c:8:6:8:18 | Unreached | Node should have one location but has 4. |
 | dostmt.c:16:6:16:18 | AliasedDefinition | Node should have one location but has 4. |
 | dostmt.c:16:6:16:18 | AliasedUse | Node should have one location but has 4. |
@@ -155,7 +142,6 @@ uniqueNodeLocation
 | dostmt.c:16:6:16:18 | InitializeNonLocal | Node should have one location but has 4. |
 | dostmt.c:16:6:16:18 | ReturnVoid | Node should have one location but has 4. |
 | dostmt.c:16:6:16:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| dostmt.c:16:6:16:18 | UnmodeledUse | Node should have one location but has 4. |
 | dostmt.c:16:6:16:18 | Unreached | Node should have one location but has 4. |
 | dostmt.c:25:6:25:18 | AliasedDefinition | Node should have one location but has 2. |
 | dostmt.c:25:6:25:18 | Chi | Node should have one location but has 2. |
@@ -171,7 +157,6 @@ uniqueNodeLocation
 | dostmt.c:32:6:32:11 | InitializeNonLocal | Node should have one location but has 4. |
 | dostmt.c:32:6:32:11 | ReturnVoid | Node should have one location but has 4. |
 | dostmt.c:32:6:32:11 | UnmodeledDefinition | Node should have one location but has 4. |
-| dostmt.c:32:6:32:11 | UnmodeledUse | Node should have one location but has 4. |
 | duff.c:2:6:2:6 | AliasedDefinition | Node should have one location but has 20. |
 | duff.c:2:6:2:6 | AliasedUse | Node should have one location but has 20. |
 | duff.c:2:6:2:6 | Chi | Node should have one location but has 20. |
@@ -181,7 +166,6 @@ uniqueNodeLocation
 | duff.c:2:6:2:6 | Phi | Node should have one location but has 20. |
 | duff.c:2:6:2:6 | ReturnVoid | Node should have one location but has 20. |
 | duff.c:2:6:2:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| duff.c:2:6:2:6 | UnmodeledUse | Node should have one location but has 20. |
 | duff.c:2:6:2:6 | Unreached | Node should have one location but has 20. |
 | duff.c:2:12:2:12 | VariableAddress | Node should have one location but has 4. |
 | duff.c:2:12:2:12 | i | Node should have one location but has 4. |
@@ -197,7 +181,6 @@ uniqueNodeLocation
 | dummyblock.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | dummyblock.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | dummyblock.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| dummyblock.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | dummyblock.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | emptyblock.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | emptyblock.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -208,7 +191,6 @@ uniqueNodeLocation
 | emptyblock.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | emptyblock.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | emptyblock.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| emptyblock.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | emptyblock.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | enum.c:5:5:5:5 | AliasedDefinition | Node should have one location but has 20. |
 | enum.c:5:5:5:5 | AliasedUse | Node should have one location but has 20. |
@@ -219,7 +201,6 @@ uniqueNodeLocation
 | enum.c:5:5:5:5 | Phi | Node should have one location but has 20. |
 | enum.c:5:5:5:5 | ReturnVoid | Node should have one location but has 20. |
 | enum.c:5:5:5:5 | UnmodeledDefinition | Node should have one location but has 20. |
-| enum.c:5:5:5:5 | UnmodeledUse | Node should have one location but has 20. |
 | enum.c:5:5:5:5 | Unreached | Node should have one location but has 20. |
 | exprstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | exprstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -230,7 +211,6 @@ uniqueNodeLocation
 | exprstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | exprstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | exprstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| exprstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | exprstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | fieldaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
 | fieldaccess.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
@@ -242,7 +222,6 @@ uniqueNodeLocation
 | fieldaccess.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | fieldaccess.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | fieldaccess.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| fieldaccess.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | file://:0:0:0:0 | InitializeIndirection | Node should have one location but has 0. |
 | file://:0:0:0:0 | Load | Node should have one location but has 0. |
 | file://:0:0:0:0 | ReturnIndirection | Node should have one location but has 0. |
@@ -282,7 +261,6 @@ uniqueNodeLocation
 | forstmt.cpp:1:6:1:7 | Phi | Node should have one location but has 2. |
 | forstmt.cpp:1:6:1:7 | ReturnVoid | Node should have one location but has 2. |
 | forstmt.cpp:1:6:1:7 | UnmodeledDefinition | Node should have one location but has 2. |
-| forstmt.cpp:1:6:1:7 | UnmodeledUse | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | AliasedDefinition | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | AliasedUse | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | Chi | Node should have one location but has 2. |
@@ -292,7 +270,6 @@ uniqueNodeLocation
 | forstmt.cpp:8:6:8:7 | Phi | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | ReturnVoid | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | UnmodeledDefinition | Node should have one location but has 2. |
-| forstmt.cpp:8:6:8:7 | UnmodeledUse | Node should have one location but has 2. |
 | forstmt.cpp:8:6:8:7 | Unreached | Node should have one location but has 2. |
 | ifelsestmt.c:1:6:1:19 | AliasedDefinition | Node should have one location but has 3. |
 | ifelsestmt.c:1:6:1:19 | AliasedUse | Node should have one location but has 3. |
@@ -302,7 +279,6 @@ uniqueNodeLocation
 | ifelsestmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
 | ifelsestmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
 | ifelsestmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| ifelsestmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
 | ifelsestmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
 | ifelsestmt.c:11:6:11:19 | AliasedDefinition | Node should have one location but has 3. |
 | ifelsestmt.c:11:6:11:19 | AliasedUse | Node should have one location but has 3. |
@@ -312,7 +288,6 @@ uniqueNodeLocation
 | ifelsestmt.c:11:6:11:19 | InitializeNonLocal | Node should have one location but has 3. |
 | ifelsestmt.c:11:6:11:19 | ReturnVoid | Node should have one location but has 3. |
 | ifelsestmt.c:11:6:11:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| ifelsestmt.c:11:6:11:19 | UnmodeledUse | Node should have one location but has 3. |
 | ifelsestmt.c:11:6:11:19 | Unreached | Node should have one location but has 3. |
 | ifelsestmt.c:19:6:19:18 | AliasedDefinition | Node should have one location but has 4. |
 | ifelsestmt.c:19:6:19:18 | AliasedUse | Node should have one location but has 4. |
@@ -322,7 +297,6 @@ uniqueNodeLocation
 | ifelsestmt.c:19:6:19:18 | InitializeNonLocal | Node should have one location but has 4. |
 | ifelsestmt.c:19:6:19:18 | ReturnVoid | Node should have one location but has 4. |
 | ifelsestmt.c:19:6:19:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifelsestmt.c:19:6:19:18 | UnmodeledUse | Node should have one location but has 4. |
 | ifelsestmt.c:19:6:19:18 | Unreached | Node should have one location but has 4. |
 | ifelsestmt.c:29:6:29:18 | AliasedDefinition | Node should have one location but has 4. |
 | ifelsestmt.c:29:6:29:18 | AliasedUse | Node should have one location but has 4. |
@@ -332,7 +306,6 @@ uniqueNodeLocation
 | ifelsestmt.c:29:6:29:18 | InitializeNonLocal | Node should have one location but has 4. |
 | ifelsestmt.c:29:6:29:18 | ReturnVoid | Node should have one location but has 4. |
 | ifelsestmt.c:29:6:29:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifelsestmt.c:29:6:29:18 | UnmodeledUse | Node should have one location but has 4. |
 | ifelsestmt.c:29:6:29:18 | Unreached | Node should have one location but has 4. |
 | ifelsestmt.c:37:6:37:11 | AliasedDefinition | Node should have one location but has 4. |
 | ifelsestmt.c:37:6:37:11 | AliasedUse | Node should have one location but has 4. |
@@ -342,7 +315,6 @@ uniqueNodeLocation
 | ifelsestmt.c:37:6:37:11 | InitializeNonLocal | Node should have one location but has 4. |
 | ifelsestmt.c:37:6:37:11 | ReturnVoid | Node should have one location but has 4. |
 | ifelsestmt.c:37:6:37:11 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifelsestmt.c:37:6:37:11 | UnmodeledUse | Node should have one location but has 4. |
 | ifelsestmt.c:37:17:37:17 | VariableAddress | Node should have one location but has 2. |
 | ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
 | ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
@@ -357,7 +329,6 @@ uniqueNodeLocation
 | ifstmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
 | ifstmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
 | ifstmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| ifstmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
 | ifstmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
 | ifstmt.c:8:6:8:19 | AliasedDefinition | Node should have one location but has 3. |
 | ifstmt.c:8:6:8:19 | AliasedUse | Node should have one location but has 3. |
@@ -367,7 +338,6 @@ uniqueNodeLocation
 | ifstmt.c:8:6:8:19 | InitializeNonLocal | Node should have one location but has 3. |
 | ifstmt.c:8:6:8:19 | ReturnVoid | Node should have one location but has 3. |
 | ifstmt.c:8:6:8:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| ifstmt.c:8:6:8:19 | UnmodeledUse | Node should have one location but has 3. |
 | ifstmt.c:8:6:8:19 | Unreached | Node should have one location but has 3. |
 | ifstmt.c:14:6:14:18 | AliasedDefinition | Node should have one location but has 4. |
 | ifstmt.c:14:6:14:18 | AliasedUse | Node should have one location but has 4. |
@@ -377,7 +347,6 @@ uniqueNodeLocation
 | ifstmt.c:14:6:14:18 | InitializeNonLocal | Node should have one location but has 4. |
 | ifstmt.c:14:6:14:18 | ReturnVoid | Node should have one location but has 4. |
 | ifstmt.c:14:6:14:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifstmt.c:14:6:14:18 | UnmodeledUse | Node should have one location but has 4. |
 | ifstmt.c:14:6:14:18 | Unreached | Node should have one location but has 4. |
 | ifstmt.c:21:6:21:18 | AliasedDefinition | Node should have one location but has 4. |
 | ifstmt.c:21:6:21:18 | AliasedUse | Node should have one location but has 4. |
@@ -387,7 +356,6 @@ uniqueNodeLocation
 | ifstmt.c:21:6:21:18 | InitializeNonLocal | Node should have one location but has 4. |
 | ifstmt.c:21:6:21:18 | ReturnVoid | Node should have one location but has 4. |
 | ifstmt.c:21:6:21:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifstmt.c:21:6:21:18 | UnmodeledUse | Node should have one location but has 4. |
 | ifstmt.c:21:6:21:18 | Unreached | Node should have one location but has 4. |
 | ifstmt.c:27:6:27:11 | AliasedDefinition | Node should have one location but has 4. |
 | ifstmt.c:27:6:27:11 | AliasedUse | Node should have one location but has 4. |
@@ -397,7 +365,6 @@ uniqueNodeLocation
 | ifstmt.c:27:6:27:11 | InitializeNonLocal | Node should have one location but has 4. |
 | ifstmt.c:27:6:27:11 | ReturnVoid | Node should have one location but has 4. |
 | ifstmt.c:27:6:27:11 | UnmodeledDefinition | Node should have one location but has 4. |
-| ifstmt.c:27:6:27:11 | UnmodeledUse | Node should have one location but has 4. |
 | ifstmt.c:27:17:27:17 | VariableAddress | Node should have one location but has 2. |
 | ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
 | ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
@@ -413,7 +380,6 @@ uniqueNodeLocation
 | initializer.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | initializer.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | initializer.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| initializer.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | initializer.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | landexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | landexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -424,7 +390,6 @@ uniqueNodeLocation
 | landexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | landexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | landexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| landexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | landexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | lorexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | lorexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -435,7 +400,6 @@ uniqueNodeLocation
 | lorexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | lorexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | lorexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| lorexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | lorexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | ltrbinopexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | ltrbinopexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -446,7 +410,6 @@ uniqueNodeLocation
 | ltrbinopexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | ltrbinopexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | ltrbinopexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| ltrbinopexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | ltrbinopexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | membercallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
 | membercallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
@@ -457,7 +420,6 @@ uniqueNodeLocation
 | membercallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | membercallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | membercallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| membercallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | membercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
 | membercallexpr_args.cpp:4:14:4:14 | x | Node should have one location but has 2. |
 | membercallexpr_args.cpp:4:21:4:21 | y | Node should have one location but has 2. |
@@ -470,7 +432,6 @@ uniqueNodeLocation
 | membercallexpr_args.cpp:7:6:7:6 | Phi | Node should have one location but has 14. |
 | membercallexpr_args.cpp:7:6:7:6 | ReturnVoid | Node should have one location but has 14. |
 | membercallexpr_args.cpp:7:6:7:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| membercallexpr_args.cpp:7:6:7:6 | UnmodeledUse | Node should have one location but has 14. |
 | newexpr.cpp:3:9:3:9 | i | Node should have one location but has 2. |
 | newexpr.cpp:3:9:3:9 | x | Node should have one location but has 2. |
 | newexpr.cpp:3:16:3:16 | j | Node should have one location but has 2. |
@@ -484,7 +445,6 @@ uniqueNodeLocation
 | newexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | newexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | newexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| newexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | no_dynamic_init.cpp:9:5:9:8 | AliasedDefinition | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | AliasedUse | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | Chi | Node should have one location but has 4. |
@@ -495,7 +455,6 @@ uniqueNodeLocation
 | no_dynamic_init.cpp:9:5:9:8 | Phi | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | ReturnValue | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | UnmodeledDefinition | Node should have one location but has 4. |
-| no_dynamic_init.cpp:9:5:9:8 | UnmodeledUse | Node should have one location but has 4. |
 | no_dynamic_init.cpp:9:5:9:8 | VariableAddress | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | nodefaultswitchstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -506,7 +465,6 @@ uniqueNodeLocation
 | nodefaultswitchstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | nodefaultswitchstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | nodefaultswitchstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| nodefaultswitchstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | nodefaultswitchstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | nodefaultswitchstmt.c:1:12:1:12 | VariableAddress | Node should have one location but has 4. |
 | nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
@@ -521,7 +479,6 @@ uniqueNodeLocation
 | nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 2. |
 | nonmembercallexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 2. |
 | nonmembercallexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 2. |
-| nonmembercallexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 2. |
 | nonmembercallexpr.c:3:6:3:6 | AliasedDefinition | Node should have one location but has 20. |
 | nonmembercallexpr.c:3:6:3:6 | AliasedUse | Node should have one location but has 20. |
 | nonmembercallexpr.c:3:6:3:6 | Chi | Node should have one location but has 20. |
@@ -531,7 +488,6 @@ uniqueNodeLocation
 | nonmembercallexpr.c:3:6:3:6 | Phi | Node should have one location but has 20. |
 | nonmembercallexpr.c:3:6:3:6 | ReturnVoid | Node should have one location but has 20. |
 | nonmembercallexpr.c:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| nonmembercallexpr.c:3:6:3:6 | UnmodeledUse | Node should have one location but has 20. |
 | nonmembercallexpr.c:3:6:3:6 | Unreached | Node should have one location but has 20. |
 | nonmemberfp2callexpr.c:3:6:3:6 | AliasedDefinition | Node should have one location but has 20. |
 | nonmemberfp2callexpr.c:3:6:3:6 | AliasedUse | Node should have one location but has 20. |
@@ -542,7 +498,6 @@ uniqueNodeLocation
 | nonmemberfp2callexpr.c:3:6:3:6 | Phi | Node should have one location but has 20. |
 | nonmemberfp2callexpr.c:3:6:3:6 | ReturnVoid | Node should have one location but has 20. |
 | nonmemberfp2callexpr.c:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| nonmemberfp2callexpr.c:3:6:3:6 | UnmodeledUse | Node should have one location but has 20. |
 | nonmemberfp2callexpr.c:3:6:3:6 | Unreached | Node should have one location but has 20. |
 | nonmemberfpcallexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | nonmemberfpcallexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -553,7 +508,6 @@ uniqueNodeLocation
 | nonmemberfpcallexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | nonmemberfpcallexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | nonmemberfpcallexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| nonmemberfpcallexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | nonmemberfpcallexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | parameterinitializer.cpp:18:5:18:8 | AliasedDefinition | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | AliasedUse | Node should have one location but has 4. |
@@ -565,7 +519,6 @@ uniqueNodeLocation
 | parameterinitializer.cpp:18:5:18:8 | Phi | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | ReturnValue | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | UnmodeledDefinition | Node should have one location but has 4. |
-| parameterinitializer.cpp:18:5:18:8 | UnmodeledUse | Node should have one location but has 4. |
 | parameterinitializer.cpp:18:5:18:8 | VariableAddress | Node should have one location but has 4. |
 | pmcallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
 | pmcallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
@@ -576,7 +529,6 @@ uniqueNodeLocation
 | pmcallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | pmcallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | pmcallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| pmcallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | questionexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | questionexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
 | questionexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
@@ -586,7 +538,6 @@ uniqueNodeLocation
 | questionexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | questionexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | questionexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| questionexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | questionexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | revsubscriptexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 2. |
 | revsubscriptexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 2. |
@@ -596,7 +547,6 @@ uniqueNodeLocation
 | revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 2. |
 | revsubscriptexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 2. |
 | revsubscriptexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 2. |
-| revsubscriptexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 2. |
 | staticmembercallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
 | staticmembercallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
 | staticmembercallexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
@@ -606,7 +556,6 @@ uniqueNodeLocation
 | staticmembercallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
 | staticmembercallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
 | staticmembercallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| staticmembercallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
 | staticmembercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
 | staticmembercallexpr_args.cpp:4:21:4:21 | x | Node should have one location but has 2. |
 | staticmembercallexpr_args.cpp:4:28:4:28 | y | Node should have one location but has 2. |
@@ -619,7 +568,6 @@ uniqueNodeLocation
 | staticmembercallexpr_args.cpp:7:6:7:6 | Phi | Node should have one location but has 14. |
 | staticmembercallexpr_args.cpp:7:6:7:6 | ReturnVoid | Node should have one location but has 14. |
 | staticmembercallexpr_args.cpp:7:6:7:6 | UnmodeledDefinition | Node should have one location but has 14. |
-| staticmembercallexpr_args.cpp:7:6:7:6 | UnmodeledUse | Node should have one location but has 14. |
 | stream_it.cpp:16:5:16:8 | AliasedDefinition | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | AliasedUse | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | Chi | Node should have one location but has 4. |
@@ -630,7 +578,6 @@ uniqueNodeLocation
 | stream_it.cpp:16:5:16:8 | Phi | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | ReturnValue | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | UnmodeledDefinition | Node should have one location but has 4. |
-| stream_it.cpp:16:5:16:8 | UnmodeledUse | Node should have one location but has 4. |
 | stream_it.cpp:16:5:16:8 | VariableAddress | Node should have one location but has 4. |
 | subscriptexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | subscriptexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -641,7 +588,6 @@ uniqueNodeLocation
 | subscriptexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | subscriptexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | subscriptexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| subscriptexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | subscriptexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | switchstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | switchstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -652,7 +598,6 @@ uniqueNodeLocation
 | switchstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | switchstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | switchstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| switchstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | switchstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | switchstmt.c:1:12:1:12 | VariableAddress | Node should have one location but has 4. |
 | switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
@@ -668,7 +613,6 @@ uniqueNodeLocation
 | tinyforstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | tinyforstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | tinyforstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| tinyforstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | tinyforstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | unaryopexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | unaryopexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
@@ -679,7 +623,6 @@ uniqueNodeLocation
 | unaryopexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
 | unaryopexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
 | unaryopexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
-| unaryopexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
 | unaryopexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
 | whilestmt.c:1:6:1:19 | AliasedDefinition | Node should have one location but has 3. |
 | whilestmt.c:1:6:1:19 | AliasedUse | Node should have one location but has 3. |
@@ -689,7 +632,6 @@ uniqueNodeLocation
 | whilestmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
 | whilestmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
 | whilestmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| whilestmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
 | whilestmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
 | whilestmt.c:8:6:8:19 | AliasedDefinition | Node should have one location but has 3. |
 | whilestmt.c:8:6:8:19 | AliasedUse | Node should have one location but has 3. |
@@ -699,7 +641,6 @@ uniqueNodeLocation
 | whilestmt.c:8:6:8:19 | InitializeNonLocal | Node should have one location but has 3. |
 | whilestmt.c:8:6:8:19 | ReturnVoid | Node should have one location but has 3. |
 | whilestmt.c:8:6:8:19 | UnmodeledDefinition | Node should have one location but has 3. |
-| whilestmt.c:8:6:8:19 | UnmodeledUse | Node should have one location but has 3. |
 | whilestmt.c:8:6:8:19 | Unreached | Node should have one location but has 3. |
 | whilestmt.c:15:6:15:18 | AliasedDefinition | Node should have one location but has 4. |
 | whilestmt.c:15:6:15:18 | AliasedUse | Node should have one location but has 4. |
@@ -709,7 +650,6 @@ uniqueNodeLocation
 | whilestmt.c:15:6:15:18 | InitializeNonLocal | Node should have one location but has 4. |
 | whilestmt.c:15:6:15:18 | ReturnVoid | Node should have one location but has 4. |
 | whilestmt.c:15:6:15:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| whilestmt.c:15:6:15:18 | UnmodeledUse | Node should have one location but has 4. |
 | whilestmt.c:15:6:15:18 | Unreached | Node should have one location but has 4. |
 | whilestmt.c:23:6:23:18 | AliasedDefinition | Node should have one location but has 4. |
 | whilestmt.c:23:6:23:18 | AliasedUse | Node should have one location but has 4. |
@@ -719,7 +659,6 @@ uniqueNodeLocation
 | whilestmt.c:23:6:23:18 | InitializeNonLocal | Node should have one location but has 4. |
 | whilestmt.c:23:6:23:18 | ReturnVoid | Node should have one location but has 4. |
 | whilestmt.c:23:6:23:18 | UnmodeledDefinition | Node should have one location but has 4. |
-| whilestmt.c:23:6:23:18 | UnmodeledUse | Node should have one location but has 4. |
 | whilestmt.c:23:6:23:18 | Unreached | Node should have one location but has 4. |
 | whilestmt.c:32:6:32:18 | AliasedDefinition | Node should have one location but has 2. |
 | whilestmt.c:32:6:32:18 | Chi | Node should have one location but has 2. |
@@ -735,7 +674,6 @@ uniqueNodeLocation
 | whilestmt.c:39:6:39:11 | InitializeNonLocal | Node should have one location but has 4. |
 | whilestmt.c:39:6:39:11 | ReturnVoid | Node should have one location but has 4. |
 | whilestmt.c:39:6:39:11 | UnmodeledDefinition | Node should have one location but has 4. |
-| whilestmt.c:39:6:39:11 | UnmodeledUse | Node should have one location but has 4. |
 missingLocation
 | Nodes without location: 30 |
 uniqueNodeToString

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.expected
@@ -68,9 +68,8 @@ test.cpp:
 #    7|         valnum = m5_7, m6_7, m7_4, r5_5, r6_5, r7_2
 #    8|     v8_1(void)                 = NoOp                    : 
 #    1|     v1_10(void)                = ReturnVoid              : 
-#    1|     v1_11(void)                = UnmodeledUse            : mu*
-#    1|     v1_12(void)                = AliasedUse              : m1_3
-#    1|     v1_13(void)                = ExitFunction            : 
+#    1|     v1_11(void)                = AliasedUse              : m1_3
+#    1|     v1_12(void)                = ExitFunction            : 
 
 #   12| void test01(int, int)
 #   12|   Block 0
@@ -153,9 +152,8 @@ test.cpp:
 #   18|         valnum = m16_10, m17_10, m18_4, r16_8, r17_8, r18_2
 #   19|     v19_1(void)                 = NoOp                      : 
 #   12|     v12_10(void)                = ReturnVoid                : 
-#   12|     v12_11(void)                = UnmodeledUse              : mu*
-#   12|     v12_12(void)                = AliasedUse                : m12_3
-#   12|     v12_13(void)                = ExitFunction              : 
+#   12|     v12_11(void)                = AliasedUse                : m12_3
+#   12|     v12_12(void)                = ExitFunction              : 
 
 #   25| void test02(int, int)
 #   25|   Block 0
@@ -245,9 +243,8 @@ test.cpp:
 #   32|         valnum = m31_10, m32_4, r31_8, r32_2
 #   33|     v33_1(void)                 = NoOp                             : 
 #   25|     v25_10(void)                = ReturnVoid                       : 
-#   25|     v25_11(void)                = UnmodeledUse                     : mu*
-#   25|     v25_12(void)                = AliasedUse                       : ~m30_4
-#   25|     v25_13(void)                = ExitFunction                     : 
+#   25|     v25_11(void)                = AliasedUse                       : ~m30_4
+#   25|     v25_12(void)                = ExitFunction                     : 
 
 #   39| void test03(int, int, int*)
 #   39|   Block 0
@@ -351,9 +348,8 @@ test.cpp:
 #   47|     v47_1(void)                 = NoOp                      : 
 #   39|     v39_14(void)                = ReturnIndirection[p2]     : &:r39_12, m44_6
 #   39|     v39_15(void)                = ReturnVoid                : 
-#   39|     v39_16(void)                = UnmodeledUse              : mu*
-#   39|     v39_17(void)                = AliasedUse                : m39_3
-#   39|     v39_18(void)                = ExitFunction              : 
+#   39|     v39_16(void)                = AliasedUse                : m39_3
+#   39|     v39_17(void)                = ExitFunction              : 
 
 #   49| unsigned int my_strspn(char const*, char const*)
 #   49|   Block 0
@@ -528,9 +524,8 @@ test.cpp:
 #   49|     r49_16(glval<unsigned int>) = VariableAddress[#return] : 
 #   49|         valnum = r49_16, r65_1
 #   49|     v49_17(void)                = ReturnValue              : &:r49_16, m65_4
-#   49|     v49_18(void)                = UnmodeledUse             : mu*
-#   49|     v49_19(void)                = AliasedUse               : m49_3
-#   49|     v49_20(void)                = ExitFunction             : 
+#   49|     v49_18(void)                = AliasedUse               : m49_3
+#   49|     v49_19(void)                = ExitFunction             : 
 
 #   75| void test04(two_values*)
 #   75|   Block 0
@@ -622,9 +617,8 @@ test.cpp:
 #   82|     v82_2(void)    = NoOp                    : 
 #   75|     v75_10(void)   = ReturnIndirection[vals] : &:r75_8, m75_9
 #   75|     v75_11(void)   = ReturnVoid              : 
-#   75|     v75_12(void)   = UnmodeledUse            : mu*
-#   75|     v75_13(void)   = AliasedUse              : ~m82_1
-#   75|     v75_14(void)   = ExitFunction            : 
+#   75|     v75_12(void)   = AliasedUse              : ~m82_1
+#   75|     v75_13(void)   = ExitFunction            : 
 
 #   84| void test05(int, int, void*)
 #   84|   Block 0
@@ -683,9 +677,8 @@ test.cpp:
 #   89|     v89_1(void)       = NoOp                       : 
 #   84|     v84_14(void)      = ReturnIndirection[p]       : &:r84_12, m84_13
 #   84|     v84_15(void)      = ReturnVoid                 : 
-#   84|     v84_16(void)      = UnmodeledUse               : mu*
-#   84|     v84_17(void)      = AliasedUse                 : m84_3
-#   84|     v84_18(void)      = ExitFunction               : 
+#   84|     v84_16(void)      = AliasedUse                 : m84_3
+#   84|     v84_17(void)      = ExitFunction               : 
 
 #   88|   Block 2
 #   88|     r88_11(glval<int>) = VariableAddress[x]         : 
@@ -743,9 +736,8 @@ test.cpp:
 #   91|     r91_6(glval<int>) = VariableAddress[#return] : 
 #   91|         valnum = r91_6, r93_1
 #   91|     v91_7(void)       = ReturnValue              : &:r91_6, m93_4
-#   91|     v91_8(void)       = UnmodeledUse             : mu*
-#   91|     v91_9(void)       = AliasedUse               : m91_3
-#   91|     v91_10(void)      = ExitFunction             : 
+#   91|     v91_8(void)       = AliasedUse               : m91_3
+#   91|     v91_9(void)       = ExitFunction             : 
 
 #  104| int inheritanceConversions(Derived*)
 #  104|   Block 0
@@ -814,9 +806,8 @@ test.cpp:
 #  104|     r104_11(glval<int>)      = VariableAddress[#return]                : 
 #  104|         valnum = r104_11, r109_1
 #  104|     v104_12(void)            = ReturnValue                             : &:r104_11, m109_4
-#  104|     v104_13(void)            = UnmodeledUse                            : mu*
-#  104|     v104_14(void)            = AliasedUse                              : m104_3
-#  104|     v104_15(void)            = ExitFunction                            : 
+#  104|     v104_13(void)            = AliasedUse                              : m104_3
+#  104|     v104_14(void)            = ExitFunction                            : 
 
 #  112| void test06()
 #  112|   Block 0
@@ -839,9 +830,8 @@ test.cpp:
 #  116|         valnum = unique
 #  117|     v117_1(void)           = NoOp                : 
 #  112|     v112_6(void)           = ReturnVoid          : 
-#  112|     v112_7(void)           = UnmodeledUse        : mu*
-#  112|     v112_8(void)           = AliasedUse          : m112_3
-#  112|     v112_9(void)           = ExitFunction        : 
+#  112|     v112_7(void)           = AliasedUse          : m112_3
+#  112|     v112_8(void)           = ExitFunction        : 
 
 #  124| void test_read_arg_same(A*, int)
 #  124|   Block 0
@@ -919,9 +909,8 @@ test.cpp:
 #  130|     v130_1(void)        = NoOp                      : 
 #  124|     v124_12(void)       = ReturnIndirection[pa]     : &:r124_8, m128_7
 #  124|     v124_13(void)       = ReturnVoid                : 
-#  124|     v124_14(void)       = UnmodeledUse              : mu*
-#  124|     v124_15(void)       = AliasedUse                : m124_3
-#  124|     v124_16(void)       = ExitFunction              : 
+#  124|     v124_14(void)       = AliasedUse                : m124_3
+#  124|     v124_15(void)       = ExitFunction              : 
 
 #  135| void test_read_global_same()
 #  135|   Block 0
@@ -986,9 +975,8 @@ test.cpp:
 #  140|         valnum = m140_6, r140_5
 #  141|     v141_1(void)       = NoOp                      : 
 #  135|     v135_6(void)       = ReturnVoid                : 
-#  135|     v135_7(void)       = UnmodeledUse              : mu*
-#  135|     v135_8(void)       = AliasedUse                : ~m139_7
-#  135|     v135_9(void)       = ExitFunction              : 
+#  135|     v135_7(void)       = AliasedUse                : ~m139_7
+#  135|     v135_8(void)       = ExitFunction              : 
 
 #  143| void test_read_arg_different(A*)
 #  143|   Block 0
@@ -1062,9 +1050,8 @@ test.cpp:
 #  150|     v150_1(void)       = NoOp                      : 
 #  143|     v143_10(void)      = ReturnIndirection[pa]     : &:r143_8, m147_7
 #  143|     v143_11(void)      = ReturnVoid                : 
-#  143|     v143_12(void)      = UnmodeledUse              : mu*
-#  143|     v143_13(void)      = AliasedUse                : m143_3
-#  143|     v143_14(void)      = ExitFunction              : 
+#  143|     v143_12(void)      = AliasedUse                : m143_3
+#  143|     v143_13(void)      = ExitFunction              : 
 
 #  152| void test_read_global_different(int)
 #  152|   Block 0
@@ -1133,6 +1120,5 @@ test.cpp:
 #  158|         valnum = m158_6, r158_5
 #  159|     v159_1(void)       = NoOp                      : 
 #  152|     v152_8(void)       = ReturnVoid                : 
-#  152|     v152_9(void)       = UnmodeledUse              : mu*
-#  152|     v152_10(void)      = AliasedUse                : ~m156_7
-#  152|     v152_11(void)      = ExitFunction              : 
+#  152|     v152_9(void)       = AliasedUse                : ~m156_7
+#  152|     v152_10(void)      = ExitFunction              : 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
@@ -61,7 +61,6 @@ private newtype TOpcode =
   TReThrow() or
   TUnwind() or
   TUnmodeledDefinition() or
-  TUnmodeledUse() or
   TAliasedDefinition() or
   TInitializeNonLocal() or
   TAliasedUse() or
@@ -585,12 +584,6 @@ module Opcode {
     final override MemoryAccessKind getWriteMemoryAccess() {
       result instanceof UnmodeledMemoryAccess
     }
-  }
-
-  class UnmodeledUse extends Opcode, TUnmodeledUse {
-    final override string toString() { result = "UnmodeledUse" }
-
-    final override predicate hasOperandInternal(OperandTag tag) { none() }
   }
 
   class AliasedDefinition extends Opcode, TAliasedDefinition {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/Opcode.qll
@@ -590,9 +590,7 @@ module Opcode {
   class UnmodeledUse extends Opcode, TUnmodeledUse {
     final override string toString() { result = "UnmodeledUse" }
 
-    final override predicate hasOperandInternal(OperandTag tag) {
-      tag instanceof UnmodeledUseOperandTag
-    }
+    final override predicate hasOperandInternal(OperandTag tag) { none() }
   }
 
   class AliasedDefinition extends Opcode, TAliasedDefinition {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
@@ -15,7 +15,6 @@ private newtype TOperandTag =
   TLeftOperand() or
   TRightOperand() or
   TConditionOperand() or
-  TUnmodeledUseOperand() or
   TCallTargetOperand() or
   TThisArgumentOperand() or
   TPositionalArgumentOperand(int argIndex) { Language::hasPositionalArgIndex(argIndex) } or
@@ -164,18 +163,6 @@ class ConditionOperandTag extends RegisterOperandTag, TConditionOperand {
 }
 
 ConditionOperandTag conditionOperand() { result = TConditionOperand() }
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperandTag extends MemoryOperandTag, TUnmodeledUseOperand {
-  final override string toString() { result = "UnmodeledUse" }
-
-  final override int getSortOrder() { result = 9 }
-}
-
-UnmodeledUseOperandTag unmodeledUseOperand() { result = TUnmodeledUseOperand() }
 
 /**
  * The operand representing the target function of an `Call` instruction.

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRBlock.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRBlock.qll
@@ -31,10 +31,14 @@ class IRBlockBase extends TIRBlock {
       config.shouldEvaluateDebugStringsForFunction(this.getEnclosingFunction())
     ) and
     this =
-      rank[result + 1](IRBlock funcBlock |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction()
+      rank[result + 1](IRBlock funcBlock, int sortOverride |
+        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        // Ensure that the block containing `EnterFunction` always comes first.
+        if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
+        then sortOverride = 0
+        else sortOverride = 1
       |
-        funcBlock order by funcBlock.getUniqueId()
+        funcBlock order by sortOverride, funcBlock.getUniqueId()
       )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRConsistency.qll
@@ -257,7 +257,6 @@ module InstructionConsistency {
     Operand useOperand, string message, IRFunction func, string funcText
   ) {
     exists(IRBlock useBlock, int useIndex, Instruction defInstr, IRBlock defBlock, int defIndex |
-      not useOperand.getUse() instanceof UnmodeledUseInstruction and
       not defInstr instanceof UnmodeledDefinitionInstruction and
       pointOfEvaluation(useOperand, useBlock, useIndex) and
       defInstr = useOperand.getAnyDef() and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRConsistency.qll
@@ -55,7 +55,6 @@ module InstructionConsistency {
           operand.getOperandTag() = tag
         ) and
       operandCount > 1 and
-      not tag instanceof UnmodeledUseOperandTag and
       message =
         "Instruction has " + operandCount + " operands with tag '" + tag.toString() + "'" +
           " in function '$@'." and
@@ -158,7 +157,6 @@ module InstructionConsistency {
   ) {
     exists(MemoryOperand operand, Instruction def |
       operand = instr.getAnOperand() and
-      not operand instanceof UnmodeledUseOperand and
       def = operand.getAnyDef() and
       not def.isResultModeled() and
       not def instanceof UnmodeledDefinitionInstruction and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRFunction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/IRFunction.qll
@@ -45,11 +45,6 @@ class IRFunction extends TIRFunction {
     result.getEnclosingIRFunction() = this
   }
 
-  pragma[noinline]
-  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
-    result.getEnclosingIRFunction() = this
-  }
-
   /**
    * Gets the single return instruction for this function.
    */

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -320,8 +320,7 @@ class Instruction extends Construction::TInstruction {
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
    * holds for a register result. For a memory result, a modeled result is
-   * connected to its actual uses. An unmodeled result is connected to the
-   * `UnmodeledUse` instruction.
+   * connected to its actual uses. An unmodeled result has no uses.
    *
    * For example:
    * ```
@@ -1246,12 +1245,6 @@ class AliasedDefinitionInstruction extends Instruction {
  */
 class AliasedUseInstruction extends Instruction {
   AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
-}
-
-class UnmodeledUseInstruction extends Instruction {
-  UnmodeledUseInstruction() { getOpcode() instanceof Opcode::UnmodeledUse }
-
-  override string getOperandsString() { result = "mu*" }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -19,11 +19,7 @@ private newtype TOperand =
   ) {
     defInstr = Construction::getMemoryOperandDefinition(useInstr, tag, overlap) and
     not Construction::isInCycle(useInstr) and
-    (
-      strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
-      or
-      tag instanceof UnmodeledUseOperandTag
-    )
+    strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
   } or
   TPhiOperand(
     PhiInstruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
@@ -325,16 +321,6 @@ class ConditionOperand extends RegisterOperand {
   override ConditionOperandTag tag;
 
   override string toString() { result = "Condition" }
-}
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperand extends NonPhiMemoryOperand {
-  override UnmodeledUseOperandTag tag;
-
-  override string toString() { result = "UnmodeledUse" }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/InstructionTag.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/InstructionTag.qll
@@ -30,7 +30,6 @@ newtype TInstructionTag =
   ReturnTag() or
   ExitFunctionTag() or
   UnmodeledDefinitionTag() or
-  UnmodeledUseTag() or
   AliasedDefinitionTag() or
   AliasedUseTag() or
   SwitchBranchTag() or
@@ -127,8 +126,6 @@ string getInstructionTagId(TInstructionTag tag) {
   tag = ExitFunctionTag() and result = "ExitFunc"
   or
   tag = UnmodeledDefinitionTag() and result = "UnmodeledDef"
-  or
-  tag = UnmodeledUseTag() and result = "UnmodeledUse"
   or
   tag = AliasedDefinitionTag() and result = "AliasedDef"
   or

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedFunction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedFunction.qll
@@ -93,13 +93,10 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
       result = this.getInstruction(ReturnTag())
       or
       tag = ReturnTag() and
-      result = this.getInstruction(UnmodeledUseTag())
+      result = this.getInstruction(AliasedUseTag())
       or
       tag = UnwindTag() and
-      result = this.getInstruction(UnmodeledUseTag())
-      or
-      tag = UnmodeledUseTag() and
-      result = getInstruction(AliasedUseTag())
+      result = this.getInstruction(AliasedUseTag())
       or
       tag = AliasedUseTag() and
       result = this.getInstruction(ExitFunctionTag())
@@ -170,10 +167,6 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
         exists(TryStmt try | try.getEnclosingCallable() = callable) or
         exists(ThrowStmt throw | throw.getEnclosingCallable() = callable)
       )
-      or
-      tag = UnmodeledUseTag() and
-      opcode instanceof Opcode::UnmodeledUse and
-      resultType = getVoidType()
       or
       tag = AliasedUseTag() and
       opcode instanceof Opcode::AliasedUse and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedFunction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/internal/TranslatedFunction.qll
@@ -190,15 +190,6 @@ class TranslatedFunction extends TranslatedElement, TTranslatedFunction {
   }
 
   final override Instruction getInstructionOperand(InstructionTag tag, OperandTag operandTag) {
-    tag = UnmodeledUseTag() and
-    operandTag instanceof UnmodeledUseOperandTag and
-    result.getEnclosingFunction() = callable and
-    result.hasMemoryResult()
-    or
-    tag = UnmodeledUseTag() and
-    operandTag instanceof UnmodeledUseOperandTag and
-    result = getUnmodeledDefinitionInstruction()
-    or
     tag = AliasedUseTag() and
     operandTag instanceof SideEffectOperandTag and
     result = getUnmodeledDefinitionInstruction()

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRBlock.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRBlock.qll
@@ -31,10 +31,14 @@ class IRBlockBase extends TIRBlock {
       config.shouldEvaluateDebugStringsForFunction(this.getEnclosingFunction())
     ) and
     this =
-      rank[result + 1](IRBlock funcBlock |
-        funcBlock.getEnclosingFunction() = getEnclosingFunction()
+      rank[result + 1](IRBlock funcBlock, int sortOverride |
+        funcBlock.getEnclosingFunction() = getEnclosingFunction() and
+        // Ensure that the block containing `EnterFunction` always comes first.
+        if funcBlock.getFirstInstruction() instanceof EnterFunctionInstruction
+        then sortOverride = 0
+        else sortOverride = 1
       |
-        funcBlock order by funcBlock.getUniqueId()
+        funcBlock order by sortOverride, funcBlock.getUniqueId()
       )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -257,7 +257,6 @@ module InstructionConsistency {
     Operand useOperand, string message, IRFunction func, string funcText
   ) {
     exists(IRBlock useBlock, int useIndex, Instruction defInstr, IRBlock defBlock, int defIndex |
-      not useOperand.getUse() instanceof UnmodeledUseInstruction and
       not defInstr instanceof UnmodeledDefinitionInstruction and
       pointOfEvaluation(useOperand, useBlock, useIndex) and
       defInstr = useOperand.getAnyDef() and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRConsistency.qll
@@ -55,7 +55,6 @@ module InstructionConsistency {
           operand.getOperandTag() = tag
         ) and
       operandCount > 1 and
-      not tag instanceof UnmodeledUseOperandTag and
       message =
         "Instruction has " + operandCount + " operands with tag '" + tag.toString() + "'" +
           " in function '$@'." and
@@ -158,7 +157,6 @@ module InstructionConsistency {
   ) {
     exists(MemoryOperand operand, Instruction def |
       operand = instr.getAnOperand() and
-      not operand instanceof UnmodeledUseOperand and
       def = operand.getAnyDef() and
       not def.isResultModeled() and
       not def instanceof UnmodeledDefinitionInstruction and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRFunction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/IRFunction.qll
@@ -45,11 +45,6 @@ class IRFunction extends TIRFunction {
     result.getEnclosingIRFunction() = this
   }
 
-  pragma[noinline]
-  final UnmodeledUseInstruction getUnmodeledUseInstruction() {
-    result.getEnclosingIRFunction() = this
-  }
-
   /**
    * Gets the single return instruction for this function.
    */

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -320,8 +320,7 @@ class Instruction extends Construction::TInstruction {
   /**
    * Holds if the result of this instruction is precisely modeled in SSA. Always
    * holds for a register result. For a memory result, a modeled result is
-   * connected to its actual uses. An unmodeled result is connected to the
-   * `UnmodeledUse` instruction.
+   * connected to its actual uses. An unmodeled result has no uses.
    *
    * For example:
    * ```
@@ -1246,12 +1245,6 @@ class AliasedDefinitionInstruction extends Instruction {
  */
 class AliasedUseInstruction extends Instruction {
   AliasedUseInstruction() { getOpcode() instanceof Opcode::AliasedUse }
-}
-
-class UnmodeledUseInstruction extends Instruction {
-  UnmodeledUseInstruction() { getOpcode() instanceof Opcode::UnmodeledUse }
-
-  override string getOperandsString() { result = "mu*" }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
@@ -19,11 +19,7 @@ private newtype TOperand =
   ) {
     defInstr = Construction::getMemoryOperandDefinition(useInstr, tag, overlap) and
     not Construction::isInCycle(useInstr) and
-    (
-      strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
-      or
-      tag instanceof UnmodeledUseOperandTag
-    )
+    strictcount(Construction::getMemoryOperandDefinition(useInstr, tag, _)) = 1
   } or
   TPhiOperand(
     PhiInstruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
@@ -325,16 +321,6 @@ class ConditionOperand extends RegisterOperand {
   override ConditionOperandTag tag;
 
   override string toString() { result = "Condition" }
-}
-
-/**
- * An operand of the special `UnmodeledUse` instruction, representing a value
- * whose set of uses is unknown.
- */
-class UnmodeledUseOperand extends NonPhiMemoryOperand {
-  override UnmodeledUseOperandTag tag;
-
-  override string toString() { result = "UnmodeledUse" }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -247,6 +247,10 @@ private predicate resultMayReachReturn(Instruction instr) { operandMayReachRetur
 private predicate resultEscapesNonReturn(Instruction instr) {
   // The result escapes if it has at least one use that escapes.
   operandEscapesNonReturn(instr.getAUse())
+  or
+  // The result also escapes if it is not modeled in SSA, because we do not know where it might be
+  // used.
+  not instr.isResultModeled()
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SSAConstruction.qll
@@ -128,23 +128,10 @@ private module Cached {
       oldOperand = oldInstruction.getAnOperand() and
       tag = oldOperand.getOperandTag() and
       (
-        (
-          if exists(Alias::getOperandMemoryLocation(oldOperand))
-          then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
-          else (
-            result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
-            overlap instanceof MustTotallyOverlap
-          )
-        )
-        or
-        // Connect any definitions that are not being modeled in SSA to the
-        // `UnmodeledUse` instruction.
-        exists(OldInstruction oldDefinition |
-          instruction instanceof UnmodeledUseInstruction and
-          tag instanceof UnmodeledUseOperandTag and
-          oldDefinition = oldOperand.getAnyDef() and
-          not exists(Alias::getResultMemoryLocation(oldDefinition)) and
-          result = getNewInstruction(oldDefinition) and
+        if exists(Alias::getOperandMemoryLocation(oldOperand))
+        then hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
+        else (
+          result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
           overlap instanceof MustTotallyOverlap
         )
       )
@@ -153,13 +140,6 @@ private module Cached {
     instruction = Chi(getOldInstruction(result)) and
     tag instanceof ChiPartialOperandTag and
     overlap instanceof MustExactlyOverlap
-    or
-    exists(IRFunction f |
-      tag instanceof UnmodeledUseOperandTag and
-      result = f.getUnmodeledDefinitionInstruction() and
-      instruction = f.getUnmodeledUseInstruction() and
-      overlap instanceof MustTotallyOverlap
-    )
     or
     tag instanceof ChiTotalOperandTag and
     result = getChiInstructionTotalOperand(instruction) and

--- a/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/csharp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -52,9 +52,8 @@ array.cs:
 #   10|     r10_6(Int32[])         = PointerAdd[4]            : r10_3, r10_5
 #   10|     mu10_7(Int32)          = Store                    : &:r10_6, r10_1
 #    2|     v2_5(Void)             = ReturnVoid               : 
-#    2|     v2_6(Void)             = UnmodeledUse             : mu*
-#    2|     v2_7(Void)             = AliasedUse               : ~mu2_3
-#    2|     v2_8(Void)             = ExitFunction             : 
+#    2|     v2_6(Void)             = AliasedUse               : ~mu2_3
+#    2|     v2_7(Void)             = ExitFunction             : 
 
 #   13| System.Void ArrayTest.twod_and_init_acc()
 #   13|   Block 0
@@ -144,9 +143,8 @@ array.cs:
 #   20|     r20_8(Int32[])          = PointerAdd[4]       : r20_6, r20_7
 #   20|     mu20_9(Int32)           = Store               : &:r20_8, r20_1
 #   13|     v13_5(Void)             = ReturnVoid          : 
-#   13|     v13_6(Void)             = UnmodeledUse        : mu*
-#   13|     v13_7(Void)             = AliasedUse          : ~mu13_3
-#   13|     v13_8(Void)             = ExitFunction        : 
+#   13|     v13_6(Void)             = AliasedUse          : ~mu13_3
+#   13|     v13_7(Void)             = ExitFunction        : 
 
 assignop.cs:
 #    4| System.Void AssignOp.Main()
@@ -216,9 +214,8 @@ assignop.cs:
 #   17|     r17_4(Int32)        = BitOr               : r17_3, r17_1
 #   17|     mu17_5(Int32)       = Store               : &:r17_2, r17_4
 #    4|     v4_4(Void)          = ReturnVoid          : 
-#    4|     v4_5(Void)          = UnmodeledUse        : mu*
-#    4|     v4_6(Void)          = AliasedUse          : ~mu4_3
-#    4|     v4_7(Void)          = ExitFunction        : 
+#    4|     v4_5(Void)          = AliasedUse          : ~mu4_3
+#    4|     v4_6(Void)          = ExitFunction        : 
 
 casts.cs:
 #   11| System.Void Casts.Main()
@@ -243,9 +240,8 @@ casts.cs:
 #   15|     r15_4(Casts_B)        = CheckedConvertOrNull     : r15_3
 #   15|     mu15_5(Casts_B)       = Store                    : &:r15_1, r15_4
 #   11|     v11_4(Void)           = ReturnVoid               : 
-#   11|     v11_5(Void)           = UnmodeledUse             : mu*
-#   11|     v11_6(Void)           = AliasedUse               : ~mu11_3
-#   11|     v11_7(Void)           = ExitFunction             : 
+#   11|     v11_5(Void)           = AliasedUse               : ~mu11_3
+#   11|     v11_6(Void)           = ExitFunction             : 
 
 collections.cs:
 #   11| System.Void Collections.Main()
@@ -288,9 +284,8 @@ collections.cs:
 #   16|     mu16_14(<unknown>)                      = ^CallSideEffect             : ~mu11_3
 #   13|     mu13_6(Dictionary<Int32,MyClass>)       = Store                       : &:r13_1, r13_2
 #   11|     v11_4(Void)                             = ReturnVoid                  : 
-#   11|     v11_5(Void)                             = UnmodeledUse                : mu*
-#   11|     v11_6(Void)                             = AliasedUse                  : ~mu11_3
-#   11|     v11_7(Void)                             = ExitFunction                : 
+#   11|     v11_5(Void)                             = AliasedUse                  : ~mu11_3
+#   11|     v11_6(Void)                             = ExitFunction                : 
 
 constructor_init.cs:
 #    5| System.Void BaseClass..ctor()
@@ -301,9 +296,8 @@ constructor_init.cs:
 #    5|     r5_4(glval<BaseClass>) = InitializeThis      : 
 #    6|     v6_1(Void)             = NoOp                : 
 #    5|     v5_5(Void)             = ReturnVoid          : 
-#    5|     v5_6(Void)             = UnmodeledUse        : mu*
-#    5|     v5_7(Void)             = AliasedUse          : ~mu5_3
-#    5|     v5_8(Void)             = ExitFunction        : 
+#    5|     v5_6(Void)             = AliasedUse          : ~mu5_3
+#    5|     v5_7(Void)             = ExitFunction        : 
 
 #    9| System.Void BaseClass..ctor(System.Int32)
 #    9|   Block 0
@@ -319,9 +313,8 @@ constructor_init.cs:
 #   11|     r11_4(glval<Int32>)    = FieldAddress[num]      : r11_3
 #   11|     mu11_5(Int32)          = Store                  : &:r11_4, r11_2
 #    9|     v9_7(Void)             = ReturnVoid             : 
-#    9|     v9_8(Void)             = UnmodeledUse           : mu*
-#    9|     v9_9(Void)             = AliasedUse             : ~mu9_3
-#    9|     v9_10(Void)            = ExitFunction           : 
+#    9|     v9_8(Void)             = AliasedUse             : ~mu9_3
+#    9|     v9_9(Void)             = ExitFunction           : 
 
 #   17| System.Void DerivedClass..ctor()
 #   17|   Block 0
@@ -335,9 +328,8 @@ constructor_init.cs:
 #   17|     mu17_8(<unknown>)          = ^CallSideEffect                   : ~mu17_3
 #   18|     v18_1(Void)                = NoOp                              : 
 #   17|     v17_9(Void)                = ReturnVoid                        : 
-#   17|     v17_10(Void)               = UnmodeledUse                      : mu*
-#   17|     v17_11(Void)               = AliasedUse                        : ~mu17_3
-#   17|     v17_12(Void)               = ExitFunction                      : 
+#   17|     v17_10(Void)               = AliasedUse                        : ~mu17_3
+#   17|     v17_11(Void)               = ExitFunction                      : 
 
 #   21| System.Void DerivedClass..ctor(System.Int32)
 #   21|   Block 0
@@ -355,9 +347,8 @@ constructor_init.cs:
 #   21|     mu21_12(<unknown>)         = ^CallSideEffect                   : ~mu21_3
 #   22|     v22_1(Void)                = NoOp                              : 
 #   21|     v21_13(Void)               = ReturnVoid                        : 
-#   21|     v21_14(Void)               = UnmodeledUse                      : mu*
-#   21|     v21_15(Void)               = AliasedUse                        : ~mu21_3
-#   21|     v21_16(Void)               = ExitFunction                      : 
+#   21|     v21_14(Void)               = AliasedUse                        : ~mu21_3
+#   21|     v21_15(Void)               = ExitFunction                      : 
 
 #   25| System.Void DerivedClass..ctor(System.Int32,System.Int32)
 #   25|   Block 0
@@ -376,9 +367,8 @@ constructor_init.cs:
 #   25|     mu25_13(<unknown>)         = ^CallSideEffect               : ~mu25_3
 #   26|     v26_1(Void)                = NoOp                          : 
 #   25|     v25_14(Void)               = ReturnVoid                    : 
-#   25|     v25_15(Void)               = UnmodeledUse                  : mu*
-#   25|     v25_16(Void)               = AliasedUse                    : ~mu25_3
-#   25|     v25_17(Void)               = ExitFunction                  : 
+#   25|     v25_15(Void)               = AliasedUse                    : ~mu25_3
+#   25|     v25_16(Void)               = ExitFunction                  : 
 
 #   29| System.Void DerivedClass.Main()
 #   29|   Block 0
@@ -407,9 +397,8 @@ constructor_init.cs:
 #   33|     mu33_7(<unknown>)          = ^CallSideEffect               : ~mu29_3
 #   33|     mu33_8(DerivedClass)       = Store                         : &:r33_1, r33_2
 #   29|     v29_4(Void)                = ReturnVoid                    : 
-#   29|     v29_5(Void)                = UnmodeledUse                  : mu*
-#   29|     v29_6(Void)                = AliasedUse                    : ~mu29_3
-#   29|     v29_7(Void)                = ExitFunction                  : 
+#   29|     v29_5(Void)                = AliasedUse                    : ~mu29_3
+#   29|     v29_6(Void)                = ExitFunction                  : 
 
 crement.cs:
 #    3| System.Void CrementOpsTest.Main()
@@ -449,9 +438,8 @@ crement.cs:
 #    9|     r9_6(glval<Int32>) = VariableAddress[x]  : 
 #    9|     mu9_7(Int32)       = Store               : &:r9_6, r9_2
 #    3|     v3_4(Void)         = ReturnVoid          : 
-#    3|     v3_5(Void)         = UnmodeledUse        : mu*
-#    3|     v3_6(Void)         = AliasedUse          : ~mu3_3
-#    3|     v3_7(Void)         = ExitFunction        : 
+#    3|     v3_5(Void)         = AliasedUse          : ~mu3_3
+#    3|     v3_6(Void)         = ExitFunction        : 
 
 delegates.cs:
 #    6| System.Int32 Delegates.returns(System.Int32)
@@ -467,9 +455,8 @@ delegates.cs:
 #    8|     mu8_4(Int32)       = Store                    : &:r8_1, r8_3
 #    6|     r6_6(glval<Int32>) = VariableAddress[#return] : 
 #    6|     v6_7(Void)         = ReturnValue              : &:r6_6, ~mu6_3
-#    6|     v6_8(Void)         = UnmodeledUse             : mu*
-#    6|     v6_9(Void)         = AliasedUse               : ~mu6_3
-#    6|     v6_10(Void)        = ExitFunction             : 
+#    6|     v6_8(Void)         = AliasedUse               : ~mu6_3
+#    6|     v6_9(Void)         = ExitFunction             : 
 
 #   11| System.Void Delegates.Main()
 #   11|   Block 0
@@ -490,9 +477,8 @@ delegates.cs:
 #   13|     v13_5(Void)       = Call                     : func:r13_3, this:r13_2, 0:r13_4
 #   13|     mu13_6(<unknown>) = ^CallSideEffect          : ~mu11_3
 #   11|     v11_4(Void)       = ReturnVoid               : 
-#   11|     v11_5(Void)       = UnmodeledUse             : mu*
-#   11|     v11_6(Void)       = AliasedUse               : ~mu11_3
-#   11|     v11_7(Void)       = ExitFunction             : 
+#   11|     v11_5(Void)       = AliasedUse               : ~mu11_3
+#   11|     v11_6(Void)       = ExitFunction             : 
 
 events.cs:
 #    8| System.Void Events..ctor()
@@ -510,9 +496,8 @@ events.cs:
 #   10|     r10_7(glval<MyDel>) = FieldAddress[Inst]     : r10_6
 #   10|     mu10_8(MyDel)       = Store                  : &:r10_7, r10_1
 #    8|     v8_5(Void)          = ReturnVoid             : 
-#    8|     v8_6(Void)          = UnmodeledUse           : mu*
-#    8|     v8_7(Void)          = AliasedUse             : ~mu8_3
-#    8|     v8_8(Void)          = ExitFunction           : 
+#    8|     v8_6(Void)          = AliasedUse             : ~mu8_3
+#    8|     v8_7(Void)          = ExitFunction           : 
 
 #   13| System.Void Events.AddEvent()
 #   13|   Block 0
@@ -528,9 +513,8 @@ events.cs:
 #   15|     v15_6(Void)          = Call                         : func:r15_2, this:r15_1, 0:r15_5
 #   15|     mu15_7(<unknown>)    = ^CallSideEffect              : ~mu13_3
 #   13|     v13_5(Void)          = ReturnVoid                   : 
-#   13|     v13_6(Void)          = UnmodeledUse                 : mu*
-#   13|     v13_7(Void)          = AliasedUse                   : ~mu13_3
-#   13|     v13_8(Void)          = ExitFunction                 : 
+#   13|     v13_6(Void)          = AliasedUse                   : ~mu13_3
+#   13|     v13_7(Void)          = ExitFunction                 : 
 
 #   18| System.Void Events.RemoveEvent()
 #   18|   Block 0
@@ -546,9 +530,8 @@ events.cs:
 #   20|     v20_6(Void)          = Call                            : func:r20_2, this:r20_1, 0:r20_5
 #   20|     mu20_7(<unknown>)    = ^CallSideEffect                 : ~mu18_3
 #   18|     v18_5(Void)          = ReturnVoid                      : 
-#   18|     v18_6(Void)          = UnmodeledUse                    : mu*
-#   18|     v18_7(Void)          = AliasedUse                      : ~mu18_3
-#   18|     v18_8(Void)          = ExitFunction                    : 
+#   18|     v18_6(Void)          = AliasedUse                      : ~mu18_3
+#   18|     v18_7(Void)          = ExitFunction                    : 
 
 #   23| System.String Events.Fun(System.String)
 #   23|   Block 0
@@ -564,9 +547,8 @@ events.cs:
 #   25|     mu25_4(String)       = Store                    : &:r25_1, r25_3
 #   23|     r23_7(glval<String>) = VariableAddress[#return] : 
 #   23|     v23_8(Void)          = ReturnValue              : &:r23_7, ~mu23_3
-#   23|     v23_9(Void)          = UnmodeledUse             : mu*
-#   23|     v23_10(Void)         = AliasedUse               : ~mu23_3
-#   23|     v23_11(Void)         = ExitFunction             : 
+#   23|     v23_9(Void)          = AliasedUse               : ~mu23_3
+#   23|     v23_10(Void)         = ExitFunction             : 
 
 #   28| System.Void Events.Main(System.String[])
 #   28|   Block 0
@@ -600,9 +582,8 @@ events.cs:
 #   33|     v33_4(Void)            = Call                         : func:r33_3, this:r33_2
 #   33|     mu33_5(<unknown>)      = ^CallSideEffect              : ~mu28_3
 #   28|     v28_6(Void)            = ReturnVoid                   : 
-#   28|     v28_7(Void)            = UnmodeledUse                 : mu*
-#   28|     v28_8(Void)            = AliasedUse                   : ~mu28_3
-#   28|     v28_9(Void)            = ExitFunction                 : 
+#   28|     v28_7(Void)            = AliasedUse                   : ~mu28_3
+#   28|     v28_8(Void)            = ExitFunction                 : 
 
 foreach.cs:
 #    4| System.Void ForEach.Main()
@@ -680,9 +661,8 @@ foreach.cs:
 #    7|     v7_24(Void)           = Call                      : func:r7_23, this:r7_22
 #    7|     mu7_25(<unknown>)     = ^CallSideEffect           : ~mu4_3
 #    4|     v4_4(Void)            = ReturnVoid                : 
-#    4|     v4_5(Void)            = UnmodeledUse              : mu*
-#    4|     v4_6(Void)            = AliasedUse                : ~mu4_3
-#    4|     v4_7(Void)            = ExitFunction              : 
+#    4|     v4_5(Void)            = AliasedUse                : ~mu4_3
+#    4|     v4_6(Void)            = ExitFunction              : 
 
 func_with_param_call.cs:
 #    5| System.Int32 test_call_with_param.f(System.Int32,System.Int32)
@@ -703,9 +683,8 @@ func_with_param_call.cs:
 #    7|     mu7_7(Int32)       = Store                    : &:r7_1, r7_6
 #    5|     r5_8(glval<Int32>) = VariableAddress[#return] : 
 #    5|     v5_9(Void)         = ReturnValue              : &:r5_8, ~mu5_3
-#    5|     v5_10(Void)        = UnmodeledUse             : mu*
-#    5|     v5_11(Void)        = AliasedUse               : ~mu5_3
-#    5|     v5_12(Void)        = ExitFunction             : 
+#    5|     v5_10(Void)        = AliasedUse               : ~mu5_3
+#    5|     v5_11(Void)        = ExitFunction             : 
 
 #   10| System.Int32 test_call_with_param.g()
 #   10|   Block 0
@@ -721,9 +700,8 @@ func_with_param_call.cs:
 #   12|     mu12_7(Int32)       = Store                    : &:r12_1, r12_5
 #   10|     r10_4(glval<Int32>) = VariableAddress[#return] : 
 #   10|     v10_5(Void)         = ReturnValue              : &:r10_4, ~mu10_3
-#   10|     v10_6(Void)         = UnmodeledUse             : mu*
-#   10|     v10_7(Void)         = AliasedUse               : ~mu10_3
-#   10|     v10_8(Void)         = ExitFunction             : 
+#   10|     v10_6(Void)         = AliasedUse               : ~mu10_3
+#   10|     v10_7(Void)         = ExitFunction             : 
 
 indexers.cs:
 #    8| System.String Indexers.MyClass.get_Item(System.Int32)
@@ -745,9 +723,8 @@ indexers.cs:
 #   10|     mu10_9(String)         = Store                      : &:r10_1, r10_8
 #    8|     r8_5(glval<String>)    = VariableAddress[#return]   : 
 #    8|     v8_6(Void)             = ReturnValue                : &:r8_5, ~mu8_3
-#    8|     v8_7(Void)             = UnmodeledUse               : mu*
-#    8|     v8_8(Void)             = AliasedUse                 : ~mu8_3
-#    8|     v8_9(Void)             = ExitFunction               : 
+#    8|     v8_7(Void)             = AliasedUse                 : ~mu8_3
+#    8|     v8_8(Void)             = ExitFunction               : 
 
 #   12| System.Void Indexers.MyClass.set_Item(System.Int32,System.String)
 #   12|   Block 0
@@ -769,9 +746,8 @@ indexers.cs:
 #   14|     r14_8(String[])        = PointerAdd[8]              : r14_5, r14_7
 #   14|     mu14_9(String)         = Store                      : &:r14_8, r14_2
 #   12|     v12_7(Void)            = ReturnVoid                 : 
-#   12|     v12_8(Void)            = UnmodeledUse               : mu*
-#   12|     v12_9(Void)            = AliasedUse                 : ~mu12_3
-#   12|     v12_10(Void)           = ExitFunction               : 
+#   12|     v12_8(Void)            = AliasedUse                 : ~mu12_3
+#   12|     v12_9(Void)            = ExitFunction               : 
 
 #   19| System.Void Indexers.Main()
 #   19|   Block 0
@@ -811,9 +787,8 @@ indexers.cs:
 #   24|     v24_11(Void)          = Call                      : func:r24_3, this:r24_2, 0:r24_4, 1:r24_9
 #   24|     mu24_12(<unknown>)    = ^CallSideEffect           : ~mu19_3
 #   19|     v19_4(Void)           = ReturnVoid                : 
-#   19|     v19_5(Void)           = UnmodeledUse              : mu*
-#   19|     v19_6(Void)           = AliasedUse                : ~mu19_3
-#   19|     v19_7(Void)           = ExitFunction              : 
+#   19|     v19_5(Void)           = AliasedUse                : ~mu19_3
+#   19|     v19_6(Void)           = ExitFunction              : 
 
 inheritance_polymorphism.cs:
 #    3| System.Int32 A.function()
@@ -827,9 +802,8 @@ inheritance_polymorphism.cs:
 #    5|     mu5_3(Int32)       = Store                    : &:r5_1, r5_2
 #    3|     r3_5(glval<Int32>) = VariableAddress[#return] : 
 #    3|     v3_6(Void)         = ReturnValue              : &:r3_5, ~mu3_3
-#    3|     v3_7(Void)         = UnmodeledUse             : mu*
-#    3|     v3_8(Void)         = AliasedUse               : ~mu3_3
-#    3|     v3_9(Void)         = ExitFunction             : 
+#    3|     v3_7(Void)         = AliasedUse               : ~mu3_3
+#    3|     v3_8(Void)         = ExitFunction             : 
 
 #   15| System.Int32 C.function()
 #   15|   Block 0
@@ -842,9 +816,8 @@ inheritance_polymorphism.cs:
 #   17|     mu17_3(Int32)       = Store                    : &:r17_1, r17_2
 #   15|     r15_5(glval<Int32>) = VariableAddress[#return] : 
 #   15|     v15_6(Void)         = ReturnValue              : &:r15_5, ~mu15_3
-#   15|     v15_7(Void)         = UnmodeledUse             : mu*
-#   15|     v15_8(Void)         = AliasedUse               : ~mu15_3
-#   15|     v15_9(Void)         = ExitFunction             : 
+#   15|     v15_7(Void)         = AliasedUse               : ~mu15_3
+#   15|     v15_8(Void)         = ExitFunction             : 
 
 #   23| System.Void Program.Main()
 #   23|   Block 0
@@ -887,9 +860,8 @@ inheritance_polymorphism.cs:
 #   34|     r34_4(Int32)      = Call                      : func:r34_3, this:r34_2
 #   34|     mu34_5(<unknown>) = ^CallSideEffect           : ~mu23_3
 #   23|     v23_4(Void)       = ReturnVoid                : 
-#   23|     v23_5(Void)       = UnmodeledUse              : mu*
-#   23|     v23_6(Void)       = AliasedUse                : ~mu23_3
-#   23|     v23_7(Void)       = ExitFunction              : 
+#   23|     v23_5(Void)       = AliasedUse                : ~mu23_3
+#   23|     v23_6(Void)       = ExitFunction              : 
 
 inoutref.cs:
 #   11| System.Void InOutRef.set(MyClass,MyClass)
@@ -907,9 +879,8 @@ inoutref.cs:
 #   13|     r13_4(MyClass)        = Load                    : &:r13_3, ~mu11_3
 #   13|     mu13_5(MyClass)       = Store                   : &:r13_4, r13_2
 #   11|     v11_8(Void)           = ReturnVoid              : 
-#   11|     v11_9(Void)           = UnmodeledUse            : mu*
-#   11|     v11_10(Void)          = AliasedUse              : ~mu11_3
-#   11|     v11_11(Void)          = ExitFunction            : 
+#   11|     v11_9(Void)           = AliasedUse              : ~mu11_3
+#   11|     v11_10(Void)          = ExitFunction            : 
 
 #   16| System.Void InOutRef.F(System.Int32,MyStruct,MyStruct,MyClass,MyClass)
 #   16|   Block 0
@@ -967,9 +938,8 @@ inoutref.cs:
 #   26|     v26_7(Void)            = Call                    : func:r26_1, 0:r26_3, 1:r26_6
 #   26|     mu26_8(<unknown>)      = ^CallSideEffect         : ~mu16_3
 #   16|     v16_14(Void)           = ReturnVoid              : 
-#   16|     v16_15(Void)           = UnmodeledUse            : mu*
-#   16|     v16_16(Void)           = AliasedUse              : ~mu16_3
-#   16|     v16_17(Void)           = ExitFunction            : 
+#   16|     v16_15(Void)           = AliasedUse              : ~mu16_3
+#   16|     v16_16(Void)           = ExitFunction            : 
 
 #   29| System.Void InOutRef.Main()
 #   29|   Block 0
@@ -1006,9 +976,8 @@ inoutref.cs:
 #   36|     r36_4(Int32)           = Load                      : &:r36_3, ~mu29_3
 #   36|     mu36_5(Int32)          = Store                     : &:r36_1, r36_4
 #   29|     v29_4(Void)            = ReturnVoid                : 
-#   29|     v29_5(Void)            = UnmodeledUse              : mu*
-#   29|     v29_6(Void)            = AliasedUse                : ~mu29_3
-#   29|     v29_7(Void)            = ExitFunction              : 
+#   29|     v29_5(Void)            = AliasedUse                : ~mu29_3
+#   29|     v29_6(Void)            = ExitFunction              : 
 
 isexpr.cs:
 #    8| System.Void IsExpr.Main()
@@ -1038,9 +1007,8 @@ isexpr.cs:
 
 #    8|   Block 1
 #    8|     v8_4(Void) = ReturnVoid   : 
-#    8|     v8_5(Void) = UnmodeledUse : mu*
-#    8|     v8_6(Void) = AliasedUse   : ~mu8_3
-#    8|     v8_7(Void) = ExitFunction : 
+#    8|     v8_5(Void) = AliasedUse   : ~mu8_3
+#    8|     v8_6(Void) = ExitFunction : 
 
 #   13|   Block 2
 #   13|     v13_9(Void) = ConditionalBranch : r13_7
@@ -1245,9 +1213,8 @@ jumps.cs:
 #   38|     v38_3(Void)       = Call                       : func:r38_1, 0:r38_2
 #   38|     mu38_4(<unknown>) = ^CallSideEffect            : ~mu5_3
 #    5|     v5_4(Void)        = ReturnVoid                 : 
-#    5|     v5_5(Void)        = UnmodeledUse               : mu*
-#    5|     v5_6(Void)        = AliasedUse                 : ~mu5_3
-#    5|     v5_7(Void)        = ExitFunction               : 
+#    5|     v5_5(Void)        = AliasedUse                 : ~mu5_3
+#    5|     v5_6(Void)        = ExitFunction               : 
 
 lock.cs:
 #    5| System.Void LockTest.A()
@@ -1290,9 +1257,8 @@ lock.cs:
 
 #    5|   Block 1
 #    5|     v5_4(Void) = ReturnVoid   : 
-#    5|     v5_5(Void) = UnmodeledUse : mu*
-#    5|     v5_6(Void) = AliasedUse   : ~mu5_3
-#    5|     v5_7(Void) = ExitFunction : 
+#    5|     v5_5(Void) = AliasedUse   : ~mu5_3
+#    5|     v5_6(Void) = ExitFunction : 
 
 #    8|   Block 2
 #    8|     r8_17(<funcaddr>)    = FunctionAddress[Exit]     : 
@@ -1311,9 +1277,8 @@ obj_creation.cs:
 #    7|     r7_4(glval<MyClass>) = InitializeThis      : 
 #    8|     v8_1(Void)           = NoOp                : 
 #    7|     v7_5(Void)           = ReturnVoid          : 
-#    7|     v7_6(Void)           = UnmodeledUse        : mu*
-#    7|     v7_7(Void)           = AliasedUse          : ~mu7_3
-#    7|     v7_8(Void)           = ExitFunction        : 
+#    7|     v7_6(Void)           = AliasedUse          : ~mu7_3
+#    7|     v7_7(Void)           = ExitFunction        : 
 
 #   11| System.Void ObjCreation.MyClass..ctor(System.Int32)
 #   11|   Block 0
@@ -1329,9 +1294,8 @@ obj_creation.cs:
 #   13|     r13_4(glval<Int32>)   = FieldAddress[x]         : r13_3
 #   13|     mu13_5(Int32)         = Store                   : &:r13_4, r13_2
 #   11|     v11_7(Void)           = ReturnVoid              : 
-#   11|     v11_8(Void)           = UnmodeledUse            : mu*
-#   11|     v11_9(Void)           = AliasedUse              : ~mu11_3
-#   11|     v11_10(Void)          = ExitFunction            : 
+#   11|     v11_8(Void)           = AliasedUse              : ~mu11_3
+#   11|     v11_9(Void)           = ExitFunction            : 
 
 #   17| System.Void ObjCreation.SomeFun(ObjCreation.MyClass)
 #   17|   Block 0
@@ -1342,9 +1306,8 @@ obj_creation.cs:
 #   17|     mu17_5(MyClass)       = InitializeParameter[x] : &:r17_4
 #   18|     v18_1(Void)           = NoOp                   : 
 #   17|     v17_6(Void)           = ReturnVoid             : 
-#   17|     v17_7(Void)           = UnmodeledUse           : mu*
-#   17|     v17_8(Void)           = AliasedUse             : ~mu17_3
-#   17|     v17_9(Void)           = ExitFunction           : 
+#   17|     v17_7(Void)           = AliasedUse             : ~mu17_3
+#   17|     v17_8(Void)           = ExitFunction           : 
 
 #   21| System.Void ObjCreation.Main()
 #   21|   Block 0
@@ -1382,9 +1345,8 @@ obj_creation.cs:
 #   27|     v27_7(Void)           = Call                          : func:r27_1, 0:r27_2
 #   27|     mu27_8(<unknown>)     = ^CallSideEffect               : ~mu21_3
 #   21|     v21_4(Void)           = ReturnVoid                    : 
-#   21|     v21_5(Void)           = UnmodeledUse                  : mu*
-#   21|     v21_6(Void)           = AliasedUse                    : ~mu21_3
-#   21|     v21_7(Void)           = ExitFunction                  : 
+#   21|     v21_5(Void)           = AliasedUse                    : ~mu21_3
+#   21|     v21_6(Void)           = ExitFunction                  : 
 
 pointers.cs:
 #    3| System.Void Pointers.addone(System.Int32[])
@@ -1417,9 +1379,8 @@ pointers.cs:
 
 #    3|   Block 1
 #    3|     v3_6(Void) = ReturnVoid   : 
-#    3|     v3_7(Void) = UnmodeledUse : mu*
-#    3|     v3_8(Void) = AliasedUse   : ~mu3_3
-#    3|     v3_9(Void) = ExitFunction : 
+#    3|     v3_7(Void) = AliasedUse   : ~mu3_3
+#    3|     v3_8(Void) = ExitFunction : 
 
 #    9|   Block 2
 #    9|     r9_4(glval<Int32>) = VariableAddress[i]      : 
@@ -1513,9 +1474,8 @@ pointers.cs:
 #   40|     v40_4(Void)             = Call                      : func:r40_1, 0:r40_3
 #   40|     mu40_5(<unknown>)       = ^CallSideEffect           : ~mu25_3
 #   25|     v25_4(Void)             = ReturnVoid                : 
-#   25|     v25_5(Void)             = UnmodeledUse              : mu*
-#   25|     v25_6(Void)             = AliasedUse                : ~mu25_3
-#   25|     v25_7(Void)             = ExitFunction              : 
+#   25|     v25_5(Void)             = AliasedUse                : ~mu25_3
+#   25|     v25_6(Void)             = ExitFunction              : 
 
 prop.cs:
 #    7| System.Int32 PropClass.get_Prop()
@@ -1532,9 +1492,8 @@ prop.cs:
 #    9|     mu9_6(Int32)           = Store                    : &:r9_1, r9_4
 #    7|     r7_5(glval<Int32>)     = VariableAddress[#return] : 
 #    7|     v7_6(Void)             = ReturnValue              : &:r7_5, ~mu7_3
-#    7|     v7_7(Void)             = UnmodeledUse             : mu*
-#    7|     v7_8(Void)             = AliasedUse               : ~mu7_3
-#    7|     v7_9(Void)             = ExitFunction             : 
+#    7|     v7_7(Void)             = AliasedUse               : ~mu7_3
+#    7|     v7_8(Void)             = ExitFunction             : 
 
 #   12| System.Void PropClass.set_Prop(System.Int32)
 #   12|   Block 0
@@ -1549,9 +1508,8 @@ prop.cs:
 #   14|     r14_3(glval<Int32>)     = VariableAddress[prop]      : 
 #   14|     mu14_4(Int32)           = Store                      : &:r14_3, r14_2
 #   12|     v12_7(Void)             = ReturnVoid                 : 
-#   12|     v12_8(Void)             = UnmodeledUse               : mu*
-#   12|     v12_9(Void)             = AliasedUse                 : ~mu12_3
-#   12|     v12_10(Void)            = ExitFunction               : 
+#   12|     v12_8(Void)             = AliasedUse                 : ~mu12_3
+#   12|     v12_9(Void)             = ExitFunction               : 
 
 #   18| System.Int32 PropClass.func()
 #   18|   Block 0
@@ -1564,9 +1522,8 @@ prop.cs:
 #   20|     mu20_3(Int32)           = Store                    : &:r20_1, r20_2
 #   18|     r18_5(glval<Int32>)     = VariableAddress[#return] : 
 #   18|     v18_6(Void)             = ReturnValue              : &:r18_5, ~mu18_3
-#   18|     v18_7(Void)             = UnmodeledUse             : mu*
-#   18|     v18_8(Void)             = AliasedUse               : ~mu18_3
-#   18|     v18_9(Void)             = ExitFunction             : 
+#   18|     v18_7(Void)             = AliasedUse               : ~mu18_3
+#   18|     v18_8(Void)             = ExitFunction             : 
 
 #   26| System.Void Prog.Main()
 #   26|   Block 0
@@ -1593,9 +1550,8 @@ prop.cs:
 #   30|     mu30_6(<unknown>)       = ^CallSideEffect            : ~mu26_3
 #   30|     mu30_7(Int32)           = Store                      : &:r30_1, r30_5
 #   26|     v26_4(Void)             = ReturnVoid                 : 
-#   26|     v26_5(Void)             = UnmodeledUse               : mu*
-#   26|     v26_6(Void)             = AliasedUse                 : ~mu26_3
-#   26|     v26_7(Void)             = ExitFunction               : 
+#   26|     v26_5(Void)             = AliasedUse                 : ~mu26_3
+#   26|     v26_6(Void)             = ExitFunction               : 
 
 simple_call.cs:
 #    5| System.Int32 test_simple_call.f()
@@ -1608,9 +1564,8 @@ simple_call.cs:
 #    7|     mu7_3(Int32)       = Store                    : &:r7_1, r7_2
 #    5|     r5_4(glval<Int32>) = VariableAddress[#return] : 
 #    5|     v5_5(Void)         = ReturnValue              : &:r5_4, ~mu5_3
-#    5|     v5_6(Void)         = UnmodeledUse             : mu*
-#    5|     v5_7(Void)         = AliasedUse               : ~mu5_3
-#    5|     v5_8(Void)         = ExitFunction             : 
+#    5|     v5_6(Void)         = AliasedUse               : ~mu5_3
+#    5|     v5_7(Void)         = ExitFunction             : 
 
 #   10| System.Int32 test_simple_call.g()
 #   10|   Block 0
@@ -1625,9 +1580,8 @@ simple_call.cs:
 #   12|     mu12_5(Int32)                  = Store                    : &:r12_1, r12_3
 #   10|     r10_5(glval<Int32>)            = VariableAddress[#return] : 
 #   10|     v10_6(Void)                    = ReturnValue              : &:r10_5, ~mu10_3
-#   10|     v10_7(Void)                    = UnmodeledUse             : mu*
-#   10|     v10_8(Void)                    = AliasedUse               : ~mu10_3
-#   10|     v10_9(Void)                    = ExitFunction             : 
+#   10|     v10_7(Void)                    = AliasedUse               : ~mu10_3
+#   10|     v10_8(Void)                    = ExitFunction             : 
 
 simple_function.cs:
 #    5| System.Int32 test_simple_function.f()
@@ -1640,9 +1594,8 @@ simple_function.cs:
 #    7|     mu7_3(Int32)       = Store                    : &:r7_1, r7_2
 #    5|     r5_4(glval<Int32>) = VariableAddress[#return] : 
 #    5|     v5_5(Void)         = ReturnValue              : &:r5_4, ~mu5_3
-#    5|     v5_6(Void)         = UnmodeledUse             : mu*
-#    5|     v5_7(Void)         = AliasedUse               : ~mu5_3
-#    5|     v5_8(Void)         = ExitFunction             : 
+#    5|     v5_6(Void)         = AliasedUse               : ~mu5_3
+#    5|     v5_7(Void)         = ExitFunction             : 
 
 stmts.cs:
 #    5| System.Int32 test_stmts.ifStmt(System.Int32)
@@ -1663,9 +1616,8 @@ stmts.cs:
 #    5|   Block 1
 #    5|     r5_6(glval<Int32>) = VariableAddress[#return] : 
 #    5|     v5_7(Void)         = ReturnValue              : &:r5_6, ~mu5_3
-#    5|     v5_8(Void)         = UnmodeledUse             : mu*
-#    5|     v5_9(Void)         = AliasedUse               : ~mu5_3
-#    5|     v5_10(Void)        = ExitFunction             : 
+#    5|     v5_8(Void)         = AliasedUse               : ~mu5_3
+#    5|     v5_9(Void)         = ExitFunction             : 
 
 #   10|   Block 2
 #   10|     r10_1(glval<Int32>) = VariableAddress[#return] : 
@@ -1693,9 +1645,8 @@ stmts.cs:
 
 #   13|   Block 1
 #   13|     v13_6(Void) = ReturnVoid   : 
-#   13|     v13_7(Void) = UnmodeledUse : mu*
-#   13|     v13_8(Void) = AliasedUse   : ~mu13_3
-#   13|     v13_9(Void) = ExitFunction : 
+#   13|     v13_7(Void) = AliasedUse   : ~mu13_3
+#   13|     v13_8(Void) = ExitFunction : 
 
 #   16|   Block 2
 #   16|     r16_1(glval<Int32>) = VariableAddress[i] : 
@@ -1741,9 +1692,8 @@ stmts.cs:
 #   22|   Block 1
 #   22|     r22_4(glval<Int32>) = VariableAddress[#return] : 
 #   22|     v22_5(Void)         = ReturnValue              : &:r22_4, ~mu22_3
-#   22|     v22_6(Void)         = UnmodeledUse             : mu*
-#   22|     v22_7(Void)         = AliasedUse               : ~mu22_3
-#   22|     v22_8(Void)         = ExitFunction             : 
+#   22|     v22_6(Void)         = AliasedUse               : ~mu22_3
+#   22|     v22_7(Void)         = ExitFunction             : 
 
 #   29|   Block 2
 #   29|     v29_1(Void) = NoOp : 
@@ -1799,12 +1749,11 @@ stmts.cs:
 #-----|   True -> Block 3
 
 #   46|   Block 1
-#   46|     v46_4(Void) = UnmodeledUse : mu*
-#   46|     v46_5(Void) = AliasedUse   : ~mu46_3
-#   46|     v46_6(Void) = ExitFunction : 
+#   46|     v46_4(Void) = AliasedUse   : ~mu46_3
+#   46|     v46_5(Void) = ExitFunction : 
 
 #   46|   Block 2
-#   46|     v46_7(Void) = Unwind : 
+#   46|     v46_6(Void) = Unwind : 
 #-----|   Goto -> Block 1
 
 #   52|   Block 3
@@ -1827,7 +1776,7 @@ stmts.cs:
 #   65|     r65_1(Int32)        = Constant[2]        : 
 #   65|     r65_2(glval<Int32>) = VariableAddress[x] : 
 #   65|     mu65_3(Int32)       = Store              : &:r65_2, r65_1
-#   46|     v46_8(Void)         = ReturnVoid         : 
+#   46|     v46_7(Void)         = ReturnVoid         : 
 #-----|   Goto -> Block 1
 
 #   55|   Block 6
@@ -1866,9 +1815,8 @@ stmts.cs:
 
 #   69|   Block 1
 #   69|     v69_4(Void) = ReturnVoid   : 
-#   69|     v69_5(Void) = UnmodeledUse : mu*
-#   69|     v69_6(Void) = AliasedUse   : ~mu69_3
-#   69|     v69_7(Void) = ExitFunction : 
+#   69|     v69_5(Void) = AliasedUse   : ~mu69_3
+#   69|     v69_6(Void) = ExitFunction : 
 
 #   72|   Block 2
 #   72|     r72_7(glval<Int32>) = VariableAddress[i] : 
@@ -1944,9 +1892,8 @@ stmts.cs:
 
 #   89|   Block 1
 #   89|     v89_4(Void) = ReturnVoid   : 
-#   89|     v89_5(Void) = UnmodeledUse : mu*
-#   89|     v89_6(Void) = AliasedUse   : ~mu89_3
-#   89|     v89_7(Void) = ExitFunction : 
+#   89|     v89_5(Void) = AliasedUse   : ~mu89_3
+#   89|     v89_6(Void) = ExitFunction : 
 
 #   94|   Block 2
 #   94|     r94_1(glval<Int32>) = VariableAddress[x] : 
@@ -1985,9 +1932,8 @@ stmts.cs:
 #  108|     r108_5(glval<Int32>) = VariableAddress[num] : 
 #  108|     mu108_6(Int32)       = Store                : &:r108_5, r108_4
 #   99|     v99_4(Void)          = ReturnVoid           : 
-#   99|     v99_5(Void)          = UnmodeledUse         : mu*
-#   99|     v99_6(Void)          = AliasedUse           : ~mu99_3
-#   99|     v99_7(Void)          = ExitFunction         : 
+#   99|     v99_5(Void)          = AliasedUse           : ~mu99_3
+#   99|     v99_6(Void)          = ExitFunction         : 
 
 using.cs:
 #    7| System.Void UsingStmt.MyDisposable..ctor()
@@ -1998,9 +1944,8 @@ using.cs:
 #    7|     r7_4(glval<MyDisposable>) = InitializeThis      : 
 #    7|     v7_5(Void)                = NoOp                : 
 #    7|     v7_6(Void)                = ReturnVoid          : 
-#    7|     v7_7(Void)                = UnmodeledUse        : mu*
-#    7|     v7_8(Void)                = AliasedUse          : ~mu7_3
-#    7|     v7_9(Void)                = ExitFunction        : 
+#    7|     v7_7(Void)                = AliasedUse          : ~mu7_3
+#    7|     v7_8(Void)                = ExitFunction        : 
 
 #    8| System.Void UsingStmt.MyDisposable.DoSomething()
 #    8|   Block 0
@@ -2010,9 +1955,8 @@ using.cs:
 #    8|     r8_4(glval<MyDisposable>) = InitializeThis      : 
 #    8|     v8_5(Void)                = NoOp                : 
 #    8|     v8_6(Void)                = ReturnVoid          : 
-#    8|     v8_7(Void)                = UnmodeledUse        : mu*
-#    8|     v8_8(Void)                = AliasedUse          : ~mu8_3
-#    8|     v8_9(Void)                = ExitFunction        : 
+#    8|     v8_7(Void)                = AliasedUse          : ~mu8_3
+#    8|     v8_8(Void)                = ExitFunction        : 
 
 #    9| System.Void UsingStmt.MyDisposable.Dispose()
 #    9|   Block 0
@@ -2022,9 +1966,8 @@ using.cs:
 #    9|     r9_4(glval<MyDisposable>) = InitializeThis      : 
 #    9|     v9_5(Void)                = NoOp                : 
 #    9|     v9_6(Void)                = ReturnVoid          : 
-#    9|     v9_7(Void)                = UnmodeledUse        : mu*
-#    9|     v9_8(Void)                = AliasedUse          : ~mu9_3
-#    9|     v9_9(Void)                = ExitFunction        : 
+#    9|     v9_7(Void)                = AliasedUse          : ~mu9_3
+#    9|     v9_8(Void)                = ExitFunction        : 
 
 #   12| System.Void UsingStmt.Main()
 #   12|   Block 0
@@ -2065,9 +2008,8 @@ using.cs:
 #   26|     v26_4(Void)                = Call                          : func:r26_3, this:r26_2
 #   26|     mu26_5(<unknown>)          = ^CallSideEffect               : ~mu12_3
 #   12|     v12_4(Void)                = ReturnVoid                    : 
-#   12|     v12_5(Void)                = UnmodeledUse                  : mu*
-#   12|     v12_6(Void)                = AliasedUse                    : ~mu12_3
-#   12|     v12_7(Void)                = ExitFunction                  : 
+#   12|     v12_5(Void)                = AliasedUse                    : ~mu12_3
+#   12|     v12_6(Void)                = ExitFunction                  : 
 
 variables.cs:
 #    5| System.Void test_variables.f()
@@ -2092,6 +2034,5 @@ variables.cs:
 #   10|     r10_3(Int32)        = Load                : &:r10_2, ~mu5_3
 #   10|     mu10_4(Int32)       = Store               : &:r10_1, r10_3
 #    5|     v5_4(Void)          = ReturnVoid          : 
-#    5|     v5_5(Void)          = UnmodeledUse        : mu*
-#    5|     v5_6(Void)          = AliasedUse          : ~mu5_3
-#    5|     v5_7(Void)          = ExitFunction        : 
+#    5|     v5_5(Void)          = AliasedUse          : ~mu5_3
+#    5|     v5_6(Void)          = ExitFunction        : 


### PR DESCRIPTION
This is the first of several steps toward implementing https://github.com/github/codeql-c-analysis-team/issues/69.

The `UnmodeledUse` instruction has one operand for each unmodeled memory result in the function. This will make it slightly annoying when trying to reuse `Operand` objects across IR phases, but this instruction has been problematic from day one. It exists in order to provide a dummy "use" for every unmodeled memory result, with the intention being that analyses that care about finding uses of a result will not think that the result is dead just because we didn't try to model that result in SSA. However, this means that it's the only instruction whose uses might not be dominated by their respective definitions. It's also a fair bit of work just to hook up all those unmodeled results when building the IR. Finally, it comes at the cost of adding one instruction and a potentially large number of operands to each function, for each stage of the IR. It's been on my hit list for a long time, but now I think removing it will actually make future work easier.

This PR removes the `UnmodeledUse` instruction and its associated operands. Most of the changes are just about removing all references to `Opcode::UnmodeledUse` and `UnmodeledUseOperand`, but there are a few more significant changes:

In C++ IR construction, `TranslatedElement::getInstructionOperand()` is renamed to `getInstructionRegisterOperand()`, and now applies only to register operands. Memory operands are identified by seeing if `TranslatedElement::getMemoryOperandType()` has a result for that `OperandTag`.

I added a small hack to the ordering of blocks in IR dumps so that the block containing the `EnterFunction` instruction always comes first. Otherwise, for functions with exception handling, we get a block that starts with `AliasedUse` but has the same location as the block containing `EnterFunction`. Since we sort blocks within the same location by the name of their instruction tag, we would wind up with the `AliasedUse` block preceding the `EnterFunction` block, making the IR diffs more complicated and making looking at such IR dumps confusing.

I had to add one term to `AliasAnalysis.qll` to treat an address as escaped if it flowed to an unmodeled result. _This is the only place in all of our code that actually cared about whether a result actually had a use._ Note that any code that consumes the aliased SSA IR can't possibly be affected by this change, because aliased SSA IR never has unmodeled results anyway. The problem that `UnmodeledUse` was trying to solve only affected code analyzing intermediate stages of the IR, which we don't even expose outside of the standard library.

Next up: Removing `UnmodeledDefinition`, which is a bit trickier because it will leave unmodeled memory operands with no definition instruction.