### PR TITLE
JS: Make ValueNode the representation of a parameter

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -46,3 +46,7 @@
 
 * A library `semmle.javascript.explore.CallGraph` has been added to help write queries for exploring the call graph.
 * Added data flow for `Map` and `Set`, and added matching type-tracking steps that can accessed using the `CollectionsTypeTracking` module.
+* The data-flow node representing a parameter or destructuring pattern is now always the `ValueNode` corresponding to that AST node. This has a few consequences:
+  - `Parameter.flow()` now gets the correct data flow node for a parameter. Previously this had a result, but the node was disconnected from the data flow graph.
+  - `ParameterNode.asExpr()` and `.getAstNode()` now gets the parameter's AST node, whereas previously it had no result.
+  - `Expr.flow()` now has a more meaningful result for destructuring patterns. Previously this node was disconnected from the data flow graph. Now it represents the values being destructured by the pattern.

--- a/javascript/ql/src/Statements/UselessConditional.ql
+++ b/javascript/ql/src/Statements/UselessConditional.ql
@@ -62,6 +62,14 @@ predicate isInitialParameterUse(Expr e) {
     not p.isRestParameter()
   )
   or
+  // same as above, but for captured variables
+  exists(SimpleParameter p, LocalVariable var |
+    var = p.getVariable() and
+    var.isCaptured() and
+    e = var.getAnAccess() and
+    not p.isRestParameter()
+  )
+  or
   isInitialParameterUse(e.(LogNotExpr).getOperand())
 }
 

