### PR TITLE
C++: Test field conflation with array in struct

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/defaulttainttracking.cpp
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/defaulttainttracking.cpp
@@ -97,3 +97,23 @@ void test_outparams() {
     flow_to_outparam(&p2, getenv("VAR"));
     sink(p2); // tainted
 }
+
+
+void *memcpy(void *dst, void *src, int size);
+
+struct ContainsArray {
+  int arr[16];
+  int x;
+};
+
+void taint_array(ContainsArray *ca, int offset) {
+  int tainted = getenv("VAR")[0];
+  memcpy(ca->arr + offset, &tainted, sizeof(int));
+}
+
+void test_conflated_fields3(int arbitrary) {
+  ContainsArray ca;
+  ca.x = 0;
+  taint_array(&ca, arbitrary);
+  sink(ca.x); // not tainted [FALSE POSITIVE]
+}

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
@@ -109,6 +109,17 @@
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | (const char *)... |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:10:11:10:13 | p#0 |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:102:31:102:33 | src |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:7:110:13 | tainted |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:22 | call to getenv |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:32 | (int)... |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:32 | access to array |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:3:111:8 | call to memcpy |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:28:111:35 | & ... |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:28:111:35 | (void *)... |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:118:11:118:11 | x |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | test_diff.cpp:2:11:2:13 | p#0 |
 | globals.cpp:5:20:5:25 | call to getenv | globals.cpp:2:17:2:25 | sinkParam |
 | globals.cpp:5:20:5:25 | call to getenv | globals.cpp:5:12:5:16 | local |
 | globals.cpp:5:20:5:25 | call to getenv | globals.cpp:5:20:5:25 | call to getenv |

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
@@ -23,6 +23,12 @@
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | (const char *)... | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 | IR only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:10:11:10:13 | p#0 | IR only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:102:20:102:22 | dst | AST only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:10:111:25 | ... + ... | AST only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:29:111:35 | tainted | AST only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:118:11:118:11 | x | IR only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | test_diff.cpp:2:11:2:13 | p#0 | IR only |
 | globals.cpp:13:15:13:20 | call to getenv | globals.cpp:13:5:13:11 | global1 | AST only |
 | globals.cpp:23:15:23:20 | call to getenv | globals.cpp:23:5:23:11 | global2 | AST only |
 | test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:11:104:20 | (...) | IR only |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,4 +1,13 @@
 edges
+| field_conflation.c:12:22:12:27 | call to getenv | field_conflation.c:13:10:13:25 | Chi |
+| field_conflation.c:12:22:12:34 | (const char *)... | field_conflation.c:13:10:13:25 | Chi |
+| field_conflation.c:13:10:13:25 | Chi | field_conflation.c:19:15:19:17 | taint_array output argument |
+| field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:10:20:13 | (unsigned long)... |
+| field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:13:20:13 | x |
+| field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:13:20:13 | x |
+| field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:13:20:13 | x |
+| field_conflation.c:20:13:20:13 | x | field_conflation.c:20:10:20:13 | (unsigned long)... |
+| field_conflation.c:20:13:20:13 | x | field_conflation.c:20:13:20:13 | x |
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | (size_t)... |
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | (size_t)... |
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
@@ -60,6 +69,15 @@ edges
 | test.cpp:235:11:235:20 | (size_t)... | test.cpp:214:23:214:23 | s |
 | test.cpp:237:10:237:19 | (size_t)... | test.cpp:220:21:220:21 | s |
 nodes
+| field_conflation.c:12:22:12:27 | call to getenv | semmle.label | call to getenv |
+| field_conflation.c:12:22:12:34 | (const char *)... | semmle.label | (const char *)... |
+| field_conflation.c:13:10:13:25 | Chi | semmle.label | Chi |
+| field_conflation.c:19:15:19:17 | taint_array output argument | semmle.label | taint_array output argument |
+| field_conflation.c:20:10:20:13 | (unsigned long)... | semmle.label | (unsigned long)... |
+| field_conflation.c:20:10:20:13 | (unsigned long)... | semmle.label | (unsigned long)... |
+| field_conflation.c:20:13:20:13 | x | semmle.label | x |
+| field_conflation.c:20:13:20:13 | x | semmle.label | x |
+| field_conflation.c:20:13:20:13 | x | semmle.label | x |
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
 | test.cpp:39:21:39:24 | argv | semmle.label | argv |
 | test.cpp:42:38:42:44 | (size_t)... | semmle.label | (size_t)... |
@@ -123,6 +141,7 @@ nodes
 | test.cpp:235:11:235:20 | (size_t)... | semmle.label | (size_t)... |
 | test.cpp:237:10:237:19 | (size_t)... | semmle.label | (size_t)... |
 #select
+| field_conflation.c:20:3:20:8 | call to malloc | field_conflation.c:12:22:12:27 | call to getenv | field_conflation.c:20:13:20:13 | x | This allocation size is derived from $@ and might overflow | field_conflation.c:12:22:12:27 | call to getenv | user input (getenv) |
 | test.cpp:42:31:42:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |
 | test.cpp:45:31:45:36 | call to malloc | test.cpp:39:21:39:24 | argv | test.cpp:45:38:45:63 | ... + ... | This allocation size is derived from $@ and might overflow | test.cpp:39:21:39:24 | argv | user input (argv) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/field_conflation.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/field_conflation.c
@@ -1,0 +1,21 @@
+int atoi(const char *nptr);
+void *malloc(unsigned long size);
+char *getenv(const char *name);
+void *memcpy(void *dst, void *src, unsigned long size);
+
+struct ContainsArray {
+  int arr[16];
+  int x;
+};
+
+void taint_array(struct ContainsArray *ca, int offset) {
+  int tainted = atoi(getenv("VAR"));
+  memcpy(ca->arr + offset, &tainted, sizeof(int));
+}
+
+void test_conflated_fields3(int arbitrary) {
+  struct ContainsArray ca;
+  ca.x = 4;
+  taint_array(&ca, arbitrary);
+  malloc(ca.x); // not tainted [FALSE POSITIVE]
+}


### PR DESCRIPTION
This PR adds a test for a field conflation issue that's currently blocking #3123. It turns out the issue is present already without #3123, and it can be distilled down to this test case. I've added the test case both in the library test and a query test.

I _think_ the fundamental problem the interaction between https://github.com/github/codeql/blob/23532ae49afc6c7be9c049457fa80e5de35d8032/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll#L236-L237 and https://github.com/github/codeql/blob/23532ae49afc6c7be9c049457fa80e5de35d8032/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll#L224-L226, but I haven't investigated that.