### PR TITLE
JS: model fastify

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -5,6 +5,7 @@
 * Support for the following frameworks and libraries has been improved:
   - [bluebird](http://bluebirdjs.com/)
   - [express](https://www.npmjs.com/package/express)
+  - [fastify](https://www.npmjs.com/package/fastify)
   - [fstream](https://www.npmjs.com/package/fstream)
   - [jGrowl](https://github.com/stanlemon/jGrowl)
   - [jQuery](https://jquery.com/)

--- a/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
@@ -5,6 +5,9 @@
 import javascript
 import semmle.javascript.frameworks.HTTP
 
+/**
+ * Provides classes for working with [Fastify](https://www.fastify.io/) applications.
+ */
 module Fastify {
   /**
    * An expression that creates a new Fastify server.

--- a/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
@@ -132,9 +132,7 @@ module Fastify {
     string kind;
 
     RequestInputAccess() {
-      exists(DataFlow::PropRead read, string name |
-        this = read and read = rh.getARequestSource().ref().getAPropertyRead(name)
-      |
+      exists(string name | this = rh.getARequestSource().ref().getAPropertyRead(name) |
         kind = "parameter" and
         name = ["params", "query"]
         or
@@ -150,7 +148,8 @@ module Fastify {
     override predicate isUserControlledObject() {
       kind = "body" and
       (
-        usesFastifyPlugin(rh, DataFlow::moduleImport(["fastify-xml-body-parser", "fastify-formbody"]))
+        usesFastifyPlugin(rh,
+          DataFlow::moduleImport(["fastify-xml-body-parser", "fastify-formbody"]))
         or
         usesMiddleware(rh,
           any(ExpressLibraries::BodyParser bodyParser | bodyParser.producesUserControlledObjects()))

--- a/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Fastify.qll
@@ -1,0 +1,249 @@
+/**
+ * Provides classes for working with [Fastify](https://www.fastify.io/) applications.
+ */
+
+import javascript
+import semmle.javascript.frameworks.HTTP
+
+module Fastify {
+  /**
+   * An expression that creates a new Fastify server.
+   */
+  abstract class ServerDefinition extends HTTP::Servers::StandardServerDefinition { }
+
+  /**
+   * A standard way to create a Fastify server.
+   */
+  class StandardServerDefinition extends ServerDefinition {
+    StandardServerDefinition() {
+      this = DataFlow::moduleImport("fastify").getAnInvocation().asExpr()
+    }
+  }
+
+  /**
+   * A function used as a Fastify route handler.
+   *
+   * By default, only handlers installed by an Fastify route setup are recognized,
+   * but support for other kinds of route handlers can be added by implementing
+   * additional subclasses of this class.
+   */
+  abstract class RouteHandler extends HTTP::Servers::StandardRouteHandler, DataFlow::ValueNode {
+    /**
+     * Gets the parameter of the route handler that contains the request object.
+     */
+    abstract SimpleParameter getRequestParameter();
+
+    /**
+     * Gets the parameter of the route handler that contains the reply object.
+     */
+    abstract SimpleParameter getReplyParameter();
+  }
+
+  /**
+   * A Fastify route handler installed by a route setup.
+   */
+  class StandardRouteHandler extends RouteHandler, DataFlow::FunctionNode {
+    StandardRouteHandler() { this = any(RouteSetup setup).getARouteHandler() }
+
+    override SimpleParameter getRequestParameter() { result = this.getParameter(0).getParameter() }
+
+    override SimpleParameter getReplyParameter() { result = this.getParameter(1).getParameter() }
+  }
+
+  /**
+   * A Fastify reply source, that is, the `reply` parameter of a
+   * route handler.
+   */
+  private class ReplySource extends HTTP::Servers::ResponseSource {
+    RouteHandler rh;
+
+    ReplySource() { this = DataFlow::parameterNode(rh.getReplyParameter()) }
+
+    /**
+     * Gets the route handler that provides this response.
+     */
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
+  /**
+   * A Fastify request source, that is, the request parameter of a
+   * route handler.
+   */
+  private class RequestSource extends HTTP::Servers::RequestSource {
+    RouteHandler rh;
+
+    RequestSource() { this = DataFlow::parameterNode(rh.getRequestParameter()) }
+
+    /**
+     * Gets the route handler that handles this request.
+     */
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
+  /**
+   * A call to a Fastify method that sets up a route.
+   */
+  class RouteSetup extends MethodCallExpr, HTTP::Servers::StandardRouteSetup {
+    ServerDefinition server;
+    string methodName;
+
+    RouteSetup() {
+      this.getMethodName() = methodName and
+      methodName = ["route", "get", "head", "post", "put", "delete", "options", "patch"] and
+      server.flowsTo(this.getReceiver())
+    }
+
+    override DataFlow::SourceNode getARouteHandler() {
+      result = getARouteHandler(DataFlow::TypeBackTracker::end())
+    }
+
+    private DataFlow::SourceNode getARouteHandler(DataFlow::TypeBackTracker t) {
+      t.start() and
+      result = this.getARouteHandlerExpr().getALocalSource()
+      or
+      exists(DataFlow::TypeBackTracker t2 | result = this.getARouteHandler(t2).backtrack(t2, t))
+    }
+
+    override Expr getServer() { result = server }
+
+    /** Gets an argument that represents a route handler being registered. */
+    private DataFlow::Node getARouteHandlerExpr() {
+      if methodName = "route"
+      then
+        result =
+          this
+              .flow()
+              .(DataFlow::MethodCallNode)
+              .getOptionArgument(0,
+                ["onRequest", "preParsing", "preValidation", "preHandler", "preSerialization",
+                    "onSend", "onResponse", "handler"])
+      else result = getLastArgument().flow()
+    }
+  }
+
+  /**
+   * An access to a user-controlled Fastify request input.
+   */
+  private class RequestInputAccess extends HTTP::RequestInputAccess {
+    RouteHandler rh;
+    string kind;
+
+    RequestInputAccess() {
+      exists(string name | this.(DataFlow::PropRead).accesses(rh.getARequestExpr().flow(), name) |
+        kind = "parameter" and
+        name = ["params", "query"]
+        or
+        kind = "body" and
+        name = "body"
+      )
+    }
+
+    override RouteHandler getRouteHandler() { result = rh }
+
+    override string getKind() { result = kind }
+  }
+
+  /**
+   * An access to a header on a Fastify request.
+   */
+  private class RequestHeaderAccess extends HTTP::RequestHeaderAccess {
+    RouteHandler rh;
+
+    RequestHeaderAccess() {
+      exists(DataFlow::PropRead headers |
+        headers.accesses(rh.getARequestExpr().flow(), "headers") and
+        this = headers.getAPropertyRead()
+      )
+    }
+
+    override string getAHeaderName() {
+      result = this.(DataFlow::PropRead).getPropertyName().toLowerCase()
+    }
+
+    override RouteHandler getRouteHandler() { result = rh }
+
+    override string getKind() { result = "header" }
+  }
+
+  /**
+   * An argument passed to the `send` or `end` method of an HTTP response object.
+   */
+  private class ResponseSendArgument extends HTTP::ResponseSendArgument {
+    RouteHandler rh;
+
+    ResponseSendArgument() {
+      exists(MethodCallExpr mce |
+        mce.calls(rh.getAResponseExpr(), "send") and
+        this = mce.getArgument(0)
+      )
+      or
+      exists(Function f |
+        f = rh.(DataFlow::FunctionNode).getFunction() and
+        f.isAsync() and
+        f.getAReturnedExpr() = this
+      )
+    }
+
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
+  /**
+   * An invocation of the `redirect` method of an HTTP response object.
+   */
+  private class RedirectInvocation extends HTTP::RedirectInvocation, MethodCallExpr {
+    RouteHandler rh;
+
+    RedirectInvocation() { this.calls(rh.getAResponseExpr(), "redirect") }
+
+    override Expr getUrlArgument() { result = this.getLastArgument() }
+
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
+  /**
+   * An invocation that sets a single header of the HTTP response.
+   */
+  private class SetOneHeader extends HTTP::Servers::StandardHeaderDefinition {
+    RouteHandler rh;
+
+    SetOneHeader() {
+      astNode.calls(rh.getAResponseExpr(), "header") and
+      astNode.getNumArgument() = 2
+    }
+
+    override RouteHandler getRouteHandler() { result = rh }
+  }
+
+  /**
+   * An invocation that sets any number of headers of the HTTP response.
+   */
+  class SetMultipleHeaders extends HTTP::ExplicitHeaderDefinition, DataFlow::MethodCallNode {
+    RouteHandler rh;
+
+    SetMultipleHeaders() {
+      this.calls(rh.getAResponseExpr().flow(), "headers") and
+      this.getNumArgument() = 1
+    }
+
+    /**
+     * Gets a reference to the multiple headers object that is to be set.
+     */
+    private DataFlow::SourceNode getAHeaderSource() { result.flowsTo(this.getArgument(0)) }
+
+    override predicate definesExplicitly(string headerName, Expr headerValue) {
+      exists(string header |
+        getAHeaderSource().hasPropertyWrite(header, headerValue.flow()) and
+        headerName = header.toLowerCase()
+      )
+    }
+
+    override RouteHandler getRouteHandler() { result = rh }
+
+    override Expr getNameExpr() {
+      exists(DataFlow::PropWrite write |
+        this.getAHeaderSource().flowsTo(write.getBase()) and
+        result = write.getPropertyNameExpr()
+      )
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/HttpFrameworks.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HttpFrameworks.qll
@@ -4,3 +4,4 @@ import semmle.javascript.frameworks.Koa
 import semmle.javascript.frameworks.NodeJSLib
 import semmle.javascript.frameworks.Restify
 import semmle.javascript.frameworks.Connect
+import semmle.javascript.frameworks.Fastify

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderAccess.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_HeaderAccess(HTTP::RequestHeaderAccess access, string res) {
+  res = access.getAHeaderName()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_HeaderDefinition(HTTP::HeaderDefinition hd, Fastify::RouteHandler rh) {
+  rh = hd.getRouteHandler()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_defines.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_defines.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_HeaderDefinition_defines(HTTP::HeaderDefinition hd, string name, string value) {
+  hd.defines(name, value) and hd.getRouteHandler() instanceof Fastify::RouteHandler
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_getAHeaderName.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/HeaderDefinition_getAHeaderName.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_HeaderDefinition_getAHeaderName(HTTP::HeaderDefinition hd, string res) {
+  hd.getRouteHandler() instanceof Fastify::RouteHandler and res = hd.getAHeaderName()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RedirectInvocation.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RedirectInvocation.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_RedirectInvocation(HTTP::RedirectInvocation invk, Fastify::RouteHandler rh) {
+  invk.getRouteHandler() = rh
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
@@ -1,0 +1,7 @@
+import javascript
+
+query predicate test_RequestInputAccess(
+  HTTP::RequestInputAccess ria, string res, Fastify::RouteHandler rh
+) {
+  ria.getRouteHandler() = rh and res = ria.getKind()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RequestInputAccess.qll
@@ -1,7 +1,11 @@
 import javascript
 
 query predicate test_RequestInputAccess(
-  HTTP::RequestInputAccess ria, string res, Fastify::RouteHandler rh
+  HTTP::RequestInputAccess ria, string res, Fastify::RouteHandler rh, boolean isUserControlledObject
 ) {
-  ria.getRouteHandler() = rh and res = ria.getKind()
+  ria.getRouteHandler() = rh and
+  res = ria.getKind() and
+  if ria.isUserControlledObject()
+  then isUserControlledObject = true
+  else isUserControlledObject = false
 }

--- a/javascript/ql/test/library-tests/frameworks/fastify/ResponseSendArgument.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/ResponseSendArgument.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_ResponseSendArgument(HTTP::ResponseSendArgument arg, Fastify::RouteHandler rh) {
+  arg.getRouteHandler() = rh
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler.qll
@@ -1,0 +1,3 @@
+import javascript
+
+query predicate test_RouteHandler(Fastify::RouteHandler rh, Expr res) { res = rh.getServer() }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getARequestExpr.qll
@@ -1,0 +1,5 @@
+import semmle.javascript.frameworks.Express
+
+query predicate test_RouteHandler_getARequestExpr(Fastify::RouteHandler rh, HTTP::RequestExpr res) {
+  res = rh.getARequestExpr()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getAResponseHeader.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteHandler_getAResponseHeader.qll
@@ -1,0 +1,7 @@
+import semmle.javascript.frameworks.Express
+
+query predicate test_RouteHandler_getAResponseHeader(
+  Fastify::RouteHandler rh, string name, HTTP::HeaderDefinition res
+) {
+  res = rh.getAResponseHeader(name)
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup.qll
@@ -1,0 +1,3 @@
+import javascript
+
+query predicate test_RouteSetup(Fastify::RouteSetup rs) { any() }

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getARouteHandler.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getARouteHandler.qll
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate test_RouteSetup_getARouteHandler(Fastify::RouteSetup r, DataFlow::SourceNode res) {
+  res = r.getARouteHandler()
+}

--- a/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getServer.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/RouteSetup_getServer.qll
@@ -1,0 +1,3 @@
+import javascript
+
+query predicate test_RouteSetup_getServer(Fastify::RouteSetup rs, Expr res) { res = rs.getServer() }

--- a/javascript/ql/test/library-tests/frameworks/fastify/ServerDefinition.qll
+++ b/javascript/ql/test/library-tests/frameworks/fastify/ServerDefinition.qll
@@ -1,0 +1,3 @@
+import javascript
+
+query predicate test_ServerDefinition(Fastify::ServerDefinition s) { any() }

--- a/javascript/ql/test/library-tests/frameworks/fastify/src/fastify.js
+++ b/javascript/ql/test/library-tests/frameworks/fastify/src/fastify.js
@@ -1,0 +1,48 @@
+var fastify = require("fastify")();
+
+fastify.get(
+  "/",
+  /* handler */ async (request, reply) => {
+    return { hello: "world" }; // response
+  }
+);
+
+fastify.route({
+  method: "GET",
+  url: "/",
+  onRequest: /* handler */ (request, reply, done) => {},
+  preParsing: /* handler */ (request, reply, done) => {},
+  preValidation: /* handler */ (request, reply, done) => {},
+  preHandler: /* handler */ (request, reply, done) => {},
+  preSerialization: /* handler */ (request, reply, payload, done) => {},
+  onSend: /* handler */ (request, reply, payload, done) => {},
+  onResponse: /* handler */ (request, reply, done) => {},
+  handler: /* handler */ (request, reply) => {}
+});
+
+fastify.get(
+  "/",
+  opts,
+  /* handler */ (request, reply) => {
+    reply.send({ hello: "world" }); // response
+  }
+);
+
+fastify.post(
+  "/:params",
+  options,
+  /* handler */ function(request, reply) {
+    // request properties
+    request.query.name; // the parsed querystring
+    request.body; // the body
+    request.params.name; // the params matching the URL
+    request.headers.name; // the headers
+
+    // reply properties
+    reply.header("name", "value"); // Sets a response header.
+    reply.headers({ name: "value" }); // Sets all the keys of the object as a response headers.
+    reply.redirect(code, url); // Redirect to the specified url, the status code is optional (default to 302).
+    reply.send(payload); // Sends the payload to the user, could be a plain text, a buffer, JSON, stream
+  }
+);
+fastify.listen(3000);

--- a/javascript/ql/test/library-tests/frameworks/fastify/src/fastify.js
+++ b/javascript/ql/test/library-tests/frameworks/fastify/src/fastify.js
@@ -46,3 +46,47 @@ fastify.post(
   }
 );
 fastify.listen(3000);
+
+var fastifyWithObjects1 = require("fastify")();
+fastifyWithObjects1.register(require("fastify-xml-body-parser"));
+fastifyWithObjects1.post(
+  "/:params",
+  /* handler */ function(request, reply) {
+    request.query;
+    request.body;
+    request.params;
+  }
+);
+
+var fastifyWithObjects2 = require("fastify")();
+fastifyWithObjects2.register(require("fastify-formbody"));
+fastifyWithObjects2.post(
+  "/:params",
+  /* handler */ function(request, reply) {
+    request.query;
+    request.body;
+    request.params;
+  }
+);
+
+var fastifyWithObjects3 = require("fastify")();
+fastifyWithObjects3.register(require("fastify-qs"));
+fastifyWithObjects3.post(
+  "/:params",
+  /* handler */ function(request, reply) {
+    request.query;
+    request.body;
+    request.params;
+  }
+);
+
+var fastifyWithObjects4 = require("fastify")();
+fastifyWithObjects4.use(require("body-parser").urlencoded({ extended: true }));
+fastifyWithObjects4.post(
+  "/:params",
+  /* handler */ function(request, reply) {
+    request.query;
+    request.body;
+    request.params;
+  }
+);

--- a/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
@@ -3,11 +3,27 @@ test_RouteSetup
 | src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) |
 | src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) |
 | src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) |
+| src/fastify.js:52:1:59:1 | fastify ... ;\\n  }\\n) |
+| src/fastify.js:63:1:70:1 | fastify ... ;\\n  }\\n) |
+| src/fastify.js:74:1:81:1 | fastify ... ;\\n  }\\n) |
+| src/fastify.js:85:1:92:1 | fastify ... ;\\n  }\\n) |
 test_RequestInputAccess
-| src/fastify.js:36:5:36:17 | request.query | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
-| src/fastify.js:37:5:37:16 | request.body | body | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
-| src/fastify.js:38:5:38:18 | request.params | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
-| src/fastify.js:39:5:39:24 | request.headers.name | header | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:36:5:36:17 | request.query | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | false |
+| src/fastify.js:37:5:37:16 | request.body | body | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | false |
+| src/fastify.js:38:5:38:18 | request.params | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | false |
+| src/fastify.js:39:5:39:24 | request.headers.name | header | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | false |
+| src/fastify.js:55:5:55:17 | request.query | parameter | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:56:5:56:16 | request.body | body | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | true |
+| src/fastify.js:57:5:57:18 | request.params | parameter | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:66:5:66:17 | request.query | parameter | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:67:5:67:16 | request.body | body | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | true |
+| src/fastify.js:68:5:68:18 | request.params | parameter | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:77:5:77:17 | request.query | parameter | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | true |
+| src/fastify.js:78:5:78:16 | request.body | body | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:79:5:79:18 | request.params | parameter | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | true |
+| src/fastify.js:88:5:88:17 | request.query | parameter | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | false |
+| src/fastify.js:89:5:89:16 | request.body | body | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | true |
+| src/fastify.js:90:5:90:18 | request.params | parameter | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | false |
 test_RouteHandler_getAResponseHeader
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | name | src/fastify.js:42:5:42:33 | reply.h ... value") |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | name | src/fastify.js:43:5:43:36 | reply.h ... lue" }) |
@@ -22,11 +38,19 @@ test_RouteSetup_getServer
 | src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:1:15:1:34 | require("fastify")() |
 | src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) | src/fastify.js:1:15:1:34 | require("fastify")() |
 | src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:52:1:59:1 | fastify ... ;\\n  }\\n) | src/fastify.js:50:27:50:46 | require("fastify")() |
+| src/fastify.js:63:1:70:1 | fastify ... ;\\n  }\\n) | src/fastify.js:61:27:61:46 | require("fastify")() |
+| src/fastify.js:74:1:81:1 | fastify ... ;\\n  }\\n) | src/fastify.js:72:27:72:46 | require("fastify")() |
+| src/fastify.js:85:1:92:1 | fastify ... ;\\n  }\\n) | src/fastify.js:83:27:83:46 | require("fastify")() |
 test_HeaderDefinition_getAHeaderName
 | src/fastify.js:42:5:42:33 | reply.h ... value") | name |
 | src/fastify.js:43:5:43:36 | reply.h ... lue" }) | name |
 test_ServerDefinition
 | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:50:27:50:46 | require("fastify")() |