--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -447,9 +447,9 @@ class StmtContainer extends @stmt_container, ASTNode {
  */
 module AST {
   /**
-   * A program element that evaluates to a value at runtime. This includes expressions,
-   * but also function and class declaration statements, as well as TypeScript
-   * namespace and enum declarations.
+   * A program element that evaluates to a value or destructures a value at runtime.
+   * This includes expressions and destructuring patterns, but also function and
+   * class declaration statements, as well as TypeScript namespace and enum declarations.
    *
    * Examples:
    *

--- a/javascript/ql/src/semmle/javascript/CFG.qll
+++ b/javascript/ql/src/semmle/javascript/CFG.qll
@@ -300,7 +300,7 @@ class ControlFlowNode extends @cfg_node, Locatable, NodeInStmtContainer {
   predicate isStart() { this = any(StmtContainer sc).getStart() }
 
   /**
-   * Holds if this is a final node of the given container, that is, a CFG node where execution
+   * Holds if this is a final node of `container`, that is, a CFG node where execution
    * of that toplevel or function terminates.
    */
   predicate isAFinalNodeOfContainer(StmtContainer container) {

--- a/javascript/ql/src/semmle/javascript/CFG.qll
+++ b/javascript/ql/src/semmle/javascript/CFG.qll
@@ -300,10 +300,20 @@ class ControlFlowNode extends @cfg_node, Locatable, NodeInStmtContainer {
   predicate isStart() { this = any(StmtContainer sc).getStart() }
 
   /**
+   * Holds if this is a final node of the given container, that is, a CFG node where execution
+   * of that toplevel or function terminates.
+   */
+  predicate isAFinalNodeOfContainer(StmtContainer container) {
+    getASuccessor().(SyntheticControlFlowNode).isAFinalNodeOfContainer(container)
+  }
+
+  /**
    * Holds if this is a final node, that is, a CFG node where execution of a
    * toplevel or function terminates.
    */
-  predicate isAFinalNode() { getASuccessor().(SyntheticControlFlowNode).isAFinalNode() }
+  final predicate isAFinalNode() {
+    isAFinalNodeOfContainer(_)
+  }
 
   /**
    * Holds if this node is unreachable, that is, it has no predecessors in the CFG.
@@ -361,7 +371,7 @@ class ControlFlowEntryNode extends SyntheticControlFlowNode, @entry_node {
 
 /** A synthetic CFG node marking the exit of a function or toplevel script. */
 class ControlFlowExitNode extends SyntheticControlFlowNode, @exit_node {
-  override predicate isAFinalNode() { any() }
+  override predicate isAFinalNodeOfContainer(StmtContainer container) { exit_cfg_node(this, container) }
 
   override string toString() { result = "exit node of " + getContainer().toString() }
 }

--- a/javascript/ql/src/semmle/javascript/CFG.qll
+++ b/javascript/ql/src/semmle/javascript/CFG.qll
@@ -311,9 +311,7 @@ class ControlFlowNode extends @cfg_node, Locatable, NodeInStmtContainer {
    * Holds if this is a final node, that is, a CFG node where execution of a
    * toplevel or function terminates.
    */
-  final predicate isAFinalNode() {
-    isAFinalNodeOfContainer(_)
-  }
+  final predicate isAFinalNode() { isAFinalNodeOfContainer(_) }
 
   /**
    * Holds if this node is unreachable, that is, it has no predecessors in the CFG.
@@ -371,7 +369,9 @@ class ControlFlowEntryNode extends SyntheticControlFlowNode, @entry_node {
 
 /** A synthetic CFG node marking the exit of a function or toplevel script. */
 class ControlFlowExitNode extends SyntheticControlFlowNode, @exit_node {
-  override predicate isAFinalNodeOfContainer(StmtContainer container) { exit_cfg_node(this, container) }
+  override predicate isAFinalNodeOfContainer(StmtContainer container) {
+    exit_cfg_node(this, container)
+  }
 
   override string toString() { result = "exit node of " + getContainer().toString() }
 }

--- a/javascript/ql/src/semmle/javascript/DefUse.qll
+++ b/javascript/ql/src/semmle/javascript/DefUse.qll
@@ -45,8 +45,6 @@ private predicate defn(ControlFlowNode def, Expr lhs, AST::ValueNode rhs) {
   exists(EnumMember member | def = member.getIdentifier() |
     lhs = def and rhs = member.getInitializer()
   )
-  or
-  lhs = def and def.(Parameter).getDefault() = rhs
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -1601,6 +1601,9 @@ class MidPathNode extends PathNode, MkMidNode {
     nd.(DataFlow::SsaDefinitionNode).getSsaVariable().getDefinition() instanceof
       SsaImplicitDefinition
     or
+    // Skip SSA definition of parameter as its location coincides with the parameter node
+    nd = DataFlow::ssaDefinitionNode(SSA::definition(any(SimpleParameter p)))
+    or
     // Skip to the top of big left-leaning string concatenation trees.
     nd = any(AddExpr add).flow() and
     nd = any(AddExpr add).getAnOperand().flow()

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -67,13 +67,11 @@ module DataFlow {
     /**
      * Gets the expression enclosing this data flow node.
      * In most cases the result is the same as `asExpr()`, however this method
-     * additionally the `InvokeExpr` corresponding to reflective calls, and the `Parameter`
-     * for a `DataFlow::ParameterNode`.
+     * additionally includes the `InvokeExpr` corresponding to reflective calls.
      */
     Expr getEnclosingExpr() {
       result = asExpr() or
-      this = DataFlow::reflectiveCallNode(result) or
-      result = this.(ParameterNode).getParameter()
+      this = DataFlow::reflectiveCallNode(result)
     }
 
     /** Gets the AST node corresponding to this data flow node, if any. */

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -21,32 +21,9 @@
 import javascript
 private import internal.CallGraphs
 private import internal.FlowSteps as FlowSteps
+private import internal.DataFlowNode
 
 module DataFlow {
-  cached
-  private newtype TNode =
-    TValueNode(AST::ValueNode nd) or
-    TSsaDefNode(SsaDefinition d) or
-    TCapturedVariableNode(LocalVariable v) { v.isCaptured() } or
-    TPropNode(@property p) or
-    TRestPatternNode(DestructuringPattern dp, Expr rest) { rest = dp.getRest() } or
-    TDestructuringPatternNode(DestructuringPattern dp) or
-    TElementPatternNode(ArrayPattern ap, Expr p) { p = ap.getElement(_) } or
-    TElementNode(ArrayExpr arr, Expr e) { e = arr.getAnElement() } or
-    TReflectiveCallNode(MethodCallExpr ce, string kind) {
-      ce.getMethodName() = kind and
-      (kind = "call" or kind = "apply")
-    } or
-    TThisNode(StmtContainer f) { f.(Function).getThisBinder() = f or f instanceof TopLevel } or
-    TUnusedParameterNode(SimpleParameter p) { not exists(SSA::definition(p)) } or
-    TDestructuredModuleImportNode(ImportDeclaration decl) {
-      exists(decl.getASpecifier().getImportedName())
-    } or
-    THtmlAttributeNode(HTML::Attribute attr) or
-    TExceptionalFunctionReturnNode(Function f) or
-    TExceptionalInvocationReturnNode(InvokeExpr e) or
-    TGlobalAccessPathRoot()
-
   /**
    * A node in the data flow graph.
    */

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1225,9 +1225,7 @@ module DataFlow {
   /**
    * INTERNAL: Use `parameterNode(Parameter)` instead.
    */
-  predicate parameterNode(DataFlow::Node nd, Parameter p) {
-    nd = valueNode(p)
-  }
+  predicate parameterNode(DataFlow::Node nd, Parameter p) { nd = valueNode(p) }
 
   /**
    * INTERNAL: Use `thisNode(StmtContainer container)` instead.

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -229,7 +229,7 @@ module DataFlow {
      */
     private JSDocTypeExpr getFallbackTypeAnnotation() {
       exists(BindingPattern pattern |
-        this = lvalueNode(pattern) and
+        this = valueNode(pattern) and
         not ast_node_type(pattern, _) and
         result = pattern.getTypeAnnotation()
       )

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -22,6 +22,7 @@ import javascript
 private import internal.CallGraphs
 private import internal.FlowSteps as FlowSteps
 private import internal.DataFlowNode
+private import internal.AnalyzedParameters
 
 module DataFlow {
   /**
@@ -1527,8 +1528,12 @@ module DataFlow {
       e instanceof TaggedTemplateExpr
       or
       e instanceof Parameter and
-      not localArgumentPassing(_, e)
+      not localArgumentPassing(_, e) and
+      not isAnalyzedParameter(e) and
+      not e.(Parameter).isRestParameter()
     )
+    or
+    nd.(AnalyzedParameter).hasIncompleteness(cause)
     or
     nd.asExpr() instanceof ExternalModuleReference and
     cause = "import"

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -258,8 +258,8 @@ module DataFlow {
   }
 
   /**
-   * An expression or a declaration of a function, class, namespace or enum,
-   * viewed as a node in the data flow graph.
+   * A node in the data flow graph which corresponds to an expression,
+   * destructuring pattern, or declaration of a function, class, namespace, or enum.
    *
    * Examples:
    * ```js

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1533,7 +1533,7 @@ module DataFlow {
       not e.(Parameter).isRestParameter()
     )
     or
-    nd.(AnalyzedParameter).hasIncompleteness(cause)
+    nd.(AnalyzedNode).hasAdditionalIncompleteness(cause)
     or
     nd.asExpr() instanceof ExternalModuleReference and
     cause = "import"

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1527,6 +1527,9 @@ module DataFlow {
       e instanceof FunctionBindExpr
       or
       e instanceof TaggedTemplateExpr
+      or
+      e instanceof Parameter and
+      not localArgumentPassing(_, e)
     )
     or
     nd.asExpr() instanceof ExternalModuleReference and
@@ -1562,10 +1565,6 @@ module DataFlow {
    * Holds if definition `def` cannot be completely analyzed due to `cause`.
    */
   private predicate defIsIncomplete(VarDef def, Incompleteness cause) {
-    def instanceof Parameter and
-    not localArgumentPassing(_, def) and
-    cause = "call"
-    or
     def instanceof ImportSpecifier and
     cause = "import"
     or

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -1340,6 +1340,12 @@ module DataFlow {
       succ = lvalueNode(param) // The SSA node represents the parameters's local variable
     )
     or
+    exists(Expr arg, Parameter param |
+      localArgumentPassing(arg, param) and
+      pred = valueNode(arg) and
+      succ = valueNode(param)
+    )
+    or
     exists(PropertyPattern pattern |
       pred = TPropNode(pattern) and
       succ = lvalueNode(pattern.getValuePattern())
@@ -1475,8 +1481,7 @@ module DataFlow {
    */
   private AST::ValueNode defSourceNode(VarDef def) {
     result = def.getSource() or
-    result = def.getDestructuringSource() or
-    localArgumentPassing(result, def)
+    result = def.getDestructuringSource()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -369,30 +369,6 @@ module DataFlow {
   }
 
   /**
-   * A node in the data flow graph which corresponds to the value destructured by an
-   * object or array pattern.
-   */
-  private class DestructuringPatternNode extends Node, TDestructuringPatternNode {
-    DestructuringPattern pattern;
-
-    DestructuringPatternNode() { this = TDestructuringPatternNode(pattern) }
-
-    override BasicBlock getBasicBlock() { result = pattern.getBasicBlock() }
-
-    override predicate hasLocationInfo(
-      string filepath, int startline, int startcolumn, int endline, int endcolumn
-    ) {
-      pattern.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-    }
-
-    override string toString() { result = pattern.toString() }
-
-    override File getFile() { result = pattern.getFile() }
-
-    override ASTNode getAstNode() { result = pattern }
-  }
-
-  /**
    * A node in the data flow graph which corresponds to an element pattern of an
    * array pattern.
    */
@@ -828,7 +804,7 @@ module DataFlow {
     /** Gets the value pattern of this property pattern. */
     Expr getValuePattern() { result = prop.getValuePattern() }
 
-    override Node getBase() { result = TDestructuringPatternNode(prop.getObjectPattern()) }
+    override Node getBase() { result = TValueNode(prop.getObjectPattern()) }
 
     override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
 
@@ -841,7 +817,7 @@ module DataFlow {
    * for `[ ...elts ] = arr`.
    */
   private class RestPatternAsPropRead extends PropRead, RestPatternNode {
-    override Node getBase() { result = TDestructuringPatternNode(pattern) }
+    override Node getBase() { result = TValueNode(pattern) }
 
     override Expr getPropertyNameExpr() { none() }
 
@@ -854,7 +830,7 @@ module DataFlow {
    * for `y`.
    */
   private class ElementPatternAsPropRead extends PropRead, ElementPatternNode {
-    override Node getBase() { result = TDestructuringPatternNode(pattern) }
+    override Node getBase() { result = TValueNode(pattern) }
 
     override Expr getPropertyNameExpr() { none() }
 
@@ -1332,7 +1308,7 @@ module DataFlow {
       result = TSsaDefNode(ssa)
     )
     or
-    result = TDestructuringPatternNode(lvalue)
+    result = TValueNode(lvalue.(DestructuringPattern))
     or
     result = TUnusedParameterNode(lvalue)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -263,9 +263,7 @@ class AnalyzedFunction extends DataFlow::AnalyzedValueNode {
    * of functions that cannot actually complete normally, since it does not
    * account for `finally` blocks and does not check reachability.
    */
-  private predicate mayReturnImplicitly() {
-    terminalNode(astNode, any(ExprOrStmt st))
-  }
+  private predicate mayReturnImplicitly() { terminalNode(astNode, any(ExprOrStmt st)) }
 }
 
 pragma[noinline]

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -256,13 +256,15 @@ class AnalyzedFunction extends DataFlow::AnalyzedValueNode {
    * account for `finally` blocks and does not check reachability.
    */
   private predicate mayReturnImplicitly() {
-    exists(ConcreteControlFlowNode final |
-      final.getContainer() = astNode and
-      final.isAFinalNode() and
-      not final instanceof ReturnStmt and
-      not final instanceof ThrowStmt
-    )
+    terminalNode(astNode, any(ExprOrStmt st))
   }
+}
+
+pragma[noinline]
+private predicate terminalNode(Function f, ControlFlowNode final) {
+  final.isAFinalNodeOfContainer(f) and
+  not final instanceof ReturnStmt and
+  not final instanceof ThrowStmt
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TypeInference.qll
@@ -156,6 +156,14 @@ class AnalyzedNode extends DataFlow::Node {
 
   /** Holds if the flow analysis can infer at least one abstract value for this node. */
   predicate hasFlow() { exists(getAValue()) }
+
+  /**
+   * INTERNAL. Use `isIncomplete()` instead.
+   *
+   * Subclasses may override this to contribute additional incompleteness to this node
+   * without overriding `isIncomplete()`.
+   */
+  predicate hasAdditionalIncompleteness(DataFlow::Incompleteness cause) { none() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
@@ -34,13 +34,7 @@ class AnalyzedParameter extends AnalyzedValueNode {
     result = astNode.getDefault().analyze().getALocalValue()
   }
 
-  /**
-   * Whether this node should be considered incomplete with the given cause.
-   *
-   * For performance reasons, this is not an override of `isIncomplete`, but is
-   * explicitly included in that predicate.
-   */
-  predicate hasIncompleteness(DataFlow::Incompleteness cause) {
+  override predicate hasAdditionalIncompleteness(DataFlow::Incompleteness cause) {
     getFunction().isIncomplete(cause)
     or
     not getFunction().argumentPassing(astNode, _) and

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/AnalyzedParameters.qll
@@ -1,0 +1,50 @@
+private import javascript
+private import VariableTypeInference
+
+/**
+ * Holds if `p` is analyzed precisely by the type inference.
+ */
+pragma[nomagic]
+predicate isAnalyzedParameter(Parameter p) {
+  exists(FunctionWithAnalyzedParameters f, int parmIdx | p = f.getParameter(parmIdx) |
+    // we cannot track flow into rest parameters
+    not p.(Parameter).isRestParameter()
+  )
+}
+
+/**
+ * A parameter whose value is propagated interprocedurally.
+ */
+class AnalyzedParameter extends AnalyzedValueNode {
+  override Parameter astNode;
+
+  AnalyzedParameter() { isAnalyzedParameter(astNode) }
+
+  FunctionWithAnalyzedParameters getFunction() { astNode = result.getAParameter() }
+
+  override AbstractValue getALocalValue() {
+    exists(DataFlow::AnalyzedNode pred |
+      getFunction().argumentPassing(astNode, pred.asExpr()) and
+      result = pred.getALocalValue()
+    )
+    or
+    not getFunction().mayReceiveArgument(astNode) and
+    result = TAbstractUndefined()
+    or
+    result = astNode.getDefault().analyze().getALocalValue()
+  }
+
+  /**
+   * Whether this node should be considered incomplete with the given cause.
+   *
+   * For performance reasons, this is not an override of `isIncomplete`, but is
+   * explicitly included in that predicate.
+   */
+  predicate hasIncompleteness(DataFlow::Incompleteness cause) {
+    getFunction().isIncomplete(cause)
+    or
+    not getFunction().argumentPassing(astNode, _) and
+    getFunction().mayReceiveArgument(astNode) and
+    cause = "call"
+  }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -416,23 +416,3 @@ private class AnalyzedOptionalChainExpr extends DataFlow::AnalyzedValueNode {
     result = TAbstractUndefined()
   }
 }
-
-/**
- * Flow analysis for parameter AST nodes.
- *
- * For legacy reasons this node takes its value from the SSA variable node,
- * even though the SSA variable node is a successor of this node.
- */
-private class AnalyzedParameterValueNode extends AnalyzedNode {
-  Parameter p;
-
-  AnalyzedParameterValueNode() {
-    DataFlow::parameterNode(this, p)
-  }
-
-  override AbstractValue getAValue() {
-    result = p.(AnalyzedVarDef).getAnRhsValue()
-    or
-    result = TIndefiniteAbstractValue("call")
-  }
-}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -239,29 +239,34 @@ private class AnalyzedBinaryExpr extends DataFlow::AnalyzedValueNode {
 }
 
 /**
- * Gets a primitive type to which the local value of `e` can be coerced.
+ * Gets the `n`th operand of the given `+` or `+=` expression.
  */
-private PrimitiveType getALocalPrimitiveType(Expr e) {
-  result = e.analyze().getALocalValue().toPrimitive().getType()
+pragma[nomagic]
+private DataFlow::AnalyzedValueNode getAddOperand(Expr e, int n) {
+  (e instanceof AddExpr or e instanceof AssignAddExpr) and
+  result = DataFlow::valueNode(e.getChildExpr(n))
 }
 
 /**
- * Holds if `e` may hold a string value.
+ * Gets a primitive type of the `n`th operand of the given `+` or `+=` expression.
  */
-private predicate maybeString(Expr e) { getALocalPrimitiveType(e) = TTString() }
-
-/**
- * Holds if `e` may hold a non-string value.
- */
-private predicate maybeNonString(Expr e) { getALocalPrimitiveType(e) != TTString() }
+pragma[noopt]
+private PrimitiveType getAnAddOperandPrimitiveType(Expr e, int n) {
+  exists(DataFlow::AnalyzedValueNode operand, AbstractValue value, AbstractValue prim |
+    operand = getAddOperand(e, n) and
+    value = operand.getALocalValue() and
+    prim = value.toPrimitive() and
+    result = prim.getType() and
+    result instanceof PrimitiveType
+  )
+}
 
 /**
  * Holds if `e` is a `+` or `+=` expression that could be interpreted as a string append
  * (as opposed to a numeric addition) at runtime.
  */
 private predicate isStringAppend(Expr e) {
-  (e instanceof AddExpr or e instanceof AssignAddExpr) and
-  maybeString(e.getAChildExpr())
+  getAnAddOperandPrimitiveType(e, _) = TTString()
 }
 
 /**
@@ -269,9 +274,8 @@ private predicate isStringAppend(Expr e) {
  * (as opposed to a string append) at runtime.
  */
 private predicate isAddition(Expr e) {
-  (e instanceof AddExpr or e instanceof AssignAddExpr) and
-  maybeNonString(e.getChildExpr(0)) and
-  maybeNonString(e.getChildExpr(1))
+  getAnAddOperandPrimitiveType(e, 0) != TTString() and
+  getAnAddOperandPrimitiveType(e, 1) != TTString()
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -416,3 +416,23 @@ private class AnalyzedOptionalChainExpr extends DataFlow::AnalyzedValueNode {
     result = TAbstractUndefined()
   }
 }
+
+/**
+ * Flow analysis for parameter AST nodes.
+ *
+ * For legacy reasons this node takes its value from the SSA variable node,
+ * even though the SSA variable node is a successor of this node.
+ */
+private class AnalyzedParameterValueNode extends AnalyzedNode {
+  Parameter p;
+
+  AnalyzedParameterValueNode() {
+    DataFlow::parameterNode(this, p)
+  }
+
+  override AbstractValue getAValue() {
+    result = p.(AnalyzedVarDef).getAnRhsValue()
+    or
+    result = TIndefiniteAbstractValue("call")
+  }
+}

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/BasicExprTypeInference.qll
@@ -265,9 +265,7 @@ private PrimitiveType getAnAddOperandPrimitiveType(Expr e, int n) {
  * Holds if `e` is a `+` or `+=` expression that could be interpreted as a string append
  * (as opposed to a numeric addition) at runtime.
  */
-private predicate isStringAppend(Expr e) {
-  getAnAddOperandPrimitiveType(e, _) = TTString()
-}
+private predicate isStringAppend(Expr e) { getAnAddOperandPrimitiveType(e, _) = TTString() }
 
 /**
  * Holds if `e` is a `+` or `+=` expression that could be interpreted as a numeric addition

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -15,7 +15,6 @@ newtype TNode =
   TCapturedVariableNode(LocalVariable v) { v.isCaptured() } or
   TPropNode(@property p) or
   TRestPatternNode(DestructuringPattern dp, Expr rest) { rest = dp.getRest() } or
-  TDestructuringPatternNode(DestructuringPattern dp) or
   TElementPatternNode(ArrayPattern ap, Expr p) { p = ap.getElement(_) } or
   TElementNode(ArrayExpr arr, Expr e) { e = arr.getAnElement() } or
   TReflectiveCallNode(MethodCallExpr ce, string kind) {

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -3,6 +3,7 @@
  *
  * Contains the raw data type underlying `DataFlow::Node`.
  */
+
 private import javascript
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -22,7 +22,6 @@ newtype TNode =
     (kind = "call" or kind = "apply")
   } or
   TThisNode(StmtContainer f) { f.(Function).getThisBinder() = f or f instanceof TopLevel } or
-  TUnusedParameterNode(SimpleParameter p) { not exists(SSA::definition(p)) } or
   TDestructuredModuleImportNode(ImportDeclaration decl) {
     exists(decl.getASpecifier().getImportedName())
   } or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -1,0 +1,33 @@
+/**
+ * INTERNAL: Do not use outside the data flow library.
+ *
+ * Contains the raw data type underlying `DataFlow::Node`.
+ */
+private import javascript
+
+/**
+ * The raw data type underlying `DataFlow::Node`.
+ */
+cached
+newtype TNode =
+  TValueNode(AST::ValueNode nd) or
+  TSsaDefNode(SsaDefinition d) or
+  TCapturedVariableNode(LocalVariable v) { v.isCaptured() } or
+  TPropNode(@property p) or
+  TRestPatternNode(DestructuringPattern dp, Expr rest) { rest = dp.getRest() } or
+  TDestructuringPatternNode(DestructuringPattern dp) or
+  TElementPatternNode(ArrayPattern ap, Expr p) { p = ap.getElement(_) } or
+  TElementNode(ArrayExpr arr, Expr e) { e = arr.getAnElement() } or
+  TReflectiveCallNode(MethodCallExpr ce, string kind) {
+    ce.getMethodName() = kind and
+    (kind = "call" or kind = "apply")
+  } or
+  TThisNode(StmtContainer f) { f.(Function).getThisBinder() = f or f instanceof TopLevel } or
+  TUnusedParameterNode(SimpleParameter p) { not exists(SSA::definition(p)) } or
+  TDestructuredModuleImportNode(ImportDeclaration decl) {
+    exists(decl.getASpecifier().getImportedName())
+  } or
+  THtmlAttributeNode(HTML::Attribute attr) or
+  TExceptionalFunctionReturnNode(Function f) or
+  TExceptionalInvocationReturnNode(InvokeExpr e) or
+  TGlobalAccessPathRoot()

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -92,8 +92,11 @@ private module CachedSteps {
   cached
   predicate calls(DataFlow::InvokeNode invk, Function f) { f = invk.getACallee(0) }
 
-  private predicate callsBoundInternal(DataFlow::InvokeNode invk, Function f, int boundArgs, boolean contextDependent) {
-    CallGraph::getABoundFunctionReference(f.flow(), boundArgs, contextDependent).flowsTo(invk.getCalleeNode())
+  private predicate callsBoundInternal(
+    DataFlow::InvokeNode invk, Function f, int boundArgs, boolean contextDependent
+  ) {
+    CallGraph::getABoundFunctionReference(f.flow(), boundArgs, contextDependent)
+        .flowsTo(invk.getCalleeNode())
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -92,6 +92,10 @@ private module CachedSteps {
   cached
   predicate calls(DataFlow::InvokeNode invk, Function f) { f = invk.getACallee(0) }
 
+  private predicate callsBoundInternal(DataFlow::InvokeNode invk, Function f, int boundArgs, boolean contextDependent) {
+    CallGraph::getABoundFunctionReference(f.flow(), boundArgs, contextDependent).flowsTo(invk.getCalleeNode())
+  }
+
   /**
    * Holds if `invk` may invoke a bound version of `f` with `boundArgs` already bound.
    *
@@ -101,7 +105,7 @@ private module CachedSteps {
    */
   cached
   predicate callsBound(DataFlow::InvokeNode invk, Function f, int boundArgs) {
-    CallGraph::getABoundFunctionReference(f.flow(), boundArgs, false).flowsTo(invk.getCalleeNode())
+    callsBoundInternal(invk, f, boundArgs, false)
   }
 
   /**
@@ -111,10 +115,10 @@ private module CachedSteps {
    */
   cached
   predicate exploratoryBoundInvokeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(DataFlow::InvokeNode invk, DataFlow::FunctionNode f, int i, int boundArgs |
-      CallGraph::getABoundFunctionReference(f, boundArgs, _).flowsTo(invk.getCalleeNode()) and
+    exists(DataFlow::InvokeNode invk, Function f, int i, int boundArgs |
+      callsBoundInternal(invk, f, boundArgs, _) and
       pred = invk.getArgument(i) and
-      succ = f.getParameter(i + boundArgs)
+      succ = DataFlow::parameterNode(f.getParameter(i + boundArgs))
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -387,9 +387,7 @@ private class AnalyzedGlobalVarUse extends DataFlow::AnalyzedValueNode {
     result.getBase().analyze().getALocalValue() instanceof AbstractGlobalObject
   }
 
-  override predicate isIncomplete(DataFlow::Incompleteness reason) {
-    super.isIncomplete(reason)
-    or
+  override predicate hasAdditionalIncompleteness(DataFlow::Incompleteness reason) {
     clobberedProp(gv, reason)
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -421,7 +421,7 @@ private AnalyzedVarDef defIn(GlobalVariable gv, TopLevel tl) {
  * Holds if there is a write to a property with the same name as `gv` on an object
  * for which the analysis is incomplete due to the given `reason`.
  */
-pragma[noinline]
+cached
 private predicate clobberedProp(GlobalVariable gv, DataFlow::Incompleteness reason) {
   exists(AnalyzedNode base |
     potentialPropWriteOfGlobal(base, gv) and
@@ -429,13 +429,13 @@ private predicate clobberedProp(GlobalVariable gv, DataFlow::Incompleteness reas
   )
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate indefiniteObjectValue(AbstractValue val, DataFlow::Incompleteness reason) {
   val.isIndefinite(reason) and
   val.getType() = TTObject()
 }
 
-pragma[noinline]
+pragma[nomagic]
 private predicate potentialPropWriteOfGlobal(AnalyzedNode base, GlobalVariable gv) {
   exists(DataFlow::PropWrite pwn |
     pwn.getPropertyName() = gv.getName() and

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -7,9 +7,7 @@ import semmle.javascript.frameworks.HTTP
 import semmle.javascript.security.SensitiveActions
 
 module NodeJSLib {
-  private GlobalVariable processVariable() {
-    variables(result, "process", any(GlobalScope sc))
-  }
+  private GlobalVariable processVariable() { variables(result, "process", any(GlobalScope sc)) }
 
   pragma[nomagic]
   private GlobalVarAccess processExprInTopLevel(TopLevel tl) {
@@ -27,9 +25,7 @@ module NodeJSLib {
    * an import of the `process` module.
    */
   private class ImplicitProcessImport extends DataFlow::ModuleImportNode::Range {
-    ImplicitProcessImport() {
-      this = DataFlow::exprNode(processExprInNodeModule())
-    }
+    ImplicitProcessImport() { this = DataFlow::exprNode(processExprInNodeModule()) }
 
     override string getPath() { result = "process" }
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -7,17 +7,28 @@ import semmle.javascript.frameworks.HTTP
 import semmle.javascript.security.SensitiveActions
 
 module NodeJSLib {
+  private GlobalVariable processVariable() {
+    variables(result, "process", any(GlobalScope sc))
+  }
+
+  pragma[nomagic]
+  private GlobalVarAccess processExprInTopLevel(TopLevel tl) {
+    result = processVariable().getAnAccess() and
+    tl = result.getTopLevel()
+  }
+
+  pragma[nomagic]
+  private GlobalVarAccess processExprInNodeModule() {
+    result = processExprInTopLevel(any(NodeModule m))
+  }
+
   /**
    * An access to the global `process` variable in a Node.js module, interpreted as
    * an import of the `process` module.
    */
   private class ImplicitProcessImport extends DataFlow::ModuleImportNode::Range {
     ImplicitProcessImport() {
-      exists(GlobalVariable process |
-        process.getName() = "process" and
-        this = DataFlow::exprNode(process.getAnAccess())
-      ) and
-      getTopLevel() instanceof NodeModule
+      this = DataFlow::exprNode(processExprInNodeModule())
     }
 
     override string getPath() { result = "process" }

--- a/javascript/ql/test/library-tests/AMD/AmdModuleDefinition.expected
+++ b/javascript/ql/test/library-tests/AMD/AmdModuleDefinition.expected
@@ -7,4 +7,5 @@
 | tst3.js:1:1:3:2 | define( ...  42;\\n}) | tst3.js:1:8:3:1 | functio ... = 42;\\n} |
 | tst4.js:1:1:11:2 | define( ...   };\\n}) | tst4.js:6:11:11:1 | functio ...    };\\n} |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:1:28:6:1 | functio ...    };\\n} |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:9:9:14:1 | functio ...    };\\n} |

--- a/javascript/ql/test/library-tests/AMD/AmdModuleExpr.expected
+++ b/javascript/ql/test/library-tests/AMD/AmdModuleExpr.expected
@@ -5,4 +5,9 @@
 | lib/nested/a.js:1:1:3:2 | define( ... 2 };\\n}) | lib/nested/a.js:2:12:2:22 | { foo: 42 } | lib/nested/a.js:2:12:2:22 | { foo: 42 } |
 | tst4.js:1:1:11:2 | define( ...   };\\n}) | tst4.js:7:12:10:5 | {\\n      ... r\\n    } | tst4.js:7:12:10:5 | {\\n      ... r\\n    } |
 | tst.js:1:1:6:2 | define( ...   };\\n}) | tst.js:2:12:5:5 | {\\n      ... r\\n    } | tst.js:2:12:5:5 | {\\n      ... r\\n    } |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:1:18:1:24 | factory |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:9:9:14:1 | functio ...    };\\n} |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:1:18:1:24 | factory | umd.js:10:12:13:5 | {\\n      ... r\\n    } |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:10:12:13:5 | {\\n      ... r\\n    } | umd.js:1:18:1:24 | factory |
+| umd.js:4:9:4:43 | define( ... actory) | umd.js:10:12:13:5 | {\\n      ... r\\n    } | umd.js:9:9:14:1 | functio ...    };\\n} |
 | umd.js:4:9:4:43 | define( ... actory) | umd.js:10:12:13:5 | {\\n      ... r\\n    } | umd.js:10:12:13:5 | {\\n      ... r\\n    } |

--- a/javascript/ql/test/library-tests/DataFlow/enclosingExpr.expected
+++ b/javascript/ql/test/library-tests/DataFlow/enclosingExpr.expected
@@ -9,13 +9,11 @@
 | sources.js:1:1:1:12 | new (x => x) | sources.js:1:1:1:12 | new (x => x) |
 | sources.js:1:5:1:12 | (x => x) | sources.js:1:5:1:12 | (x => x) |
 | sources.js:1:6:1:6 | x | sources.js:1:6:1:6 | x |
-| sources.js:1:6:1:6 | x | sources.js:1:6:1:6 | x |
 | sources.js:1:6:1:11 | x => x | sources.js:1:6:1:11 | x => x |
 | sources.js:1:11:1:11 | x | sources.js:1:11:1:11 | x |
 | sources.js:3:1:5:2 | (functi ... +19;\\n}) | sources.js:3:1:5:2 | (functi ... +19;\\n}) |
 | sources.js:3:1:5:6 | (functi ... \\n})(23) | sources.js:3:1:5:6 | (functi ... \\n})(23) |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} | sources.js:3:2:5:1 | functio ... x+19;\\n} |
-| sources.js:3:11:3:11 | x | sources.js:3:11:3:11 | x |
 | sources.js:3:11:3:11 | x | sources.js:3:11:3:11 | x |
 | sources.js:4:10:4:10 | x | sources.js:4:10:4:10 | x |
 | sources.js:4:10:4:13 | x+19 | sources.js:4:10:4:13 | x+19 |
@@ -23,7 +21,6 @@
 | sources.js:5:4:5:5 | 23 | sources.js:5:4:5:5 | 23 |
 | sources.js:7:1:7:3 | /x/ | sources.js:7:1:7:3 | /x/ |
 | sources.js:9:10:9:12 | foo | sources.js:9:10:9:12 | foo |
-| sources.js:9:14:9:18 | array | sources.js:9:14:9:18 | array |
 | sources.js:9:14:9:18 | array | sources.js:9:14:9:18 | array |
 | sources.js:10:12:10:14 | key | sources.js:10:12:10:14 | key |
 | sources.js:10:12:10:14 | key | sources.js:10:12:10:14 | key |
@@ -59,7 +56,6 @@
 | tst2.ts:13:26:13:37 | List<string> | tst2.ts:13:26:13:37 | List<string> |
 | tst2.ts:13:39:13:38 | (...arg ... rgs); } | tst2.ts:13:39:13:38 | (...arg ... rgs); } |
 | tst2.ts:13:39:13:38 | ...args | tst2.ts:13:39:13:38 | ...args |
-| tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | constructor | tst2.ts:13:39:13:38 | constructor |
@@ -102,7 +98,6 @@
 | tst.js:16:2:20:1 | functio ... n "";\\n} | tst.js:16:2:20:1 | functio ... n "";\\n} |
 | tst.js:16:11:16:11 | f | tst.js:16:11:16:11 | f |
 | tst.js:16:13:16:13 | a | tst.js:16:13:16:13 | a |
-| tst.js:16:13:16:13 | a | tst.js:16:13:16:13 | a |
 | tst.js:17:7:17:10 | Math | tst.js:17:7:17:10 | Math |
 | tst.js:17:7:17:17 | Math.random | tst.js:17:7:17:17 | Math.random |
 | tst.js:17:7:17:19 | Math.random() | tst.js:17:7:17:19 | Math.random() |
@@ -126,7 +121,6 @@
 | tst.js:28:2:29:3 | () =>\\n  x | tst.js:28:2:29:3 | () =>\\n  x |
 | tst.js:29:3:29:3 | x | tst.js:29:3:29:3 | x |
 | tst.js:32:10:32:10 | g | tst.js:32:10:32:10 | g |
-| tst.js:32:12:32:12 | b | tst.js:32:12:32:12 | b |
 | tst.js:32:12:32:12 | b | tst.js:32:12:32:12 | b |
 | tst.js:33:10:33:10 | x | tst.js:33:10:33:10 | x |
 | tst.js:35:1:35:1 | g | tst.js:35:1:35:1 | g |
@@ -225,7 +219,6 @@
 | tst.js:87:1:96:2 | (functi ... r: 0\\n}) | tst.js:87:1:96:2 | (functi ... r: 0\\n}) |
 | tst.js:87:2:92:1 | functio ...  + z;\\n} | tst.js:87:2:92:1 | functio ...  + z;\\n} |
 | tst.js:87:11:87:24 | { p: x, ...o } | tst.js:87:11:87:24 | { p: x, ...o } |
-| tst.js:87:11:87:24 | { p: x, ...o } | tst.js:87:11:87:24 | { p: x, ...o } |
 | tst.js:87:13:87:13 | p | tst.js:87:13:87:13 | p |
 | tst.js:87:16:87:16 | x | tst.js:87:16:87:16 | x |
 | tst.js:87:22:87:22 | o | tst.js:87:22:87:22 | o |
@@ -257,7 +250,6 @@
 | tst.js:98:1:103:2 | (functi ... + z;\\n}) | tst.js:98:1:103:2 | (functi ... + z;\\n}) |
 | tst.js:98:1:103:17 | (functi ... 3, 0 ]) | tst.js:98:1:103:17 | (functi ... 3, 0 ]) |
 | tst.js:98:2:103:1 | functio ...  + z;\\n} | tst.js:98:2:103:1 | functio ...  + z;\\n} |
-| tst.js:98:11:98:24 | [ x, ...rest ] | tst.js:98:11:98:24 | [ x, ...rest ] |
 | tst.js:98:11:98:24 | [ x, ...rest ] | tst.js:98:11:98:24 | [ x, ...rest ] |
 | tst.js:98:13:98:13 | x | tst.js:98:13:98:13 | x |
 | tst.js:98:19:98:22 | rest | tst.js:98:19:98:22 | rest |

--- a/javascript/ql/test/library-tests/DataFlow/flowStep.expected
+++ b/javascript/ql/test/library-tests/DataFlow/flowStep.expected
@@ -1,12 +1,15 @@
 | eval.js:2:7:2:12 | x | eval.js:4:3:4:3 | x |
 | eval.js:2:11:2:12 | 42 | eval.js:2:7:2:12 | x |
+| sources.js:1:6:1:6 | x | sources.js:1:6:1:6 | x |
 | sources.js:1:6:1:6 | x | sources.js:1:11:1:11 | x |
 | sources.js:1:6:1:11 | x => x | sources.js:1:5:1:12 | (x => x) |
 | sources.js:1:11:1:11 | x | sources.js:1:1:1:12 | new (x => x) |
 | sources.js:3:2:5:1 | functio ... x+19;\\n} | sources.js:3:1:5:2 | (functi ... +19;\\n}) |
+| sources.js:3:11:3:11 | x | sources.js:3:11:3:11 | x |
 | sources.js:3:11:3:11 | x | sources.js:4:10:4:10 | x |
 | sources.js:4:10:4:13 | x+19 | sources.js:3:1:5:6 | (functi ... \\n})(23) |
 | sources.js:5:4:5:5 | 23 | sources.js:3:11:3:11 | x |
+| sources.js:9:14:9:18 | array | sources.js:9:14:9:18 | array |
 | sources.js:9:14:9:18 | array | sources.js:10:19:10:23 | array |
 | sources.js:9:14:9:18 | array | sources.js:11:23:11:27 | array |
 | sources.js:10:12:10:14 | key | sources.js:10:28:10:30 | key |
@@ -26,6 +29,7 @@
 | tst2.ts:8:9:8:10 | 23 | tst2.ts:8:3:8:10 | A.x = 23 |
 | tst2.ts:11:11:11:13 | A.x | tst2.ts:11:11:11:23 | A.x as number |
 | tst2.ts:13:26:13:29 | List | tst2.ts:13:26:13:37 | List<string> |
+| tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | args |
 | tst2.ts:13:39:13:38 | args | tst2.ts:13:39:13:38 | args |
 | tst.js:1:1:1:1 | x | tst.js:3:5:3:5 | x |
 | tst.js:1:10:1:11 | fs | tst.js:1:10:1:11 | fs |
@@ -69,6 +73,7 @@
 | tst.js:14:5:14:5 | x | tst.js:14:1:14:9 | z ? x : y |
 | tst.js:14:9:14:9 | y | tst.js:14:1:14:9 | z ? x : y |
 | tst.js:16:2:20:1 | functio ... n "";\\n} | tst.js:16:1:20:2 | (functi ...  "";\\n}) |
+| tst.js:16:13:16:13 | a | tst.js:16:13:16:13 | a |
 | tst.js:16:13:16:13 | a | tst.js:18:12:18:12 | a |
 | tst.js:18:12:18:12 | a | tst.js:16:1:20:9 | (functi ... ("arg") |
 | tst.js:19:10:19:11 | "" | tst.js:16:1:20:9 | (functi ... ("arg") |

--- a/javascript/ql/test/library-tests/DataFlow/incomplete.expected
+++ b/javascript/ql/test/library-tests/DataFlow/incomplete.expected
@@ -4,7 +4,6 @@
 | eval.js:3:3:3:16 | eval("x = 23") | call |
 | eval.js:3:3:3:16 | exceptional return of eval("x = 23") | call |
 | sources.js:1:1:1:12 | exceptional return of new (x => x) | call |
-| sources.js:1:6:1:6 | x | call |
 | sources.js:1:6:1:11 | exceptional return of anonymous function | call |
 | sources.js:3:1:5:6 | exceptional return of (functi ... \\n})(23) | call |
 | sources.js:3:2:5:1 | exceptional return of anonymous function | call |
@@ -20,7 +19,6 @@
 | tst2.ts:8:3:8:5 | A.x | heap |
 | tst2.ts:11:11:11:13 | A.x | heap |
 | tst2.ts:13:26:13:29 | List | global |
-| tst2.ts:13:39:13:38 | args | call |
 | tst2.ts:13:39:13:38 | exceptional return of default constructor of class StringList | call |
 | tst2.ts:13:39:13:38 | exceptional return of super(...args) | call |
 | tst2.ts:13:39:13:38 | super | call |

--- a/javascript/ql/test/library-tests/DefUse/VarDefSource.expected
+++ b/javascript/ql/test/library-tests/DefUse/VarDefSource.expected
@@ -32,4 +32,3 @@
 | tst.js:11:11:11:11 | g | tst.js:11:2:15:1 | functio ... rn x;\\n} |
 | tst.js:12:2:12:7 | x = 42 | tst.js:12:6:12:7 | 42 |
 | tst.js:19:11:19:11 | x | tst.js:19:2:19:16 | function x() {} |
-| tst.js:26:11:26:11 | a | tst.js:26:15:26:15 | b |

--- a/javascript/ql/test/library-tests/Flow/AbstractValues.expected
+++ b/javascript/ql/test/library-tests/Flow/AbstractValues.expected
@@ -168,6 +168,16 @@
 | h.js:2:23:2:22 | default constructor of class C |
 | h_import.js:1:1:3:0 | exports object of module h_import |
 | h_import.js:1:1:3:0 | module object of module h_import |
+| implicit-returns.js:1:1:27:0 | exports object of module implicit-returns |
+| implicit-returns.js:1:1:27:0 | module object of module implicit-returns |
+| implicit-returns.js:3:1:12:1 | function endWithLoop |
+| implicit-returns.js:3:1:12:1 | instance of function endWithLoop |
+| implicit-returns.js:14:1:16:1 | function useLoop |
+| implicit-returns.js:14:1:16:1 | instance of function useLoop |
+| implicit-returns.js:18:1:22:1 | function endWithShortIf |
+| implicit-returns.js:18:1:22:1 | instance of function endWithShortIf |
+| implicit-returns.js:24:1:26:1 | function useShortIf |
+| implicit-returns.js:24:1:26:1 | instance of function useShortIf |
 | import.js:1:1:13:0 | exports object of module import |
 | import.js:1:1:13:0 | module object of module import |
 | imports.ts:1:1:8:0 | exports object of module imports |

--- a/javascript/ql/test/library-tests/Flow/abseval.expected
+++ b/javascript/ql/test/library-tests/Flow/abseval.expected
@@ -142,6 +142,11 @@
 | globals.html:26:52:26:53 | x2 | globals.html:26:57:26:66 | someGlobal | file://:0:0:0:0 | non-zero value |
 | globals.html:26:52:26:53 | x2 | globals.html:26:57:26:66 | someGlobal | file://:0:0:0:0 | true |
 | h_import.js:2:5:2:6 | ff | h_import.js:2:10:2:10 | f | h.js:1:8:1:22 | function f |
+| implicit-returns.js:4:9:4:9 | i | implicit-returns.js:4:13:4:13 | 0 | file://:0:0:0:0 | 0 |
+| implicit-returns.js:15:9:15:9 | x | implicit-returns.js:15:13:15:25 | endWithLoop() | file://:0:0:0:0 | true |
+| implicit-returns.js:15:9:15:9 | x | implicit-returns.js:15:13:15:25 | endWithLoop() | file://:0:0:0:0 | undefined |
+| implicit-returns.js:25:9:25:9 | x | implicit-returns.js:25:13:25:28 | endWithShortIf() | file://:0:0:0:0 | true |
+| implicit-returns.js:25:9:25:9 | x | implicit-returns.js:25:13:25:28 | endWithShortIf() | file://:0:0:0:0 | undefined |
 | import.js:2:5:2:5 | m | import.js:2:9:2:13 | mixin | mixins.js:1:16:1:32 | anonymous function |
 | import.js:5:5:5:7 | myf | import.js:5:11:5:11 | f | n.js:1:1:1:15 | function f |
 | import.js:8:5:8:11 | someVar | import.js:8:15:8:23 | someStuff | file://:0:0:0:0 | indefinite value (call) |

--- a/javascript/ql/test/library-tests/Flow/getAPrototype.expected
+++ b/javascript/ql/test/library-tests/Flow/getAPrototype.expected
@@ -30,6 +30,10 @@
 | globals.html:22:7:22:21 | instance of function x | globals.html:22:7:22:21 | instance of function x |
 | globals.html:26:23:26:69 | instance of anonymous function | globals.html:26:23:26:69 | instance of anonymous function |
 | h.js:1:8:1:22 | instance of function f | h.js:1:8:1:22 | instance of function f |
+| implicit-returns.js:3:1:12:1 | instance of function endWithLoop | implicit-returns.js:3:1:12:1 | instance of function endWithLoop |
+| implicit-returns.js:14:1:16:1 | instance of function useLoop | implicit-returns.js:14:1:16:1 | instance of function useLoop |
+| implicit-returns.js:18:1:22:1 | instance of function endWithShortIf | implicit-returns.js:18:1:22:1 | instance of function endWithShortIf |
+| implicit-returns.js:24:1:26:1 | instance of function useShortIf | implicit-returns.js:24:1:26:1 | instance of function useShortIf |
 | instances.js:1:1:4:1 | instance of function A | instances.js:1:1:4:1 | instance of function A |
 | instances.js:3:14:3:26 | instance of anonymous function | instances.js:3:14:3:26 | instance of anonymous function |
 | instances.js:6:19:6:31 | instance of anonymous function | instances.js:6:19:6:31 | instance of anonymous function |

--- a/javascript/ql/test/library-tests/Flow/implicit-returns.js
+++ b/javascript/ql/test/library-tests/Flow/implicit-returns.js
@@ -1,0 +1,26 @@
+import 'dummy';
+
+function endWithLoop() {
+    var i = 0;
+    while (i < 10) {
+        if (Math.random() * 10 < i) {
+            return true;
+        }
+        ++i;
+    }
+    // Can fall over end
+}
+
+function useLoop() {
+    let x = endWithLoop(); // can be true or undefined
+}
+
+function endWithShortIf() {
+    if (something() < 10) {
+        return true;
+    }
+}
+
+function useShortIf() {
+    let x = endWithShortIf(); // true or undefined
+}

--- a/javascript/ql/test/library-tests/Flow/types.expected
+++ b/javascript/ql/test/library-tests/Flow/types.expected
@@ -78,6 +78,9 @@
 | globals.html:26:40:26:41 | x1 | globals.html:26:45:26:45 | x | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | globals.html:26:52:26:53 | x2 | globals.html:26:57:26:66 | someGlobal | boolean, class, date, function, null, number, object, regular expression,string or undefined |
 | h_import.js:2:5:2:6 | ff | h_import.js:2:10:2:10 | f | function |
+| implicit-returns.js:4:9:4:9 | i | implicit-returns.js:4:13:4:13 | 0 | number |
+| implicit-returns.js:15:9:15:9 | x | implicit-returns.js:15:13:15:25 | endWithLoop() | boolean or undefined |
+| implicit-returns.js:25:9:25:9 | x | implicit-returns.js:25:13:25:28 | endWithShortIf() | boolean or undefined |
 | import.js:2:5:2:5 | m | import.js:2:9:2:13 | mixin | function |
 | import.js:5:5:5:7 | myf | import.js:5:11:5:11 | f | function |
 | import.js:8:5:8:11 | someVar | import.js:8:15:8:23 | someStuff | boolean, class, date, function, null, number, object, regular expression,string or undefined |

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
@@ -1,5 +1,6 @@
 test_getAReferenceTo
 | other_ns.js:2:11:2:12 | ns | NS |
+| other_ns.js:2:11:2:12 | ns | NS |
 | other_ns.js:3:3:3:4 | ns | NS |
 | other_ns.js:3:3:3:8 | ns.foo | NS.foo |
 | other_ns.js:3:3:3:12 | ns.foo.bar | NS.foo.bar |
@@ -42,6 +43,7 @@ test_getAReferenceTo
 | test.js:14:5:14:23 | notUnique = bar.baz | bar.baz |
 | test.js:14:17:14:19 | bar | bar |
 | test.js:14:17:14:23 | bar.baz | bar.baz |
+| test.js:22:11:22:12 | ns | NS |
 | test.js:22:11:22:12 | ns | NS |
 | test.js:23:3:23:4 | ns | NS |
 | test.js:23:3:23:8 | ns.foo | NS.foo |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/TrackedNodes.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/TrackedNodes.expected
@@ -1,37 +1,55 @@
 | missing | callback.js:17:15:17:23 | "source2" | callback.js:8:16:8:20 | xs[i] |
 | missing | callback.js:17:15:17:23 | "source2" | callback.js:12:16:12:16 | x |
+| missing | callback.js:17:15:17:23 | "source2" | callback.js:12:16:12:16 | x |
 | missing | callback.js:17:15:17:23 | "source2" | callback.js:13:14:13:14 | x |
+| missing | promises.js:1:2:1:2 | source | promises.js:6:26:6:28 | val |
 | missing | promises.js:1:2:1:2 | source | promises.js:6:26:6:28 | val |
 | missing | promises.js:1:2:1:2 | source | promises.js:7:16:7:18 | val |
 | missing | promises.js:1:2:1:2 | source | promises.js:37:11:37:11 | v |
+| missing | promises.js:1:2:1:2 | source | promises.js:37:11:37:11 | v |
 | missing | promises.js:1:2:1:2 | source | promises.js:38:32:38:32 | v |
+| missing | promises.js:2:16:2:24 | "tainted" | promises.js:6:26:6:28 | val |
 | missing | promises.js:2:16:2:24 | "tainted" | promises.js:6:26:6:28 | val |
 | missing | promises.js:2:16:2:24 | "tainted" | promises.js:7:16:7:18 | val |
 | missing | promises.js:2:16:2:24 | "tainted" | promises.js:37:11:37:11 | v |
+| missing | promises.js:2:16:2:24 | "tainted" | promises.js:37:11:37:11 | v |
 | missing | promises.js:2:16:2:24 | "tainted" | promises.js:38:32:38:32 | v |
+| missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:20:7:20:7 | v |
 | missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:20:7:20:7 | v |
 | missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:21:20:21:20 | v |
 | missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:23:19:23:19 | v |
+| missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:23:19:23:19 | v |
 | missing | promises.js:10:30:17:3 | exceptional return of anonymous function | promises.js:24:20:24:20 | v |
+| missing | promises.js:11:22:11:31 | "resolved" | promises.js:18:18:18:18 | v |
 | missing | promises.js:11:22:11:31 | "resolved" | promises.js:18:18:18:18 | v |
 | missing | promises.js:11:22:11:31 | "resolved" | promises.js:19:20:19:20 | v |
 | missing | promises.js:12:22:12:31 | "rejected" | promises.js:20:7:20:7 | v |
+| missing | promises.js:12:22:12:31 | "rejected" | promises.js:20:7:20:7 | v |
 | missing | promises.js:12:22:12:31 | "rejected" | promises.js:21:20:21:20 | v |
+| missing | promises.js:12:22:12:31 | "rejected" | promises.js:23:19:23:19 | v |
 | missing | promises.js:12:22:12:31 | "rejected" | promises.js:23:19:23:19 | v |
 | missing | promises.js:12:22:12:31 | "rejected" | promises.js:24:20:24:20 | v |
 | missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:20:7:20:7 | v |
+| missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:20:7:20:7 | v |
 | missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:21:20:21:20 | v |
+| missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:23:19:23:19 | v |
 | missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:23:19:23:19 | v |
 | missing | promises.js:13:9:13:21 | exceptional return of Math.random() | promises.js:24:20:24:20 | v |
 | missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:20:7:20:7 | v |
+| missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:20:7:20:7 | v |
 | missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:21:20:21:20 | v |
+| missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:23:19:23:19 | v |
 | missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:23:19:23:19 | v |
 | missing | promises.js:14:7:14:21 | exceptional return of res(res_source) | promises.js:24:20:24:20 | v |
 | missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:20:7:20:7 | v |
+| missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:20:7:20:7 | v |
 | missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:21:20:21:20 | v |
+| missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:23:19:23:19 | v |
 | missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:23:19:23:19 | v |
 | missing | promises.js:16:7:16:21 | exceptional return of rej(rej_source) | promises.js:24:20:24:20 | v |
 | missing | promises.js:32:24:32:37 | "also tainted" | promises.js:37:11:37:11 | v |
+| missing | promises.js:32:24:32:37 | "also tainted" | promises.js:37:11:37:11 | v |
 | missing | promises.js:32:24:32:37 | "also tainted" | promises.js:38:32:38:32 | v |
+| missing | tst.js:2:17:2:22 | "src1" | tst.js:27:22:27:24 | elt |
 | missing | tst.js:2:17:2:22 | "src1" | tst.js:27:22:27:24 | elt |
 | missing | tst.js:2:17:2:22 | "src1" | tst.js:28:20:28:22 | elt |

--- a/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
+++ b/javascript/ql/test/library-tests/ModuleImportNodes/tests.expected
@@ -1,4 +1,5 @@
 test_ModuleImportNode
+| amd1.js:1:25:1:26 | fs | fs | amd1.js:1:25:1:26 | fs | fs |
 | amd1.js:1:25:1:26 | fs | fs | amd1.js:2:3:2:4 | fs | fs |
 | amd2.js:2:12:2:24 | require('fs') | fs | amd2.js:3:3:3:4 | fs | fs |
 | client1.ts:4:28:4:29 | F1 | framework1 | client1.ts:4:28:4:29 | F1 | F1 |

--- a/javascript/ql/test/library-tests/PropWrite/tests.expected
+++ b/javascript/ql/test/library-tests/PropWrite/tests.expected
@@ -133,7 +133,6 @@ test_hasPropertyWrite
 | classes.ts:8:3:8:2 | this | parameterField | classes.ts:8:22:8:35 | parameterField |
 | classes.ts:12:5:12:4 | this | parameterField | classes.ts:12:24:12:37 | parameterField |
 | classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:24:16:37 | parameterField |
-| classes.ts:16:5:16:4 | this | parameterField | classes.ts:16:41:16:42 | {} |
 | tst.js:1:11:9:1 | {\\n    x ...     }\\n} | f | tst.js:6:6:8:5 | () {\\n   ... ;\\n    } |
 | tst.js:1:11:9:1 | {\\n    x ...     }\\n} | func | tst.js:3:11:5:5 | functio ... ;\\n    } |
 | tst.js:1:11:9:1 | {\\n    x ...     }\\n} | x | tst.js:2:8:2:8 | 4 |
