### PR TITLE
C++/C#: Allow memory operands to lack a definition

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -23,32 +23,49 @@ private newtype TOperand =
     defInstr = Construction::getPhiOperandDefinition(useInstr, predecessorBlock, overlap)
   }
 
-private class OperandBase extends TOperand {
+/**
+ * Base class for all register operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class RegisterOperandBase extends TRegisterOperand {
   abstract string toString();
 }
 
-private class RegisterOperandBase extends OperandBase, TRegisterOperand {
-  abstract override string toString();
-}
-
+/**
+ * Returns the register operand with the specified parameters.
+ */
 private RegisterOperandBase registerOperand(
   Instruction useInstr, RegisterOperandTag tag, Instruction defInstr
 ) {
   result = TRegisterOperand(useInstr, tag, defInstr)
 }
 
-private class NonPhiMemoryOperandBase extends OperandBase, TNonPhiMemoryOperand {
-  abstract override string toString();
+/**
+ * Base class for all non-Phi memory operands. This is a placeholder for the IPA union type that we
+ * will eventually use for this purpose.
+ */
+private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the non-Phi memory operand with the specified parameters.
+ */
 private NonPhiMemoryOperandBase nonPhiMemoryOperand(Instruction useInstr, MemoryOperandTag tag) {
   result = TNonPhiMemoryOperand(useInstr, tag)
 }
 
-private class PhiOperandBase extends OperandBase, TPhiOperand {
-  abstract override string toString();
+/**
+ * Base class for all Phi operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class PhiOperandBase extends TPhiOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the Phi operand with the specified parameters.
+ */
 private PhiOperandBase phiOperand(
   Instruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
 ) {
@@ -58,8 +75,8 @@ private PhiOperandBase phiOperand(
 /**
  * A source operand of an `Instruction`. The operand represents a value consumed by the instruction.
  */
-class Operand extends OperandBase {
-  override string toString() { result = "Operand" }
+class Operand extends TOperand {
+  string toString() { result = "Operand" }
 
   final Language::Location getLocation() { result = getUse().getLocation() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -289,7 +289,9 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, NonPhiMemoryOper
 
   final override string toString() { result = tag.toString() }
 
-  final override Instruction getAnyDef() { hasDefinition(result, _) }
+  final override Instruction getAnyDef() {
+    result = unique(Instruction defInstr | hasDefinition(defInstr, _))
+  }
 
   final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Operand.qll
@@ -28,6 +28,7 @@ private newtype TOperand =
  * eventually use for this purpose.
  */
 private class RegisterOperandBase extends TRegisterOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -45,6 +46,7 @@ private RegisterOperandBase registerOperand(
  * will eventually use for this purpose.
  */
 private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -221,8 +221,7 @@ PositionalArgumentOperandTag positionalArgumentOperand(int argIndex) {
   result = TPositionalArgumentOperand(argIndex)
 }
 
-abstract class ChiOperandTag extends MemoryOperandTag {
-}
+abstract class ChiOperandTag extends MemoryOperandTag { }
 
 class ChiTotalOperandTag extends ChiOperandTag, TChiTotalOperand {
   final override string toString() { result = "ChiTotal" }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/internal/OperandTag.qll
@@ -221,7 +221,10 @@ PositionalArgumentOperandTag positionalArgumentOperand(int argIndex) {
   result = TPositionalArgumentOperand(argIndex)
 }
 
-class ChiTotalOperandTag extends MemoryOperandTag, TChiTotalOperand {
+abstract class ChiOperandTag extends MemoryOperandTag {
+}
+
+class ChiTotalOperandTag extends ChiOperandTag, TChiTotalOperand {
   final override string toString() { result = "ChiTotal" }
 
   final override int getSortOrder() { result = 13 }
@@ -231,7 +234,7 @@ class ChiTotalOperandTag extends MemoryOperandTag, TChiTotalOperand {
 
 ChiTotalOperandTag chiTotalOperand() { result = TChiTotalOperand() }
 
-class ChiPartialOperandTag extends MemoryOperandTag, TChiPartialOperand {
+class ChiPartialOperandTag extends ChiOperandTag, TChiPartialOperand {
   final override string toString() { result = "ChiPartial" }
 
   final override int getSortOrder() { result = 14 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -23,32 +23,49 @@ private newtype TOperand =
     defInstr = Construction::getPhiOperandDefinition(useInstr, predecessorBlock, overlap)
   }
 
-private class OperandBase extends TOperand {
+/**
+ * Base class for all register operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class RegisterOperandBase extends TRegisterOperand {
   abstract string toString();
 }
 
-private class RegisterOperandBase extends OperandBase, TRegisterOperand {
-  abstract override string toString();
-}
-
+/**
+ * Returns the register operand with the specified parameters.
+ */
 private RegisterOperandBase registerOperand(
   Instruction useInstr, RegisterOperandTag tag, Instruction defInstr
 ) {
   result = TRegisterOperand(useInstr, tag, defInstr)
 }
 
-private class NonPhiMemoryOperandBase extends OperandBase, TNonPhiMemoryOperand {
-  abstract override string toString();
+/**
+ * Base class for all non-Phi memory operands. This is a placeholder for the IPA union type that we
+ * will eventually use for this purpose.
+ */
+private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the non-Phi memory operand with the specified parameters.
+ */
 private NonPhiMemoryOperandBase nonPhiMemoryOperand(Instruction useInstr, MemoryOperandTag tag) {
   result = TNonPhiMemoryOperand(useInstr, tag)
 }
 
-private class PhiOperandBase extends OperandBase, TPhiOperand {
-  abstract override string toString();
+/**
+ * Base class for all Phi operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class PhiOperandBase extends TPhiOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the Phi operand with the specified parameters.
+ */
 private PhiOperandBase phiOperand(
   Instruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
 ) {
@@ -58,8 +75,8 @@ private PhiOperandBase phiOperand(
 /**
  * A source operand of an `Instruction`. The operand represents a value consumed by the instruction.
  */
-class Operand extends OperandBase {
-  override string toString() { result = "Operand" }
+class Operand extends TOperand {
+  string toString() { result = "Operand" }
 
   final Language::Location getLocation() { result = getUse().getLocation() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -289,7 +289,9 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, NonPhiMemoryOper
 
   final override string toString() { result = tag.toString() }
 
-  final override Instruction getAnyDef() { hasDefinition(result, _) }
+  final override Instruction getAnyDef() {
+    result = unique(Instruction defInstr | hasDefinition(defInstr, _))
+  }
 
   final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Operand.qll
@@ -28,6 +28,7 @@ private newtype TOperand =
  * eventually use for this purpose.
  */
 private class RegisterOperandBase extends TRegisterOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -45,6 +46,7 @@ private RegisterOperandBase registerOperand(
  * will eventually use for this purpose.
  */
 private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -23,32 +23,49 @@ private newtype TOperand =
     defInstr = Construction::getPhiOperandDefinition(useInstr, predecessorBlock, overlap)
   }
 
-private class OperandBase extends TOperand {
+/**
+ * Base class for all register operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class RegisterOperandBase extends TRegisterOperand {
   abstract string toString();
 }
 
-private class RegisterOperandBase extends OperandBase, TRegisterOperand {
-  abstract override string toString();
-}
-
+/**
+ * Returns the register operand with the specified parameters.
+ */
 private RegisterOperandBase registerOperand(
   Instruction useInstr, RegisterOperandTag tag, Instruction defInstr
 ) {
   result = TRegisterOperand(useInstr, tag, defInstr)
 }
 
-private class NonPhiMemoryOperandBase extends OperandBase, TNonPhiMemoryOperand {
-  abstract override string toString();
+/**
+ * Base class for all non-Phi memory operands. This is a placeholder for the IPA union type that we
+ * will eventually use for this purpose.
+ */
+private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the non-Phi memory operand with the specified parameters.
+ */
 private NonPhiMemoryOperandBase nonPhiMemoryOperand(Instruction useInstr, MemoryOperandTag tag) {
   result = TNonPhiMemoryOperand(useInstr, tag)
 }
 
-private class PhiOperandBase extends OperandBase, TPhiOperand {
-  abstract override string toString();
+/**
+ * Base class for all Phi operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class PhiOperandBase extends TPhiOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the Phi operand with the specified parameters.
+ */
 private PhiOperandBase phiOperand(
   Instruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
 ) {
@@ -58,8 +75,8 @@ private PhiOperandBase phiOperand(
 /**
  * A source operand of an `Instruction`. The operand represents a value consumed by the instruction.
  */
-class Operand extends OperandBase {
-  override string toString() { result = "Operand" }
+class Operand extends TOperand {
+  string toString() { result = "Operand" }
 
   final Language::Location getLocation() { result = getUse().getLocation() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -289,7 +289,9 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, NonPhiMemoryOper
 
   final override string toString() { result = tag.toString() }
 
-  final override Instruction getAnyDef() { hasDefinition(result, _) }
+  final override Instruction getAnyDef() {
+    result = unique(Instruction defInstr | hasDefinition(defInstr, _))
+  }
 
   final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Operand.qll
@@ -28,6 +28,7 @@ private newtype TOperand =
  * eventually use for this purpose.
  */
 private class RegisterOperandBase extends TRegisterOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -45,6 +46,7 @@ private RegisterOperandBase registerOperand(
  * will eventually use for this purpose.
  */
 private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_consistency_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_consistency_unsound.expected
@@ -1,7 +1,6 @@
 missingOperand
 unexpectedOperand
 duplicateOperand
-| ssa.cpp:301:27:301:30 | ReturnIndirection: argv | Instruction has 2 operands with tag 'SideEffect' in function '$@'. | ssa.cpp:301:5:301:8 | IR: main | int main(int, char**) |
 missingPhiOperand
 missingOperandType
 duplicateChiOperand

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
@@ -1480,7 +1480,7 @@ ssa.cpp:
 #  304|     r304_5(char)           = Load                             : &:r304_4, ~m303_8
 #  304|     r304_6(int)            = Convert                          : r304_5
 #  304|     m304_7(int)            = Store                            : &:r304_1, r304_6
-#  301|     v301_12(void)          = ReturnIndirection[argv]          : &:r301_10, ~m303_11, m303_11
+#  301|     v301_12(void)          = ReturnIndirection[argv]          : &:r301_10, m303_11
 #  301|     r301_13(glval<int>)    = VariableAddress[#return]         : 
 #  301|     v301_14(void)          = ReturnValue                      : &:r301_13, m304_7
 #  301|     v301_15(void)          = AliasedUse                       : ~m303_8

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
@@ -221,8 +221,7 @@ PositionalArgumentOperandTag positionalArgumentOperand(int argIndex) {
   result = TPositionalArgumentOperand(argIndex)
 }
 
-abstract class ChiOperandTag extends MemoryOperandTag {
-}
+abstract class ChiOperandTag extends MemoryOperandTag { }
 
 class ChiTotalOperandTag extends ChiOperandTag, TChiTotalOperand {
   final override string toString() { result = "ChiTotal" }

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/internal/OperandTag.qll
@@ -221,7 +221,10 @@ PositionalArgumentOperandTag positionalArgumentOperand(int argIndex) {
   result = TPositionalArgumentOperand(argIndex)
 }
 
-class ChiTotalOperandTag extends MemoryOperandTag, TChiTotalOperand {
+abstract class ChiOperandTag extends MemoryOperandTag {
+}
+
+class ChiTotalOperandTag extends ChiOperandTag, TChiTotalOperand {
   final override string toString() { result = "ChiTotal" }
 
   final override int getSortOrder() { result = 13 }
@@ -231,7 +234,7 @@ class ChiTotalOperandTag extends MemoryOperandTag, TChiTotalOperand {
 
 ChiTotalOperandTag chiTotalOperand() { result = TChiTotalOperand() }
 
-class ChiPartialOperandTag extends MemoryOperandTag, TChiPartialOperand {
+class ChiPartialOperandTag extends ChiOperandTag, TChiPartialOperand {
   final override string toString() { result = "ChiPartial" }
 
   final override int getSortOrder() { result = 14 }

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -23,32 +23,49 @@ private newtype TOperand =
     defInstr = Construction::getPhiOperandDefinition(useInstr, predecessorBlock, overlap)
   }
 
-private class OperandBase extends TOperand {
+/**
+ * Base class for all register operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class RegisterOperandBase extends TRegisterOperand {
   abstract string toString();
 }
 
-private class RegisterOperandBase extends OperandBase, TRegisterOperand {
-  abstract override string toString();
-}
-
+/**
+ * Returns the register operand with the specified parameters.
+ */
 private RegisterOperandBase registerOperand(
   Instruction useInstr, RegisterOperandTag tag, Instruction defInstr
 ) {
   result = TRegisterOperand(useInstr, tag, defInstr)
 }
 
-private class NonPhiMemoryOperandBase extends OperandBase, TNonPhiMemoryOperand {
-  abstract override string toString();
+/**
+ * Base class for all non-Phi memory operands. This is a placeholder for the IPA union type that we
+ * will eventually use for this purpose.
+ */
+private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the non-Phi memory operand with the specified parameters.
+ */
 private NonPhiMemoryOperandBase nonPhiMemoryOperand(Instruction useInstr, MemoryOperandTag tag) {
   result = TNonPhiMemoryOperand(useInstr, tag)
 }
 
-private class PhiOperandBase extends OperandBase, TPhiOperand {
-  abstract override string toString();
+/**
+ * Base class for all Phi operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class PhiOperandBase extends TPhiOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the Phi operand with the specified parameters.
+ */
 private PhiOperandBase phiOperand(
   Instruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
 ) {
@@ -58,8 +75,8 @@ private PhiOperandBase phiOperand(
 /**
  * A source operand of an `Instruction`. The operand represents a value consumed by the instruction.
  */
-class Operand extends OperandBase {
-  override string toString() { result = "Operand" }
+class Operand extends TOperand {
+  string toString() { result = "Operand" }
 
   final Language::Location getLocation() { result = getUse().getLocation() }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -289,7 +289,9 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, NonPhiMemoryOper
 
   final override string toString() { result = tag.toString() }
 
-  final override Instruction getAnyDef() { hasDefinition(result, _) }
+  final override Instruction getAnyDef() {
+    result = unique(Instruction defInstr | hasDefinition(defInstr, _))
+  }
 
   final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Operand.qll
@@ -28,6 +28,7 @@ private newtype TOperand =
  * eventually use for this purpose.
  */
 private class RegisterOperandBase extends TRegisterOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -45,6 +46,7 @@ private RegisterOperandBase registerOperand(
  * will eventually use for this purpose.
  */
 private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
@@ -23,32 +23,49 @@ private newtype TOperand =
     defInstr = Construction::getPhiOperandDefinition(useInstr, predecessorBlock, overlap)
   }
 
-private class OperandBase extends TOperand {
+/**
+ * Base class for all register operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class RegisterOperandBase extends TRegisterOperand {
   abstract string toString();
 }
 
-private class RegisterOperandBase extends OperandBase, TRegisterOperand {
-  abstract override string toString();
-}
-
+/**
+ * Returns the register operand with the specified parameters.
+ */
 private RegisterOperandBase registerOperand(
   Instruction useInstr, RegisterOperandTag tag, Instruction defInstr
 ) {
   result = TRegisterOperand(useInstr, tag, defInstr)
 }
 
-private class NonPhiMemoryOperandBase extends OperandBase, TNonPhiMemoryOperand {
-  abstract override string toString();
+/**
+ * Base class for all non-Phi memory operands. This is a placeholder for the IPA union type that we
+ * will eventually use for this purpose.
+ */
+private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the non-Phi memory operand with the specified parameters.
+ */
 private NonPhiMemoryOperandBase nonPhiMemoryOperand(Instruction useInstr, MemoryOperandTag tag) {
   result = TNonPhiMemoryOperand(useInstr, tag)
 }
 
-private class PhiOperandBase extends OperandBase, TPhiOperand {
-  abstract override string toString();
+/**
+ * Base class for all Phi operands. This is a placeholder for the IPA union type that we will
+ * eventually use for this purpose.
+ */
+private class PhiOperandBase extends TPhiOperand {
+  abstract string toString();
 }
 
+/**
+ * Returns the Phi operand with the specified parameters.
+ */
 private PhiOperandBase phiOperand(
   Instruction useInstr, Instruction defInstr, IRBlock predecessorBlock, Overlap overlap
 ) {
@@ -58,8 +75,8 @@ private PhiOperandBase phiOperand(
 /**
  * A source operand of an `Instruction`. The operand represents a value consumed by the instruction.
  */
-class Operand extends OperandBase {
-  override string toString() { result = "Operand" }
+class Operand extends TOperand {
+  string toString() { result = "Operand" }
 
   final Language::Location getLocation() { result = getUse().getLocation() }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
@@ -289,7 +289,9 @@ class NonPhiMemoryOperand extends NonPhiOperand, MemoryOperand, NonPhiMemoryOper
 
   final override string toString() { result = tag.toString() }
 
-  final override Instruction getAnyDef() { hasDefinition(result, _) }
+  final override Instruction getAnyDef() {
+    result = unique(Instruction defInstr | hasDefinition(defInstr, _))
+  }
 
   final override Overlap getDefinitionOverlap() { hasDefinition(_, result) }
 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Operand.qll
@@ -28,6 +28,7 @@ private newtype TOperand =
  * eventually use for this purpose.
  */
 private class RegisterOperandBase extends TRegisterOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 
@@ -45,6 +46,7 @@ private RegisterOperandBase registerOperand(
  * will eventually use for this purpose.
  */
 private class NonPhiMemoryOperandBase extends TNonPhiMemoryOperand {
+  /** Gets a textual representation of this element. */
   abstract string toString();
 }
 


### PR DESCRIPTION
Another step toward https://github.com/github/codeql-c-analysis-team/issues/69

We want to reuse `TOperand` objects across IR phases. Before we can do this, we have to ensure that the parameters to the IPA constructors for those shared operands do not contain data that changes between phases. `RegisterOperand`s will always keep the same definition across all phases, but `NonPhiMemoryOperand`s may wind up with different definitions in different phases, depending on how precise SSA's alias analysis is. Furthermore, in order to remove all `UnmodeledDefinition` instructions, we have to allow for the possibility that a `NonPhiMemoryOperand` will not have a definition at all.

This change first refactors `Operand.qll` into a form closer to what we will want once the `TOperand` IPA type is shared across phases. I've wrapped each branch of the IPA type in a private class, and `Operand` and subclasses now extend one or more of those private classes, rather than extending an IPA type or branch directly. Once we actually have IPA branch union type support, we can implement the IPA branches in a single shared file, expose the base operand types as union types with the right names, and we shouldn't have to change the rest of `Operand.qll`.

I looked at the RA diffs from this refactoring, and other than predicate names, the only thing that changed was that the optimizer was able to replace a use of `Operand::PositionalArgumentOperand#class#fffff` with a use of `Operand::PositionalArgumentOperand::getIndex_dispred#ff`, which has the same RA body except that it uses two fewer columns.

The second commit removes the `defInstr` and `overlap` parameters from `TNonPhiMemoryOperand`. The `TNonPhiMemoryOperand` objects are now created by simply asking the `Opcode` if it expects an operand with that tag. The actual lookup of definitions for those operands now happens in `NonPhiMemoryOperand::hasDefinition()`, which has essentially the same implementation as the old constructor for `TNonPhiMemoryOperand`. Other than introducing a dedupe operation to cope with the potential for an operand having multiple overlap values, the RA for the important `Operand::getAnyDef()` predicate is pretty much the same as before.

As a useful side effect, this change partially fixed an existing bug where we would create two `Operand`s with the same use instruction and tag because SSA construction was giving two different `Overlap` values for the operand's definition. The SSA bug is still there, but now we only create one `Operand` with two values for `getDefinitionOverlap()`, rather than two `Operand`s each with a single value for `getDefinitionOverlap()`. The `.expected` file that I fixed still has one consistency failure caused by that SSA bug, because one of the two `Overlap` values is `MayPartiallyOverlap`, which is invalid.