+| src/fastify.js:61:27:61:46 | require("fastify")() |
+| src/fastify.js:72:27:72:46 | require("fastify")() |
+| src/fastify.js:83:27:83:46 | require("fastify")() |
 test_HeaderAccess
 | src/fastify.js:39:5:39:24 | request.headers.name | name |
 test_RouteSetup_getARouteHandler
@@ -41,6 +65,10 @@ test_RouteSetup_getARouteHandler
 | src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:20:26:20:47 | (reques ... ) => {} |
 | src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } |
 | src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:52:1:59:1 | fastify ... ;\\n  }\\n) | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } |
+| src/fastify.js:63:1:70:1 | fastify ... ;\\n  }\\n) | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } |
+| src/fastify.js:74:1:81:1 | fastify ... ;\\n  }\\n) | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } |
+| src/fastify.js:85:1:92:1 | fastify ... ;\\n  }\\n) | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } |
 test_RouteHandler
 | src/fastify.js:5:17:7:3 | async ( ... nse\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
 | src/fastify.js:13:28:13:55 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
@@ -53,11 +81,27 @@ test_RouteHandler
 | src/fastify.js:20:26:20:47 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
 | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:50:27:50:46 | require("fastify")() |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:61:27:61:46 | require("fastify")() |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:72:27:72:46 | require("fastify")() |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:83:27:83:46 | require("fastify")() |
 test_RouteHandler_getARequestExpr
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:36:5:36:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:37:5:37:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:38:5:38:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:39:5:39:11 | request |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:55:5:55:11 | request |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:56:5:56:11 | request |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:57:5:57:11 | request |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:66:5:66:11 | request |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:67:5:67:11 | request |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:68:5:68:11 | request |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:77:5:77:11 | request |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:78:5:78:11 | request |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:79:5:79:11 | request |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:88:5:88:11 | request |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:89:5:89:11 | request |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:90:5:90:11 | request |
 test_ResponseSendArgument
 | src/fastify.js:6:12:6:29 | { hello: "world" } | src/fastify.js:5:17:7:3 | async ( ... nse\\n  } |
 | src/fastify.js:27:16:27:33 | { hello: "world" } | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } |

