### PR TITLE
C++: Simplify field conflation test

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/defaulttainttracking.cpp
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/defaulttainttracking.cpp
@@ -99,21 +99,21 @@ void test_outparams() {
 }
 
 
-void *memcpy(void *dst, void *src, int size);
 
-struct ContainsArray {
-  int arr[16];
+
+struct XY {
   int x;
+  int y;
 };
 
-void taint_array(ContainsArray *ca, int offset) {
+void taint_y(XY *xyp) {
   int tainted = getenv("VAR")[0];
-  memcpy(ca->arr + offset, &tainted, sizeof(int));
+  xyp->y = tainted;
 }
 
-void test_conflated_fields3(int arbitrary) {
-  ContainsArray ca;
-  ca.x = 0;
-  taint_array(&ca, arbitrary);
-  sink(ca.x); // not tainted [FALSE POSITIVE]
+void test_conflated_fields3() {
+  XY xy;
+  xy.x = 0;
+  taint_y(&xy);
+  sink(xy.x); // not tainted [FALSE POSITIVE]
 }

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
@@ -110,14 +110,11 @@
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:10:11:10:13 | p#0 |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:102:31:102:33 | src |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:7:110:13 | tainted |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:22 | call to getenv |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:32 | (int)... |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:110:17:110:32 | access to array |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:3:111:8 | call to memcpy |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:28:111:35 | & ... |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:28:111:35 | (void *)... |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:12:111:18 | tainted |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:118:11:118:11 | x |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | test_diff.cpp:2:11:2:13 | p#0 |
 | globals.cpp:5:20:5:25 | call to getenv | globals.cpp:2:17:2:25 | sinkParam |

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
@@ -24,9 +24,7 @@
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 | IR only |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:10:11:10:13 | p#0 | IR only |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:102:20:102:22 | dst | AST only |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:10:111:25 | ... + ... | AST only |
-| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:29:111:35 | tainted | AST only |
+| defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:111:8:111:8 | y | AST only |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | defaulttainttracking.cpp:118:11:118:11 | x | IR only |
 | defaulttainttracking.cpp:110:17:110:22 | call to getenv | test_diff.cpp:2:11:2:13 | p#0 | IR only |
 | globals.cpp:13:15:13:20 | call to getenv | globals.cpp:13:5:13:11 | global1 | AST only |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -1,7 +1,7 @@
 edges
-| field_conflation.c:12:22:12:27 | call to getenv | field_conflation.c:13:10:13:25 | Chi |
-| field_conflation.c:12:22:12:34 | (const char *)... | field_conflation.c:13:10:13:25 | Chi |
-| field_conflation.c:13:10:13:25 | Chi | field_conflation.c:19:15:19:17 | taint_array output argument |
+| field_conflation.c:12:22:12:27 | call to getenv | field_conflation.c:13:3:13:18 | Chi |
+| field_conflation.c:12:22:12:34 | (const char *)... | field_conflation.c:13:3:13:18 | Chi |
+| field_conflation.c:13:3:13:18 | Chi | field_conflation.c:19:15:19:17 | taint_array output argument |
 | field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:10:20:13 | (unsigned long)... |
 | field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:13:20:13 | x |
 | field_conflation.c:19:15:19:17 | taint_array output argument | field_conflation.c:20:13:20:13 | x |
@@ -71,7 +71,7 @@ edges
 nodes
 | field_conflation.c:12:22:12:27 | call to getenv | semmle.label | call to getenv |
 | field_conflation.c:12:22:12:34 | (const char *)... | semmle.label | (const char *)... |
-| field_conflation.c:13:10:13:25 | Chi | semmle.label | Chi |
+| field_conflation.c:13:3:13:18 | Chi | semmle.label | Chi |
 | field_conflation.c:19:15:19:17 | taint_array output argument | semmle.label | taint_array output argument |
 | field_conflation.c:20:10:20:13 | (unsigned long)... | semmle.label | (unsigned long)... |
 | field_conflation.c:20:10:20:13 | (unsigned long)... | semmle.label | (unsigned long)... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/field_conflation.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/field_conflation.c
@@ -1,21 +1,21 @@
 int atoi(const char *nptr);
 void *malloc(unsigned long size);
 char *getenv(const char *name);
-void *memcpy(void *dst, void *src, unsigned long size);
 
-struct ContainsArray {
-  int arr[16];
+
+struct XY {
   int x;
+  int y;
 };
 
-void taint_array(struct ContainsArray *ca, int offset) {
+void taint_array(struct XY *xyp) {
   int tainted = atoi(getenv("VAR"));
-  memcpy(ca->arr + offset, &tainted, sizeof(int));
+  xyp->y = tainted;
 }
 
-void test_conflated_fields3(int arbitrary) {
-  struct ContainsArray ca;
-  ca.x = 4;
-  taint_array(&ca, arbitrary);
-  malloc(ca.x); // not tainted [FALSE POSITIVE]
+void test_conflated_fields3(void) {
+  struct XY xy;
+  xy.x = 4;
+  taint_array(&xy);
+  malloc(xy.x); // not tainted [FALSE POSITIVE]
 }


### PR DESCRIPTION
It turned out the `memcpy` step was not even necessary.