### PR TITLE
Java: Add CFG edges for Java 14 pattern-matching instanceof.

### DIFF
--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -711,7 +711,8 @@ private module ControlFlowGraphImpl {
     )
     or
     exists(InstanceOfExpr ioe | ioe.isPattern() and ioe = n |
-      last = n and completion = basicBooleanCompletion(false) or
+      last = n and completion = basicBooleanCompletion(false)
+      or
       last = ioe.getLocalVariableDeclExpr() and completion = basicBooleanCompletion(true)
     )
     or

--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -405,7 +405,7 @@ private module ControlFlowGraphImpl {
    * Expressions and statements with CFG edges in post-order AST traversal.
    *
    * This includes most expressions, except those that initiate or propagate branching control
-   * flow (`LogicExpr`, `ConditionalExpr`), and parentheses, which aren't in the CFG.
+   * flow (`LogicExpr`, `ConditionalExpr`).
    * Only a few statements are included; those with specific side-effects
    * occurring after the evaluation of their children, that is, `Call`, `ReturnStmt`,
    * and `ThrowStmt`. CFG nodes without child nodes in the CFG that may complete
@@ -429,9 +429,10 @@ private module ControlFlowGraphImpl {
       or
       this instanceof CastExpr
       or
-      this instanceof InstanceOfExpr
+      this instanceof InstanceOfExpr and not this.(InstanceOfExpr).isPattern()
       or
-      this instanceof LocalVariableDeclExpr
+      this instanceof LocalVariableDeclExpr and
+      not this = any(InstanceOfExpr ioe).getLocalVariableDeclExpr()
       or
       this instanceof RValue
       or
@@ -573,6 +574,8 @@ private module ControlFlowGraphImpl {
     or
     result = first(n.(PostOrderNode).firstChild())
     or
+    result = first(n.(InstanceOfExpr).getExpr())
+    or
     result = first(n.(SynchronizedStmt).getExpr())
     or
     result = n and
@@ -705,6 +708,11 @@ private module ControlFlowGraphImpl {
     exists(ConditionalExpr condexpr | condexpr = n |
       last(condexpr.getFalseExpr(), last, completion) or
       last(condexpr.getTrueExpr(), last, completion)
+    )
+    or
+    exists(InstanceOfExpr ioe | ioe.isPattern() and ioe = n |
+      last = n and completion = basicBooleanCompletion(false) or
+      last = ioe.getLocalVariableDeclExpr() and completion = basicBooleanCompletion(true)
     )
     or
     // The last node of a node executed in post-order is the node itself.
@@ -914,6 +922,14 @@ private module ControlFlowGraphImpl {
       last(e.getCondition(), n, completion) and
       completion = BooleanCompletion(false, _) and
       result = first(e.getFalseExpr())
+    )
+    or
+    exists(InstanceOfExpr ioe | ioe.isPattern() |
+      last(ioe.getExpr(), n, completion) and completion = NormalCompletion() and result = ioe
+      or
+      n = ioe and
+      result = ioe.getLocalVariableDeclExpr() and
+      completion = basicBooleanCompletion(true)
     )
     or
     // In other expressions control flows from left to right and ends in the node itself.

--- a/java/ql/test/library-tests/ssa/TestInstanceOfPattern.java
+++ b/java/ql/test/library-tests/ssa/TestInstanceOfPattern.java
@@ -1,0 +1,31 @@
+class TestInstanceOfPattern {
+	private String s = "field";
+	void test(Object obj) {
+		if (obj instanceof String s) {
+			if (s.contains("abc")) {}
+		} else {
+			if (s.contains("def")) {}
+		}
+	}
+	void test2(Object obj) {
+		if (!(obj instanceof String s)) {
+			if (s.contains("abc")) {}
+		} else {
+			if (s.contains("def")) {}
+		}
+	}
+	void test3(Object obj) {
+		if (obj instanceof String s && s.length() > 5) {
+			if (s.contains("abc")) {}
+		} else {
+			if (s.contains("def")) {}
+		}
+	}
+	void test4(Object obj) {
+		if (obj instanceof String s || s.length() > 5) {
+			if (s.contains("abc")) {}
+		} else {
+			if (s.contains("def")) {}
+		}
+	}
+}

--- a/java/ql/test/library-tests/ssa/adjacentUses.expected
+++ b/java/ql/test/library-tests/ssa/adjacentUses.expected
@@ -30,3 +30,6 @@
 | Test.java:20:14:20:14 | y | Test.java:31:14:31:14 | y |
 | Test.java:27:19:27:19 | i | Test.java:28:9:28:9 | i |
 | Test.java:28:9:28:9 | i | Test.java:27:25:27:25 | i |
+| TestInstanceOfPattern.java:18:34:18:34 | s | TestInstanceOfPattern.java:19:8:19:8 | s |
+| TestInstanceOfPattern.java:25:34:25:34 | s | TestInstanceOfPattern.java:26:8:26:8 | s |
+| TestInstanceOfPattern.java:25:34:25:34 | s | TestInstanceOfPattern.java:28:8:28:8 | s |

--- a/java/ql/test/library-tests/ssa/firstUse.expected
+++ b/java/ql/test/library-tests/ssa/firstUse.expected
@@ -58,3 +58,15 @@
 | Test.java:27:25:27:27 | SSA def(i) | Test.java:27:19:27:19 | i |
 | Test.java:28:4:28:9 | SSA def(x) | Test.java:28:4:28:4 | x |
 | Test.java:28:4:28:9 | SSA def(x) | Test.java:31:10:31:10 | x |
+| TestInstanceOfPattern.java:3:24:9:2 | SSA init(obj) | TestInstanceOfPattern.java:4:7:4:9 | obj |
+| TestInstanceOfPattern.java:4:29:4:29 | SSA def(s) | TestInstanceOfPattern.java:5:8:5:8 | s |
+| TestInstanceOfPattern.java:7:8:7:8 | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:7:8:7:8 | s |
+| TestInstanceOfPattern.java:10:25:16:2 | SSA init(obj) | TestInstanceOfPattern.java:11:9:11:11 | obj |
+| TestInstanceOfPattern.java:11:31:11:31 | SSA def(s) | TestInstanceOfPattern.java:14:8:14:8 | s |
+| TestInstanceOfPattern.java:12:8:12:8 | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:12:8:12:8 | s |
+| TestInstanceOfPattern.java:17:25:23:2 | SSA init(obj) | TestInstanceOfPattern.java:18:7:18:9 | obj |
+| TestInstanceOfPattern.java:18:29:18:29 | SSA def(s) | TestInstanceOfPattern.java:18:34:18:34 | s |
+| TestInstanceOfPattern.java:21:8:21:8 | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:21:8:21:8 | s |
+| TestInstanceOfPattern.java:24:25:30:2 | SSA init(obj) | TestInstanceOfPattern.java:25:7:25:9 | obj |
+| TestInstanceOfPattern.java:24:25:30:2 | SSA init(this.s) | TestInstanceOfPattern.java:25:34:25:34 | s |
+| TestInstanceOfPattern.java:24:25:30:2 | SSA init(this.s) | TestInstanceOfPattern.java:26:8:26:8 | s |

--- a/java/ql/test/library-tests/ssa/options
+++ b/java/ql/test/library-tests/ssa/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args --enable-preview -source 14 -target 14

--- a/java/ql/test/library-tests/ssa/ssaDef.expected
+++ b/java/ql/test/library-tests/ssa/ssaDef.expected
@@ -91,3 +91,15 @@
 | Test.java:27:8:27:16 | i | Test.java:27:12:27:16 | i | SSA def(i) |
 | Test.java:27:8:27:16 | i | Test.java:27:19:27:19 | i | SSA phi(i) |
 | Test.java:27:8:27:16 | i | Test.java:27:25:27:27 | ...++ | SSA def(i) |
+| TestInstanceOfPattern.java:3:12:3:21 | obj | TestInstanceOfPattern.java:3:24:9:2 | stmt | SSA init(obj) |
+| TestInstanceOfPattern.java:4:22:4:29 | s | TestInstanceOfPattern.java:4:29:4:29 | s | SSA def(s) |
+| TestInstanceOfPattern.java:7:8:7:8 | this.s | TestInstanceOfPattern.java:7:8:7:8 | s | SSA impl upd[untracked](this.s) |
+| TestInstanceOfPattern.java:10:13:10:22 | obj | TestInstanceOfPattern.java:10:25:16:2 | stmt | SSA init(obj) |
+| TestInstanceOfPattern.java:11:24:11:31 | s | TestInstanceOfPattern.java:11:31:11:31 | s | SSA def(s) |
+| TestInstanceOfPattern.java:12:8:12:8 | this.s | TestInstanceOfPattern.java:12:8:12:8 | s | SSA impl upd[untracked](this.s) |
+| TestInstanceOfPattern.java:17:13:17:22 | obj | TestInstanceOfPattern.java:17:25:23:2 | stmt | SSA init(obj) |
+| TestInstanceOfPattern.java:18:22:18:29 | s | TestInstanceOfPattern.java:18:29:18:29 | s | SSA def(s) |
+| TestInstanceOfPattern.java:21:8:21:8 | this.s | TestInstanceOfPattern.java:21:8:21:8 | s | SSA impl upd[untracked](this.s) |
+| TestInstanceOfPattern.java:24:13:24:22 | obj | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(obj) |
+| TestInstanceOfPattern.java:25:22:25:29 | s | TestInstanceOfPattern.java:25:29:25:29 | s | SSA def(s) |
+| TestInstanceOfPattern.java:25:34:25:34 | this.s | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(this.s) |

--- a/java/ql/test/library-tests/ssa/ssaUse.expected
+++ b/java/ql/test/library-tests/ssa/ssaUse.expected
@@ -58,3 +58,17 @@
 | Test.java:27:8:27:16 | i | Test.java:27:19:27:19 | i | SSA phi(i) | Test.java:27:19:27:19 | i |
 | Test.java:27:8:27:16 | i | Test.java:27:19:27:19 | i | SSA phi(i) | Test.java:27:25:27:25 | i |
 | Test.java:27:8:27:16 | i | Test.java:27:19:27:19 | i | SSA phi(i) | Test.java:28:9:28:9 | i |
+| TestInstanceOfPattern.java:3:12:3:21 | obj | TestInstanceOfPattern.java:3:24:9:2 | stmt | SSA init(obj) | TestInstanceOfPattern.java:4:7:4:9 | obj |
+| TestInstanceOfPattern.java:4:22:4:29 | s | TestInstanceOfPattern.java:4:29:4:29 | s | SSA def(s) | TestInstanceOfPattern.java:5:8:5:8 | s |
+| TestInstanceOfPattern.java:7:8:7:8 | this.s | TestInstanceOfPattern.java:7:8:7:8 | s | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:7:8:7:8 | s |
+| TestInstanceOfPattern.java:10:13:10:22 | obj | TestInstanceOfPattern.java:10:25:16:2 | stmt | SSA init(obj) | TestInstanceOfPattern.java:11:9:11:11 | obj |
+| TestInstanceOfPattern.java:11:24:11:31 | s | TestInstanceOfPattern.java:11:31:11:31 | s | SSA def(s) | TestInstanceOfPattern.java:14:8:14:8 | s |
+| TestInstanceOfPattern.java:12:8:12:8 | this.s | TestInstanceOfPattern.java:12:8:12:8 | s | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:12:8:12:8 | s |
+| TestInstanceOfPattern.java:17:13:17:22 | obj | TestInstanceOfPattern.java:17:25:23:2 | stmt | SSA init(obj) | TestInstanceOfPattern.java:18:7:18:9 | obj |
+| TestInstanceOfPattern.java:18:22:18:29 | s | TestInstanceOfPattern.java:18:29:18:29 | s | SSA def(s) | TestInstanceOfPattern.java:18:34:18:34 | s |
+| TestInstanceOfPattern.java:18:22:18:29 | s | TestInstanceOfPattern.java:18:29:18:29 | s | SSA def(s) | TestInstanceOfPattern.java:19:8:19:8 | s |
+| TestInstanceOfPattern.java:21:8:21:8 | this.s | TestInstanceOfPattern.java:21:8:21:8 | s | SSA impl upd[untracked](this.s) | TestInstanceOfPattern.java:21:8:21:8 | s |
+| TestInstanceOfPattern.java:24:13:24:22 | obj | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(obj) | TestInstanceOfPattern.java:25:7:25:9 | obj |
+| TestInstanceOfPattern.java:25:34:25:34 | this.s | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(this.s) | TestInstanceOfPattern.java:25:34:25:34 | s |
+| TestInstanceOfPattern.java:25:34:25:34 | this.s | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(this.s) | TestInstanceOfPattern.java:26:8:26:8 | s |
+| TestInstanceOfPattern.java:25:34:25:34 | this.s | TestInstanceOfPattern.java:24:25:30:2 | stmt | SSA init(this.s) | TestInstanceOfPattern.java:28:8:28:8 | s |


### PR DESCRIPTION
The control flow for the new `instanceof` variant is tested through SSA construction.  The definition becomes available in the right branches through the use of true- and false-successors.