### PR TITLE
Java: Clean up deprecated overrides.

### DIFF
--- a/java/ql/src/semmle/code/FileSystem.qll
+++ b/java/ql/src/semmle/code/FileSystem.qll
@@ -151,33 +151,6 @@ class Container extends @container, Top {
    * This is the absolute path of the container.
    */
   override string toString() { result = getAbsolutePath() }
-
-  /**
-   * DEPRECATED: use `getAbsolutePath()`, `getBaseName()` or `getStem()` instead.
-   *
-   * Gets the name of this container.
-   */
-  deprecated string getName() { result = getAbsolutePath() }
-
-  /**
-   * DEPRECATED: use `getBaseName()` or `getStem()` instead.
-   *
-   * The short name of this container, excluding its path and (for files) extension.
-   *
-   * For folders, the short name includes the extension (if any), so the short name
-   * of the folder with absolute path `/home/user/.m2` is `.m2`.
-   */
-  deprecated string getShortName() {
-    folders(this, _, result) or
-    files(this, _, result, _, _)
-  }
-
-  /**
-   * DEPRECATED: use `getAbsolutePath()` instead.
-   *
-   * Gets the full name of this container, including its path and extension (if any).
-   */
-  deprecated string getFullName() { result = getAbsolutePath() }
 }
 
 /** A folder. */
@@ -198,13 +171,6 @@ class File extends Container, @file {
 
   /** Gets the URL of this file. */
   override string getURL() { result = "file://" + this.getAbsolutePath() + ":0:0:0:0" }
-
-  /**
-   * DEPRECATED: use `getAbsolutePath()`, `getBaseName()` or `getStem()` instead.
-   *
-   * Holds if this file has the specified `name`.
-   */
-  deprecated predicate hasName(string name) { name = this.getAbsolutePath() }
 }
 
 /**

--- a/java/ql/src/semmle/code/java/Statement.qll
+++ b/java/ql/src/semmle/code/java/Statement.qll
@@ -117,7 +117,7 @@ class IfStmt extends ConditionalStmt, @ifstmt {
    * Gets the statement that is executed whenever the condition
    * of this branch statement evaluates to `true`.
    */
-  override Stmt getTrueSuccessor() { result = getThen() }
+  deprecated override Stmt getTrueSuccessor() { result = getThen() }
 
   /** Gets the `else` branch of this `if` statement. */
   Stmt getElse() { result.isNthChildOf(this, 2) }
@@ -168,7 +168,7 @@ class ForStmt extends ConditionalStmt, @forstmt {
    * Gets the statement that is executed whenever the condition
    * of this branch statement evaluates to true.
    */
-  override Stmt getTrueSuccessor() { result = getStmt() }
+  deprecated override Stmt getTrueSuccessor() { result = getStmt() }
 
   /**
    * Gets a variable that is used as an iteration variable: it is defined,
@@ -228,7 +228,7 @@ class WhileStmt extends ConditionalStmt, @whilestmt {
    * Gets the statement that is executed whenever the condition
    * of this branch statement evaluates to true.
    */
-  override Stmt getTrueSuccessor() { result = getStmt() }
+  deprecated override Stmt getTrueSuccessor() { result = getStmt() }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "while (...) " + this.getStmt().pp() }
@@ -249,7 +249,7 @@ class DoStmt extends ConditionalStmt, @dostmt {
    * Gets the statement that is executed whenever the condition
    * of this branch statement evaluates to `true`.
    */
-  override Stmt getTrueSuccessor() { result = getStmt() }
+  deprecated override Stmt getTrueSuccessor() { result = getStmt() }
 
   /** Gets a printable representation of this statement. May include more detail than `toString()`. */
   override string pp() { result = "do " + this.getStmt().pp() + " while (...)" }


### PR DESCRIPTION
Adding a warning for override of a deprecated predicate gave the following unique warnings, which should all be fixed by this PR:
```
[WARN] Overridden predicate getName has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/CompilationUnit.qll:15,3-16,65)
[WARN] Overridden predicate getName has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/xml/XML.qll:121,3-122,70)
[WARN] Overridden predicate getTrueSuccessor has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/Statement.qll:116,3-120,58)
[WARN] Overridden predicate getTrueSuccessor has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/Statement.qll:167,3-171,58)
[WARN] Overridden predicate getTrueSuccessor has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/Statement.qll:227,3-231,58)
[WARN] Overridden predicate getTrueSuccessor has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/Statement.qll:248,3-252,58)
[WARN] Overridden predicate hasName has been deprecated and may be removed in future (/home/jenkins/workspace/Language-Tests/Java/job/ql/java/ql/src/semmle/code/java/CompilationUnit.qll:18,3-22,74)
```
The deprecated predicates in `FileSystem.qll` have been deprecated since before the move to the public repo, so should be fine to delete.