--- a/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
@@ -1,0 +1,66 @@
+test_RouteSetup
+| src/fastify.js:3:1:8:1 | fastify ... e\\n  }\\n) |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) |
+| src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) |
+| src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) |
+test_RequestInputAccess
+| src/fastify.js:36:5:36:17 | request.query | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:37:5:37:16 | request.body | body | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:38:5:38:18 | request.params | parameter | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:39:5:39:24 | request.headers.name | header | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+test_RouteHandler_getAResponseHeader
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | name | src/fastify.js:42:5:42:33 | reply.h ... value") |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | name | src/fastify.js:43:5:43:36 | reply.h ... lue" }) |
+test_HeaderDefinition_defines
+| src/fastify.js:42:5:42:33 | reply.h ... value") | name | value |
+| src/fastify.js:43:5:43:36 | reply.h ... lue" }) | name | value |
+test_HeaderDefinition
+| src/fastify.js:42:5:42:33 | reply.h ... value") | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+| src/fastify.js:43:5:43:36 | reply.h ... lue" }) | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+test_RouteSetup_getServer
+| src/fastify.js:3:1:8:1 | fastify ... e\\n  }\\n) | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) | src/fastify.js:1:15:1:34 | require("fastify")() |
+test_HeaderDefinition_getAHeaderName
+| src/fastify.js:42:5:42:33 | reply.h ... value") | name |
+| src/fastify.js:43:5:43:36 | reply.h ... lue" }) | name |
+test_ServerDefinition
+| src/fastify.js:1:15:1:34 | require("fastify")() |
+test_HeaderAccess
+| src/fastify.js:39:5:39:24 | request.headers.name | name |
+test_RouteSetup_getARouteHandler
+| src/fastify.js:3:1:8:1 | fastify ... e\\n  }\\n) | src/fastify.js:5:17:7:3 | async ( ... nse\\n  } |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:13:28:13:55 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:14:29:14:56 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:15:32:15:59 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:16:29:16:56 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:17:35:17:71 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:18:25:18:61 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:19:29:19:56 | (reques ... ) => {} |
+| src/fastify.js:10:1:21:2 | fastify ... > {}\\n}) | src/fastify.js:20:26:20:47 | (reques ... ) => {} |
+| src/fastify.js:23:1:29:1 | fastify ... e\\n  }\\n) | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } |
+| src/fastify.js:31:1:47:1 | fastify ... m\\n  }\\n) | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+test_RouteHandler
+| src/fastify.js:5:17:7:3 | async ( ... nse\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:13:28:13:55 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:14:29:14:56 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:15:32:15:59 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:16:29:16:56 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:17:35:17:71 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:18:25:18:61 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:19:29:19:56 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:20:26:20:47 | (reques ... ) => {} | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:26:17:28:3 | (reques ... nse\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:1:15:1:34 | require("fastify")() |
+test_RouteHandler_getARequestExpr
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:36:5:36:11 | request |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:37:5:37:11 | request |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:38:5:38:11 | request |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:39:5:39:11 | request |
+test_ResponseSendArgument
+| src/fastify.js:6:12:6:29 | { hello: "world" } | src/fastify.js:5:17:7:3 | async ( ... nse\\n  } |
+| src/fastify.js:27:16:27:33 | { hello: "world" } | src/fastify.js:26:17:28:3 | (reques ... nse\\n  } |
+| src/fastify.js:45:16:45:22 | payload | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |
+test_RedirectInvocation
+| src/fastify.js:44:5:44:29 | reply.r ... e, url) | src/fastify.js:34:17:46:3 | functio ... eam\\n  } |

