### PR TITLE
JS: Typescript 3.9.2

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -18,6 +18,8 @@
   - [ssh2](https://www.npmjs.com/package/ssh2)
   - [ssh2-streams](https://www.npmjs.com/package/ssh2-streams)
 
+* TypeScript 3.9 is now supported.
+
 ## New queries
 
 | **Query**                                                                       | **Tags**                                                          | **Purpose**                                                                                                                                                                            |

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "3.8.2"
+        "typescript": "3.9.2"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json",

--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -225,9 +225,9 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.8.2:
-  version "3.8.2"
-  resolved typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a
+typescript@3.9.2:
+  version "3.9.2"
+  resolved "typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
 
 wrappy@1:
   version "1.0.2"

--- a/javascript/ql/test/library-tests/TypeScript/CallResolution/CallResolution.expected
+++ b/javascript/ql/test/library-tests/TypeScript/CallResolution/CallResolution.expected
@@ -4,16 +4,16 @@
 | tst.ts:55:3:55:27 | obj.ove ... od(num) | (x: number): number | 0 |
 | tst.ts:56:3:56:27 | obj.ove ... od(str) | (x: string): string | 1 |
 | tst.ts:57:3:57:26 | obj.ove ... hod([]) | (x: any): any | 2 |
-| tst.ts:58:3:58:36 | obj.gen ... ([num]) | (x: number[]): number | 0 |
-| tst.ts:59:3:59:39 | obj.gen ... : str}) | (x: Box<string>): string | 1 |
+| tst.ts:58:3:58:36 | obj.gen ... ([num]) | (x: number[]): T | 0 |
+| tst.ts:59:3:59:39 | obj.gen ... : str}) | (x: Box<string>): T | 1 |
 | tst.ts:60:3:60:34 | obj.gen ... od(num) | (x: any): any | 2 |
 | tst.ts:64:3:64:23 | obj.sim ... od(str) | (x: string): number | 0 |
 | tst.ts:65:3:65:24 | obj.gen ... od(str) | (x: string): string | 0 |
 | tst.ts:66:3:66:24 | obj.gen ... od(num) | (x: number): number | 0 |
 | tst.ts:67:3:67:27 | obj.ove ... od(num) | (x: number): number | 0 |
 | tst.ts:68:3:68:27 | obj.ove ... od(str) | (x: string): string | 1 |
-| tst.ts:69:3:69:36 | obj.gen ... ([num]) | (x: number[]): number | 0 |
-| tst.ts:70:3:70:39 | obj.gen ... : str}) | (x: Box<string>): string | 1 |
+| tst.ts:69:3:69:36 | obj.gen ... ([num]) | (x: number[]): T | 0 |
+| tst.ts:70:3:70:39 | obj.gen ... : str}) | (x: Box<string>): T | 1 |
 | tst.ts:74:3:74:28 | new Sim ... or(str) | new (x: string): SimpleConstructor | 0 |
 | tst.ts:75:3:75:29 | new Gen ... or(str) | new (x: string): GenericConstructor<string> | 0 |
 | tst.ts:76:3:76:29 | new Gen ... or(num) | new (x: number): GenericConstructor<number> | 0 |

--- a/javascript/ql/test/library-tests/TypeScript/CallSignatureTypes/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/CallSignatureTypes/test.expected
@@ -108,36 +108,36 @@ test_FunctionCallSig
 | tst.ts:63:3:63:23 | method2 ... ing[]); | (y: string[]): any |
 | tst.ts:64:3:64:21 | method3(y: string); | (y: string): any |
 test_getRestParameterType
-| (...items: (string \| ConcatArray<string>)[]): string[] | string \| ConcatArray<string> |
-| (...items: ConcatArray<string>[]): string[] | ConcatArray<string> |
+| (...items: (string \| ConcatArray<string>)[]): T[] | string \| ConcatArray<string> |
+| (...items: ConcatArray<string>[]): T[] | ConcatArray<string> |
 | (...items: string[]): number | string |
 | (...strings: string[]): string | string |
 | (...y: string[]): any | string |
-| (start: number, deleteCount: number, ...items: string[]): string[] | string |
+| (start: number, deleteCount: number, ...items: string[]): T[] | string |
 | (substring: string, ...args: any[]): string | any |
 | (x: number, ...y: string[]): any | string |
 | new (...y: string[]): any | string |
 | new (x: number, ...y: string[]): any | string |
 test_getRestParameterArray