@@ -257,7 +256,6 @@ test_PropWriteRhs
 | classes.ts:12:17:12:37 | public  ... erField | classes.ts:12:24:12:37 | parameterField |
 | classes.ts:16:5:16:46 | constru ...  {}) {} | classes.ts:16:5:16:46 | constru ...  {}) {} |
 | classes.ts:16:17:16:37 | public  ... erField | classes.ts:16:24:16:37 | parameterField |
-| classes.ts:16:17:16:37 | public  ... erField | classes.ts:16:41:16:42 | {} |
 | tst.js:2:5:2:8 | x: 4 | tst.js:2:8:2:8 | 4 |
 | tst.js:3:5:5:5 | func: f ... ;\\n    } | tst.js:3:11:5:5 | functio ... ;\\n    } |
 | tst.js:6:5:8:5 | f() {\\n  ... ;\\n    } | tst.js:6:6:8:5 | () {\\n   ... ;\\n    } |

--- a/javascript/ql/test/library-tests/frameworks/AngularJS/scopes/ScopeAccess.expected
+++ b/javascript/ql/test/library-tests/frameworks/AngularJS/scopes/ScopeAccess.expected
@@ -1,9 +1,13 @@
+| isolate scope for directive1 | scope-access.js:4:41:4:45 | scope |
 | isolate scope for directive1 | scope-access.js:5:17:5:21 | scope |
 | isolate scope for directive1 | scope-access.js:7:20:7:21 | {} |