--- a/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/fastify/tests.expected
@@ -86,19 +86,34 @@ test_RouteHandler
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:72:27:72:46 | require("fastify")() |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:83:27:83:46 | require("fastify")() |
 test_RouteHandler_getARequestExpr
+| src/fastify.js:5:17:7:3 | async ( ... nse\\n  } | src/fastify.js:5:24:5:30 | request |
+| src/fastify.js:13:28:13:55 | (reques ... ) => {} | src/fastify.js:13:29:13:35 | request |
+| src/fastify.js:14:29:14:56 | (reques ... ) => {} | src/fastify.js:14:30:14:36 | request |
+| src/fastify.js:15:32:15:59 | (reques ... ) => {} | src/fastify.js:15:33:15:39 | request |
+| src/fastify.js:16:29:16:56 | (reques ... ) => {} | src/fastify.js:16:30:16:36 | request |
+| src/fastify.js:17:35:17:71 | (reques ... ) => {} | src/fastify.js:17:36:17:42 | request |
+| src/fastify.js:18:25:18:61 | (reques ... ) => {} | src/fastify.js:18:26:18:32 | request |
+| src/fastify.js:19:29:19:56 | (reques ... ) => {} | src/fastify.js:19:30:19:36 | request |
+| src/fastify.js:20:26:20:47 | (reques ... ) => {} | src/fastify.js:20:27:20:33 | request |
+| src/fastify.js:26:17:28:3 | (reques ... nse\\n  } | src/fastify.js:26:18:26:24 | request |
+| src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:34:26:34:32 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:36:5:36:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:37:5:37:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:38:5:38:11 | request |
 | src/fastify.js:34:17:46:3 | functio ... eam\\n  } | src/fastify.js:39:5:39:11 | request |
