### PR TITLE
C#: Recognize more calls to `IHtmlHelper.Raw`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -200,8 +200,8 @@ class MicrosoftAspNetCoreMvcController extends Class {
 }
 
 /** The `Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper` interface. */
-class MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface extends Interface {
-  MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface() {
+class MicrosoftAspNetCoreMvcRenderingIHtmlHelperInterface extends Interface {
+  MicrosoftAspNetCoreMvcRenderingIHtmlHelperInterface() {
     getNamespace() instanceof MicrosoftAspNetCoreMvcRendering and
     hasName("IHtmlHelper")
   }

--- a/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -27,6 +27,14 @@ class MicrosoftAspNetCoreMvcViewFeatures extends Namespace {
   }
 }
 
+/** The 'Microsoft.AspNetCore.Mvc.Rendering' namespace. */
+class MicrosoftAspNetCoreMvcRendering extends Namespace {
+  MicrosoftAspNetCoreMvcRendering() {
+    getParentNamespace() instanceof MicrosoftAspNetCoreMvcNamespace and
+    hasName("Rendering")
+  }
+}
+
 /** An attribute whose type is in the `Microsoft.AspNetCore.Mvc` namespace. */
 class MicrosoftAspNetCoreMvcAttribute extends Attribute {
   MicrosoftAspNetCoreMvcAttribute() {
@@ -191,11 +199,11 @@ class MicrosoftAspNetCoreMvcController extends Class {
   }
 }
 
-/** The `Microsoft.AspNetCore.Mvc.ViewFeatures.HtmlHelper` class. */
-class MicrosoftAspNetCoreMvcHtmlHelperClass extends Class {
-  MicrosoftAspNetCoreMvcHtmlHelperClass() {
-    getNamespace() instanceof MicrosoftAspNetCoreMvcViewFeatures and
-    hasName("HtmlHelper")
+/** The `Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper` interface. */
+class MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface extends Interface {
+  MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface() {
+    getNamespace() instanceof MicrosoftAspNetCoreMvcRendering and
+    hasName("IHtmlHelper")
   }
 
   /** Gets the `Raw` method. */

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
@@ -176,13 +176,18 @@ class WebPageWriteLiteralToSink extends HtmlSink {
 abstract class AspNetCoreHtmlSink extends HtmlSink { }
 
 /**
- * An expression that is used as an argument to `HtmlHelper.Raw`, typically in
+ * An expression that is used as an argument to `IHtmlHelper.Raw`, typically in
  * a `.cshtml` file.
  */
 class MicrosoftAspNetCoreMvcHtmlHelperRawSink extends AspNetCoreHtmlSink {
   MicrosoftAspNetCoreMvcHtmlHelperRawSink() {
-    this.getExpr() =
-      any(MicrosoftAspNetCoreMvcHtmlHelperClass h).getRawMethod().getACall().getAnArgument()
+    exists(Call c, Callable target |
+      c.getTarget() = target and
+      target.hasName("Raw") and
+      target.getDeclaringType().getABaseType*() instanceof
+        MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface and
+      this.getExpr() = c.getAnArgument()
+    )
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
@@ -185,7 +185,7 @@ class MicrosoftAspNetCoreMvcHtmlHelperRawSink extends AspNetCoreHtmlSink {
       c.getTarget() = target and
       target.hasName("Raw") and
       target.getDeclaringType().getABaseType*() instanceof
-        MicrosoftAspNetCoreMvcRenderingHtmlHelperInterface and
+        MicrosoftAspNetCoreMvcRenderingIHtmlHelperInterface and
       this.getExpr() = c.getAnArgument()
     )
   }


### PR DESCRIPTION
Generalize logic by recognizing not only calls to `Microsoft.AspNetCore.Mvc.ViewFeatures.HtmlHelper.Raw()`, but calls to all `Raw()` methods that implement `Microsoft.AspNetCore.Mvc.Rendering.IHtmlHelper.Raw()`.