+| isolate scope for directive2 | scope-access.js:12:34:12:39 | $scope |
 | isolate scope for directive2 | scope-access.js:13:17:13:22 | $scope |
 | isolate scope for directive2 | scope-access.js:15:20:15:21 | {} |
+| isolate scope for directive3 | scope-access.js:20:39:20:44 | $scope |
 | isolate scope for directive3 | scope-access.js:21:17:21:22 | $scope |
 | isolate scope for directive3 | scope-access.js:23:20:23:21 | {} |
+| isolate scope for directive4 | scope-access.js:28:45:28:45 | a |
 | isolate scope for directive4 | scope-access.js:29:17:29:17 | a |
 | isolate scope for directive4 | scope-access.js:31:20:31:21 | {} |
 | isolate scope for directive5 | scope-access.js:37:17:37:20 | this |
@@ -12,51 +16,77 @@
 | isolate scope for directive6 | scope-access.js:48:20:48:21 | {} |
 | isolate scope for myCustomer | dev-guide-5.js:11:12:13:5 | { // Sc ... y\\n    } |
 | isolate scope for myCustomer | dev-guide-6.js:11:12:13:5 | { // Sc ... y\\n    } |
+| scope for <directive7>...</> | scope-access.js:54:34:54:39 | $scope |
 | scope for <directive7>...</> | scope-access.js:55:17:55:22 | $scope |
+| scope for <div>...</> | dev-guide-1.js:4:49:4:54 | $scope |
 | scope for <div>...</> | dev-guide-1.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-1.js:7:3:7:8 | $scope |
 | scope for <div>...</> | dev-guide-1.js:8:5:8:10 | $scope |
 | scope for <div>...</> | dev-guide-1.js:8:34:8:39 | $scope |
+| scope for <div>...</> | dev-guide-2.js:4:66:4:71 | $scope |
 | scope for <div>...</> | dev-guide-2.js:5:3:5:8 | $scope |
+| scope for <div>...</> | dev-guide-2.js:8:51:8:56 | $scope |
 | scope for <div>...</> | dev-guide-2.js:9:3:9:8 | $scope |
+| scope for <div>...</> | dev-guide-3.js:4:52:4:57 | $scope |
 | scope for <div>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-3.js:6:3:6:8 | $scope |
 | scope for <div>...</> | dev-guide-3.js:7:5:7:10 | $scope |
+| scope for <div>...</> | dev-guide-4.js:4:52:4:57 | $scope |
 | scope for <div>...</> | dev-guide-4.js:5:3:5:8 | $scope |
+| scope for <div>...</> | dev-guide-4.js:10:51:10:56 | $scope |
 | scope for <div>...</> | dev-guide-4.js:11:3:11:8 | $scope |
+| scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
+| scope for <div>...</> | dev-guide-5.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-5.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:6:3:6:8 | $scope |
 | scope for <div>...</> | dev-guide-5.js:6:3:6:8 | $scope |
+| scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
+| scope for <div>...</> | dev-guide-6.js:4:47:4:52 | $scope |
 | scope for <div>...</> | dev-guide-6.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-6.js:5:3:5:8 | $scope |
 | scope for <div>...</> | dev-guide-6.js:6:3:6:8 | $scope |
 | scope for <div>...</> | dev-guide-6.js:6:3:6:8 | $scope |
+| scope for <elementthatusescontroller1>...</> | scope-access.js:59:52:59:57 | $scope |
 | scope for <elementthatusescontroller1>...</> | scope-access.js:60:9:60:14 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
+| scope for <li>...</> | dev-guide-3.js:4:52:4:57 | $scope |
 | scope for <li>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:5:3:5:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:6:3:6:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:6:3:6:8 | $scope |
 | scope for <li>...</> | dev-guide-3.js:7:5:7:10 | $scope |
 | scope for <li>...</> | dev-guide-3.js:7:5:7:10 | $scope |
+| scope in dev-guide-1.html | dev-guide-1.js:4:49:4:54 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:5:3:5:8 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:7:3:7:8 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:8:5:8:10 | $scope |
 | scope in dev-guide-1.html | dev-guide-1.js:8:34:8:39 | $scope |
+| scope in dev-guide-2.html | dev-guide-2.js:4:66:4:71 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:5:3:5:8 | $scope |
+| scope in dev-guide-2.html | dev-guide-2.js:8:51:8:56 | $scope |
 | scope in dev-guide-2.html | dev-guide-2.js:9:3:9:8 | $scope |
+| scope in dev-guide-3.html | dev-guide-3.js:4:52:4:57 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:5:3:5:8 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:6:3:6:8 | $scope |
 | scope in dev-guide-3.html | dev-guide-3.js:7:5:7:10 | $scope |
+| scope in dev-guide-4.html | dev-guide-4.js:4:52:4:57 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:5:3:5:8 | $scope |
+| scope in dev-guide-4.html | dev-guide-4.js:10:51:10:56 | $scope |
 | scope in dev-guide-4.html | dev-guide-4.js:11:3:11:8 | $scope |
+| scope in dev-guide-5.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-5.html | dev-guide-5.js:5:3:5:8 | $scope |
 | scope in dev-guide-5.html | dev-guide-5.js:6:3:6:8 | $scope |
+| scope in dev-guide-5.html | dev-guide-6.js:4:47:4:52 | $scope |
 | scope in dev-guide-5.html | dev-guide-6.js:5:3:5:8 | $scope |
 | scope in dev-guide-5.html | dev-guide-6.js:6:3:6:8 | $scope |
+| scope in dev-guide-6.html | dev-guide-5.js:4:47:4:52 | $scope |
 | scope in dev-guide-6.html | dev-guide-5.js:5:3:5:8 | $scope |
 | scope in dev-guide-6.html | dev-guide-5.js:6:3:6:8 | $scope |
+| scope in dev-guide-6.html | dev-guide-6.js:4:47:4:52 | $scope |
 | scope in dev-guide-6.html | dev-guide-6.js:5:3:5:8 | $scope |
 | scope in dev-guide-6.html | dev-guide-6.js:6:3:6:8 | $scope |
+| scope in scope-access.html | scope-access.js:54:34:54:39 | $scope |
 | scope in scope-access.html | scope-access.js:55:17:55:22 | $scope |
+| scope in scope-access.html | scope-access.js:59:52:59:57 | $scope |
 | scope in scope-access.html | scope-access.js:60:9:60:14 | $scope |

--- a/javascript/ql/test/library-tests/frameworks/Electron/BrowserObject.expected
+++ b/javascript/ql/test/library-tests/frameworks/Electron/BrowserObject.expected
@@ -3,6 +3,7 @@
 | electron.js:4:5:4:46 | bv |
 | electron.js:4:10:4:46 | new Bro ... s: {}}) |
 | electron.js:35:14:35:14 | x |
