### PR TITLE
CodeQL docs: remove stray GH variable

### DIFF
--- a/docs/language/learn-ql/java/introduce-libraries-java.rst
+++ b/docs/language/learn-ql/java/introduce-libraries-java.rst
@@ -1,7 +1,7 @@
 CodeQL library for Java
 =======================
 
-When you're analyzing a Java program in {{ site.data.variables.product.prodname_dotcom }}, you can make use of the large collection of classes in the CodeQL library for Java.
+When you're analyzing a Java program, you can make use of the large collection of classes in the CodeQL library for Java.
 
 About the CodeQL library for Java
 ---------------------------------


### PR DESCRIPTION
Removes a GitHub style variable that made it's way into a CodeQL article. I thought I fixed this ages ago 🤷 