### PR TITLE
C++: Mark deprecated overrides as deprecated

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -262,18 +262,6 @@ class File extends Container, @file {
   predicate compiledAsCpp() { fileannotations(underlyingElement(this), 1, "compiled as c++", "1") }
 
   /**
-   * DEPRECATED: Objective-C is no longer supported.
-   * Holds if this file was compiled as Objective C (at any point).
-   */
-  deprecated predicate compiledAsObjC() { none() }
-
-  /**
-   * DEPRECATED: Objective-C is no longer supported.
-   * Holds if this file was compiled as Objective C++ (at any point).
-   */
-  deprecated predicate compiledAsObjCpp() { none() }
-
-  /**
    * Holds if this file was compiled by a Microsoft compiler (at any point).
    *
    * Note: currently unreliable - on some projects only some of the files that
@@ -317,14 +305,6 @@ class File extends Container, @file {
   }
 
   /**
-   * DEPRECATED: use `getParentContainer` instead.
-   * Gets the folder which contains this file.
-   */
-  deprecated Folder getParent() {
-    containerparent(unresolveElement(result), underlyingElement(this))
-  }
-
-  /**
    * Holds if this file may be from source. This predicate holds for all files
    * except the dummy file, whose name is the empty string, which contains
    * declarations that are built into the compiler.
@@ -342,28 +322,6 @@ class File extends Container, @file {
   MetricFile getMetrics() { result = this }
 
   /**
-   * DEPRECATED: Use `getAbsolutePath` instead.
-   * Gets the full name of this file, for example:
-   * "/usr/home/me/myprogram.c".
-   */
-  deprecated string getName() { files(underlyingElement(this), result, _, _, _) }
-
-  /**
-   * DEPRECATED: Use `getAbsolutePath` instead.
-   * Holds if this file has the specified full name.
-   *
-   * Example usage: `f.hasName("/usr/home/me/myprogram.c")`.
-   */
-  deprecated predicate hasName(string name) { name = this.getName() }
-
-  /**
-   * DEPRECATED: Use `getAbsolutePath` instead.
-   * Gets the full name of this file, for example
-   * "/usr/home/me/myprogram.c".
-   */
-  deprecated string getFullName() { result = this.getName() }
-
-  /**
    * Gets the remainder of the base name after the first dot character. Note
    * that the name of this predicate is in plural form, unlike `getExtension`,
    * which gets the remainder of the base name after the _last_ dot character.
@@ -376,22 +334,6 @@ class File extends Container, @file {
    * "tar.gz", while `getExtension` will have the result "gz".
    */
   string getExtensions() { files(underlyingElement(this), _, _, result, _) }
-
-  /**
-   * DEPRECATED: Use `getBaseName` instead.
-   * Gets the name and extension(s), but not path, of a file. For example,
-   * if the full name is "/path/to/filename.a.bcd" then the filename is
-   * "filename.a.bcd".
-   */
-  deprecated string getFileName() {
-    // [a/b.c/d/]fileName
-    //         ^ beginAfter
-    exists(string fullName, int beginAfter |
-      fullName = this.getName() and
-      beginAfter = max(int i | i = -1 or fullName.charAt(i) = "/" | i) and
-      result = fullName.suffix(beginAfter + 1)
-    )
-  }
 
   /**
    * Gets the short name of this file, that is, the prefix of its base name up

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -119,7 +119,7 @@ class XMLFile extends XMLParent, File {
   override string toString() { result = XMLParent.super.toString() }
 
   /** Gets the name of this XML file. */
-  deprecated override string getName() { result = File.super.getAbsolutePath() }
+  override string getName() { result = File.super.getAbsolutePath() }
 
   /**
    * DEPRECATED: Use `getAbsolutePath()` instead.

--- a/cpp/ql/src/semmle/code/cpp/XML.qll
+++ b/cpp/ql/src/semmle/code/cpp/XML.qll
@@ -119,7 +119,7 @@ class XMLFile extends XMLParent, File {
   override string toString() { result = XMLParent.super.toString() }
 
   /** Gets the name of this XML file. */
-  override string getName() { result = File.super.getAbsolutePath() }
+  deprecated override string getName() { result = File.super.getAbsolutePath() }
 
   /**
    * DEPRECATED: Use `getAbsolutePath()` instead.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -19,7 +19,7 @@ class Printf extends FormattingFunction, AliasFunction {
 
   override int getFormatParameterIndex() { result = 0 }
 
-  override predicate isWideCharDefault() {
+  deprecated override predicate isWideCharDefault() {
     hasGlobalOrStdName("wprintf") or
     hasGlobalName("wprintf_s")
   }
@@ -47,7 +47,7 @@ class Fprintf extends FormattingFunction {
 
   override int getFormatParameterIndex() { result = 1 }
 
-  override predicate isWideCharDefault() { hasGlobalOrStdName("fwprintf") }
+  deprecated override predicate isWideCharDefault() { hasGlobalOrStdName("fwprintf") }
 
   override int getOutputParameterIndex() { result = 0 }
 }
@@ -70,7 +70,7 @@ class Sprintf extends FormattingFunction {
     not exists(getDefinition().getFile().getRelativePath())
   }
 
-  override predicate isWideCharDefault() {
+  deprecated override predicate isWideCharDefault() {
     getParameter(getFormatParameterIndex())
         .getType()
         .getUnspecifiedType()
@@ -136,7 +136,7 @@ class Snprintf extends FormattingFunction {
     else result = getFirstFormatArgumentIndex() - 1
   }
 
-  override predicate isWideCharDefault() {
+  deprecated override predicate isWideCharDefault() {
     getParameter(getFormatParameterIndex())
         .getType()
         .getUnspecifiedType()
@@ -201,7 +201,7 @@ class StringCchPrintf extends FormattingFunction {
     if getName().matches("%Ex") then result = 5 else result = 2
   }
 
-  override predicate isWideCharDefault() {
+  deprecated override predicate isWideCharDefault() {
     getParameter(getFormatParameterIndex())
         .getType()
         .getUnspecifiedType()


### PR DESCRIPTION
Fixes github/codeql-c-analysis-team#79

The QL compiler is about to be changed to emit a warning when overriding a deprecated predicate. This PR marks the existing overrides of deprecated predicates as `deprecated` themselves, which avoids the warning.

The `Print.qll` models seem to preserve the `isWideCharDefault()` predicate for backwards compatibility, so we can't remove them and must continue overriding them.

The `XML.qll` override is necessary because both superclasses declare the `getName()` predicate. One is `deprecated`, and the other is `abstract`, so we have to have an override.