+| electron.js:35:14:35:14 | x |
 | electron.js:36:12:36:12 | x |
 | electron.js:39:1:39:7 | foo(bw) |
 | electron.js:39:5:39:6 | bw |

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -182,16 +182,30 @@ test_RouterDefinition_getMiddlewareStackAt
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:7:1:12:1 | functio ... uter;\\n} | src/subrouter.js:5:14:5:28 | makeSubRouter() |
 | src/subrouter.js:2:11:2:19 | express() | src/subrouter.js:13:1:13:0 | exit node of <toplevel> | src/subrouter.js:5:14:5:28 | makeSubRouter() |
 test_isRequest
+| src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:22:35:22:37 | req |
+| src/csurf-example.js:25:32:25:34 | req |
+| src/csurf-example.js:32:40:32:42 | req |
+| src/csurf-example.js:39:36:39:38 | req |
+| src/csurf-example.js:40:37:40:39 | req |
+| src/exportedHandler.js:1:44:1:46 | req |
+| src/express2.js:3:34:3:36 | req |
 | src/express2.js:3:46:3:48 | req |
+| src/express2.js:4:41:4:47 | request |
 | src/express2.js:4:60:4:66 | request |
+| src/express3.js:4:32:4:34 | req |
 | src/express3.js:5:14:5:16 | req |
 | src/express3.js:5:35:5:37 | req |
+| src/express3.js:10:22:10:24 | req |
+| src/express4.js:4:32:4:34 | req |
 | src/express4.js:5:27:5:29 | req |
 | src/express4.js:6:18:6:20 | req |
 | src/express4.js:7:18:7:20 | req |
+| src/express.js:4:32:4:34 | req |
 | src/express.js:5:16:5:18 | req |
 | src/express.js:6:26:6:28 | req |
+| src/express.js:16:28:16:30 | req |
+| src/express.js:22:39:22:41 | req |
 | src/express.js:23:3:23:5 | req |
 | src/express.js:24:3:24:5 | req |
 | src/express.js:25:3:25:5 | req |
@@ -200,15 +214,28 @@ test_isRequest
 | src/express.js:28:3:28:5 | req |
 | src/express.js:29:3:29:5 | req |
 | src/express.js:30:3:30:5 | req |
+| src/express.js:37:22:37:24 | req |
+| src/express.js:42:13:42:15 | req |
+| src/express.js:46:31:46:33 | req |
 | src/express.js:47:3:47:5 | req |
 | src/express.js:48:3:48:5 | req |
 | src/express.js:49:3:49:5 | req |
 | src/express.js:50:3:50:5 | req |
+| src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/params.js:4:19:4:21 | req |
 | src/params.js:5:17:5:19 | req |
 | src/params.js:6:17:6:19 | req |
+| src/params.js:14:33:14:35 | req |
+| src/passport.js:27:13:27:15 | req |
 | src/passport.js:28:2:28:4 | req |
+| src/responseExprs.js:4:32:4:34 | req |
+| src/responseExprs.js:7:32:7:34 | req |
+| src/responseExprs.js:10:39:10:41 | req |
+| src/responseExprs.js:13:32:13:34 | req |
+| src/responseExprs.js:16:39:16:41 | req |
 | src/responseExprs.js:17:5:17:7 | req |
+| src/route.js:5:21:5:23 | req |
 test_RouteSetup_getRouter
 | src/auth.js:4:1:4:53 | app.use ... d' }})) | src/auth.js:1:13:1:32 | require('express')() |
 | src/csurf-example.js:13:1:13:20 | app.use('/api', api) | src/csurf-example.js:7:11:7:19 | express() |
@@ -341,43 +368,69 @@ test_RouteSetup_handlesSameRequestMethodAs
 test_HeaderDefinition_defines
 | src/express.js:7:3:7:42 | res.hea ... plain") | content-type | text/plain |
 test_ResponseExpr
+| src/csurf-example.js:20:33:20:35 | res | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:22:3:22:5 | res | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
+| src/csurf-example.js:25:37:25:39 | res | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:26:3:26:5 | res | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
 | src/csurf-example.js:26:3:26:43 | res.sen ...  here') | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
+| src/csurf-example.js:32:45:32:47 | res | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/csurf-example.js:33:5:33:7 | res | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
 | src/csurf-example.js:33:5:33:35 | res.sen ...  here') | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
