### PR TITLE
JS: apply the unique aggregate where trivially applicable

### DIFF
--- a/javascript/ql/src/semmle/javascript/AMD.qll
+++ b/javascript/ql/src/semmle/javascript/AMD.qll
@@ -259,8 +259,7 @@ private class AmdDependencyImport extends Import {
    * Gets the module whose absolute path matches this import, if there is only a single such module.
    */
   private Module resolveByAbsolutePath() {
-    count(guessTarget()) = 1 and
-    result.getFile() = guessTarget()
+    result.getFile() = unique(File file | file = guessTarget())
   }
 
   override Module getImportedModule() {
@@ -291,7 +290,7 @@ private class AmdDependencyImport extends Import {
  */
 class AmdModule extends Module {
   cached
-  AmdModule() { strictcount(AmdModuleDefinition def | amdModuleTopLevel(def, this)) = 1 }
+  AmdModule() { exists(unique(AmdModuleDefinition def | amdModuleTopLevel(def, this))) }
 
   /** Gets the definition of this module. */
   AmdModuleDefinition getDefine() { amdModuleTopLevel(result, this) }

--- a/javascript/ql/src/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/src/semmle/javascript/InclusionTests.qll
@@ -66,10 +66,8 @@ module InclusionTest {
     Function callee;
 
     IndirectInclusionTest() {
-      inner.getEnclosingExpr() = callee.getAReturnedExpr() and
-      this.getACallee() = callee and
-      count(this.getACallee()) = 1 and
-      count(callee.getAReturnedExpr()) = 1 and
+      inner.getEnclosingExpr() = unique(Expr ret | ret = callee.getAReturnedExpr()) and
+      callee = unique(Function f | f = this.getACallee()) and
       not this.isImprecise() and
       inner.getContainedNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter()) and
       inner.getContainerNode().getALocalSource() = DataFlow::parameterNode(callee.getAParameter())

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -64,10 +64,8 @@ module StringOps {
       Function callee;
 
       IndirectStartsWith() {
-        inner.getEnclosingExpr() = callee.getAReturnedExpr() and
-        this.getACallee() = callee and
-        count(this.getACallee()) = 1 and
-        count(callee.getAReturnedExpr()) = 1 and
+        inner.getEnclosingExpr() = unique(Expr ret | ret = callee.getAReturnedExpr()) and
+        callee = unique(Function f | f = this.getACallee()) and
         not this.isImprecise() and
         inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
@@ -295,10 +293,8 @@ module StringOps {
       Function callee;
 
       IndirectEndsWith() {
-        inner.getEnclosingExpr() = callee.getAReturnedExpr() and
-        this.getACallee() = callee and
-        count(this.getACallee()) = 1 and
-        count(callee.getAReturnedExpr()) = 1 and
+        inner.getEnclosingExpr() = unique(Expr ret | ret = callee.getAReturnedExpr()) and
+        callee = unique(Function f | f = this.getACallee()) and
         not this.isImprecise() and
         inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
         inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -218,8 +218,7 @@ module DataFlow {
       // IIFE call -> return value of IIFE
       exists(Function fun |
         localCall(this.asExpr(), fun) and
-        result = fun.getAReturnedExpr().flow() and
-        strictcount(fun.getAReturnedExpr()) = 1 and
+        result = unique(Expr ret | ret = fun.getAReturnedExpr()).flow() and
         not fun.getExit().isJoin() // can only reach exit by the return statement
       )
     }

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -100,7 +100,7 @@ class AnalyzedNode extends DataFlow::Node {
   boolean getTheBooleanValue() { forex(boolean bv | bv = getABooleanValue() | result = bv) }
 
   /** Gets the unique type inferred for this node, if any. */
-  InferredType getTheType() { count(getAType()) = 1 and result = getAType() }
+  InferredType getTheType() { result = unique(InferredType t | t = getAType()) }
 
   /**
    * Gets a pretty-printed representation of all types inferred for this node

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -187,8 +187,7 @@ private class IIFEWithAnalyzedReturnFlow extends CallWithAnalyzedReturnFlow {
  */
 private VarAccess getOnlyAccess(FunctionDeclStmt fn, LocalVariable v) {
   v = fn.getVariable() and
-  result = v.getAnAccess() and
-  strictcount(v.getAnAccess()) = 1
+  result = unique(VarAccess acc | acc = v.getAnAccess())
 }
 
 /** A function that only is used locally, making it amenable to type inference. */


### PR DESCRIPTION
I did a bunch of experiments related to the `unique` aggregate. 
The only thing that ended up working is applying the `unique` aggregate where trivially applicable.  

For example, applying the unique aggregate on a predicate that already has a unique result just ended up with a performance regression (`getChild()`, `getContainer()` etc).

[An evaluation shows a performance improvement](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1589800013978), but the improvement is well below 1%. 