### PR TITLE
CSHARP: Add experimental query for tainted WebClient

### DIFF
--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.cs
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Web;
+using System.Net;
+
+public class TaintedWebClientHandler : IHttpHandler
+{
+    public void ProcessRequest(HttpContext ctx)
+    {
+        String url = ctx.Request.QueryString["domain"];
+
+        // BAD: This could read any file on the filesystem. (../../../../etc/passwd)
+		using(WebClient client = new WebClient()) {
+			ctx.Response.Write(client.DownloadString(url));
+        }
+
+        // BAD: This could still read any file on the filesystem. (https://../../../../etc/passwd)
+        if (url.StartsWith("https://")){
+            using(WebClient client = new WebClient()) {
+                ctx.Response.Write(client.DownloadString(url));
+            }
+        }
+
+        // GOOD: IsWellFormedUriString ensures that it is a valid URL
+        if (Uri.IsWellFormedUriString(url, UriKind.Absolute)){
+            using(WebClient client = new WebClient()) {
+                ctx.Response.Write(client.DownloadString(url));
+            }
+        }
+    }
+}

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
@@ -53,11 +53,6 @@ system's passwords.</p>
 OWASP:
 <a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
 </li>
-<li>
-CWE-099:
-<a href="https://cwe.mitre.org/data/definitions/99.html">Resource
-Injection</a>.
-</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
@@ -1,34 +1,48 @@
 <!DOCTYPE qhelp PUBLIC
-  "-//Semmle//qhelp//EN"
-  "qhelp.dtd">
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
 <qhelp>
 <overview>
-<p>The WebClient class provices common methods for sending data to and receiving data from a resource identified by a URI.
-Even that the name of the class is WebClient the support is not only limited to WebResources but also local resources. This
-can result in sensitive information being revealed.</p>
+<p>The WebClient class provides a variety of methods for data transmission and
+communication with a particular URI. Despite of the class' naming convention,
+the URI scheme can also identify local resources, not only remote ones. Tainted
+by user-supplied input, the URI can be leveraged to access resources available
+on the local file system, therefore leading to the disclosure of sensitive
+information. This can be trivially achieved by supplying path traversal
+sequences (../) followed by an existing directory or file path.</p>
 
-<p>URIs that are naively constructed from data controlled by a user may contain local paths with unexpected special characters,
-such as "..". Such a path may potentially point to any directory on the file system.</p>
+<p>Sanitization of  user-supplied URI values using the
+<code>StartsWith("https://")</code> method is deemed insufficient in preventing
+arbitrary file reads. This is due to the fact that .NET ignores the protocol
+handler (https in this case) in URIs like the following:
+"https://../../../../etc/passwd".</p>
 
 </overview>
 <recommendation>
 
-<p>Validate user input before using it to ensure that is a URI of an external resource and not a local one. 
-Pontetial solutions:</p>
+<p>Validate user input before using it to ensure that is a URI of an external
+resource and not a local one. 
+Potential solutions:</p>
 
 <ul>
-<li>Sanitize potentially tainted paths using <code>System.Uri.IsWellFormedUriString</code>.</li>
+<li>Sanitize potentially tainted paths using
+<code>System.Uri.IsWellFormedUriString</code>.</li>
 </ul>
 
 </recommendation>
 <example>
 
-<p>In the first example, a domain name is read from a <code>HttpRequest</code> and then used to request this domain. However, a
-malicious user could enter a local path - for example, "../../../etc/passwd". In the second example, it
-appears that user is restricted to the HTTPS protocol handler. However, a malicious user could
-still enter a local path. For example, the string "../../../etc/passwd" will result in the code
-reading the file located at "/etc/passwd", which is the system's password file. This file would then be
-sent back to the user, giving them access to all the system's passwords.</p>
+<p>In the first example, a domain name is read from a <code>HttpRequest</code>
+and then this domain is requested using the method <code>DownloadString</code>.
+However, a malicious user could enter a local path - for example,
+"../../../etc/passwd" instead of a domain. 
+In the second example, it appears that the user is restricted to the HTTPS
+protocol handler. However, a malicious user could still enter a local path,
+since as explained above the protocol handler will be ignored by .net. For
+example, the string "https://../../../etc/passwd" will result in the code
+reading the file located at "/etc/passwd", which is the system's password file.
+This file would then be sent back to the user, giving them access to all the
+system's passwords.</p>
 
 <sample src="TaintedWebClient.cs" />
 
