### PR TITLE
Fixes FPs in SpringBootActuators query

### DIFF
--- a/java/ql/test/experimental/query-tests/security/CWE-016/SpringBootActuators.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-016/SpringBootActuators.java
@@ -37,4 +37,68 @@ public class SpringBootActuators {
   protected void configureOk2(HttpSecurity http) throws Exception {
     http.requestMatchers().requestMatchers(EndpointRequest.toAnyEndpoint());
   }
+
+  protected void configureOk3(HttpSecurity http) throws Exception {
+    http.authorizeRequests().anyRequest().permitAll();
+  }
+
+  protected void configureOk4(HttpSecurity http) throws Exception {
+    http.authorizeRequests(authz -> authz.anyRequest().permitAll());
+  }
+
+  protected void configureOkSafeEndpoints1(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.to("health", "info")).authorizeRequests(requests -> requests.anyRequest().permitAll());
+  }
+
+  protected void configureOkSafeEndpoints2(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.to("health")).authorizeRequests().requestMatchers(EndpointRequest.to("health")).permitAll();
+  }
+
+  protected void configureOkSafeEndpoints3(HttpSecurity http) throws Exception {
+    http.requestMatchers(matcher -> EndpointRequest.to("health", "info")).authorizeRequests().requestMatchers(EndpointRequest.to("health", "info")).permitAll();
+  }
+
+  protected void configureOkSafeEndpoints4(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.to("health", "info")).authorizeRequests().anyRequest().permitAll();
+  }
+
+  protected void configureOkSafeEndpoints5(HttpSecurity http) throws Exception {
+    http.authorizeRequests().requestMatchers(EndpointRequest.to("health", "info")).permitAll();
+  }
+
+  protected void configureOkSafeEndpoints6(HttpSecurity http) throws Exception {
+    http.authorizeRequests(requests -> requests.requestMatchers(EndpointRequest.to("health", "info")).permitAll());
+  }
+
+  protected void configureOkSafeEndpoints7(HttpSecurity http) throws Exception {
+    http.requestMatchers(matcher -> EndpointRequest.to("health", "info")).authorizeRequests().anyRequest().permitAll();
+  }
+
+  protected void configureOkNoPermitAll1(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeRequests(requests -> requests.anyRequest());
+  }
+
+  protected void configureOkNoPermitAll2(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeRequests().requestMatchers(EndpointRequest.toAnyEndpoint());
+  }
+
+  protected void configureOkNoPermitAll3(HttpSecurity http) throws Exception {
+    http.requestMatchers(matcher -> EndpointRequest.toAnyEndpoint()).authorizeRequests().requestMatchers(EndpointRequest.toAnyEndpoint());
+  }
+
+  protected void configureOkNoPermitAll4(HttpSecurity http) throws Exception {
+    http.requestMatcher(EndpointRequest.toAnyEndpoint()).authorizeRequests().anyRequest();
+  }
+
+  protected void configureOkNoPermitAll5(HttpSecurity http) throws Exception {
+    http.authorizeRequests().requestMatchers(EndpointRequest.toAnyEndpoint());
+  }
+
+  protected void configureOkNoPermitAll6(HttpSecurity http) throws Exception {
+    http.authorizeRequests(requests -> requests.requestMatchers(EndpointRequest.toAnyEndpoint()));
+  }
+
+  protected void configureOkNoPermitAll7(HttpSecurity http) throws Exception {
+    http.requestMatchers(matcher -> EndpointRequest.toAnyEndpoint()).authorizeRequests().anyRequest();
+  }
 }

--- a/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
+++ b/java/ql/test/experimental/stubs/springframework-5.2.3/org/springframework/boot/actuate/autoconfigure/security/servlet/EndpointRequest.java
@@ -7,6 +7,10 @@ public final class EndpointRequest {
 	public static EndpointRequestMatcher toAnyEndpoint() {
 		return null;
   }
+
+  public static EndpointRequestMatcher to(String... endpoints) {
+		return null;
+	}
   
   public static final class EndpointRequestMatcher extends AbstractRequestMatcher {}
 


### PR DESCRIPTION
This PR fixes FPs in SpringBootActuators query, as pointed out in https://github.com/github/codeql/pull/2901#discussion_r425733806.
* No evidence that Spring Actuators are being used, e.g. `http.authorizeRequests().anyRequest().permitAll()`
  --> The query now makes sure that the `permitAll()` refers to Spring Actuators (`EndpointRequest`)
* Only safe Actuators are enabled, e.g. `EndpointRequest.to("health", "info")`
  --> The query now raises the flag only if `EndpointRequest.toAnyEndpoint()` is being used.

More tests to handle the above cases are added.