### PR TITLE
Data flow: Use `accessPathLimit()` in partial flow as well

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2564,7 +2564,7 @@ private module FlowExploration {
 
   private newtype TPartialAccessPath =
     TPartialNil(DataFlowType t) or
-    TPartialCons(TypedContent tc, int len) { len in [1 .. 5] }
+    TPartialCons(TypedContent tc, int len) { len in [1 .. accessPathLimit()] }
 
   /**
    * Conceptually a list of `TypedContent`s followed by a `Type`, but only the first


### PR DESCRIPTION
I forgot to apply `accessPathLimit()` to partial flow, when it [was introduced](https://github.com/github/codeql/pull/2631).