+| src/csurf-example.js:39:41:39:43 | res | src/csurf-example.js:39:26:39:47 | functio ... res) {} |
+| src/csurf-example.js:40:42:40:44 | res | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
+| src/exportedHandler.js:1:49:1:51 | res | src/exportedHandler.js:1:19:1:55 | functio ... res) {} |
+| src/express2.js:3:39:3:41 | res | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:46:3:53 | req, res | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:51:3:53 | res | src/express2.js:3:25:3:55 | functio ... , res } |
+| src/express2.js:4:50:4:55 | result | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:60:4:74 | request, result | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:69:4:74 | result | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express3.js:4:37:4:39 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:3:5:5 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:3:5:51 | res.hea ... "val")) | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:6:3:6:5 | res | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:6:3:6:17 | res.send("val") | src/express3.js:4:23:7:1 | functio ... al");\\n} |
+| src/express3.js:10:27:10:29 | res | src/express3.js:10:12:10:32 | functio ...  res){} |
+| src/express4.js:4:37:4:39 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:8:3:8:5 | res | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:8:3:8:20 | res.send(dynamic1) | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express.js:4:37:4:39 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:5:3:5:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:3:6:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:3:6:45 | res.hea ... rget")) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:7:3:7:5 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:7:3:7:42 | res.hea ... plain") | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:8:7:8:9 | res | src/express.js:4:23:9:1 | functio ... res);\\n} |
+| src/express.js:11:14:11:16 | arg | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:12:3:12:5 | arg | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:12:3:12:54 | arg.hea ... , true) | src/express.js:4:23:9:1 | functio ... res);\\n} |
+| src/express.js:16:33:16:35 | res | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:17:5:17:7 | res | src/express.js:16:19:18:3 | functio ... ");\\n  } |
 | src/express.js:17:5:17:24 | res.send("Go away.") | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:22:44:22:46 | res | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:31:3:31:5 | res | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:31:3:31:26 | res.coo ...  'bar') | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:37:27:37:29 | res | src/express.js:37:12:37:32 | functio ...  res){} |
+| src/express.js:42:18:42:20 | res | src/express.js:42:12:42:28 | (req, res) => f() |
+| src/express.js:46:36:46:38 | res | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/inheritedFromNode.js:4:29:4:31 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:5:2:5:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:6:2:6:4 | res | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:24:4:26 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:11 | res | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:8:9:8:23 | res.send(value) | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:38:14:40 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/params.js:15:3:15:5 | res | src/params.js:14:24:16:1 | functio ... lo");\\n} |
 | src/params.js:15:3:15:19 | res.send("Hello") | src/params.js:14:24:16:1 | functio ... lo");\\n} |
+| src/responseExprs.js:4:37:4:40 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
 | src/responseExprs.js:5:5:5:8 | res1 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
+| src/responseExprs.js:7:37:7:40 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
 | src/responseExprs.js:8:5:8:8 | res2 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
+| src/responseExprs.js:10:44:10:47 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
 | src/responseExprs.js:11:5:11:8 | res3 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
+| src/responseExprs.js:13:37:13:40 | res4 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
 | src/responseExprs.js:14:5:14:8 | res4 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
+| src/responseExprs.js:16:44:16:46 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:19:5:19:7 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:19:5:19:16 | res.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:20:5:20:7 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
@@ -415,8 +468,10 @@ test_ResponseExpr
 | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:37:7:37:9 | res | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:37:7:37:18 | res.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/responseExprs.js:39:16:39:21 | resArg | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:40:16:40:21 | resArg | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:40:16:40:30 | resArg.append() | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/route.js:5:26:5:28 | res | src/route.js:5:12:5:38 | functio ... ext) {} |
 test_RouterDefinition_getARouteHandler
 | src/csurf-example.js:7:11:7:19 | express() | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:7:11:7:19 | express() | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
@@ -664,43 +719,69 @@ test_RouteExpr
 | src/subrouter.js:9:3:9:35 | router. ... ndler1) | src/subrouter.js:8:16:8:31 | express.Router() |
 | src/subrouter.js:10:3:10:41 | router. ... ndler2) | src/subrouter.js:8:16:8:31 | express.Router() |
 test_RouteHandler_getAResponseExpr
+| src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:33:20:35 | res |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:22:3:22:5 | res |
+| src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:26:3:26:5 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:26:3:26:43 | res.sen ...  here') |
+| src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:33:5:33:7 | res |
 | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:33:5:33:35 | res.sen ...  here') |
+| src/csurf-example.js:39:26:39:47 | functio ... res) {} | src/csurf-example.js:39:41:39:43 | res |
+| src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:40:42:40:44 | res |
+| src/exportedHandler.js:1:19:1:55 | functio ... res) {} | src/exportedHandler.js:1:49:1:51 | res |
+| src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:39:3:41 | res |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:46:3:53 | req, res |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:51:3:53 | res |
+| src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:50:4:55 | result |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:60:4:74 | request, result |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:69:4:74 | result |
+| src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:37:4:39 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:3:5:5 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:3:5:51 | res.hea ... "val")) |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:6:3:6:5 | res |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:6:3:6:17 | res.send("val") |
+| src/express3.js:10:12:10:32 | functio ...  res){} | src/express3.js:10:27:10:29 | res |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:37:4:39 | res |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:5 | res |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:8:3:8:20 | res.send(dynamic1) |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:37:4:39 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:3:5:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:3:6:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:3:6:45 | res.hea ... rget")) |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:7:3:7:5 | res |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:7:3:7:42 | res.hea ... plain") |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:8:7:8:9 | res |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:11:14:11:16 | arg |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:12:3:12:5 | arg |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:12:3:12:54 | arg.hea ... , true) |
+| src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:33:16:35 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:17:5:17:7 | res |
 | src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:17:5:17:24 | res.send("Go away.") |
+| src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:44:22:46 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:5 | res |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:31:3:31:26 | res.coo ...  'bar') |
+| src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:27:37:29 | res |
+| src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:18:42:20 | res |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:36:46:38 | res |
+| src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:24:4:26 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:11 | res |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:38:14:40 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:5 | res |
 | src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:15:3:15:19 | res.send("Hello") |
+| src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:5:5:5:8 | res1 |
+| src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:8:5:8:8 | res2 |
+| src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:44:10:47 | res3 |
 | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:11:5:11:8 | res3 |
+| src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:13:37:13:40 | res4 |
 | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:14:5:14:8 | res4 |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:19:5:19:7 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:19:5:19:16 | res.append() |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:20:5:20:7 | res |
@@ -738,46 +819,74 @@ test_RouteHandler_getAResponseExpr
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:7:37:9 | res |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:37:7:37:18 | res.append() |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:40:16:40:21 | resArg |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:40:16:40:30 | resArg.append() |
+| src/route.js:5:12:5:38 | functio ... ext) {} | src/route.js:5:26:5:28 | res |
 test_isResponse
+| src/csurf-example.js:20:33:20:35 | res |
 | src/csurf-example.js:22:3:22:5 | res |
+| src/csurf-example.js:25:37:25:39 | res |
 | src/csurf-example.js:26:3:26:5 | res |
 | src/csurf-example.js:26:3:26:43 | res.sen ...  here') |
+| src/csurf-example.js:32:45:32:47 | res |
 | src/csurf-example.js:33:5:33:7 | res |
 | src/csurf-example.js:33:5:33:35 | res.sen ...  here') |
+| src/csurf-example.js:39:41:39:43 | res |
+| src/csurf-example.js:40:42:40:44 | res |
+| src/exportedHandler.js:1:49:1:51 | res |
+| src/express2.js:3:39:3:41 | res |
 | src/express2.js:3:46:3:53 | req, res |
 | src/express2.js:3:51:3:53 | res |
+| src/express2.js:4:50:4:55 | result |
 | src/express2.js:4:60:4:74 | request, result |
 | src/express2.js:4:69:4:74 | result |
+| src/express3.js:4:37:4:39 | res |
 | src/express3.js:5:3:5:5 | res |
 | src/express3.js:5:3:5:51 | res.hea ... "val")) |
 | src/express3.js:6:3:6:5 | res |
 | src/express3.js:6:3:6:17 | res.send("val") |
+| src/express3.js:10:27:10:29 | res |
+| src/express4.js:4:37:4:39 | res |
 | src/express4.js:8:3:8:5 | res |
 | src/express4.js:8:3:8:20 | res.send(dynamic1) |
+| src/express.js:4:37:4:39 | res |
 | src/express.js:5:3:5:5 | res |
 | src/express.js:6:3:6:5 | res |
 | src/express.js:6:3:6:45 | res.hea ... rget")) |
 | src/express.js:7:3:7:5 | res |
 | src/express.js:7:3:7:42 | res.hea ... plain") |
 | src/express.js:8:7:8:9 | res |
+| src/express.js:11:14:11:16 | arg |
 | src/express.js:12:3:12:5 | arg |
 | src/express.js:12:3:12:54 | arg.hea ... , true) |
+| src/express.js:16:33:16:35 | res |
 | src/express.js:17:5:17:7 | res |
 | src/express.js:17:5:17:24 | res.send("Go away.") |
+| src/express.js:22:44:22:46 | res |
 | src/express.js:31:3:31:5 | res |
 | src/express.js:31:3:31:26 | res.coo ...  'bar') |
+| src/express.js:37:27:37:29 | res |
+| src/express.js:42:18:42:20 | res |
+| src/express.js:46:36:46:38 | res |
+| src/inheritedFromNode.js:4:29:4:31 | res |
 | src/inheritedFromNode.js:5:2:5:4 | res |
 | src/inheritedFromNode.js:6:2:6:4 | res |
+| src/params.js:4:24:4:26 | res |
 | src/params.js:8:9:8:11 | res |
 | src/params.js:8:9:8:23 | res.send(value) |
+| src/params.js:14:38:14:40 | res |
 | src/params.js:15:3:15:5 | res |
 | src/params.js:15:3:15:19 | res.send("Hello") |
+| src/responseExprs.js:4:37:4:40 | res1 |
 | src/responseExprs.js:5:5:5:8 | res1 |
+| src/responseExprs.js:7:37:7:40 | res2 |
 | src/responseExprs.js:8:5:8:8 | res2 |
+| src/responseExprs.js:10:44:10:47 | res3 |
 | src/responseExprs.js:11:5:11:8 | res3 |
+| src/responseExprs.js:13:37:13:40 | res4 |
 | src/responseExprs.js:14:5:14:8 | res4 |
+| src/responseExprs.js:16:44:16:46 | res |
 | src/responseExprs.js:19:5:19:7 | res |
 | src/responseExprs.js:19:5:19:16 | res.append() |
 | src/responseExprs.js:20:5:20:7 | res |
@@ -815,8 +924,10 @@ test_isResponse
 | src/responseExprs.js:37:5:37:28 | f(res.a ... ppend() |
 | src/responseExprs.js:37:7:37:9 | res |
 | src/responseExprs.js:37:7:37:18 | res.append() |
+| src/responseExprs.js:39:16:39:21 | resArg |
 | src/responseExprs.js:40:16:40:21 | resArg |
 | src/responseExprs.js:40:16:40:30 | resArg.append() |
+| src/route.js:5:26:5:28 | res |
 test_ResponseBody
 | src/csurf-example.js:22:35:22:49 | req.csrfToken() | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:26:12:26:42 | 'csrf w ... t here' | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
@@ -1073,16 +1184,30 @@ test_RouteHandlerExpr_getPreviousMiddleware
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:44:9:44:25 | getArrowHandler() |
 | src/subrouter.js:5:14:5:28 | makeSubRouter() | src/subrouter.js:4:19:4:25 | protect |
 test_RequestExpr
+| src/csurf-example.js:20:28:20:30 | req | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
 | src/csurf-example.js:22:35:22:37 | req | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} |
+| src/csurf-example.js:25:32:25:34 | req | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} |
+| src/csurf-example.js:32:40:32:42 | req | src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } |
+| src/csurf-example.js:39:36:39:38 | req | src/csurf-example.js:39:26:39:47 | functio ... res) {} |
+| src/csurf-example.js:40:37:40:39 | req | src/csurf-example.js:40:27:40:48 | functio ... res) {} |
+| src/exportedHandler.js:1:44:1:46 | req | src/exportedHandler.js:1:19:1:55 | functio ... res) {} |
+| src/express2.js:3:34:3:36 | req | src/express2.js:3:25:3:55 | functio ... , res } |
 | src/express2.js:3:46:3:48 | req | src/express2.js:3:25:3:55 | functio ... , res } |
+| src/express2.js:4:41:4:47 | request | src/express2.js:4:32:4:76 | functio ... esult } |
 | src/express2.js:4:60:4:66 | request | src/express2.js:4:32:4:76 | functio ... esult } |
+| src/express3.js:4:32:4:34 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:14:5:16 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
 | src/express3.js:5:35:5:37 | req | src/express3.js:4:23:7:1 | functio ... al");\\n} |
+| src/express3.js:10:22:10:24 | req | src/express3.js:10:12:10:32 | functio ...  res){} |
+| src/express4.js:4:32:4:34 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:5:27:5:29 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:6:18:6:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
 | src/express4.js:7:18:7:20 | req | src/express4.js:4:23:9:1 | functio ... ic1);\\n} |
+| src/express.js:4:32:4:34 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:5:16:5:18 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
 | src/express.js:6:26:6:28 | req | src/express.js:4:23:9:1 | functio ... res);\\n} |
+| src/express.js:16:28:16:30 | req | src/express.js:16:19:18:3 | functio ... ");\\n  } |
+| src/express.js:22:39:22:41 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:23:3:23:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:24:3:24:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:25:3:25:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
@@ -1091,16 +1216,30 @@ test_RequestExpr
 | src/express.js:28:3:28:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:29:3:29:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
 | src/express.js:30:3:30:5 | req | src/express.js:22:30:32:1 | functio ... ar');\\n} |
+| src/express.js:37:22:37:24 | req | src/express.js:37:12:37:32 | functio ...  res){} |
+| src/express.js:42:13:42:15 | req | src/express.js:42:12:42:28 | (req, res) => f() |
+| src/express.js:46:31:46:33 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:47:3:47:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:48:3:48:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:49:3:49:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
 | src/express.js:50:3:50:5 | req | src/express.js:46:22:51:1 | functio ... ame];\\n} |
+| src/inheritedFromNode.js:4:24:4:26 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
 | src/inheritedFromNode.js:7:2:7:4 | req | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} |
+| src/params.js:4:19:4:21 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:5:17:5:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
 | src/params.js:6:17:6:19 | req | src/params.js:4:18:12:1 | (req, r ...     }\\n} |