+| src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:54:26:54:32 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:55:5:55:11 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:56:5:56:11 | request |
 | src/fastify.js:54:17:58:3 | functio ... ms;\\n  } | src/fastify.js:57:5:57:11 | request |
+| src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:65:26:65:32 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:66:5:66:11 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:67:5:67:11 | request |
 | src/fastify.js:65:17:69:3 | functio ... ms;\\n  } | src/fastify.js:68:5:68:11 | request |
+| src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:76:26:76:32 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:77:5:77:11 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:78:5:78:11 | request |
 | src/fastify.js:76:17:80:3 | functio ... ms;\\n  } | src/fastify.js:79:5:79:11 | request |
+| src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:87:26:87:32 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:88:5:88:11 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:89:5:89:11 | request |
 | src/fastify.js:87:17:91:3 | functio ... ms;\\n  } | src/fastify.js:90:5:90:11 | request |

--- a/javascript/ql/test/library-tests/frameworks/fastify/tests.ql
+++ b/javascript/ql/test/library-tests/frameworks/fastify/tests.ql
@@ -1,0 +1,14 @@
+import RouteSetup
+import RequestInputAccess
+import RouteHandler_getAResponseHeader
+import HeaderDefinition_defines
+import HeaderDefinition
+import RouteSetup_getServer
+import HeaderDefinition_getAHeaderName
+import ServerDefinition
+import HeaderAccess
+import RouteSetup_getARouteHandler
+import RouteHandler
+import RouteHandler_getARequestExpr
+import ResponseSendArgument
+import RedirectInvocation


### PR DESCRIPTION
Yet another minimal security-related model of a HTTP server implementation. The implementation is mostly boiler-plate for this kind of model. It would be nice if the already extensive HTTP.qll could recude the boiler-plate even more, but that can be done in a separate PR.

I am evaluating this on a collection of fastify dependents.

Addresses <https://github.com/github/codeql/issues/3435>.