-| (...items: (string \| ConcatArray<string>)[]): string[] | (string \| ConcatArray<string>)[] |
-| (...items: ConcatArray<string>[]): string[] | ConcatArray<string>[] |
+| (...items: (string \| ConcatArray<string>)[]): T[] | (string \| ConcatArray<string>)[] |
+| (...items: ConcatArray<string>[]): T[] | ConcatArray<string>[] |
 | (...items: string[]): number | string[] |
 | (...strings: string[]): string | string[] |
 | (...y: string[]): any | string[] |
-| (start: number, deleteCount: number, ...items: string[]): string[] | string[] |
+| (start: number, deleteCount: number, ...items: string[]): T[] | string[] |
 | (substring: string, ...args: any[]): string | any[] |
 | (x: number, ...y: string[]): any | string[] |
 | new (...y: string[]): any | string[] |
 | new (x: number, ...y: string[]): any | string[] |
 test_RestSig_getParameter
-| (...items: (string \| ConcatArray<string>)[]): string[] | 0 | items | string \| ConcatArray<string> |
-| (...items: ConcatArray<string>[]): string[] | 0 | items | ConcatArray<string> |
+| (...items: (string \| ConcatArray<string>)[]): T[] | 0 | items | string \| ConcatArray<string> |
+| (...items: ConcatArray<string>[]): T[] | 0 | items | ConcatArray<string> |
 | (...items: string[]): number | 0 | items | string |
 | (...strings: string[]): string | 0 | strings | string |
 | (...y: string[]): any | 0 | y | string |
-| (start: number, deleteCount: number, ...items: string[]): string[] | 0 | start | number |
-| (start: number, deleteCount: number, ...items: string[]): string[] | 1 | deleteCount | number |
-| (start: number, deleteCount: number, ...items: string[]): string[] | 2 | items | string |
+| (start: number, deleteCount: number, ...items: string[]): T[] | 0 | start | number |
+| (start: number, deleteCount: number, ...items: string[]): T[] | 1 | deleteCount | number |
+| (start: number, deleteCount: number, ...items: string[]): T[] | 2 | items | string |
 | (substring: string, ...args: any[]): string | 0 | substring | string |
 | (substring: string, ...args: any[]): string | 1 | args | any |
 | (x: number, ...y: string[]): any | 0 | x | number |
@@ -146,12 +146,12 @@ test_RestSig_getParameter
 | new (x: number, ...y: string[]): any | 0 | x | number |
 | new (x: number, ...y: string[]): any | 1 | y | string |
 test_RestSig_numRequiredParams
-| (...items: (string \| ConcatArray<string>)[]): string[] | 0 |
-| (...items: ConcatArray<string>[]): string[] | 0 |
+| (...items: (string \| ConcatArray<string>)[]): T[] | 0 |
+| (...items: ConcatArray<string>[]): T[] | 0 |
 | (...items: string[]): number | 0 |
 | (...strings: string[]): string | 0 |
 | (...y: string[]): any | 0 |
-| (start: number, deleteCount: number, ...items: string[]): string[] | 2 |
+| (start: number, deleteCount: number, ...items: string[]): T[] | 2 |
 | (substring: string, ...args: any[]): string | 1 |
 | (x: number, ...y: string[]): any | 1 |
 | new (...y: string[]): any | 0 |


### PR DESCRIPTION
Based on the [announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/) there doesn't seem to be any new features we need to support from our end. Still, I'm running an evaluation to see if anything breaks.

Based on the test output changes, it seems for a call expression `foo()`, the type of the callee `foo` has changed when it's a reference to a generic method, which seems innocent enough.

[Evaluation of XSS on typescript-full](https://git.semmle.com/asger/dist-compare-reports/tree/js/typescript-3.9.2_1589912337932) looks fine.
- I'm not sure where the performance comes from, as I don't think dist-compare measures extraction time, so probably just the usual cloud VM flakiness.
- We discover a few extra call edges in `vscode` (see metrics section). I'm guessing this is because the type checker has changed a bit, and `vscode` is written against TypeScript 3.9's type system.