+| src/params.js:14:33:14:35 | req | src/params.js:14:24:16:1 | functio ... lo");\\n} |
+| src/passport.js:27:13:27:15 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
 | src/passport.js:28:2:28:4 | req | src/passport.js:27:4:29:1 | functio ... ccss`\\n} |
+| src/responseExprs.js:4:32:4:34 | req | src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} |
+| src/responseExprs.js:7:32:7:34 | req | src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} |
+| src/responseExprs.js:10:39:10:41 | req | src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} |
+| src/responseExprs.js:13:32:13:34 | req | src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} |
+| src/responseExprs.js:16:39:16:41 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
 | src/responseExprs.js:17:5:17:7 | req | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} |
+| src/route.js:5:21:5:23 | req | src/route.js:5:12:5:38 | functio ... ext) {} |
 test_RequestExprStandalone
+| typed_src/tst.ts:5:15:5:15 | x |
 | typed_src/tst.ts:6:3:6:3 | x |
 test_RouteHandlerExpr_getAsSubRouter
 | src/csurf-example.js:13:17:13:19 | api | src/csurf-example.js:30:16:30:35 | new express.Router() |
@@ -1110,16 +1249,30 @@ test_Credentials
 | src/auth.js:4:30:4:36 | 'admin' | user name |
 | src/auth.js:4:39:4:48 | 'passw0rd' | password |
 test_RouteHandler_getARequestExpr
+| src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:20:28:20:30 | req |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:22:35:22:37 | req |
+| src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:25:32:25:34 | req |
+| src/csurf-example.js:32:30:34:3 | functio ... e')\\n  } | src/csurf-example.js:32:40:32:42 | req |
+| src/csurf-example.js:39:26:39:47 | functio ... res) {} | src/csurf-example.js:39:36:39:38 | req |
+| src/csurf-example.js:40:27:40:48 | functio ... res) {} | src/csurf-example.js:40:37:40:39 | req |
+| src/exportedHandler.js:1:19:1:55 | functio ... res) {} | src/exportedHandler.js:1:44:1:46 | req |
+| src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:34:3:36 | req |
 | src/express2.js:3:25:3:55 | functio ... , res } | src/express2.js:3:46:3:48 | req |
+| src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:41:4:47 | request |
 | src/express2.js:4:32:4:76 | functio ... esult } | src/express2.js:4:60:4:66 | request |
+| src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:4:32:4:34 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:14:5:16 | req |
 | src/express3.js:4:23:7:1 | functio ... al");\\n} | src/express3.js:5:35:5:37 | req |
+| src/express3.js:10:12:10:32 | functio ...  res){} | src/express3.js:10:22:10:24 | req |
+| src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:4:32:4:34 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:5:27:5:29 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:6:18:6:20 | req |
 | src/express4.js:4:23:9:1 | functio ... ic1);\\n} | src/express4.js:7:18:7:20 | req |
+| src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:4:32:4:34 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:5:16:5:18 | req |
 | src/express.js:4:23:9:1 | functio ... res);\\n} | src/express.js:6:26:6:28 | req |
+| src/express.js:16:19:18:3 | functio ... ");\\n  } | src/express.js:16:28:16:30 | req |
+| src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:22:39:22:41 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:23:3:23:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:24:3:24:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:25:3:25:5 | req |
@@ -1128,12 +1281,25 @@ test_RouteHandler_getARequestExpr
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:28:3:28:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:29:3:29:5 | req |
 | src/express.js:22:30:32:1 | functio ... ar');\\n} | src/express.js:30:3:30:5 | req |
+| src/express.js:37:12:37:32 | functio ...  res){} | src/express.js:37:22:37:24 | req |
+| src/express.js:42:12:42:28 | (req, res) => f() | src/express.js:42:13:42:15 | req |
+| src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:46:31:46:33 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:47:3:47:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:48:3:48:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:49:3:49:5 | req |
 | src/express.js:46:22:51:1 | functio ... ame];\\n} | src/express.js:50:3:50:5 | req |
+| src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:4:24:4:26 | req |
 | src/inheritedFromNode.js:4:15:8:1 | functio ... .url;\\n} | src/inheritedFromNode.js:7:2:7:4 | req |
+| src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:4:19:4:21 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:5:17:5:19 | req |
 | src/params.js:4:18:12:1 | (req, r ...     }\\n} | src/params.js:6:17:6:19 | req |
+| src/params.js:14:24:16:1 | functio ... lo");\\n} | src/params.js:14:33:14:35 | req |
+| src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:27:13:27:15 | req |
 | src/passport.js:27:4:29:1 | functio ... ccss`\\n} | src/passport.js:28:2:28:4 | req |
+| src/responseExprs.js:4:23:6:1 | functio ...  res1\\n} | src/responseExprs.js:4:32:4:34 | req |
+| src/responseExprs.js:7:23:9:1 | functio ... res2;\\n} | src/responseExprs.js:7:32:7:34 | req |
+| src/responseExprs.js:10:23:12:1 | functio ... res3;\\n} | src/responseExprs.js:10:39:10:41 | req |
+| src/responseExprs.js:13:23:15:1 | functio ... res4;\\n} | src/responseExprs.js:13:32:13:34 | req |
+| src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:16:39:16:41 | req |
 | src/responseExprs.js:16:30:42:1 | functio ...     }\\n} | src/responseExprs.js:17:5:17:7 | req |
+| src/route.js:5:12:5:38 | functio ... ext) {} | src/route.js:5:21:5:23 | req |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -33,13 +33,24 @@ test_SystemCommandExecution
 | exec.js:6:1:6:28 | cp.spaw ... "], cb) | exec.js:6:10:6:15 | "echo" |
 | exec.js:7:1:7:37 | cp.spaw ... here"]) | exec.js:7:14:7:19 | "echo" |
 test_ResponseExpr
+| createServer.js:2:35:2:37 | res | createServer.js:2:20:2:41 | functio ... res) {} |
+| createServer.js:3:38:3:40 | res | createServer.js:3:23:3:44 | functio ... res) {} |
+| createServer.js:4:37:4:39 | res | createServer.js:4:31:4:46 | (req, res) => {} |
+| src/http.js:4:46:4:48 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:7:3:7:5 | res | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
+| src/http.js:12:33:12:35 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:13:3:13:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:14:3:14:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:3:15:5 | res | src/http.js:12:19:16:1 | functio ... ar");\\n} |
+| src/http.js:55:25:55:27 | res | src/http.js:55:12:55:30 | function(req,res){} |
+| src/http.js:60:27:60:29 | res | src/http.js:60:14:60:32 | function(req,res){} |
+| src/http.js:62:33:62:35 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:63:3:63:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:64:3:64:5 | res | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:68:17:68:19 | res | src/http.js:68:12:68:27 | (req,res) => f() |
+| src/https.js:4:47:4:49 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:7:3:7:5 | res | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
+| src/https.js:12:34:12:36 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:13:3:13:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:14:3:14:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:3:15:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
@@ -93,13 +104,24 @@ test_HeaderDefinition_getNameExpr
 | src/https.js:7:3:7:42 | res.wri ... rget }) | src/https.js:7:17:7:19 | 302 |
 | src/https.js:13:3:13:44 | res.set ... /html') | src/https.js:13:17:13:30 | 'Content-Type' |
 test_RouteHandler_getAResponseExpr
+| createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:35:2:37 | res |
+| createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:38:3:40 | res |
+| createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:37:4:39 | res |
+| src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:46:4:48 | res |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:7:3:7:5 | res |
+| src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:33:12:35 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:13:3:13:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:14:3:14:5 | res |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:15:3:15:5 | res |
+| src/http.js:55:12:55:30 | function(req,res){} | src/http.js:55:25:55:27 | res |
+| src/http.js:60:14:60:32 | function(req,res){} | src/http.js:60:27:60:29 | res |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:33:62:35 | res |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:3:63:5 | res |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:64:3:64:5 | res |
+| src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:17:68:19 | res |
+| src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:47:4:49 | res |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:7:3:7:5 | res |
+| src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:34:12:36 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:13:3:13:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:14:3:14:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:15:3:15:5 | res |
@@ -162,13 +184,24 @@ test_RouteHandler
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
 test_RequestExpr
+| createServer.js:2:30:2:32 | req | createServer.js:2:20:2:41 | functio ... res) {} |
+| createServer.js:3:33:3:35 | req | createServer.js:3:23:3:44 | functio ... res) {} |
+| createServer.js:4:32:4:34 | req | createServer.js:4:31:4:46 | (req, res) => {} |
+| src/http.js:4:41:4:43 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:6:26:6:28 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:8:3:8:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:9:3:9:5 | req | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
+| src/http.js:12:28:12:30 | req | src/http.js:12:19:16:1 | functio ... ar");\\n} |
+| src/http.js:55:21:55:23 | req | src/http.js:55:12:55:30 | function(req,res){} |
+| src/http.js:60:23:60:25 | req | src/http.js:60:14:60:32 | function(req,res){} |
+| src/http.js:62:28:62:30 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/http.js:63:17:63:19 | req | src/http.js:62:19:65:1 | functio ... r2");\\n} |
+| src/http.js:68:13:68:15 | req | src/http.js:68:12:68:27 | (req,res) => f() |
+| src/https.js:4:42:4:44 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:6:26:6:28 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
+| src/https.js:12:29:12:31 | req | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 test_SystemCommandExecution_getAnArgumentForCommand
 | exec.js:3:1:3:38 | cp.exec ... "], cb) | exec.js:3:21:3:33 | ["--version"] |
 | exec.js:4:1:4:47 | cp.exec ... sion"]) | exec.js:4:23:4:46 | ["-c",  ... rsion"] |
@@ -179,10 +212,21 @@ test_Credentials
 | src/http.js:18:22:18:27 | "auth" | credentials |
 | src/https.js:18:23:18:28 | "auth" | credentials |
 test_RouteHandler_getARequestExpr
+| createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:30:2:32 | req |
+| createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:33:3:35 | req |
+| createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:32:4:34 | req |
+| src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:41:4:43 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:6:26:6:28 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:8:3:8:5 | req |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:9:3:9:5 | req |
+| src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:28:12:30 | req |
+| src/http.js:55:12:55:30 | function(req,res){} | src/http.js:55:21:55:23 | req |
+| src/http.js:60:14:60:32 | function(req,res){} | src/http.js:60:23:60:25 | req |
+| src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:62:28:62:30 | req |
 | src/http.js:62:19:65:1 | functio ... r2");\\n} | src/http.js:63:17:63:19 | req |
+| src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:68:13:68:15 | req |
+| src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:42:4:44 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:6:26:6:28 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:9:3:9:5 | req |
+| src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:29:12:31 | req |

--- a/javascript/ql/test/library-tests/frameworks/connect/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/connect/tests.expected
@@ -14,7 +14,12 @@ test_HeaderDefinition_defines
 | src/test.js:7:5:7:32 | res.set ... 1', '') | header1 |  |
 | src/test.js:25:5:25:32 | res.set ... 2', '') | header2 |  |
 test_ResponseExpr
+| src/test.js:6:32:6:34 | res | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:7:5:7:7 | res | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:15:27:15:29 | res | src/test.js:15:12:15:32 | functio ...  res){} |
+| src/test.js:19:22:19:24 | res | src/test.js:19:9:19:27 | function(req,res){} |
+| src/test.js:20:23:20:25 | res | src/test.js:20:10:20:28 | function(req,res){} |
+| src/test.js:24:31:24:33 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 | src/test.js:25:5:25:7 | res | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 test_HeaderDefinition
 | src/test.js:7:5:7:32 | res.set ... 1', '') | src/test.js:6:9:9:1 | functio ... oo');\\n} |
@@ -32,7 +37,12 @@ test_HeaderDefinition_getAHeaderName
 test_ServerDefinition
 | src/test.js:4:11:4:19 | connect() |
 test_RouteHandler_getAResponseExpr
+| src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:32:6:34 | res |
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:7:5:7:7 | res |
+| src/test.js:15:12:15:32 | functio ...  res){} | src/test.js:15:27:15:29 | res |
+| src/test.js:19:9:19:27 | function(req,res){} | src/test.js:19:22:19:24 | res |
+| src/test.js:20:10:20:28 | function(req,res){} | src/test.js:20:23:20:25 | res |
+| src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:31:24:33 | res |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:25:5:25:7 | res |
 test_RouteSetup_getARouteHandler
 | src/test.js:6:1:9:2 | app.use ... o');\\n}) | src/test.js:6:9:9:1 | functio ... oo');\\n} |
@@ -49,9 +59,19 @@ test_RouteHandler
 | src/test.js:20:10:20:28 | function(req,res){} | src/test.js:4:11:4:19 | connect() |
 | src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:4:11:4:19 | connect() |
 test_RequestExpr
+| src/test.js:6:27:6:29 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
 | src/test.js:8:5:8:7 | req | src/test.js:6:9:9:1 | functio ... oo');\\n} |
+| src/test.js:15:22:15:24 | req | src/test.js:15:12:15:32 | functio ...  res){} |
+| src/test.js:19:18:19:20 | req | src/test.js:19:9:19:27 | function(req,res){} |
+| src/test.js:20:19:20:21 | req | src/test.js:20:10:20:28 | function(req,res){} |
+| src/test.js:24:26:24:28 | req | src/test.js:24:9:26:1 | functio ...  '');\\n} |
 test_Credentials
 | src/test.js:12:19:12:28 | 'username' | user name |
 | src/test.js:12:31:12:40 | 'password' | password |
 test_RouteHandler_getARequestExpr
+| src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:6:27:6:29 | req |
 | src/test.js:6:9:9:1 | functio ... oo');\\n} | src/test.js:8:5:8:7 | req |
+| src/test.js:15:12:15:32 | functio ...  res){} | src/test.js:15:22:15:24 | req |
+| src/test.js:19:9:19:27 | function(req,res){} | src/test.js:19:18:19:20 | req |
+| src/test.js:20:10:20:28 | function(req,res){} | src/test.js:20:19:20:21 | req |
+| src/test.js:24:9:26:1 | functio ...  '');\\n} | src/test.js:24:26:24:28 | req |

--- a/javascript/ql/test/library-tests/frameworks/hapi/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/hapi/tests.expected
@@ -46,18 +46,26 @@ test_RouteHandler
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 | src/hapi.js:34:12:34:30 | function (req, h){} | src/hapi.js:4:15:4:31 | new Hapi.Server() |
 test_RequestExpr
+| src/hapi.js:13:32:13:38 | request | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
 | src/hapi.js:14:9:14:15 | request | src/hapi.js:13:14:15:5 | functio ... n\\n    } |
+| src/hapi.js:17:48:17:54 | request | src/hapi.js:17:30:18:1 | functio ... ndler\\n} |
+| src/hapi.js:20:19:20:25 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:21:3:21:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:22:3:22:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:23:3:23:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:24:3:24:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:25:3:25:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
 | src/hapi.js:26:3:26:9 | request | src/hapi.js:20:1:27:1 | functio ... oken;\\n} |
