### PR TITLE
Python: Modernise `py/missing-equals`.

### DIFF
--- a/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.ql
+++ b/python/ql/src/Classes/DefineEqualsWhenAddingAttributes.ql
@@ -14,21 +14,21 @@ import python
 import semmle.python.SelfAttribute
 import Equality
 
-predicate class_stores_to_attribute(ClassObject cls, SelfAttributeStore store, string name) {
-    exists(FunctionObject f |
-        f = cls.declaredAttribute(_) and store.getScope() = f.getFunction() and store.getName() = name
+predicate class_stores_to_attribute(ClassValue cls, SelfAttributeStore store, string name) {
+    exists(FunctionValue f |
+        f = cls.declaredAttribute(_) and store.getScope() = f.getScope() and store.getName() = name
     ) and
     /* Exclude classes used as metaclasses */
-    not cls.getASuperType() = theTypeType()
+    not cls.getASuperType() = ClassValue::type()
 }
 
-predicate should_override_eq(ClassObject cls, Object base_eq) {
+predicate should_override_eq(ClassValue cls, Value base_eq) {
     not cls.declaresAttribute("__eq__") and
-    exists(ClassObject sup | sup = cls.getABaseType() and sup.declaredAttribute("__eq__") = base_eq |
-        not exists(GenericEqMethod eq | eq.getScope() = sup.getPyClass()) and
-        not exists(IdentityEqMethod eq | eq.getScope() = sup.getPyClass()) and
-        not base_eq.(FunctionObject).getFunction() instanceof IdentityEqMethod and
-        not base_eq = theObjectType().declaredAttribute("__eq__")
+    exists(ClassValue sup | sup = cls.getABaseType() and sup.declaredAttribute("__eq__") = base_eq |
+        not exists(GenericEqMethod eq | eq.getScope() = sup.getScope()) and
+        not exists(IdentityEqMethod eq | eq.getScope() = sup.getScope()) and
+        not base_eq.(FunctionValue).getScope() instanceof IdentityEqMethod and
+        not base_eq = ClassValue::object().declaredAttribute("__eq__")
     )
 }
 
@@ -36,16 +36,16 @@ predicate should_override_eq(ClassObject cls, Object base_eq) {
  * Does the non-overridden __eq__ method access the attribute,
  * which implies that the  __eq__ method does not need to be overridden.
  */
-predicate superclassEqExpectsAttribute(ClassObject cls, PyFunctionObject base_eq, string attrname) {
+predicate superclassEqExpectsAttribute(ClassValue cls, FunctionValue base_eq, string attrname) {
     not cls.declaresAttribute("__eq__") and
-    exists(ClassObject sup | sup = cls.getABaseType() and sup.declaredAttribute("__eq__") = base_eq |
+    exists(ClassValue sup | sup = cls.getABaseType() and sup.declaredAttribute("__eq__") = base_eq |
         exists(SelfAttributeRead store | store.getName() = attrname |
-            store.getScope() = base_eq.getFunction()
+            store.getScope() = base_eq.getScope()
         )
     )
 }
 
-from ClassObject cls, SelfAttributeStore store, Object base_eq
+from ClassValue cls, SelfAttributeStore store, Value base_eq
 where
     class_stores_to_attribute(cls, store, _) and
     should_override_eq(cls, base_eq) and

--- a/python/ql/test/3/query-tests/Classes/equals-attr/DefineEqualsWhenAddingAttributes.expected
+++ b/python/ql/test/3/query-tests/Classes/equals-attr/DefineEqualsWhenAddingAttributes.expected
@@ -1,2 +1,2 @@
-| test.py:12:1:12:24 | class C | The class 'C' does not override $@, but adds the new attribute $@. | test.py:9:5:9:28 | Function __eq__ | '__eq__' | test.py:15:9:15:14 | Attribute | a |
-| test.py:12:1:12:24 | class C | The class 'C' does not override $@, but adds the new attribute $@. | test.py:9:5:9:28 | Function __eq__ | '__eq__' | test.py:15:17:15:22 | Attribute | b |
+| test.py:12:1:12:24 | class C | The class 'C' does not override $@, but adds the new attribute $@. | test.py:9:5:9:28 | Function RedefineEquals.__eq__ | '__eq__' | test.py:15:9:15:14 | Attribute | a |
+| test.py:12:1:12:24 | class C | The class 'C' does not override $@, but adds the new attribute $@. | test.py:9:5:9:28 | Function RedefineEquals.__eq__ | '__eq__' | test.py:15:17:15:22 | Attribute | b |

--- a/python/ql/test/query-tests/Classes/equals-hash/DefineEqualsWhenAddingFields.expected
+++ b/python/ql/test/query-tests/Classes/equals-hash/DefineEqualsWhenAddingFields.expected
@@ -1,1 +1,1 @@
-| attr_eq_test.py:21:1:21:27 | class BadColorPoint | The class 'BadColorPoint' does not override $@, but adds the new attribute $@. | attr_eq_test.py:10:5:10:28 | Function __eq__ | '__eq__' | attr_eq_test.py:25:9:25:19 | Attribute | _color |
+| attr_eq_test.py:21:1:21:27 | class BadColorPoint | The class 'BadColorPoint' does not override $@, but adds the new attribute $@. | attr_eq_test.py:10:5:10:28 | Function Point.__eq__ | '__eq__' | attr_eq_test.py:25:9:25:19 | Attribute | _color |


### PR DESCRIPTION
Converts `DefineEqualsWhenAddingAttributes.ql `. There is a comment about `getASuperType` changing meaning that I need to understand.