### PR TITLE
C++: Improve getParameterString().

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -191,10 +191,10 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
     result = ""
     or
     index = getNumberOfParameters() - 1 and
-    result = getParameter(index).getTypedName()
+    result = min(getParameter(index).getTypedName())
     or
     index < getNumberOfParameters() - 1 and
-    result = getParameter(index).getTypedName() + ", " + getParameterStringFrom(index + 1)
+    result = min(getParameter(index).getTypedName()) + ", " + getParameterStringFrom(index + 1)
   }
 
   /** Gets a call to this function. */
@@ -623,11 +623,11 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
     result = ""
     or
     index = getNumberOfParameters() - 1 and
-    result = getParameterDeclarationEntry(index).getTypedName()
+    result = min(getParameterDeclarationEntry(index).getTypedName())
     or
     index < getNumberOfParameters() - 1 and
     result =
-      getParameterDeclarationEntry(index).getTypedName() + ", " + getParameterStringFrom(index + 1)
+      min(getParameterDeclarationEntry(index).getTypedName()) + ", " + getParameterStringFrom(index + 1)
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -184,17 +184,8 @@ class Function extends Declaration, ControlFlowNode, AccessHolder, @function {
    * For example: for a function `int Foo(int p1, int p2)` this would
    * return `int p1, int p2`.
    */
-  string getParameterString() { result = getParameterStringFrom(0) }
-
-  private string getParameterStringFrom(int index) {
-    index = getNumberOfParameters() and
-    result = ""
-    or
-    index = getNumberOfParameters() - 1 and
-    result = min(getParameter(index).getTypedName())
-    or
-    index < getNumberOfParameters() - 1 and
-    result = min(getParameter(index).getTypedName()) + ", " + getParameterStringFrom(index + 1)
+  string getParameterString() {
+    result = concat(int i | | min(getParameter(i).getTypedName()), ", " order by i)
   }
 
   /** Gets a call to this function. */
@@ -616,18 +607,8 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
    * For example: for a function 'int Foo(int p1, int p2)' this would
    * return 'int p1, int p2'.
    */
-  string getParameterString() { result = getParameterStringFrom(0) }
-
-  private string getParameterStringFrom(int index) {
-    index = getNumberOfParameters() and
-    result = ""
-    or
-    index = getNumberOfParameters() - 1 and
-    result = min(getParameterDeclarationEntry(index).getTypedName())
-    or
-    index < getNumberOfParameters() - 1 and
-    result =
-      min(getParameterDeclarationEntry(index).getTypedName()) + ", " + getParameterStringFrom(index + 1)
+  string getParameterString() {
+    result = concat(int i | | min(getParameterDeclarationEntry(i).getTypedName()), ", " order by i)
   }
 
   /**

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.expected
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.expected
@@ -27,3 +27,7 @@
 | functions.cpp:38:2:38:8 | MyClass | MyClass | const MyClass & from | declaration:functions.cpp:38:2:38:8 |
 | functions.cpp:39:2:39:8 | MyClass | MyClass | MyClass && from | declaration:functions.cpp:39:2:39:8 |
 | functions.cpp:40:2:40:13 | operator int | operator int |  | declaration:functions.cpp:40:2:40:13 |
+| functions.cpp:43:6:43:6 | h | h | int x | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
+| functions.cpp:43:6:43:6 | h | h | int y | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
+| functions.cpp:44:6:44:6 | h | h | int x | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
+| functions.cpp:44:6:44:6 | h | h | int y | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.expected
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.expected
@@ -1,41 +1,29 @@
-| ODASA-5186.cpp:4:8:4:8 | operator= | operator= |  |  | ODASA-5186.cpp:4:8:4:8 | declaration |
-| ODASA-5186.cpp:4:8:4:8 | operator= | operator= |  |  | ODASA-5186.cpp:4:8:4:8 | declaration |
-| ODASA-5186.cpp:5:8:5:8 | operator== | operator== |  |  | ODASA-5186.cpp:5:8:5:8 | declaration |
-| ODASA-5186.cpp:5:8:5:8 | operator== | operator== |  |  | ODASA-5186.cpp:5:8:5:8 | definition |
-| ODASA-5186.cpp:5:8:5:17 | operator== | operator== |  |  | ODASA-5186.cpp:5:8:5:17 | declaration |
-| ODASA-5186.cpp:5:8:5:17 | operator== | operator== |  |  | ODASA-5186.cpp:5:8:5:17 | definition |
-| ODASA-5186.cpp:8:6:8:9 | test | test | isTopLevel | TopLevelFunction | ODASA-5186.cpp:8:6:8:9 | declaration |
-| ODASA-5186.cpp:8:6:8:9 | test | test | isTopLevel | TopLevelFunction | ODASA-5186.cpp:8:6:8:9 | definition |
-| ODASA-5186.hpp:2:8:2:8 | operator= | operator= |  |  | ODASA-5186.hpp:2:8:2:8 | declaration |
-| ODASA-5186.hpp:2:8:2:8 | operator= | operator= |  |  | ODASA-5186.hpp:2:8:2:8 | declaration |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | isTopLevel | TopLevelFunction | ODASA-5186.hpp:4:18:4:27 | declaration |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | isTopLevel | TopLevelFunction | ODASA-5186.hpp:4:18:4:27 | declaration |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | isTopLevel | TopLevelFunction | ODASA-5186.hpp:4:18:4:27 | definition |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | isTopLevel | TopLevelFunction | ODASA-5186.hpp:4:18:4:27 | definition |
-| functions.cpp:1:6:1:6 | f | f | isTopLevel | TopLevelFunction | functions.cpp:1:6:1:6 | declaration |
-| functions.cpp:1:6:1:6 | f | f | isTopLevel | TopLevelFunction | functions.cpp:1:6:1:6 | definition |
-| functions.cpp:7:8:7:8 | operator= | operator= |  |  | functions.cpp:7:8:7:8 | declaration |
-| functions.cpp:7:8:7:8 | operator= | operator= |  |  | functions.cpp:7:8:7:8 | declaration |
-| functions.cpp:8:7:8:8 | af | af |  |  | functions.cpp:8:7:8:8 | declaration |
-| functions.cpp:8:7:8:8 | af | af |  |  | functions.cpp:8:7:8:8 | definition |
-| functions.cpp:11:7:11:8 | ag | ag |  |  | functions.cpp:11:7:11:8 | declaration |
-| functions.cpp:14:6:14:6 | g | g | isTopLevel | TopLevelFunction | functions.cpp:5:6:5:6 | declaration |
-| functions.cpp:14:6:14:6 | g | g | isTopLevel | TopLevelFunction | functions.cpp:14:6:14:6 | declaration |
-| functions.cpp:14:6:14:6 | g | g | isTopLevel | TopLevelFunction | functions.cpp:14:6:14:6 | definition |
-| functions.cpp:19:7:19:7 | operator= | operator= |  |  | functions.cpp:19:7:19:7 | declaration |
-| functions.cpp:19:7:19:7 | operator= | operator= |  |  | functions.cpp:19:7:19:7 | declaration |
-| functions.cpp:23:7:23:7 | Table | Table |  |  | functions.cpp:23:7:23:7 | declaration |
-| functions.cpp:23:7:23:7 | operator= | operator= |  |  | functions.cpp:23:7:23:7 | declaration |
-| functions.cpp:27:3:27:7 | Table | Table |  |  | functions.cpp:27:3:27:7 | declaration |
-| functions.cpp:27:3:27:7 | Table | Table |  |  | functions.cpp:27:3:27:7 | definition |
-| functions.cpp:28:3:28:8 | ~Table | ~Table |  |  | functions.cpp:28:3:28:8 | declaration |
-| functions.cpp:28:3:28:8 | ~Table | ~Table |  |  | functions.cpp:28:3:28:8 | definition |
-| functions.cpp:29:9:29:14 | lookup | lookup |  |  | functions.cpp:29:9:29:14 | declaration |
-| functions.cpp:30:8:30:13 | insert | insert |  |  | functions.cpp:30:8:30:13 | declaration |
-| functions.cpp:33:7:33:7 | operator= | operator= |  |  | functions.cpp:33:7:33:7 | declaration |
-| functions.cpp:33:7:33:7 | operator= | operator= |  |  | functions.cpp:33:7:33:7 | definition |
-| functions.cpp:36:2:36:8 | MyClass | MyClass |  |  | functions.cpp:36:2:36:8 | declaration |
-| functions.cpp:37:2:37:8 | MyClass | MyClass |  |  | functions.cpp:37:2:37:8 | declaration |
-| functions.cpp:38:2:38:8 | MyClass | MyClass |  |  | functions.cpp:38:2:38:8 | declaration |
-| functions.cpp:39:2:39:8 | MyClass | MyClass |  |  | functions.cpp:39:2:39:8 | declaration |
-| functions.cpp:40:2:40:13 | operator int | operator int |  |  | functions.cpp:40:2:40:13 | declaration |
+| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | declaration:ODASA-5186.cpp:4:8:4:8 |
+| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | declaration:ODASA-5186.cpp:4:8:4:8 |
+| ODASA-5186.cpp:5:8:5:8 | operator== | operator== | declaration:ODASA-5186.cpp:5:8:5:8, definition:ODASA-5186.cpp:5:8:5:8 |
+| ODASA-5186.cpp:5:8:5:17 | operator== | operator== | declaration:ODASA-5186.cpp:5:8:5:17, definition:ODASA-5186.cpp:5:8:5:17 |
+| ODASA-5186.cpp:8:6:8:9 | test | test | TopLevelFunction, declaration:ODASA-5186.cpp:8:6:8:9, definition:ODASA-5186.cpp:8:6:8:9, isTopLevel |
+| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | declaration:ODASA-5186.hpp:2:8:2:8 |
+| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | declaration:ODASA-5186.hpp:2:8:2:8 |
+| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
+| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
+| functions.cpp:1:6:1:6 | f | f | TopLevelFunction, declaration:functions.cpp:1:6:1:6, definition:functions.cpp:1:6:1:6, isTopLevel |
+| functions.cpp:7:8:7:8 | operator= | operator= | declaration:functions.cpp:7:8:7:8 |
+| functions.cpp:7:8:7:8 | operator= | operator= | declaration:functions.cpp:7:8:7:8 |
+| functions.cpp:8:7:8:8 | af | af | declaration:functions.cpp:8:7:8:8, definition:functions.cpp:8:7:8:8 |
+| functions.cpp:11:7:11:8 | ag | ag | declaration:functions.cpp:11:7:11:8 |
+| functions.cpp:14:6:14:6 | g | g | TopLevelFunction, declaration:functions.cpp:14:6:14:6, declaration:functions.cpp:5:6:5:6, definition:functions.cpp:14:6:14:6, isTopLevel |
+| functions.cpp:19:7:19:7 | operator= | operator= | declaration:functions.cpp:19:7:19:7 |
+| functions.cpp:19:7:19:7 | operator= | operator= | declaration:functions.cpp:19:7:19:7 |
+| functions.cpp:23:7:23:7 | Table | Table | declaration:functions.cpp:23:7:23:7 |
+| functions.cpp:23:7:23:7 | operator= | operator= | declaration:functions.cpp:23:7:23:7 |
+| functions.cpp:27:3:27:7 | Table | Table | declaration:functions.cpp:27:3:27:7, definition:functions.cpp:27:3:27:7 |
+| functions.cpp:28:3:28:8 | ~Table | ~Table | declaration:functions.cpp:28:3:28:8, definition:functions.cpp:28:3:28:8 |
+| functions.cpp:29:9:29:14 | lookup | lookup | declaration:functions.cpp:29:9:29:14 |
+| functions.cpp:30:8:30:13 | insert | insert | declaration:functions.cpp:30:8:30:13 |
+| functions.cpp:33:7:33:7 | operator= | operator= | declaration:functions.cpp:33:7:33:7, definition:functions.cpp:33:7:33:7 |
+| functions.cpp:36:2:36:8 | MyClass | MyClass | declaration:functions.cpp:36:2:36:8 |
+| functions.cpp:37:2:37:8 | MyClass | MyClass | declaration:functions.cpp:37:2:37:8 |
+| functions.cpp:38:2:38:8 | MyClass | MyClass | declaration:functions.cpp:38:2:38:8 |
+| functions.cpp:39:2:39:8 | MyClass | MyClass | declaration:functions.cpp:39:2:39:8 |
+| functions.cpp:40:2:40:13 | operator int | operator int | declaration:functions.cpp:40:2:40:13 |

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.expected
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.expected
@@ -1,29 +1,29 @@
-| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | declaration:ODASA-5186.cpp:4:8:4:8 |
-| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | declaration:ODASA-5186.cpp:4:8:4:8 |
-| ODASA-5186.cpp:5:8:5:8 | operator== | operator== | declaration:ODASA-5186.cpp:5:8:5:8, definition:ODASA-5186.cpp:5:8:5:8 |
-| ODASA-5186.cpp:5:8:5:17 | operator== | operator== | declaration:ODASA-5186.cpp:5:8:5:17, definition:ODASA-5186.cpp:5:8:5:17 |
-| ODASA-5186.cpp:8:6:8:9 | test | test | TopLevelFunction, declaration:ODASA-5186.cpp:8:6:8:9, definition:ODASA-5186.cpp:8:6:8:9, isTopLevel |
-| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | declaration:ODASA-5186.hpp:2:8:2:8 |
-| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | declaration:ODASA-5186.hpp:2:8:2:8 |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
-| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
-| functions.cpp:1:6:1:6 | f | f | TopLevelFunction, declaration:functions.cpp:1:6:1:6, definition:functions.cpp:1:6:1:6, isTopLevel |
-| functions.cpp:7:8:7:8 | operator= | operator= | declaration:functions.cpp:7:8:7:8 |
-| functions.cpp:7:8:7:8 | operator= | operator= | declaration:functions.cpp:7:8:7:8 |
-| functions.cpp:8:7:8:8 | af | af | declaration:functions.cpp:8:7:8:8, definition:functions.cpp:8:7:8:8 |
-| functions.cpp:11:7:11:8 | ag | ag | declaration:functions.cpp:11:7:11:8 |
-| functions.cpp:14:6:14:6 | g | g | TopLevelFunction, declaration:functions.cpp:14:6:14:6, declaration:functions.cpp:5:6:5:6, definition:functions.cpp:14:6:14:6, isTopLevel |
-| functions.cpp:19:7:19:7 | operator= | operator= | declaration:functions.cpp:19:7:19:7 |
-| functions.cpp:19:7:19:7 | operator= | operator= | declaration:functions.cpp:19:7:19:7 |
-| functions.cpp:23:7:23:7 | Table | Table | declaration:functions.cpp:23:7:23:7 |
-| functions.cpp:23:7:23:7 | operator= | operator= | declaration:functions.cpp:23:7:23:7 |
-| functions.cpp:27:3:27:7 | Table | Table | declaration:functions.cpp:27:3:27:7, definition:functions.cpp:27:3:27:7 |
-| functions.cpp:28:3:28:8 | ~Table | ~Table | declaration:functions.cpp:28:3:28:8, definition:functions.cpp:28:3:28:8 |
-| functions.cpp:29:9:29:14 | lookup | lookup | declaration:functions.cpp:29:9:29:14 |
-| functions.cpp:30:8:30:13 | insert | insert | declaration:functions.cpp:30:8:30:13 |
-| functions.cpp:33:7:33:7 | operator= | operator= | declaration:functions.cpp:33:7:33:7, definition:functions.cpp:33:7:33:7 |
-| functions.cpp:36:2:36:8 | MyClass | MyClass | declaration:functions.cpp:36:2:36:8 |
-| functions.cpp:37:2:37:8 | MyClass | MyClass | declaration:functions.cpp:37:2:37:8 |
-| functions.cpp:38:2:38:8 | MyClass | MyClass | declaration:functions.cpp:38:2:38:8 |
-| functions.cpp:39:2:39:8 | MyClass | MyClass | declaration:functions.cpp:39:2:39:8 |
-| functions.cpp:40:2:40:13 | operator int | operator int | declaration:functions.cpp:40:2:40:13 |
+| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | MyClass<int> && p#0 | declaration:ODASA-5186.cpp:4:8:4:8 |
+| ODASA-5186.cpp:4:8:4:8 | operator= | operator= | const MyClass<int> & p#0 | declaration:ODASA-5186.cpp:4:8:4:8 |
+| ODASA-5186.cpp:5:8:5:8 | operator== | operator== | const MyClass<int> & other | declaration:ODASA-5186.cpp:5:8:5:8, definition:ODASA-5186.cpp:5:8:5:8 |
+| ODASA-5186.cpp:5:8:5:17 | operator== | operator== | const MyClass<T> & other | declaration:ODASA-5186.cpp:5:8:5:17, definition:ODASA-5186.cpp:5:8:5:17 |
+| ODASA-5186.cpp:8:6:8:9 | test | test |  | TopLevelFunction, declaration:ODASA-5186.cpp:8:6:8:9, definition:ODASA-5186.cpp:8:6:8:9, isTopLevel |
+| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | NEQ_helper<MyClass<int>> && p#0 | declaration:ODASA-5186.hpp:2:8:2:8 |
+| ODASA-5186.hpp:2:8:2:8 | operator= | operator= | const NEQ_helper<MyClass<int>> & p#0 | declaration:ODASA-5186.hpp:2:8:2:8 |
+| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | const MyClass<int> & x, const MyClass<int> & y | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
+| ODASA-5186.hpp:4:18:4:27 | operator!= | operator!= | const T & x, const T & y | TopLevelFunction, declaration:ODASA-5186.hpp:4:18:4:27, definition:ODASA-5186.hpp:4:18:4:27, isTopLevel |
+| functions.cpp:1:6:1:6 | f | f | int a, int b | TopLevelFunction, declaration:functions.cpp:1:6:1:6, definition:functions.cpp:1:6:1:6, isTopLevel |
+| functions.cpp:7:8:7:8 | operator= | operator= | A && p#0 | declaration:functions.cpp:7:8:7:8 |
+| functions.cpp:7:8:7:8 | operator= | operator= | const A & p#0 | declaration:functions.cpp:7:8:7:8 |
+| functions.cpp:8:7:8:8 | af | af |  | declaration:functions.cpp:8:7:8:8, definition:functions.cpp:8:7:8:8 |
+| functions.cpp:11:7:11:8 | ag | ag |  | declaration:functions.cpp:11:7:11:8 |
+| functions.cpp:14:6:14:6 | g | g |  | TopLevelFunction, declaration:functions.cpp:14:6:14:6, declaration:functions.cpp:5:6:5:6, definition:functions.cpp:14:6:14:6, isTopLevel |
+| functions.cpp:19:7:19:7 | operator= | operator= | Name && p#0 | declaration:functions.cpp:19:7:19:7 |
+| functions.cpp:19:7:19:7 | operator= | operator= | const Name & p#0 | declaration:functions.cpp:19:7:19:7 |
+| functions.cpp:23:7:23:7 | Table | Table | const Table & p#0 | declaration:functions.cpp:23:7:23:7 |
+| functions.cpp:23:7:23:7 | operator= | operator= | const Table & p#0 | declaration:functions.cpp:23:7:23:7 |
+| functions.cpp:27:3:27:7 | Table | Table | int s | declaration:functions.cpp:27:3:27:7, definition:functions.cpp:27:3:27:7 |
+| functions.cpp:28:3:28:8 | ~Table | ~Table |  | declaration:functions.cpp:28:3:28:8, definition:functions.cpp:28:3:28:8 |
+| functions.cpp:29:9:29:14 | lookup | lookup | const char * p#0 | declaration:functions.cpp:29:9:29:14 |
+| functions.cpp:30:8:30:13 | insert | insert | Name * p#0 | declaration:functions.cpp:30:8:30:13 |
+| functions.cpp:33:7:33:7 | operator= | operator= | const MyClass & p#0 | declaration:functions.cpp:33:7:33:7, definition:functions.cpp:33:7:33:7 |
+| functions.cpp:36:2:36:8 | MyClass | MyClass |  | declaration:functions.cpp:36:2:36:8 |
+| functions.cpp:37:2:37:8 | MyClass | MyClass | int from | declaration:functions.cpp:37:2:37:8 |
+| functions.cpp:38:2:38:8 | MyClass | MyClass | const MyClass & from | declaration:functions.cpp:38:2:38:8 |
+| functions.cpp:39:2:39:8 | MyClass | MyClass | MyClass && from | declaration:functions.cpp:39:2:39:8 |
+| functions.cpp:40:2:40:13 | operator int | operator int |  | declaration:functions.cpp:40:2:40:13 |

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.expected
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.expected
@@ -28,6 +28,4 @@
 | functions.cpp:39:2:39:8 | MyClass | MyClass | MyClass && from | declaration:functions.cpp:39:2:39:8 |
 | functions.cpp:40:2:40:13 | operator int | operator int |  | declaration:functions.cpp:40:2:40:13 |
 | functions.cpp:43:6:43:6 | h | h | int x | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
-| functions.cpp:43:6:43:6 | h | h | int y | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
 | functions.cpp:44:6:44:6 | h | h | int x | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |
-| functions.cpp:44:6:44:6 | h | h | int y | TopLevelFunction, declaration:functions.cpp:43:6:43:6, declaration:functions.cpp:44:6:44:6, isTopLevel |

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.ql
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.ql
@@ -4,13 +4,18 @@
 
 import cpp
 
-from Function f, string top1, string top2, Location loc, string loctype
-where
-  (if f.isTopLevel() then top1 = "isTopLevel" else top1 = "") and
-  (if f instanceof TopLevelFunction then top2 = "TopLevelFunction" else top2 = "") and
-  (
-    loc = f.getADeclarationLocation() and loctype = "declaration"
-    or
-    loc = f.getDefinitionLocation() and loctype = "definition"
-  )
-select f, f.getName(), top1, top2, loc.toString(), loctype
+string describe(Function f) {
+  f.isTopLevel() and
+  result = "isTopLevel"
+  or
+  f instanceof TopLevelFunction and
+  result = "TopLevelFunction"
+  or
+  result = "declaration:" + f.getADeclarationLocation()
+  or
+  result = "definition:" + f.getDefinitionLocation()
+}
+
+from Function f
+where exists(f.getLocation())
+select f, f.getName(), concat(describe(f), ", ")

--- a/cpp/ql/test/library-tests/functions/functions/Functions1.ql
+++ b/cpp/ql/test/library-tests/functions/functions/Functions1.ql
@@ -18,4 +18,4 @@ string describe(Function f) {
 
 from Function f
 where exists(f.getLocation())
-select f, f.getName(), concat(describe(f), ", ")
+select f, f.getName(), f.getParameterString(), concat(describe(f), ", ")

--- a/cpp/ql/test/library-tests/functions/functions/functions.cpp
+++ b/cpp/ql/test/library-tests/functions/functions/functions.cpp
@@ -39,3 +39,6 @@ public:
 	MyClass(MyClass &&from);
 	operator int();
 };
+
+void h(int x);
+void h(int y);


### PR DESCRIPTION
Quickly clean up `Function.getParameterString()` and `FunctionDeclarationEntry.getParameterString()`, so that they are cleaner, more correct, and likely to use less resources (see https://jira.semmle.com/browse/ARCHITECT-512, though that particular use-case no longer matters).