+| src/hapi.js:34:22:34:24 | req | src/hapi.js:34:12:34:30 | function (req, h){} |
 test_RouteHandler_getARequestExpr
+| src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:13:32:13:38 | request |
 | src/hapi.js:13:14:15:5 | functio ... n\\n    } | src/hapi.js:14:9:14:15 | request |
+| src/hapi.js:17:30:18:1 | functio ... ndler\\n} | src/hapi.js:17:48:17:54 | request |
+| src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:20:19:20:25 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:21:3:21:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:22:3:22:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:23:3:23:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:24:3:24:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:25:3:25:9 | request |
 | src/hapi.js:20:1:27:1 | functio ... oken;\\n} | src/hapi.js:26:3:26:9 | request |
+| src/hapi.js:34:12:34:30 | function (req, h){} | src/hapi.js:34:22:34:24 | req |

--- a/javascript/ql/test/library-tests/frameworks/koa/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/koa/tests.expected
@@ -46,6 +46,7 @@ test_ResponseExpr
 | src/koa.js:18:3:18:14 | ctx.response | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:44:2:44:13 | ctx.response | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 test_RouteHandler_getAContextExpr
+| src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:10:28:10:30 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:11:3:11:6 | this |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:12:3:12:6 | this |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:13:3:13:5 | ctx |
@@ -61,6 +62,7 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:25:3:25:5 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:26:3:26:5 | ctx |
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:27:3:27:5 | ctx |
+| src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:30:16:30:18 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:31:2:31:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:32:2:32:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:33:2:33:4 | ctx |
@@ -74,6 +76,7 @@ test_RouteHandler_getAContextExpr
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:42:12:42:14 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:43:2:43:4 | ctx |
 | src/koa.js:30:10:45:1 | async c ... url);\\n} | src/koa.js:44:2:44:4 | ctx |
+| src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:47:16:47:18 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:48:16:48:18 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:51:14:51:16 | ctx |
 | src/koa.js:47:10:56:1 | async c ... .foo;\\n} | src/koa.js:54:16:54:18 | ctx |
@@ -152,6 +155,7 @@ test_RouteHandler_getARequestExpr
 | src/koa.js:10:10:28:1 | functio ... az');\\n} | src/koa.js:26:3:26:13 | ctx.request |
 | src/koa.js:59:10:61:1 | functio ... .url;\\n} | src/koa.js:60:2:60:13 | this.request |
 test_ContextExpr
+| src/koa.js:10:28:10:30 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:11:3:11:6 | this | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:12:3:12:6 | this | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:13:3:13:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
@@ -167,6 +171,7 @@ test_ContextExpr
 | src/koa.js:25:3:25:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:26:3:26:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
 | src/koa.js:27:3:27:5 | ctx | src/koa.js:10:10:28:1 | functio ... az');\\n} |
+| src/koa.js:30:16:30:18 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:31:2:31:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:32:2:32:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:33:2:33:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
@@ -180,6 +185,7 @@ test_ContextExpr
 | src/koa.js:42:12:42:14 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:43:2:43:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
 | src/koa.js:44:2:44:4 | ctx | src/koa.js:30:10:45:1 | async c ... url);\\n} |
+| src/koa.js:47:16:47:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:48:16:48:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:51:14:51:16 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |
 | src/koa.js:54:16:54:18 | ctx | src/koa.js:47:10:56:1 | async c ... .foo;\\n} |

--- a/javascript/ql/test/library-tests/frameworks/restify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/restify/tests.expected
@@ -17,7 +17,9 @@ test_HeaderDefinition_defines
 | src/test.js:10:5:10:34 | respons ... 1', '') | header1 |  |
 | src/test.js:13:5:13:37 | respons ... 2', '') | header2 |  |
 test_ResponseExpr
+| src/test.js:9:46:9:53 | response | src/test.js:9:19:11:1 | functio ... ition\\n} |
 | src/test.js:10:5:10:12 | response | src/test.js:9:19:11:1 | functio ... ition\\n} |
+| src/test.js:12:46:12:53 | response | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:13:5:13:12 | response | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 test_HeaderDefinition
 | src/test.js:10:5:10:34 | respons ... 1', '') | src/test.js:9:19:11:1 | functio ... ition\\n} |
@@ -33,7 +35,9 @@ test_ServerDefinition
 | src/test.js:1:15:1:47 | require ... erver() |
 | src/test.js:4:15:4:36 | restify ... erver() |
 test_RouteHandler_getAResponseExpr
+| src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:9:46:9:53 | response |
 | src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:10:5:10:12 | response |
+| src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:46:12:53 | response |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:13:5:13:12 | response |
 test_RouteSetup_getARouteHandler
 | src/test.js:7:1:7:26 | server2 ... ndler1) | src/test.js:6:1:6:21 | functio ... er1(){} |
@@ -44,6 +48,8 @@ test_RouteHandler
 | src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:4:15:4:36 | restify ... erver() |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:4:15:4:36 | restify ... erver() |
 test_RequestExpr
+| src/test.js:9:37:9:43 | request | src/test.js:9:19:11:1 | functio ... ition\\n} |
+| src/test.js:12:37:12:43 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:14:5:14:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:15:5:15:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:16:5:16:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
@@ -53,6 +59,8 @@ test_RequestExpr
 | src/test.js:20:5:20:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 | src/test.js:21:5:21:11 | request | src/test.js:12:19:22:1 | functio ... okie;\\n} |
 test_RouteHandler_getARequestExpr
+| src/test.js:9:19:11:1 | functio ... ition\\n} | src/test.js:9:37:9:43 | request |
+| src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:12:37:12:43 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:14:5:14:11 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:15:5:15:11 | request |
 | src/test.js:12:19:22:1 | functio ... okie;\\n} | src/test.js:16:5:16:11 | request |

--- a/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-338/InsecureRandomness.expected
@@ -108,8 +108,7 @@ edges
 | tst.js:72:18:72:48 | ts.toSt ... tring() | tst.js:72:9:72:48 | concat |
 | tst.js:72:34:72:37 | rand | tst.js:72:34:72:48 | rand.toString() |
 | tst.js:72:34:72:48 | rand.toString() | tst.js:72:18:72:48 | ts.toSt ... tring() |
-| tst.js:80:7:80:19 | Math.random() | tst.js:77:16:77:21 | secret |
-| tst.js:80:7:80:19 | Math.random() | tst.js:77:16:77:21 | secret |
+| tst.js:77:16:77:21 | secret | tst.js:77:16:77:21 | secret |
 | tst.js:80:7:80:19 | Math.random() | tst.js:77:16:77:21 | secret |
 | tst.js:80:7:80:19 | Math.random() | tst.js:77:16:77:21 | secret |
 | tst.js:84:19:84:31 | Math.random() | tst.js:84:19:84:31 | Math.random() |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -14,7 +14,6 @@
 | UselessConditional.js:60:9:60:15 | unknown | This use of variable 'unknown' always evaluates to false. |
 | UselessConditional.js:65:5:65:5 | x | This use of variable 'x' always evaluates to true. |
 | UselessConditional.js:76:13:76:13 | x | This use of variable 'x' always evaluates to true. |
-| UselessConditional.js:82:13:82:13 | x | This use of variable 'x' always evaluates to true. |
 | UselessConditional.js:89:10:89:16 | x, true | This expression always evaluates to true. |
 | UselessConditional.js:94:16:94:16 | x | This use of variable 'x' always evaluates to false. |
 | UselessConditional.js:100:13:100:24 | true && true | This expression always evaluates to true. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -28,7 +28,6 @@
 | UselessConditional.js:151:6:151:6 | v | This use of variable 'v' always evaluates to true. |
 | UselessConditional.js:163:5:163:17 | findOrThrow() | This call to findOrThrow always evaluates to true. |
 | UselessConditional.js:166:6:166:6 | v | This use of variable 'v' always evaluates to true. |
-| UselessConditional.js:183:17:183:18 | !x | This negation always evaluates to true. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.expected
@@ -29,6 +29,7 @@
 | UselessConditional.js:151:6:151:6 | v | This use of variable 'v' always evaluates to true. |
 | UselessConditional.js:163:5:163:17 | findOrThrow() | This call to findOrThrow always evaluates to true. |
 | UselessConditional.js:166:6:166:6 | v | This use of variable 'v' always evaluates to true. |
+| UselessConditional.js:183:17:183:18 | !x | This negation always evaluates to true. |
 | UselessConditionalGood.js:58:12:58:13 | x2 | This use of variable 'x2' always evaluates to false. |
 | UselessConditionalGood.js:69:12:69:13 | xy | This use of variable 'xy' always evaluates to false. |
 | UselessConditionalGood.js:85:12:85:13 | xy | This use of variable 'xy' always evaluates to false. |

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -79,7 +79,7 @@ async function awaitFlow(){
 
     function f3(x) {
         (function(){
-            x || y // NOT OK
+            x || y // NOT OK, but whitelisted
         });
     }
     f3(true);

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -180,7 +180,7 @@ async function awaitFlow(){
 (function() {
     function outer(x) {
         addEventListener("click", () => {
-            if (!x && something()) { // NOT OK
+            if (!x && something()) { // NOT OK, but whitelisted
                 something();
             }
         });

--- a/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
+++ b/javascript/ql/test/query-tests/Statements/UselessConditional/UselessConditional.js
@@ -176,3 +176,17 @@ async function awaitFlow(){
 	if (v) { // OK
 	}
 });
+
+(function() {
+    function outer(x) {
+        addEventListener("click", () => {
+            if (!x && something()) { // NOT OK
+                something();
+            }
+        });
+    }
+    function inner() {
+        outer(); // Omit parameter
+    }
+    inner();
+});


### PR DESCRIPTION
This changes how parameters are represented in the data-flow IR.

The data-flow node representing a parameter or destructuring pattern is now always the `ValueNode` corresponding to that AST node. This has a few consequences:
  - `Parameter.flow()` now gets the correct data flow node for a parameter. Previously this had a result, but the node was disconnected from the data flow graph.
  - `ParameterNode.asExpr()` and `.getAstNode()` now gets the parameter's AST node, whereas previously it had no result.
  - `Expr.flow()` now has a more meaningful result for destructuring patterns. Previously this node was disconnected from the data flow graph. Now it represents the values being destructured by the pattern.

The majority of the work is to hunt down various join order regressions, and fixing type inference. Type inference is a beast because of how it analyzes local variables, and that the variable-analysis was deeply entwined with its interprocedural analysis. I'd like to return to cleaning up type inference in the near future, but ideally we're done refactoring the data-flow IR before that work begins.

Commit-by-commit review strongly encouraged.

# Evaluations

Performance looks reasonable, and result changes are triaged below.

- [Full/smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/shared-data-flow-node_1589723072645)
- [Security/nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/shared-data-flow-node_1589786671048)
- [XSS/big-apps](https://git.semmle.com/asger/dist-compare-reports/tree/js/shared-data-flow-node_1589835026740)

# Triage of evaluation result changes:

##### Prototype pollution
- New result due to new call edges discovered through access paths rooted in a captured parameter. To explain why:
  - `ExplicitSsaDefinition.getRhs` had no result for parameter SSA definitions. (In the old model I'd say it was unclear whether the RHS of a parameter should be the SSA node itself or if there should be no RHS.)
  - Now, the RHS of that SSA definition is the `ValueNode` for the parameter.
  - This means `EffectivelyConstantVariable.getValue()` now has a result for captured parameters, and captured uses of the parameter can thus become access paths.

##### Remote property injection

- New result, due to a newly recognized `RequestExpr` from an Express route handler where the request is a destructured parameter.

##### Trivial conditional

- Fewer results, due to stricter whitelisting. The whitelisting previously relied on some quirks in how the type inference handled captured variables, and this behavior was not worth preserving IMO. Without the whitelisting change there would have been more (dubious) results instead of fewer.

# Triage of test output changes:

##### AMD:
- `getFactoryNode()` only returns `ValueNode`, which now includes parameters.

##### enclosingExpr:
- Parameters always had a corresponding `ValueNode`, it just wasn't used for anything.
  Both the `ValueNode` and SSA node had the `Parameter` as its enclosing expr, whereas
  now only the `ValueNode` has (so fewer duplicate results).

##### flowStep:
- There is new flow step from a parameter's `ValueNode` to its SSA node.

##### Angular/ScopeAccess:
- More results, since the test case uses of `Expr.mayReferToParameter`, and a parameter expr may now refer to itself.

##### Express, connect, Hapi, koa, NodeJSLib, restify:
- More results, since parameters and destructuring patterns can now be `ResponseExpr`, `RequestExpr`, etc. This is also reflected in new benign results in the evaluation (due to a request that is a destructuring pattern parameter).

##### Electron/BrowserObject:
- Duplicate results, since `BrowserObject` is closed under `flowsTo`, and thus includes both a parameter's `ValueNode` and its SSA node.

##### TrackedNodes:
- Duplicate results due to connecting a new nodes to the data flow graph (`ValueNode` for parameters).

##### ModuleImportNodes:
- More results, since the test case flags all uses of the `ModuleImportNode` that are `Identifiers`, which now includes some parameters.

##### PropWrite:
- Fewer results, since a `ParameterFieldAsPropWrite` used to have two RHS nodes if the parameter was unused.
  This was a legacy from before the `lvalueFlowStep` refactoring.
  In any case, it's no longer needed as there is flow from the default to the RHS.

##### InsecureRandomness:
- Fewer duplicate results. The explanation is a little tricky:
  - The duplication was due to `SinkPathNode` and `MidPathNode` being distinct entities with same `toString` and location.
  - A step going to a sink is actually a step to both the `SinkPathNode` and `MidPathNode`.
  - This query uses SSA nodes as sinks (its sinks are assignments to variables with certain names).
  - Previously, a certain parameter was a sink (an SSA node), but now there's an intermediate node between that parameter (the `ValueNode`) and the sink (the SSA node).

##### VarDefSource:
- The default value of a parameter is no longer returned by `VarDef.getSource`.

##### GlobalAccessPaths:
- Duplicate results due to connecting a new node to the data flow graph (`ValueNode` for parameters).

##### UselessConditional:
- Whitelisting had inconsistent handling of captured variables.
  Change is due to fixing that. This is also reflected in the evaluation.