@@ -41,7 +55,8 @@ OWASP:
 </li>
 <li>
 CWE-099:
-<a href="https://cwe.mitre.org/data/definitions/99.html">Resource Injection</a>.
+<a href="https://cwe.mitre.org/data/definitions/99.html">Resource
+Injection</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
@@ -1,0 +1,48 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>The WebClient class provices common methods for sending data to and receiving data from a resource identified by a URI.
+Even that the name of the class is WebClient the support is not only limited to WebResources but also local resources. This
+can result in sensitive information being revealed.</p>
+
+<p>URIs that are naively constructed from data controlled by a user may contain local paths with unexpected special characters,
+such as "..". Such a path may potentially point to any directory on the file system.</p>
+
+</overview>
+<recommendation>
+
+<p>Validate user input before using it to ensure that is a URI of an external resource and not a local one. 
+Pontetial solutions:</p>
+
+<ul>
+<li>Sanitize potentially tainted paths using <code>System.Uri.IsWellFormedUriString</code>.</li>
+</ul>
+
+</recommendation>
+<example>
+
+<p>In the first example, a domain name is read from a <code>HttpRequest</code> and then used to request this domain. However, a
+malicious user could enter a local path - for example, "../../../etc/passwd". In the second example, it
+appears that user is restricted to the HTTPS protocol handler. However, a malicious user could
+still enter a local path. For example, the string "../../../etc/passwd" will result in the code
+reading the file located at "/etc/passwd", which is the system's password file. This file would then be
+sent back to the user, giving them access to all the system's passwords.</p>
+
+<sample src="TaintedWebClient.cs" />
+
+</example>
+<references>
+
+<li>
+OWASP:
+<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+</li>
+<li>
+CWE-099:
+<a href="https://cwe.mitre.org/data/definitions/99.html">Resource Injection</a>.
+</li>
+
+</references>
+</qhelp>

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
@@ -1,0 +1,25 @@
+/**
+ * @name Uncontrolled data used in a WebClient
+ * @description The WebClient class allow developers to request resources,
+ *              accessing resources influenced by users can allow an attacker to access local files.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id cs/webclient-path-injection
+ * @tags security
+ *       external/cwe/cwe-099
+ *       external/cwe/cwe-022
+ *       external/cwe/cwe-023
+ *       external/cwe/cwe-036
+ *       external/cwe/cwe-073
+ *       external/cwe/cwe-022
+ */
+
+import csharp
+import TaintedWebClientLib
+import semmle.code.csharp.dataflow.DataFlow::DataFlow::PathGraph
+
+from TaintTrackingConfiguration c, DataFlow::PathNode source, DataFlow::PathNode sink
+where c.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "$@ flows to here and is used in a method of WebClient.",
+  source.getNode(), "User-provided value"

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql
@@ -1,6 +1,6 @@
 /**
  * @name Uncontrolled data used in a WebClient
- * @description The WebClient class allow developers to request resources,
+ * @description The WebClient class allows developers to request resources,
  *              accessing resources influenced by users can allow an attacker to access local files.
  * @kind path-problem
  * @problem.severity error
@@ -8,11 +8,9 @@
  * @id cs/webclient-path-injection
  * @tags security
  *       external/cwe/cwe-099
- *       external/cwe/cwe-022
  *       external/cwe/cwe-023
  *       external/cwe/cwe-036
  *       external/cwe/cwe-073
- *       external/cwe/cwe-022
  */
 
 import csharp

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
@@ -41,7 +41,7 @@ abstract class Sanitizer extends DataFlow::ExprNode { }
  * A taint-tracking configuration for uncontrolled data in path expression vulnerabilities.
  */
 class TaintTrackingConfiguration extends TaintTracking::Configuration {
-  TaintTrackingConfiguration() { this = "TaintedPath" }
+  TaintTrackingConfiguration() { this = "TaintedWebClientLib" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof Source }
 
@@ -56,7 +56,7 @@ class RemoteSource extends Source {
 }
 
 /**
- * A path argument to a `WebClient` method call that have an address argument.
+ * A path argument to a `WebClient` method call that has an address argument.
  */
 class WebClientSink extends Sink {
   WebClientSink() {

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
@@ -17,7 +17,7 @@ class SystemNetWebClientClass extends SystemNetClass {
 //Extend the already existent SystemUriClass to not touch the stdlib.
 /** The `System.Uri` class. */
 class SystemUriClassExtra extends SystemUriClass {
-  /** Gets the `DownloadString` method. */
+  /** Gets the `IsWellFormedUriString` method. */
   Method getIsWellFormedUriStringMethod() { result = this.getAMethod("IsWellFormedUriString") }
 }
 

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClientLib.qll
@@ -1,0 +1,82 @@
+import csharp
+import semmle.code.csharp.frameworks.system.Net
+import semmle.code.csharp.frameworks.System
+import semmle.code.csharp.security.dataflow.flowsources.Remote
+import semmle.code.csharp.security.Sanitizers
+
+//If this leaves experimental this should probably go in semmle.code.csharp.frameworks.system.Net
+/** The `System.Net.WebClient` class. */
+class SystemNetWebClientClass extends SystemNetClass {
+  SystemNetWebClientClass() { this.hasName("WebClient") }
+
+  /** Gets the `DownloadString` method. */
+  Method getDownloadStringMethod() { result = this.getAMethod("DownloadString") }
+}
+
+//If this leaves experimental this should probably go in semmle.code.csharp.frameworks.System
+//Extend the already existent SystemUriClass to not touch the stdlib.
+/** The `System.Uri` class. */
+class SystemUriClassExtra extends SystemUriClass {
+  /** Gets the `DownloadString` method. */
+  Method getIsWellFormedUriStringMethod() { result = this.getAMethod("IsWellFormedUriString") }
+}
+
+//If this leaves experimental this should probably go in semmle.code.csharp.frameworks.system
+/**
+ * A data flow source for uncontrolled data in path expression vulnerabilities.
+ */
+abstract class Source extends DataFlow::Node { }
+
+/**
+ * A data flow sink for uncontrolled data in path expression vulnerabilities.
+ */
+abstract class Sink extends DataFlow::ExprNode { }
+
+/**
+ * A sanitizer for uncontrolled data in path expression vulnerabilities.
+ */
+abstract class Sanitizer extends DataFlow::ExprNode { }
+
+/**
+ * A taint-tracking configuration for uncontrolled data in path expression vulnerabilities.
+ */
+class TaintTrackingConfiguration extends TaintTracking::Configuration {
+  TaintTrackingConfiguration() { this = "TaintedPath" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+}
+
+/** A source of remote user input. */
+class RemoteSource extends Source {
+  RemoteSource() { this instanceof RemoteFlowSource }
+}
+
+/**
+ * A path argument to a `WebClient` method call that have an address argument.
+ */
+class WebClientSink extends Sink {
+  WebClientSink() {
+    exists(Method m | m = any(SystemNetWebClientClass f).getAMethod() |
+      this.getExpr() = m.getACall().getArgumentForName("address")
+    )
+  }
+}
+
+/**
+ * A call to `System.Uri.IsWellFormedUriString` that is considered to sanitize the input.
+ */
+class RequestMapPathSanitizer extends Sanitizer {
+  RequestMapPathSanitizer() {
+    exists(Method m | m = any(SystemUriClassExtra uri).getIsWellFormedUriStringMethod() |
+      this.getExpr() = m.getACall().getArgument(0)
+    )
+  }
+}
+
+private class SimpleTypeSanitizer extends Sanitizer, SimpleTypeSanitizedExpr { }
+
+private class GuidSanitizer extends Sanitizer, GuidSanitizedExpr { }


### PR DESCRIPTION
The WebClient class provides common methods for sending data to and receiving data from a resource identified by a URI.
Even that the name of the class is WebClient, the support is not only limited to web resources but also local resources. This can result in sensitive information being revealed when a local path is passed for example to the method DownloadString.

I mapped `System.Net.WebClient` and `System.Uri` in the library for the query, this should go in the already existing libraries `semmle.code.csharp.frameworks.system.Net` and `semmle.code.csharp.frameworks.system`, but since this is an experimental query I didn't want to touch anything outside the experimental folder.

More sanitiser can be implemented, for the moment I just added `IsWellFormedUriString` and some other basic ones, but there are multiple other ways to sanitise the input.

I found an instance of this issue in a private repository, it was also referenced in the following presentation.
https://youtu.be/E5_S_Yip3gc?t=559