### PR TITLE
Python: Allow unicode in raw strings

### DIFF
--- a/python/ql/test/query-tests/Expressions/Regex/test.py
+++ b/python/ql/test/query-tests/Expressions/Regex/test.py
@@ -139,3 +139,6 @@ re.compile(r'(?:(?P<n1>^(?:|x)))')
 
 #Potentially mis-parsed character set
 re.compile(r"\[(?P<txt>[^[]*)\]\((?P<uri>[^)]*)")
+
+#Allow unicode in raw strings
+re.compile(r"[\U00010000-\U0010FFFF]")


### PR DESCRIPTION
Currently just contains a test