### PR TITLE
JavaScript: Model extra sinks in `vm` module

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -705,20 +705,17 @@ module NodeJSLib {
   /**
    * A call to a method from module `vm`
    */
-  class VmModuleMethodCall extends DataFlow::CallNode {
-    string methodName;
+  class VmModuleMemberInvocation extends DataFlow::InvokeNode {
+    string memberName;
 
-    VmModuleMethodCall() { this = DataFlow::moduleMember("vm", methodName).getACall() }
+    VmModuleMemberInvocation() { this = DataFlow::moduleMember("vm", memberName).getAnInvocation() }
 
     /**
      * Gets the code to be executed as part of this call.
      */
     DataFlow::Node getACodeArgument() {
-      (
-        methodName = "runInContext" or
-        methodName = "runInNewContext" or
-        methodName = "runInThisContext"
-      ) and
+      memberName in ["Script", "SourceTextModule", "compileFunction", "runInContext",
+            "runInNewContext", "runInThisContext"] and
       // all of the above methods take the command as their first argument
       result = getArgument(0)
     }

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -703,7 +703,12 @@ module NodeJSLib {
   }
 
   /**
-   * A call to a method from module `vm`
+   * DEPRECATED Use `VmModuleMemberInvocation` instead.
+   */
+  deprecated class VmModuleMethodCall = VmModuleMemberInvocation;
+
+  /**
+   * An invocation of a member from module `vm`
    */
   class VmModuleMemberInvocation extends DataFlow::InvokeNode {
     string memberName;
@@ -711,12 +716,12 @@ module NodeJSLib {
     VmModuleMemberInvocation() { this = DataFlow::moduleMember("vm", memberName).getAnInvocation() }
 
     /**
-     * Gets the code to be executed as part of this call.
+     * Gets the code to be executed as part of this invocation.
      */
     DataFlow::Node getACodeArgument() {
       memberName in ["Script", "SourceTextModule", "compileFunction", "runInContext",
             "runInNewContext", "runInThisContext"] and
-      // all of the above methods take the command as their first argument
+      // all of the above methods/constructors take the command as their first argument
       result = getArgument(0)
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -48,7 +48,9 @@ module CodeInjection {
    * `vm` module.
    */
   class NodeJSVmSink extends Sink, DataFlow::ValueNode {
-    NodeJSVmSink() { exists(NodeJSLib::VmModuleMethodCall call | this = call.getACodeArgument()) }
+    NodeJSVmSink() {
+      exists(NodeJSLib::VmModuleMemberInvocation inv | this = inv.getACodeArgument())
+    }
   }
 
   /**

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -67,6 +67,18 @@ nodes
 | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") |
 | express.js:12:28:12:46 | req.param("wobble") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:21:19:21:48 | req.par ... ntext") |
+| express.js:21:19:21:48 | req.par ... ntext") |
+| express.js:21:19:21:48 | req.par ... ntext") |
 | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
@@ -176,6 +188,10 @@ edges
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
+| express.js:15:22:15:54 | req.par ... ction") | express.js:15:22:15:54 | req.par ... ction") |
+| express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") |
+| express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") |
+| express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
@@ -229,6 +245,10 @@ edges
 | express.js:7:24:7:69 | "return ...  + "];" | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:7:44:7:62 | req.param("wobble") | User-provided value |
 | express.js:9:34:9:79 | "return ...  + "];" | express.js:9:54:9:72 | req.param("wobble") | express.js:9:34:9:79 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:9:54:9:72 | req.param("wobble") | User-provided value |
 | express.js:12:8:12:53 | "return ...  + "];" | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:12:28:12:46 | req.param("wobble") | User-provided value |
+| express.js:15:22:15:54 | req.par ... ction") | express.js:15:22:15:54 | req.par ... ction") | express.js:15:22:15:54 | req.par ... ction") | $@ flows to here and is interpreted as code. | express.js:15:22:15:54 | req.par ... ction") | User-provided value |
+| express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") | $@ flows to here and is interpreted as code. | express.js:17:30:17:53 | req.par ... cript") | User-provided value |
+| express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") | $@ flows to here and is interpreted as code. | express.js:19:37:19:70 | req.par ... odule") | User-provided value |
+| express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | $@ flows to here and is interpreted as code. | express.js:21:19:21:48 | req.par ... ntext") | User-provided value |
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react-native.js:10:23:10:29 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:10:23:10:29 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | tst.js:2:6:2:83 | documen ... t=")+8) | tst.js:2:6:2:22 | document.location | tst.js:2:6:2:83 | documen ... t=")+8) | $@ flows to here and is interpreted as code. | tst.js:2:6:2:22 | document.location | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -71,6 +71,18 @@ nodes
 | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") |
 | express.js:12:28:12:46 | req.param("wobble") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:15:22:15:54 | req.par ... ction") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:17:30:17:53 | req.par ... cript") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:19:37:19:70 | req.par ... odule") |
+| express.js:21:19:21:48 | req.par ... ntext") |
+| express.js:21:19:21:48 | req.par ... ntext") |
+| express.js:21:19:21:48 | req.par ... ntext") |
 | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
@@ -184,6 +196,10 @@ edges
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
 | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" |
+| express.js:15:22:15:54 | req.par ... ction") | express.js:15:22:15:54 | req.par ... ction") |
+| express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") |
+| express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") |
+| express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/express.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/express.js
@@ -9,5 +9,14 @@ app.get('/some/path', function(req, res) {
   require("vm").runInThisContext("return wibbles[" + req.param("wobble") + "];");
   var runC = require("vm").runInNewContext;
   // NOT OK
-  runC("return wibbles[" + req.param("wobble") + "];");  
+  runC("return wibbles[" + req.param("wobble") + "];");
+  var vm = require("vm");
+  // NOT OK
+  vm.compileFunction(req.param("code_compileFunction"));
+  // NOT OK
+  var script = new vm.Script(req.param("code_Script"));
+  // NOT OK
+  var mdl = new vm.SourceTextModule(req.param("code_SourceTextModule"));
+  // NOT OK
+  vm.runInContext(req.param("code_runInContext"), vm.createContext());
 });


### PR DESCRIPTION
This adds a few extra sinks for code injection to our NodeJS models -- basically, anything with a `code` parameter in [the documentation of the `vm` module](https://nodejs.org/api/vm.html).

Renaming the existing library class is technically a breaking change, since it is public (though not in the global namespace). If you prefer, I could retain it while introducing a supertype for `InvokeNode`s and a secondary subclass of that supertype for `VmModuleConstructorInvocation`.