### PR TITLE
C#: Fix CFG for C# 6 initializers

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -501,7 +501,7 @@ module ControlFlow {
       private class WriteAccessNoNodeExpr extends WriteAccess, NoNodeExpr {
         WriteAccessNoNodeExpr() {
           // For example a write to a static field, `Foo.Bar = 0`.
-          forall(Expr e | e = this.(QualifiableExpr).getQualifier() | e instanceof NoNodeExpr)
+          forall(Expr e | e = this.getAChildExpr() | e instanceof NoNodeExpr)
         }
       }
 
@@ -553,7 +553,17 @@ module ControlFlow {
        * not evaluated, only the qualifier and the indexer arguments (if any).
        */
       private class QualifiedWriteAccess extends WriteAccess, QualifiableExpr {
-        QualifiedWriteAccess() { this.hasQualifier() }
+        QualifiedWriteAccess() {
+          this.hasQualifier()
+          or
+          // Member initializers like
+          // ```
+          // new Dictionary<int, string>() { [0] = "Zero", [1] = "One", [2] = "Two" }
+          // ```
+          // need special treatment, because the the accesses `[0]`, `[1]`, and `[2]`
+          // have no qualifier.
+          this = any(MemberInitializer mi).getLValue()
+        }
       }
 
       /** A normal or a (potential) dynamic call to an accessor. */

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -400,14 +400,15 @@
 | Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | exit M6 | 1 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | 1 |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:39:11:39:11 | ; | 4 |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | exit Initializers | 14 |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | exit Initializers | 14 |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:10:10:10:10 | exit M | 20 |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:16:16:20 | ... = ... | 2 |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:18:11:18:23 | exit NoConstructor | 8 |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:9:29:11 | exit Sub | 11 |
-| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 8 |
-| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 18 |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | exit Initializers | 14 |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | exit M | 20 |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | 2 |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | exit NoConstructor | 8 |
+| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 11 |
+| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 8 |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 18 |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 69 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:9:13:9:28 | ... == ... | 7 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 | 1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -408,7 +408,7 @@
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | exit Sub | 11 |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | exit Sub | 8 |
 | Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | exit Sub | 18 |
-| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 69 |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | exit Test | 104 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:9:13:9:28 | ... == ... | 7 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 | 1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1774,69 +1774,104 @@ dominance
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; |
-| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:53:54:53 | 0 |
 | Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... |
 | Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... |
-| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:67:54:67 | 1 |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:58:54:63 | "Zero" |
 | Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer |
 | Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... |
-| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:80:54:80 | access to parameter i |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:72:54:76 | "One" |
 | Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer |
 | Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... |
 | Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:84:54:84 | 2 |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... |
 | Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound |
 | Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test |
-| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 |
 | Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... |
-| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 |
 | Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... |
 | Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... |
-| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:48:59:48 | 1 |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:39:59:44 | "Zero" |
 | Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer |
 | Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... |
-| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:61:59:61 | access to parameter i |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:53:59:57 | "One" |
 | Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer |
 | Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... |
 | Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:65:59:65 | 2 |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:61:59:65 | ... + ... |
 | Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer |
 | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... |
-| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:29:61:29 | 0 |
 | Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty |
 | Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... |
-| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:52:60:52 | 2 |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:42:60:48 | "Three" |
 | Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer |
 | Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... |
-| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:65:60:65 | access to parameter i |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:57:60:61 | "Two" |
 | Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer |
 | Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... |
 | Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:69:60:69 | 1 |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:65:60:69 | ... + ... |
 | Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer |
-| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:30:62:30 | 0 |
 | Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... |
-| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:43:61:43 | access to parameter i |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:34:61:39 | "Zero" |
 | Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... |
 | Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:47:61:47 | 1 |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:43:61:47 | ... + ... |
 | Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... |
-| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:32:63:32 | 1 |
 | Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... |
-| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:44:62:44 | 1 |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:33:62:33 | 1 |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:38:62:40 | "i" |
 | Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... |
 | Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:47:62:47 | access to parameter i |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:51:62:51 | 0 |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:47:62:51 | ... + ... |
 | Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... |
 | Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... |
-| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:33:64:33 | 0 |
 | Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty |
-| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:45:63:45 | access to parameter i |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:37:63:41 | "One" |
 | Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... |
 | Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:49:63:49 | 2 |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:45:63:49 | ... + ... |
 | Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... |
 | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... |
 | Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } |
 | Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 |
-| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:47:64:47 | 1 |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:36:64:36 | 1 |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:41:64:43 | "i" |
 | Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... |
 | Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:50:64:50 | access to parameter i |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:54:64:54 | 0 |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... |
@@ -4758,13 +4793,18 @@ postDominance
 | Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:79:54:93 | ... = ... |
 | Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:58:54:63 | "Zero" |
 | Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:52:54:54 | access to indexer |
-| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:53:54:53 | 0 |
 | Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:72:54:76 | "One" |
 | Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:66:54:68 | access to indexer |
-| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:52:54:63 | ... = ... |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:52:54:63 | ... = ... |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:67:54:67 | 1 |
 | Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:89:54:93 | "Two" |
 | Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:79:54:85 | access to indexer |
-| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:66:54:76 | ... = ... |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:66:54:76 | ... = ... |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:84:54:84 | 2 |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:80 | access to parameter i |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:80:54:84 | ... + ... |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... |
 | Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:58:9:65:9 | { ..., ... } |
 | Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:57:9:65:10 | ... ...; |
@@ -4773,51 +4813,81 @@ postDominance
 | Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:60:59:74 | ... = ... |
 | Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:39:59:44 | "Zero" |
 | Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:33:59:35 | access to indexer |
-| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:34:59:34 | 0 |
 | Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:53:59:57 | "One" |
 | Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:47:59:49 | access to indexer |
-| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:33:59:44 | ... = ... |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:33:59:44 | ... = ... |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:48:59:48 | 1 |
 | Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:70:59:74 | "Two" |
 | Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:60:59:66 | access to indexer |
-| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:47:59:57 | ... = ... |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:47:59:57 | ... = ... |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:65:59:65 | 2 |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:61:59:61 | access to parameter i |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:61:59:65 | ... + ... |
 | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:34:60:80 | { ..., ... } |
 | Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:13:60:30 | access to property DictionaryProperty |
 | Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:64:60:78 | ... = ... |
 | Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:42:60:48 | "Three" |
 | Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:36:60:38 | access to indexer |
-| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:59:13:59:76 | ... = ... |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:59:13:59:76 | ... = ... |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:37:60:37 | 3 |
 | Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:57:60:61 | "Two" |
 | Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:51:60:53 | access to indexer |
-| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:36:60:48 | ... = ... |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:36:60:48 | ... = ... |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:52:60:52 | 2 |
 | Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:74:60:78 | "One" |
 | Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:64:60:70 | access to indexer |
-| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:51:60:61 | ... = ... |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:51:60:61 | ... = ... |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:69:60:69 | 1 |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:65:60:65 | access to parameter i |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:65:60:69 | ... + ... |
 | Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } |
 | Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:42:61:56 | ... = ... |
 | Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
-| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:60:13:60:80 | ... = ... |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:60:13:60:80 | ... = ... |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:29:61:29 | 0 |
 | Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
-| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:28:61:39 | ... = ... |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:28:61:39 | ... = ... |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:47:61:47 | 1 |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:43:61:43 | access to parameter i |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:43:61:47 | ... + ... |
 | Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } |
 | Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:43:62:58 | ... = ... |
 | Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
-| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:61:13:61:58 | ... = ... |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:61:13:61:58 | ... = ... |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:30:62:30 | 0 |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:33:62:33 | 1 |
 | Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
-| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:29:62:40 | ... = ... |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:29:62:40 | ... = ... |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:44:62:44 | 1 |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:51:62:51 | 0 |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:47:62:47 | access to parameter i |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:47:62:51 | ... + ... |
 | Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:29:63:60 | { ..., ... } |
 | Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:13:63:25 | access to property ArrayProperty |
 | Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:44:63:58 | ... = ... |
 | Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
-| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:62:13:62:60 | ... = ... |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:62:13:62:60 | ... = ... |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:32:63:32 | 1 |
 | Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
-| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:31:63:41 | ... = ... |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:31:63:41 | ... = ... |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:49:63:49 | 2 |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:45:63:45 | access to parameter i |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:45:63:49 | ... + ... |
 | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:30:64:63 | { ..., ... } |
 | Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 |
 | Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:46:64:61 | ... = ... |
 | Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
-| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:63:13:63:60 | ... = ... |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:63:13:63:60 | ... = ... |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:33:64:33 | 0 |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:36:64:36 | 1 |
 | Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
-| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:32:64:43 | ... = ... |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:32:64:43 | ... = ... |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:47:64:47 | 1 |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:54:64:54 | 0 |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:50 | access to parameter i |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:50:64:54 | ... + ... |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:7:10:7:11 | enter M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1683,93 +1683,161 @@ dominance
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:33:38:33 | Int32 y |
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:18:38:34 | (..., ...) |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:17:3:17 | 1 |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:17:3:17 | 1 |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:9:3:17 | ... = ... |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:9:3:17 | ... = ... |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:17 | ... + ... |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:17 | ... + ... |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:25:4:31 | ... = ... |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:25:4:31 | ... = ... |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:6:20:6:22 | {...} |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:8:28:8:30 | {...} |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:31:4:31 | 2 |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:31:4:31 | 2 |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:9:4:9 | access to property G |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:9:4:9 | access to property G |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:31 | ... + ... |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:31 | ... + ... |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:6:5:6:16 | exit Initializers |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:8:5:8:16 | exit Initializers |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:11:5:14:5 | {...} |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:12:9:12:54 | ... ...; |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:12:34:12:35 | "" |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:13:9:13:64 | ... ...; |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:12:44:12:44 | 0 |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:12:17:12:53 | object creation of type Initializers |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:12:13:12:53 | Initializers i = ... |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:12:51:12:51 | 1 |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:12:40:12:44 | ... = ... |
-| Initializers.cs:12:47:12:47 | access to property G | Initializers.cs:12:47:12:51 | ... = ... |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:12:38:12:53 | { ..., ... } |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:12:47:12:47 | access to property G |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:13:18:13:63 | array creation of type Initializers[] |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:10:10:10:10 | exit M |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:13:39:13:39 | access to local variable i |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:13:13:13:63 | Initializers[] iz = ... |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:13:59:13:60 | "" |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:13:37:13:63 | { ..., ... } |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:13:42:13:61 | object creation of type Initializers |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:16:16:20 | ... = ... |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:27:20:27 | 0 |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:27:20:27 | 0 |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:27 | ... = ... |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:27 | ... = ... |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:27:21:27 | 1 |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:27:21:27 | 1 |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:18:11:18:23 | exit NoConstructor |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:27 | ... = ... |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:27 | ... = ... |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:17:26:17 | 2 |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:17:26:17 | 2 |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:29:24:29:33 | {...} |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:33:27:33:40 | {...} |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:17 | ... = ... |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:17 | ... = ... |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:17:29:20 | call to constructor NoConstructor |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:29:26:29:31 | ...; |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:30:29:30 | 3 |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:9:29:11 | exit Sub |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:26:29:26 | this access |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:26:29:30 | ... = ... |
-| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:22:31:25 | call to constructor Sub |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:29:31:38 | {...} |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:31:31:36 | ...; |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:35:31:35 | access to parameter i |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:31:31:31 | this access |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:31:31:35 | ... = ... |
-| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:33:29:33:38 | ...; |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:33:33:33 | access to parameter i |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:29:33:29 | this access |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:37:33:37 | access to parameter j |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:29:33:37 | ... = ... |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:33:33:37 | ... + ... |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:8:20:8:22 | {...} |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:10:28:10:30 | {...} |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:44:14:44 | 0 |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:17:14:53 | object creation of type Initializers |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:13:14:53 | Initializers i = ... |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:51:14:51 | 1 |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:40:14:44 | ... = ... |
+| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:14:47:14:51 | ... = ... |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:24:31:33 | {...} |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:35:27:35:40 | {...} |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |
+| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... |
+| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer |
+| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... |
+| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... |
+| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args |
@@ -4595,93 +4663,161 @@ postDominance
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:37:5:40:5 | {...} |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:38:18:38:34 | (..., ...) |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:6:5:6:16 | enter Initializers |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:8:5:8:16 | enter Initializers |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:3:13:3:17 | ... + ... |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:3:13:3:17 | ... + ... |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:17:3:17 | 1 |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:17:3:17 | 1 |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:27:4:31 | ... + ... |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:27:4:31 | ... + ... |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:3:9:3:17 | ... = ... |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:3:9:3:17 | ... = ... |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:4:9:4:9 | access to property G |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:4:9:4:9 | access to property G |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:31:4:31 | 2 |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:31:4:31 | 2 |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:6:5:6:16 | exit Initializers | Initializers.cs:6:20:6:22 | {...} |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:4:25:4:31 | ... = ... |
-| Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:28:8:30 | {...} |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:4:25:4:31 | ... = ... |
-| Initializers.cs:10:10:10:10 | exit M | Initializers.cs:13:13:13:63 | Initializers[] iz = ... |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:10:10:10:10 | enter M |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:11:5:14:5 | {...} |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:12:38:12:53 | { ..., ... } |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:12:34:12:35 | "" |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:12:9:12:54 | ... ...; |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:12:47:12:51 | ... = ... |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:12:44:12:44 | 0 |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:12:17:12:53 | object creation of type Initializers |
-| Initializers.cs:12:47:12:47 | access to property G | Initializers.cs:12:51:12:51 | 1 |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:12:47:12:47 | access to property G |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:12:40:12:44 | ... = ... |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:12:13:12:53 | Initializers i = ... |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:13:37:13:63 | { ..., ... } |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:13:9:13:64 | ... ...; |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:13:42:13:61 | object creation of type Initializers |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:13:18:13:63 | array creation of type Initializers[] |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:13:59:13:60 | "" |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:13:39:13:39 | access to local variable i |
-| Initializers.cs:16:16:16:20 | ... = ... | Initializers.cs:16:20:16:20 | 1 |
-| Initializers.cs:18:11:18:23 | exit NoConstructor | Initializers.cs:21:23:21:27 | ... = ... |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:18:11:18:23 | enter NoConstructor |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:33:9:33:11 | enter Sub |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:20:27:20:27 | 0 |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:20:27:20:27 | 0 |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:20:23:20:27 | ... = ... |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:20:23:20:27 | ... = ... |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:21:27:21:27 | 1 |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:21:27:21:27 | 1 |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:21:23:21:27 | ... = ... |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:29:17:29:20 | call to constructor NoConstructor |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:26:17:26:17 | 2 |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:26:17:26:17 | 2 |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:29:9:29:11 | exit Sub | Initializers.cs:29:26:29:30 | ... = ... |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:29:9:29:11 | enter Sub |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:26:13:26:17 | ... = ... |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:26:29:31 | ...; |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:30:29:30 | 3 |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:24:29:33 | {...} |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:26:29:26 | this access |
-| Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:31:31:35 | ... = ... |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:9:31:11 | enter Sub |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:22:31:25 | call to constructor Sub |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:31:31:36 | ...; |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:35:31:35 | access to parameter i |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:29:31:38 | {...} |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:31:31:31 | this access |
-| Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:29:33:37 | ... = ... |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:26:13:26:17 | ... = ... |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:29:33:38 | ...; |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:33:33:37 | ... + ... |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:27:33:40 | {...} |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:29:33:29 | this access |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:37:33:37 | access to parameter j |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:33:33:33 | access to parameter i |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:8:5:8:16 | enter Initializers |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:10:5:10:16 | enter Initializers |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:13:5:17 | ... + ... |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:13:5:17 | ... + ... |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:17:5:17 | 1 |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:17:5:17 | 1 |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:27:6:31 | ... + ... |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:27:6:31 | ... + ... |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:5:9:5:17 | ... = ... |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:5:9:5:17 | ... = ... |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:6:9:6:9 | access to property G |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:6:9:6:9 | access to property G |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:20:8:22 | {...} |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
+| Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:28:10:30 | {...} |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:6:25:6:31 | ... = ... |
+| Initializers.cs:12:10:12:10 | exit M | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:12:10:12:10 | enter M |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:13:5:16:5 | {...} |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:14:38:14:53 | { ..., ... } |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:34:14:35 | "" |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:9:14:54 | ... ...; |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:47:14:51 | ... = ... |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:44:14:44 | 0 |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:17:14:53 | object creation of type Initializers |
+| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:14:51:14:51 | 1 |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:47:14:47 | access to property G |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:40:14:44 | ... = ... |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:14:13:14:53 | Initializers i = ... |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:15:37:15:63 | { ..., ... } |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:9:15:64 | ... ...; |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:42:15:61 | object creation of type Initializers |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:59:15:60 | "" |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:39:15:39 | access to local variable i |
+| Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:23:23:23:27 | ... = ... |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | enter NoConstructor |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | enter Sub |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:27:22:27 | 0 |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:27:22:27 | 0 |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:22:23:22:27 | ... = ... |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:22:23:22:27 | ... = ... |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:27:23:27 | 1 |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:27:23:27 | 1 |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:23:23:23:27 | ... = ... |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:17:28:17 | 2 |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:17:28:17 | 2 |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:26:31:30 | ... = ... |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:9:31:11 | enter Sub |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:28:13:28:17 | ... = ... |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:26:31:31 | ...; |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:30:31:30 | 3 |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:24:31:33 | {...} |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:26 | this access |
+| Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:31:33:35 | ... = ... |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:9:33:11 | enter Sub |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:22:33:25 | call to constructor Sub |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:31:33:36 | ...; |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:35:33:35 | access to parameter i |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:29:33:38 | {...} |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:29:35:37 | ... = ... |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:28:13:28:17 | ... = ... |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:38 | ...; |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:33:35:37 | ... + ... |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:27:35:40 | {...} |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:29:35:29 | this access |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:37:35:37 | access to parameter j |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:33 | access to parameter i |
+| Initializers.cs:51:10:51:13 | exit Test | Initializers.cs:57:13:65:9 | Compound compound = ... |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:51:10:51:13 | enter Test |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:52:5:66:5 | {...} |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:50:54:95 | { ..., ... } |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:9:54:96 | ... ...; |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:79:54:93 | ... = ... |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:52:54:54 | access to indexer |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:66:54:68 | access to indexer |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:52:54:63 | ... = ... |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:79:54:85 | access to indexer |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:66:54:76 | ... = ... |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:58:9:65:9 | { ..., ... } |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:57:9:65:10 | ... ...; |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:64:13:64:63 | ... = ... |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:60:59:74 | ... = ... |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:33:59:35 | access to indexer |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:47:59:49 | access to indexer |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:33:59:44 | ... = ... |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:60:59:66 | access to indexer |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:47:59:57 | ... = ... |
+| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:34:60:80 | { ..., ... } |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:13:60:30 | access to property DictionaryProperty |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:64:60:78 | ... = ... |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:36:60:38 | access to indexer |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:59:13:59:76 | ... = ... |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:51:60:53 | access to indexer |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:36:60:48 | ... = ... |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:64:60:70 | access to indexer |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:51:60:61 | ... = ... |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:42:61:56 | ... = ... |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:60:13:60:80 | ... = ... |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:28:61:39 | ... = ... |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:43:62:58 | ... = ... |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:61:13:61:58 | ... = ... |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:29:62:40 | ... = ... |
+| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:29:63:60 | { ..., ... } |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:13:63:25 | access to property ArrayProperty |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:44:63:58 | ... = ... |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:62:13:62:60 | ... = ... |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:31:63:41 | ... = ... |
+| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:30:64:63 | { ..., ... } |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:46:64:61 | ... = ... |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:63:13:63:60 | ... = ... |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:32:64:43 | ... = ... |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:7:10:7:11 | enter M1 |
@@ -7044,14 +7180,15 @@ blockDominance
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:26:38:26 | String x |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | enter Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | enter Initializers |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:10:10:10:10 | enter M |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:20:16:20 | 1 |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:18:11:18:23 | enter NoConstructor |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:9:29:11 | enter Sub |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | enter Initializers |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | enter M |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | enter NoConstructor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | enter Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | enter Sub |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | enter Sub |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | enter Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
@@ -8857,14 +8994,15 @@ postBlockDominance
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:26:38:26 | String x |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | enter Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | enter Initializers |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:10:10:10:10 | enter M |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:20:16:20 | 1 |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:18:11:18:23 | enter NoConstructor |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:9:29:11 | enter Sub |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | enter Initializers |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | enter M |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | enter NoConstructor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | enter Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | enter Sub |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | enter Sub |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | enter Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -1813,99 +1813,168 @@ nodeEnclosing
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:36:10:36:11 | M6 |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:6:5:6:16 | exit Initializers | Initializers.cs:6:5:6:16 | Initializers |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:6:5:6:16 | Initializers |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:10:5:10:16 | Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | Initializers |
 | Initializers.cs:8:5:8:16 | exit Initializers | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:10:10:10:10 | exit M | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:47:12:47 | access to property G | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:18:11:18:23 | exit NoConstructor | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:9:29:11 | exit Sub | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:9:29:11 | Sub |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:9:29:11 | Sub |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | Initializers |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:10:5:10:16 | exit Initializers | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:12:10:12:10 | exit M | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:20:11:20:23 | exit NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:20:11:20:23 | NoConstructor |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:35:9:35:11 | Sub |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:31:9:31:11 | exit Sub | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:9:31:11 | Sub |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:9:31:11 | Sub |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | Sub |
 | Initializers.cs:33:9:33:11 | exit Sub | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:9:33:11 | Sub |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:9:35:11 | exit Sub | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:51:10:51:13 | exit Test | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:51:10:51:13 | Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:7:10:7:11 | M1 |
@@ -3598,13 +3667,14 @@ blockEnclosing
 | Foreach.cs:36:10:36:11 | exit M6 | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | M6 |
 | Foreach.cs:38:26:38:26 | String x | Foreach.cs:36:10:36:11 | M6 |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:6:5:6:16 | Initializers |
 | Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | Initializers |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:10:10:10:10 | M |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:18:11:18:23 | NoConstructor |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:9:29:11 | Sub |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | Initializers |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:12:10:12:10 | M |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | NoConstructor |
 | Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:9:31:11 | Sub |
 | Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:9:33:11 | Sub |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | Sub |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:51:10:51:13 | Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -1915,12 +1915,17 @@ nodeEnclosing
 | Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:72:54:76 | "One" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | Test |
@@ -1930,50 +1935,80 @@ nodeEnclosing
 | Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:53:59:57 | "One" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:60:74:60:78 | "One" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:61:52:61:56 | "One" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:38:62:40 | "i" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:62:56:62:58 | "1" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:37:63:41 | "One" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:41:64:43 | "i" | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:51:10:51:13 | Test |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:51:10:51:13 | Test |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:51:10:51:13 | Test |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1226,74 +1226,164 @@
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:33:38:33 | Int32 y |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:39:38:42 | access to parameter args |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:39:11:39:11 | ; |
-| Initializers.cs:3:9:3:9 | access to field F | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:13:3:13 | access to field H |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:17:3:17 | 1 |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:4:9:4:9 | this access |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:27:4:27 | access to field H |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:31:4:31 | 2 |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:6:20:6:22 | {...} |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:8:28:8:30 | {...} |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:11:5:14:5 | {...} |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:12:9:12:54 | ... ...; |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:12:34:12:35 | "" |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:12:34:12:35 | "" |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:12:34:12:35 | "" |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:12:44:12:44 | 0 |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:12:44:12:44 | 0 |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:12:44:12:44 | 0 |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:12:51:12:51 | 1 |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:12:51:12:51 | 1 |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:13:9:13:64 | ... ...; |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:13:18:13:63 | array creation of type Initializers[] |
-| Initializers.cs:13:18:13:63 | 2 | Initializers.cs:13:18:13:63 | 2 |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:13:18:13:63 | array creation of type Initializers[] |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:13:39:13:39 | access to local variable i |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:13:39:13:39 | access to local variable i |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:13:59:13:60 | "" |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:13:59:13:60 | "" |
-| Initializers.cs:16:16:16:20 | ... = ... | Initializers.cs:16:20:16:20 | 1 |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:20:16:20 | 1 |
-| Initializers.cs:20:23:20:23 | access to field F | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:27:20:27 | 0 |
-| Initializers.cs:21:23:21:23 | access to field G | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:21:23:21:23 | this access |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:27:21:27 | 1 |
-| Initializers.cs:26:13:26:13 | access to field H | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:26:13:26:13 | this access |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:17:26:17 | 2 |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:29:17:29:20 | call to constructor NoConstructor |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:29:24:29:33 | {...} |
-| Initializers.cs:29:26:29:26 | access to field I | Initializers.cs:29:26:29:26 | this access |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:26:29:26 | this access |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:26:29:26 | this access |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:26:29:31 | ...; |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:30:29:30 | 3 |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:22:31:25 | call to constructor Sub |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:29:31:38 | {...} |
-| Initializers.cs:31:31:31:31 | access to field I | Initializers.cs:31:31:31:31 | this access |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:31:31:31 | this access |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:31:31:31 | this access |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:31:31:36 | ...; |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:35:31:35 | access to parameter i |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:33:27:33:40 | {...} |
-| Initializers.cs:33:29:33:29 | access to field I | Initializers.cs:33:29:33:29 | this access |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:29:33:29 | this access |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:29:33:29 | this access |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:29:33:38 | ...; |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:33:33:33 | access to parameter i |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:33:33:33 | access to parameter i |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:37:33:37 | access to parameter j |
+| Initializers.cs:5:9:5:9 | access to field F | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:13:5:13 | access to field H |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:17:5:17 | 1 |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:6:9:6:9 | this access |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:27:6:27 | access to field H |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:31:6:31 | 2 |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:20:8:22 | {...} |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:28:10:30 | {...} |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:13:5:16:5 | {...} |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:9:14:54 | ... ...; |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:14:34:14:35 | "" |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:34:14:35 | "" |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:34:14:35 | "" |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:44:14:44 | 0 |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:44:14:44 | 0 |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:44:14:44 | 0 |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:51:14:51 | 1 |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:51:14:51 | 1 |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:9:15:64 | ... ...; |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |
+| Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | 2 |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:39:15:39 | access to local variable i |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:39:15:39 | access to local variable i |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:59:15:60 | "" |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:59:15:60 | "" |
+| Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 |
+| Initializers.cs:22:23:22:23 | access to field F | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:27:22:27 | 0 |
+| Initializers.cs:23:23:23:23 | access to field G | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:27:23:27 | 1 |
+| Initializers.cs:28:13:28:13 | access to field H | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:13:28:13 | this access |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:17:28:17 | 2 |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:24:31:33 | {...} |
+| Initializers.cs:31:26:31:26 | access to field I | Initializers.cs:31:26:31:26 | this access |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:26:31:26 | this access |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:26:31:26 | this access |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:31 | ...; |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:30:31:30 | 3 |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:29:33:38 | {...} |
+| Initializers.cs:33:31:33:31 | access to field I | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:31:33:31 | this access |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:36 | ...; |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:35:33:35 | access to parameter i |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:27:35:40 | {...} |
+| Initializers.cs:35:29:35:29 | access to field I | Initializers.cs:35:29:35:29 | this access |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:29 | this access |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:29:35:29 | this access |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:38 | ...; |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:33:35:33 | access to parameter i |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:33:35:33 | access to parameter i |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:37:35:37 | access to parameter j |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:52:5:66:5 | {...} |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:9:54:96 | ... ...; |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:53:54:53 | 0 |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:67:54:67 | 1 |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:80:54:80 | access to parameter i |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:80:54:80 | access to parameter i |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:84:54:84 | 2 |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:9:65:10 | ... ...; |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:57:24:65:9 | object creation of type Compound |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:34:59:34 | 0 |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:48:59:48 | 1 |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:61:59:61 | access to parameter i |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:61:59:61 | access to parameter i |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:65:59:65 | 2 |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:37:60:37 | 3 |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:52:60:52 | 2 |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:65:60:65 | access to parameter i |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:65:60:65 | access to parameter i |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:69:60:69 | 1 |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:29:61:29 | 0 |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:43:61:43 | access to parameter i |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:43:61:43 | access to parameter i |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:47:61:47 | 1 |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:30:62:30 | 0 |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:33:62:33 | 1 |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:44:62:44 | 1 |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:47:62:47 | access to parameter i |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:47:62:47 | access to parameter i |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:51:62:51 | 0 |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:32:63:32 | 1 |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:45:63:45 | access to parameter i |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:45:63:45 | access to parameter i |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:49:63:49 | 2 |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:33:64:33 | 0 |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:36:64:36 | 1 |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:47:64:47 | 1 |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:50:64:50 | access to parameter i |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:50:64:50 | access to parameter i |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:54:64:54 | 0 |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:59:64:61 | "1" |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:9:10:19 | if (...) ... |
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:16 | access to parameter args |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1298,14 +1298,17 @@
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:9:54:96 | ... ...; |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
 | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |
-| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:58:54:63 | "Zero" |
-| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:58:54:63 | "Zero" |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:53:54:53 | 0 |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:53:54:53 | 0 |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:53:54:53 | 0 |
 | Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:53:54:53 | 0 |
 | Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:58:54:63 | "Zero" |
-| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:72:54:76 | "One" |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:67:54:67 | 1 |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:67:54:67 | 1 |
 | Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:67:54:67 | 1 |
 | Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:72:54:76 | "One" |
-| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:89:54:93 | "Two" |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:80:54:80 | access to parameter i |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:80:54:80 | access to parameter i |
 | Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:80:54:80 | access to parameter i |
 | Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:80:54:80 | access to parameter i |
 | Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:84:54:84 | 2 |
@@ -1313,72 +1316,86 @@
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:9:65:10 | ... ...; |
 | Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:57:24:65:9 | object creation of type Compound |
 | Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:57:24:65:9 | object creation of type Compound |
-| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:59:39:59:44 | "Zero" |
-| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:39:59:44 | "Zero" |
-| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:39:59:44 | "Zero" |
-| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:39:59:44 | "Zero" |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:59:34:59:34 | 0 |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:34:59:34 | 0 |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:34:59:34 | 0 |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:34:59:34 | 0 |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:34:59:34 | 0 |
 | Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:34:59:34 | 0 |
 | Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:39:59:44 | "Zero" |
-| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:53:59:57 | "One" |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:48:59:48 | 1 |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:48:59:48 | 1 |
 | Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:48:59:48 | 1 |
 | Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:53:59:57 | "One" |
-| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:70:59:74 | "Two" |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:61:59:61 | access to parameter i |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:61:59:61 | access to parameter i |
 | Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:61:59:61 | access to parameter i |
 | Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:61:59:61 | access to parameter i |
 | Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:65:59:65 | 2 |
 | Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:70:59:74 | "Two" |
-| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
-| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:42:60:48 | "Three" |
-| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:42:60:48 | "Three" |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:37:60:37 | 3 |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:37:60:37 | 3 |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:37:60:37 | 3 |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:37:60:37 | 3 |
 | Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:37:60:37 | 3 |
 | Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:42:60:48 | "Three" |
-| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:57:60:61 | "Two" |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:52:60:52 | 2 |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:52:60:52 | 2 |
 | Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:52:60:52 | 2 |
 | Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:57:60:61 | "Two" |
-| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:74:60:78 | "One" |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:65:60:65 | access to parameter i |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:65:60:65 | access to parameter i |
 | Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:65:60:65 | access to parameter i |
 | Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:65:60:65 | access to parameter i |
 | Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:69:60:69 | 1 |
 | Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:74:60:78 | "One" |
-| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
-| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:34:61:39 | "Zero" |
-| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:29:61:29 | 0 |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:29:61:29 | 0 |
+| Initializers.cs:61:28:61:30 | access to array element | Initializers.cs:61:29:61:29 | 0 |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:29:61:29 | 0 |
 | Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:29:61:29 | 0 |
 | Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:34:61:39 | "Zero" |
-| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:52:61:56 | "One" |
+| Initializers.cs:61:42:61:48 | access to array element | Initializers.cs:61:43:61:43 | access to parameter i |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:43:61:43 | access to parameter i |
 | Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:43:61:43 | access to parameter i |
 | Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:43:61:43 | access to parameter i |
 | Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:47:61:47 | 1 |
 | Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:52:61:56 | "One" |
-| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
-| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:38:62:40 | "i" |
-| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:38:62:40 | "i" |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:30:62:30 | 0 |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:30:62:30 | 0 |
+| Initializers.cs:62:29:62:34 | access to array element | Initializers.cs:62:30:62:30 | 0 |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:30:62:30 | 0 |
 | Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:30:62:30 | 0 |
 | Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:33:62:33 | 1 |
 | Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:38:62:40 | "i" |
-| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:56:62:58 | "1" |
+| Initializers.cs:62:43:62:52 | access to array element | Initializers.cs:62:44:62:44 | 1 |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:44:62:44 | 1 |
 | Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:44:62:44 | 1 |
 | Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:47:62:47 | access to parameter i |
 | Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:47:62:47 | access to parameter i |
 | Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:51:62:51 | 0 |
 | Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:56:62:58 | "1" |
-| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
-| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:37:63:41 | "One" |
-| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:37:63:41 | "One" |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:32:63:32 | 1 |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:32:63:32 | 1 |
+| Initializers.cs:63:31:63:33 | access to array element | Initializers.cs:63:32:63:32 | 1 |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:32:63:32 | 1 |
 | Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:32:63:32 | 1 |
 | Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:37:63:41 | "One" |
-| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:54:63:58 | "Two" |
+| Initializers.cs:63:44:63:50 | access to array element | Initializers.cs:63:45:63:45 | access to parameter i |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:45:63:45 | access to parameter i |
 | Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:45:63:45 | access to parameter i |
 | Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:45:63:45 | access to parameter i |
 | Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:49:63:49 | 2 |
 | Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:54:63:58 | "Two" |
-| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
-| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:41:64:43 | "i" |
-| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:41:64:43 | "i" |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:33:64:33 | 0 |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:33:64:33 | 0 |
+| Initializers.cs:64:32:64:37 | access to array element | Initializers.cs:64:33:64:33 | 0 |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:33:64:33 | 0 |
 | Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:33:64:33 | 0 |
 | Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:36:64:36 | 1 |
 | Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:41:64:43 | "i" |
-| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:59:64:61 | "1" |
+| Initializers.cs:64:46:64:55 | access to array element | Initializers.cs:64:47:64:47 | 1 |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:47:64:47 | 1 |
 | Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:47:64:47 | 1 |
 | Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:50:64:50 | access to parameter i |
 | Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:50:64:50 | access to parameter i |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1793,12 +1793,15 @@
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | normal |
 | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:50:54:95 | { ..., ... } | normal |
 | Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:50:54:95 | { ..., ... } | normal |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:53:54:53 | 0 | normal |
 | Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:52:54:63 | ... = ... | normal |
 | Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:53:54:53 | 0 | normal |
 | Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:58:54:63 | "Zero" | normal |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:67:54:67 | 1 | normal |
 | Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:66:54:76 | ... = ... | normal |
 | Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:67:54:67 | 1 | normal |
 | Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:72:54:76 | "One" | normal |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:80:54:84 | ... + ... | normal |
 | Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:79:54:93 | ... = ... | normal |
 | Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:80:54:80 | access to parameter i | normal |
 | Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:80:54:84 | ... + ... | normal |
@@ -1810,12 +1813,15 @@
 | Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:58:9:65:9 | { ..., ... } | normal |
 | Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:13:59:76 | ... = ... | normal |
 | Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:31:59:76 | { ..., ... } | normal |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:34:59:34 | 0 | normal |
 | Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:33:59:44 | ... = ... | normal |
 | Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:34:59:34 | 0 | normal |
 | Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:39:59:44 | "Zero" | normal |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:48:59:48 | 1 | normal |
 | Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:47:59:57 | ... = ... | normal |
 | Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:48:59:48 | 1 | normal |
 | Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:53:59:57 | "One" | normal |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:61:59:65 | ... + ... | normal |
 | Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:60:59:74 | ... = ... | normal |
 | Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:61:59:61 | access to parameter i | normal |
 | Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:61:59:65 | ... + ... | normal |
@@ -1823,12 +1829,15 @@
 | Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:70:59:74 | "Two" | normal |
 | Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:13:60:80 | ... = ... | normal |
 | Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:34:60:80 | { ..., ... } | normal |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:37:60:37 | 3 | normal |
 | Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:36:60:48 | ... = ... | normal |
 | Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:37:60:37 | 3 | normal |
 | Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:42:60:48 | "Three" | normal |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:52:60:52 | 2 | normal |
 | Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:51:60:61 | ... = ... | normal |
 | Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:52:60:52 | 2 | normal |
 | Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:57:60:61 | "Two" | normal |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:65:60:69 | ... + ... | normal |
 | Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:64:60:78 | ... = ... | normal |
 | Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:65:60:65 | access to parameter i | normal |
 | Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:65:60:69 | ... + ... | normal |
@@ -1836,9 +1845,11 @@
 | Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:74:60:78 | "One" | normal |
 | Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:13:61:58 | ... = ... | normal |
 | Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:26:61:58 | { ..., ... } | normal |
+| Initializers.cs:61:28:61:30 | access to array element | Initializers.cs:61:29:61:29 | 0 | normal |
 | Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:28:61:39 | ... = ... | normal |
 | Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:29:61:29 | 0 | normal |
 | Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:34:61:39 | "Zero" | normal |
+| Initializers.cs:61:42:61:48 | access to array element | Initializers.cs:61:43:61:47 | ... + ... | normal |
 | Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:42:61:56 | ... = ... | normal |
 | Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:43:61:43 | access to parameter i | normal |
 | Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:43:61:47 | ... + ... | normal |
@@ -1846,10 +1857,12 @@
 | Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:52:61:56 | "One" | normal |
 | Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:13:62:60 | ... = ... | normal |
 | Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:27:62:60 | { ..., ... } | normal |
+| Initializers.cs:62:29:62:34 | access to array element | Initializers.cs:62:33:62:33 | 1 | normal |
 | Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:29:62:40 | ... = ... | normal |
 | Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:30:62:30 | 0 | normal |
 | Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:33:62:33 | 1 | normal |
 | Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:38:62:40 | "i" | normal |
+| Initializers.cs:62:43:62:52 | access to array element | Initializers.cs:62:47:62:51 | ... + ... | normal |
 | Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:43:62:58 | ... = ... | normal |
 | Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:44:62:44 | 1 | normal |
 | Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:47:62:47 | access to parameter i | normal |
@@ -1858,9 +1871,11 @@
 | Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:56:62:58 | "1" | normal |
 | Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:13:63:60 | ... = ... | normal |
 | Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:29:63:60 | { ..., ... } | normal |
+| Initializers.cs:63:31:63:33 | access to array element | Initializers.cs:63:32:63:32 | 1 | normal |
 | Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:31:63:41 | ... = ... | normal |
 | Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:32:63:32 | 1 | normal |
 | Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:37:63:41 | "One" | normal |
+| Initializers.cs:63:44:63:50 | access to array element | Initializers.cs:63:45:63:49 | ... + ... | normal |
 | Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:44:63:58 | ... = ... | normal |
 | Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:45:63:45 | access to parameter i | normal |
 | Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:45:63:49 | ... + ... | normal |
@@ -1868,10 +1883,12 @@
 | Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:54:63:58 | "Two" | normal |
 | Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:13:64:63 | ... = ... | normal |
 | Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:30:64:63 | { ..., ... } | normal |
+| Initializers.cs:64:32:64:37 | access to array element | Initializers.cs:64:36:64:36 | 1 | normal |
 | Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:32:64:43 | ... = ... | normal |
 | Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:33:64:33 | 0 | normal |
 | Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:36:64:36 | 1 | normal |
 | Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:41:64:43 | "i" | normal |
+| Initializers.cs:64:46:64:55 | access to array element | Initializers.cs:64:50:64:54 | ... + ... | normal |
 | Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:46:64:61 | ... = ... | normal |
 | Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:47:64:47 | 1 | normal |
 | Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:50:64:50 | access to parameter i | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1720,74 +1720,164 @@
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:33:38:33 | Int32 y | normal |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:39:38:42 | access to parameter args | normal |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:39:11:39:11 | ; | normal |
-| Initializers.cs:3:9:3:9 | access to field F | Initializers.cs:3:9:3:9 | this access | normal |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:9:3:9 | this access | normal |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:3:9:3:17 | ... = ... | normal |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:13:3:13 | access to field H | normal |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:13:3:17 | ... + ... | normal |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:17:3:17 | 1 | normal |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:9:4:9 | this access | normal |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:9:4:9 | this access | normal |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:4:25:4:31 | ... = ... | normal |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:27:4:27 | access to field H | normal |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:27:4:31 | ... + ... | normal |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:31:4:31 | 2 | normal |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:6:20:6:22 | {...} | normal |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:8:28:8:30 | {...} | normal |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:13:13:13:63 | Initializers[] iz = ... | normal |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:12:13:12:53 | Initializers i = ... | normal |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:12:13:12:53 | Initializers i = ... | normal |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:12:38:12:53 | { ..., ... } | normal |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:12:34:12:35 | "" | normal |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:12:38:12:53 | { ..., ... } | normal |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:12:40:12:44 | ... = ... | normal |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:12:44:12:44 | 0 | normal |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:12:47:12:51 | ... = ... | normal |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:12:51:12:51 | 1 | normal |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:13:13:13:63 | Initializers[] iz = ... | normal |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:13:13:13:63 | Initializers[] iz = ... | normal |
-| Initializers.cs:13:18:13:63 | 2 | Initializers.cs:13:18:13:63 | 2 | normal |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:13:37:13:63 | { ..., ... } | normal |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:13:37:13:63 | { ..., ... } | normal |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:13:39:13:39 | access to local variable i | normal |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:13:42:13:61 | object creation of type Initializers | normal |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:13:59:13:60 | "" | normal |
-| Initializers.cs:16:16:16:20 | ... = ... | Initializers.cs:16:16:16:20 | ... = ... | normal |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:20:16:20 | 1 | normal |
-| Initializers.cs:20:23:20:23 | access to field F | Initializers.cs:20:23:20:23 | this access | normal |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:23:20:23 | this access | normal |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:20:23:20:27 | ... = ... | normal |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:27:20:27 | 0 | normal |
-| Initializers.cs:21:23:21:23 | access to field G | Initializers.cs:21:23:21:23 | this access | normal |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:23:21:23 | this access | normal |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:21:23:21:27 | ... = ... | normal |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:27:21:27 | 1 | normal |
-| Initializers.cs:26:13:26:13 | access to field H | Initializers.cs:26:13:26:13 | this access | normal |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:13:26:13 | this access | normal |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:26:13:26:17 | ... = ... | normal |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:17:26:17 | 2 | normal |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:29:17:29:20 | call to constructor NoConstructor | normal |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:29:26:29:30 | ... = ... | normal |
-| Initializers.cs:29:26:29:26 | access to field I | Initializers.cs:29:26:29:26 | this access | normal |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:26:29:26 | this access | normal |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:26:29:30 | ... = ... | normal |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:26:29:30 | ... = ... | normal |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:30:29:30 | 3 | normal |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:22:31:25 | call to constructor Sub | normal |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:31:31:35 | ... = ... | normal |
-| Initializers.cs:31:31:31:31 | access to field I | Initializers.cs:31:31:31:31 | this access | normal |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:31:31:31 | this access | normal |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:31:31:35 | ... = ... | normal |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:31:31:35 | ... = ... | normal |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:35:31:35 | access to parameter i | normal |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:33:29:33:37 | ... = ... | normal |
-| Initializers.cs:33:29:33:29 | access to field I | Initializers.cs:33:29:33:29 | this access | normal |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:29:33:29 | this access | normal |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:29:33:37 | ... = ... | normal |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:29:33:37 | ... = ... | normal |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:33:33:33 | access to parameter i | normal |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:33:33:37 | ... + ... | normal |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:37:33:37 | access to parameter j | normal |
+| Initializers.cs:5:9:5:9 | access to field F | Initializers.cs:5:9:5:9 | this access | normal |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:9:5:9 | this access | normal |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:5:9:5:17 | ... = ... | normal |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:13:5:13 | access to field H | normal |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:13:5:17 | ... + ... | normal |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:17:5:17 | 1 | normal |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:9:6:9 | this access | normal |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:9:6:9 | this access | normal |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:6:25:6:31 | ... = ... | normal |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:27:6:27 | access to field H | normal |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:27:6:31 | ... + ... | normal |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:31:6:31 | 2 | normal |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:20:8:22 | {...} | normal |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:28:10:30 | {...} | normal |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | normal |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:13:14:53 | Initializers i = ... | normal |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:14:13:14:53 | Initializers i = ... | normal |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:38:14:53 | { ..., ... } | normal |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:34:14:35 | "" | normal |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:38:14:53 | { ..., ... } | normal |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:40:14:44 | ... = ... | normal |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:44:14:44 | 0 | normal |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:47:14:51 | ... = ... | normal |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:51:14:51 | 1 | normal |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | normal |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | normal |
+| Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | 2 | normal |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:37:15:63 | { ..., ... } | normal |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:37:15:63 | { ..., ... } | normal |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:39:15:39 | access to local variable i | normal |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:42:15:61 | object creation of type Initializers | normal |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:59:15:60 | "" | normal |
+| Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:16:18:20 | ... = ... | normal |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:20:18:20 | 1 | normal |
+| Initializers.cs:22:23:22:23 | access to field F | Initializers.cs:22:23:22:23 | this access | normal |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:23:22:23 | this access | normal |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:22:23:22:27 | ... = ... | normal |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:27:22:27 | 0 | normal |
+| Initializers.cs:23:23:23:23 | access to field G | Initializers.cs:23:23:23:23 | this access | normal |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:23:23:23 | this access | normal |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:23:23:23:27 | ... = ... | normal |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:27:23:27 | 1 | normal |
+| Initializers.cs:28:13:28:13 | access to field H | Initializers.cs:28:13:28:13 | this access | normal |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:13:28:13 | this access | normal |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:28:13:28:17 | ... = ... | normal |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:17:28:17 | 2 | normal |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | normal |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:30 | ... = ... | normal |
+| Initializers.cs:31:26:31:26 | access to field I | Initializers.cs:31:26:31:26 | this access | normal |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:26:31:26 | this access | normal |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:26:31:30 | ... = ... | normal |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:30 | ... = ... | normal |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:30:31:30 | 3 | normal |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:22:33:25 | call to constructor Sub | normal |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:35 | ... = ... | normal |
+| Initializers.cs:33:31:33:31 | access to field I | Initializers.cs:33:31:33:31 | this access | normal |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:31:33:31 | this access | normal |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:31:33:35 | ... = ... | normal |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:35 | ... = ... | normal |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:35:33:35 | access to parameter i | normal |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:37 | ... = ... | normal |
+| Initializers.cs:35:29:35:29 | access to field I | Initializers.cs:35:29:35:29 | this access | normal |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:29:35:29 | this access | normal |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:29:35:37 | ... = ... | normal |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:37 | ... = ... | normal |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:33:35:33 | access to parameter i | normal |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:33:35:37 | ... + ... | normal |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:37:35:37 | access to parameter j | normal |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:57:13:65:9 | Compound compound = ... | normal |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | normal |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | normal |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:50:54:95 | { ..., ... } | normal |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:50:54:95 | { ..., ... } | normal |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:52:54:63 | ... = ... | normal |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:53:54:53 | 0 | normal |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:58:54:63 | "Zero" | normal |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:66:54:76 | ... = ... | normal |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:67:54:67 | 1 | normal |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:72:54:76 | "One" | normal |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:79:54:93 | ... = ... | normal |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:80:54:80 | access to parameter i | normal |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:80:54:84 | ... + ... | normal |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:84:54:84 | 2 | normal |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:89:54:93 | "Two" | normal |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:13:65:9 | Compound compound = ... | normal |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:57:13:65:9 | Compound compound = ... | normal |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:58:9:65:9 | { ..., ... } | normal |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:58:9:65:9 | { ..., ... } | normal |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:59:13:59:76 | ... = ... | normal |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:31:59:76 | { ..., ... } | normal |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:33:59:44 | ... = ... | normal |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:34:59:34 | 0 | normal |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:39:59:44 | "Zero" | normal |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:47:59:57 | ... = ... | normal |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:48:59:48 | 1 | normal |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:53:59:57 | "One" | normal |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:60:59:74 | ... = ... | normal |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:61:59:61 | access to parameter i | normal |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:61:59:65 | ... + ... | normal |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:65:59:65 | 2 | normal |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:70:59:74 | "Two" | normal |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:60:13:60:80 | ... = ... | normal |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:34:60:80 | { ..., ... } | normal |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:36:60:48 | ... = ... | normal |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:37:60:37 | 3 | normal |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:42:60:48 | "Three" | normal |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:51:60:61 | ... = ... | normal |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:52:60:52 | 2 | normal |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:57:60:61 | "Two" | normal |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:64:60:78 | ... = ... | normal |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:65:60:65 | access to parameter i | normal |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:65:60:69 | ... + ... | normal |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:69:60:69 | 1 | normal |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:74:60:78 | "One" | normal |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:61:13:61:58 | ... = ... | normal |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:26:61:58 | { ..., ... } | normal |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:28:61:39 | ... = ... | normal |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:29:61:29 | 0 | normal |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:34:61:39 | "Zero" | normal |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:42:61:56 | ... = ... | normal |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:43:61:43 | access to parameter i | normal |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:43:61:47 | ... + ... | normal |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:47:61:47 | 1 | normal |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:52:61:56 | "One" | normal |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:62:13:62:60 | ... = ... | normal |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:27:62:60 | { ..., ... } | normal |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:29:62:40 | ... = ... | normal |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:30:62:30 | 0 | normal |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:33:62:33 | 1 | normal |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:38:62:40 | "i" | normal |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:43:62:58 | ... = ... | normal |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:44:62:44 | 1 | normal |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:47:62:47 | access to parameter i | normal |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:47:62:51 | ... + ... | normal |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:51:62:51 | 0 | normal |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:56:62:58 | "1" | normal |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:63:13:63:60 | ... = ... | normal |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:29:63:60 | { ..., ... } | normal |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:31:63:41 | ... = ... | normal |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:32:63:32 | 1 | normal |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:37:63:41 | "One" | normal |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:44:63:58 | ... = ... | normal |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:45:63:45 | access to parameter i | normal |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:45:63:49 | ... + ... | normal |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:49:63:49 | 2 | normal |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:54:63:58 | "Two" | normal |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:64:13:64:63 | ... = ... | normal |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:30:64:63 | { ..., ... } | normal |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:32:64:43 | ... = ... | normal |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:33:64:33 | 0 | normal |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:36:64:36 | 1 | normal |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:41:64:43 | "i" | normal |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:46:64:61 | ... = ... | normal |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:47:64:47 | 1 | normal |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:50:64:50 | access to parameter i | normal |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:50:64:54 | ... + ... | normal |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:54:64:54 | 0 | normal |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:59:64:61 | "1" | normal |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:10:13:10:19 | return ...; | return |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | empty |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:28 | ... == ... | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Initializers.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Initializers.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 class Initializers
 {
     int F = H + 1;
@@ -31,5 +33,35 @@ class Initializers
         Sub(int i) : this() { I = i; }
 
         Sub(int i, int j) { I = i + j; }
+    }
+}
+
+class IndexInitializers
+{
+    class Compound
+    {
+        public Dictionary<int, string> DictionaryField;
+        public Dictionary<int, string> DictionaryProperty { get; set; }
+        public string[] ArrayField;
+        public string[] ArrayProperty { get; set; }
+        public string[,] ArrayField2;
+        public string[,] ArrayProperty2 { get; set; }
+    }
+
+    void Test(int i)
+    {
+        // Collection initializer
+        var dict = new Dictionary<int, string>() { [0] = "Zero", [1] = "One", [i + 2] = "Two" };
+
+        // Indexed initializer
+        var compound = new Compound()
+        {
+            DictionaryField = { [0] = "Zero", [1] = "One", [i + 2] = "Two" },
+            DictionaryProperty = { [3] = "Three", [2] = "Two", [i + 1] = "One" },
+            ArrayField = { [0] = "Zero", [i + 1] = "One" },
+            ArrayField2 = { [0, 1] = "i", [1, i + 0] = "1" },
+            ArrayProperty = { [1] = "One", [i + 2] = "Two" },
+            ArrayProperty2 = { [0, 1] = "i", [1, i + 0] = "1" },
+        };
     }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1892,93 +1892,161 @@
 | Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:18:38:34 | (..., ...) | semmle.label | successor |
 | Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | semmle.label | successor |
 | Foreach.cs:39:11:39:11 | ; | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | semmle.label | successor |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:13:3:13 | access to field H | semmle.label | successor |
-| Initializers.cs:3:9:3:9 | this access | Initializers.cs:3:13:3:13 | access to field H | semmle.label | successor |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:4:9:4:9 | this access | semmle.label | successor |
-| Initializers.cs:3:9:3:17 | ... = ... | Initializers.cs:4:9:4:9 | this access | semmle.label | successor |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:17:3:17 | 1 | semmle.label | successor |
-| Initializers.cs:3:13:3:13 | access to field H | Initializers.cs:3:17:3:17 | 1 | semmle.label | successor |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:9:3:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:3:13:3:17 | ... + ... | Initializers.cs:3:9:3:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:17 | ... + ... | semmle.label | successor |
-| Initializers.cs:3:17:3:17 | 1 | Initializers.cs:3:13:3:17 | ... + ... | semmle.label | successor |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:25:4:31 | ... = ... | semmle.label | successor |
-| Initializers.cs:4:9:4:9 | access to property G | Initializers.cs:4:25:4:31 | ... = ... | semmle.label | successor |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:27:4:27 | access to field H | semmle.label | successor |
-| Initializers.cs:4:9:4:9 | this access | Initializers.cs:4:27:4:27 | access to field H | semmle.label | successor |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:6:20:6:22 | {...} | semmle.label | successor |
-| Initializers.cs:4:25:4:31 | ... = ... | Initializers.cs:8:28:8:30 | {...} | semmle.label | successor |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:31:4:31 | 2 | semmle.label | successor |
-| Initializers.cs:4:27:4:27 | access to field H | Initializers.cs:4:31:4:31 | 2 | semmle.label | successor |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:9:4:9 | access to property G | semmle.label | successor |
-| Initializers.cs:4:27:4:31 | ... + ... | Initializers.cs:4:9:4:9 | access to property G | semmle.label | successor |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:31 | ... + ... | semmle.label | successor |
-| Initializers.cs:4:31:4:31 | 2 | Initializers.cs:4:27:4:31 | ... + ... | semmle.label | successor |
-| Initializers.cs:6:5:6:16 | enter Initializers | Initializers.cs:3:9:3:9 | this access | semmle.label | successor |
-| Initializers.cs:6:20:6:22 | {...} | Initializers.cs:6:5:6:16 | exit Initializers | semmle.label | successor |
-| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:3:9:3:9 | this access | semmle.label | successor |
-| Initializers.cs:8:28:8:30 | {...} | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
-| Initializers.cs:10:10:10:10 | enter M | Initializers.cs:11:5:14:5 | {...} | semmle.label | successor |
-| Initializers.cs:11:5:14:5 | {...} | Initializers.cs:12:9:12:54 | ... ...; | semmle.label | successor |
-| Initializers.cs:12:9:12:54 | ... ...; | Initializers.cs:12:34:12:35 | "" | semmle.label | successor |
-| Initializers.cs:12:13:12:53 | Initializers i = ... | Initializers.cs:13:9:13:64 | ... ...; | semmle.label | successor |
-| Initializers.cs:12:17:12:53 | object creation of type Initializers | Initializers.cs:12:44:12:44 | 0 | semmle.label | successor |
-| Initializers.cs:12:34:12:35 | "" | Initializers.cs:12:17:12:53 | object creation of type Initializers | semmle.label | successor |
-| Initializers.cs:12:38:12:53 | { ..., ... } | Initializers.cs:12:13:12:53 | Initializers i = ... | semmle.label | successor |
-| Initializers.cs:12:40:12:44 | ... = ... | Initializers.cs:12:51:12:51 | 1 | semmle.label | successor |
-| Initializers.cs:12:44:12:44 | 0 | Initializers.cs:12:40:12:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:12:47:12:47 | access to property G | Initializers.cs:12:47:12:51 | ... = ... | semmle.label | successor |
-| Initializers.cs:12:47:12:51 | ... = ... | Initializers.cs:12:38:12:53 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:12:51:12:51 | 1 | Initializers.cs:12:47:12:47 | access to property G | semmle.label | successor |
-| Initializers.cs:13:9:13:64 | ... ...; | Initializers.cs:13:18:13:63 | array creation of type Initializers[] | semmle.label | successor |
-| Initializers.cs:13:13:13:63 | Initializers[] iz = ... | Initializers.cs:10:10:10:10 | exit M | semmle.label | successor |
-| Initializers.cs:13:18:13:63 | array creation of type Initializers[] | Initializers.cs:13:39:13:39 | access to local variable i | semmle.label | successor |
-| Initializers.cs:13:37:13:63 | { ..., ... } | Initializers.cs:13:13:13:63 | Initializers[] iz = ... | semmle.label | successor |
-| Initializers.cs:13:39:13:39 | access to local variable i | Initializers.cs:13:59:13:60 | "" | semmle.label | successor |
-| Initializers.cs:13:42:13:61 | object creation of type Initializers | Initializers.cs:13:37:13:63 | { ..., ... } | semmle.label | successor |
-| Initializers.cs:13:59:13:60 | "" | Initializers.cs:13:42:13:61 | object creation of type Initializers | semmle.label | successor |
-| Initializers.cs:16:20:16:20 | 1 | Initializers.cs:16:16:16:20 | ... = ... | semmle.label | successor |
-| Initializers.cs:18:11:18:23 | enter NoConstructor | Initializers.cs:20:23:20:23 | this access | semmle.label | successor |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:27:20:27 | 0 | semmle.label | successor |
-| Initializers.cs:20:23:20:23 | this access | Initializers.cs:20:27:20:27 | 0 | semmle.label | successor |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:21:23:21:23 | this access | semmle.label | successor |
-| Initializers.cs:20:23:20:27 | ... = ... | Initializers.cs:21:23:21:23 | this access | semmle.label | successor |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:20:27:20:27 | 0 | Initializers.cs:20:23:20:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:27:21:27 | 1 | semmle.label | successor |
-| Initializers.cs:21:23:21:23 | this access | Initializers.cs:21:27:21:27 | 1 | semmle.label | successor |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:18:11:18:23 | exit NoConstructor | semmle.label | successor |
-| Initializers.cs:21:23:21:27 | ... = ... | Initializers.cs:26:13:26:13 | this access | semmle.label | successor |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:21:27:21:27 | 1 | Initializers.cs:21:23:21:27 | ... = ... | semmle.label | successor |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:17:26:17 | 2 | semmle.label | successor |
-| Initializers.cs:26:13:26:13 | this access | Initializers.cs:26:17:26:17 | 2 | semmle.label | successor |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:29:24:29:33 | {...} | semmle.label | successor |
-| Initializers.cs:26:13:26:17 | ... = ... | Initializers.cs:33:27:33:40 | {...} | semmle.label | successor |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:26:17:26:17 | 2 | Initializers.cs:26:13:26:17 | ... = ... | semmle.label | successor |
-| Initializers.cs:29:9:29:11 | enter Sub | Initializers.cs:29:17:29:20 | call to constructor NoConstructor | semmle.label | successor |
-| Initializers.cs:29:17:29:20 | call to constructor NoConstructor | Initializers.cs:26:13:26:13 | this access | semmle.label | successor |
-| Initializers.cs:29:24:29:33 | {...} | Initializers.cs:29:26:29:31 | ...; | semmle.label | successor |
-| Initializers.cs:29:26:29:26 | this access | Initializers.cs:29:30:29:30 | 3 | semmle.label | successor |
-| Initializers.cs:29:26:29:30 | ... = ... | Initializers.cs:29:9:29:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:29:26:29:31 | ...; | Initializers.cs:29:26:29:26 | this access | semmle.label | successor |
-| Initializers.cs:29:30:29:30 | 3 | Initializers.cs:29:26:29:30 | ... = ... | semmle.label | successor |
-| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:22:31:25 | call to constructor Sub | semmle.label | successor |
-| Initializers.cs:31:22:31:25 | call to constructor Sub | Initializers.cs:31:29:31:38 | {...} | semmle.label | successor |
-| Initializers.cs:31:29:31:38 | {...} | Initializers.cs:31:31:31:36 | ...; | semmle.label | successor |
-| Initializers.cs:31:31:31:31 | this access | Initializers.cs:31:35:31:35 | access to parameter i | semmle.label | successor |
-| Initializers.cs:31:31:31:35 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:31:31:31:36 | ...; | Initializers.cs:31:31:31:31 | this access | semmle.label | successor |
-| Initializers.cs:31:35:31:35 | access to parameter i | Initializers.cs:31:31:31:35 | ... = ... | semmle.label | successor |
-| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:20:23:20:23 | this access | semmle.label | successor |
-| Initializers.cs:33:27:33:40 | {...} | Initializers.cs:33:29:33:38 | ...; | semmle.label | successor |
-| Initializers.cs:33:29:33:29 | this access | Initializers.cs:33:33:33:33 | access to parameter i | semmle.label | successor |
-| Initializers.cs:33:29:33:37 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub | semmle.label | successor |
-| Initializers.cs:33:29:33:38 | ...; | Initializers.cs:33:29:33:29 | this access | semmle.label | successor |
-| Initializers.cs:33:33:33:33 | access to parameter i | Initializers.cs:33:37:33:37 | access to parameter j | semmle.label | successor |
-| Initializers.cs:33:33:33:37 | ... + ... | Initializers.cs:33:29:33:37 | ... = ... | semmle.label | successor |
-| Initializers.cs:33:37:33:37 | access to parameter j | Initializers.cs:33:33:33:37 | ... + ... | semmle.label | successor |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H | semmle.label | successor |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H | semmle.label | successor |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access | semmle.label | successor |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access | semmle.label | successor |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 | semmle.label | successor |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 | semmle.label | successor |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... | semmle.label | successor |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... | semmle.label | successor |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... | semmle.label | successor |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... | semmle.label | successor |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... | semmle.label | successor |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... | semmle.label | successor |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H | semmle.label | successor |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H | semmle.label | successor |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:8:20:8:22 | {...} | semmle.label | successor |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:10:28:10:30 | {...} | semmle.label | successor |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 | semmle.label | successor |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 | semmle.label | successor |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G | semmle.label | successor |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G | semmle.label | successor |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... | semmle.label | successor |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:5:9:5:9 | this access | semmle.label | successor |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers | semmle.label | successor |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} | semmle.label | successor |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; | semmle.label | successor |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" | semmle.label | successor |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; | semmle.label | successor |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:44:14:44 | 0 | semmle.label | successor |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:17:14:53 | object creation of type Initializers | semmle.label | successor |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:13:14:53 | Initializers i = ... | semmle.label | successor |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:51:14:51 | 1 | semmle.label | successor |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:40:14:44 | ... = ... | semmle.label | successor |
+| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:14:47:14:51 | ... = ... | semmle.label | successor |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G | semmle.label | successor |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | array creation of type Initializers[] | semmle.label | successor |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M | semmle.label | successor |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i | semmle.label | successor |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... | semmle.label | successor |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" | semmle.label | successor |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers | semmle.label | successor |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... | semmle.label | successor |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 | semmle.label | successor |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access | semmle.label | successor |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... | semmle.label | successor |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 | semmle.label | successor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | exit NoConstructor | semmle.label | successor |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... | semmle.label | successor |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 | semmle.label | successor |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:24:31:33 | {...} | semmle.label | successor |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:35:27:35:40 | {...} | semmle.label | successor |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... | semmle.label | successor |
+| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor | semmle.label | successor |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access | semmle.label | successor |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; | semmle.label | successor |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 | semmle.label | successor |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access | semmle.label | successor |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... | semmle.label | successor |
+| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub | semmle.label | successor |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} | semmle.label | successor |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; | semmle.label | successor |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i | semmle.label | successor |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access | semmle.label | successor |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... | semmle.label | successor |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:22:23:22:23 | this access | semmle.label | successor |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; | semmle.label | successor |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i | semmle.label | successor |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub | semmle.label | successor |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access | semmle.label | successor |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j | semmle.label | successor |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... | semmle.label | successor |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... | semmle.label | successor |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} | semmle.label | successor |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; | semmle.label | successor |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | semmle.label | successor |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; | semmle.label | successor |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:58:54:63 | "Zero" | semmle.label | successor |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | semmle.label | successor |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... | semmle.label | successor |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:72:54:76 | "One" | semmle.label | successor |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer | semmle.label | successor |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... | semmle.label | successor |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:89:54:93 | "Two" | semmle.label | successor |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer | semmle.label | successor |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... | semmle.label | successor |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer | semmle.label | successor |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound | semmle.label | successor |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test | semmle.label | successor |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:39:59:44 | "Zero" | semmle.label | successor |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... | semmle.label | successor |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:42:60:48 | "Three" | semmle.label | successor |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... | semmle.label | successor |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... | semmle.label | successor |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:53:59:57 | "One" | semmle.label | successor |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer | semmle.label | successor |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... | semmle.label | successor |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:70:59:74 | "Two" | semmle.label | successor |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer | semmle.label | successor |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... | semmle.label | successor |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer | semmle.label | successor |
+| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... | semmle.label | successor |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" | semmle.label | successor |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | semmle.label | successor |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... | semmle.label | successor |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:57:60:61 | "Two" | semmle.label | successor |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer | semmle.label | successor |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... | semmle.label | successor |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:74:60:78 | "One" | semmle.label | successor |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer | semmle.label | successor |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... | semmle.label | successor |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer | semmle.label | successor |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:38:62:40 | "i" | semmle.label | successor |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... | semmle.label | successor |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:52:61:56 | "One" | semmle.label | successor |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... | semmle.label | successor |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... | semmle.label | successor |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" | semmle.label | successor |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... | semmle.label | successor |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:56:62:58 | "1" | semmle.label | successor |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... | semmle.label | successor |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... | semmle.label | successor |
+| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... | semmle.label | successor |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:41:64:43 | "i" | semmle.label | successor |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty | semmle.label | successor |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:54:63:58 | "Two" | semmle.label | successor |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... | semmle.label | successor |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... | semmle.label | successor |
+| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... | semmle.label | successor |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | semmle.label | successor |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:59:64:61 | "1" | semmle.label | successor |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... | semmle.label | successor |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... | semmle.label | successor |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... | semmle.label | successor |
 | LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1983,69 +1983,104 @@
 | Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; | semmle.label | successor |
 | Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | semmle.label | successor |
 | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; | semmle.label | successor |
-| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:58:54:63 | "Zero" | semmle.label | successor |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:53:54:53 | 0 | semmle.label | successor |
 | Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | semmle.label | successor |
 | Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... | semmle.label | successor |
-| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:72:54:76 | "One" | semmle.label | successor |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:67:54:67 | 1 | semmle.label | successor |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:58:54:63 | "Zero" | semmle.label | successor |
 | Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer | semmle.label | successor |
 | Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... | semmle.label | successor |
-| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:89:54:93 | "Two" | semmle.label | successor |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:80:54:80 | access to parameter i | semmle.label | successor |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:72:54:76 | "One" | semmle.label | successor |
 | Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer | semmle.label | successor |
 | Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... | semmle.label | successor |
 | Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:84:54:84 | 2 | semmle.label | successor |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:89:54:93 | "Two" | semmle.label | successor |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... | semmle.label | successor |
 | Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer | semmle.label | successor |
 | Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound | semmle.label | successor |
 | Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test | semmle.label | successor |
-| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:39:59:44 | "Zero" | semmle.label | successor |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 | semmle.label | successor |
 | Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... | semmle.label | successor |
-| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:42:60:48 | "Three" | semmle.label | successor |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 | semmle.label | successor |
 | Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... | semmle.label | successor |
 | Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:53:59:57 | "One" | semmle.label | successor |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:48:59:48 | 1 | semmle.label | successor |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:39:59:44 | "Zero" | semmle.label | successor |
 | Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer | semmle.label | successor |
 | Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... | semmle.label | successor |
-| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:70:59:74 | "Two" | semmle.label | successor |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:61:59:61 | access to parameter i | semmle.label | successor |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:53:59:57 | "One" | semmle.label | successor |
 | Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer | semmle.label | successor |
 | Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... | semmle.label | successor |
 | Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:65:59:65 | 2 | semmle.label | successor |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:70:59:74 | "Two" | semmle.label | successor |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:61:59:65 | ... + ... | semmle.label | successor |
 | Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer | semmle.label | successor |
 | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:34:61:39 | "Zero" | semmle.label | successor |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:29:61:29 | 0 | semmle.label | successor |
 | Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty | semmle.label | successor |
 | Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:57:60:61 | "Two" | semmle.label | successor |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:52:60:52 | 2 | semmle.label | successor |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:42:60:48 | "Three" | semmle.label | successor |
 | Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer | semmle.label | successor |
 | Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... | semmle.label | successor |
-| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:74:60:78 | "One" | semmle.label | successor |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:65:60:65 | access to parameter i | semmle.label | successor |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:57:60:61 | "Two" | semmle.label | successor |
 | Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer | semmle.label | successor |
 | Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... | semmle.label | successor |
 | Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:69:60:69 | 1 | semmle.label | successor |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:74:60:78 | "One" | semmle.label | successor |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:65:60:69 | ... + ... | semmle.label | successor |
 | Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer | semmle.label | successor |
-| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:38:62:40 | "i" | semmle.label | successor |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:30:62:30 | 0 | semmle.label | successor |
 | Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... | semmle.label | successor |
-| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:52:61:56 | "One" | semmle.label | successor |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:43:61:43 | access to parameter i | semmle.label | successor |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:34:61:39 | "Zero" | semmle.label | successor |
 | Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... | semmle.label | successor |
 | Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:47:61:47 | 1 | semmle.label | successor |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:52:61:56 | "One" | semmle.label | successor |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:43:61:47 | ... + ... | semmle.label | successor |
 | Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... | semmle.label | successor |
-| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:37:63:41 | "One" | semmle.label | successor |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:32:63:32 | 1 | semmle.label | successor |
 | Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... | semmle.label | successor |
-| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:56:62:58 | "1" | semmle.label | successor |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:44:62:44 | 1 | semmle.label | successor |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:33:62:33 | 1 | semmle.label | successor |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:38:62:40 | "i" | semmle.label | successor |
 | Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... | semmle.label | successor |
 | Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:47:62:47 | access to parameter i | semmle.label | successor |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:51:62:51 | 0 | semmle.label | successor |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:56:62:58 | "1" | semmle.label | successor |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:47:62:51 | ... + ... | semmle.label | successor |
 | Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... | semmle.label | successor |
 | Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... | semmle.label | successor |
-| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:41:64:43 | "i" | semmle.label | successor |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:33:64:33 | 0 | semmle.label | successor |
 | Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty | semmle.label | successor |
-| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:54:63:58 | "Two" | semmle.label | successor |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:45:63:45 | access to parameter i | semmle.label | successor |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:37:63:41 | "One" | semmle.label | successor |
 | Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... | semmle.label | successor |
 | Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:49:63:49 | 2 | semmle.label | successor |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:54:63:58 | "Two" | semmle.label | successor |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:45:63:49 | ... + ... | semmle.label | successor |
 | Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... | semmle.label | successor |
 | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... | semmle.label | successor |
 | Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } | semmle.label | successor |
 | Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | semmle.label | successor |
-| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:59:64:61 | "1" | semmle.label | successor |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:47:64:47 | 1 | semmle.label | successor |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:36:64:36 | 1 | semmle.label | successor |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:41:64:43 | "i" | semmle.label | successor |
 | Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... | semmle.label | successor |
 | Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } | semmle.label | successor |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:50:64:50 | access to parameter i | semmle.label | successor |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:54:64:54 | 0 | semmle.label | successor |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:59:64:61 | "1" | semmle.label | successor |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... | semmle.label | successor |
 | Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... | semmle.label | successor |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -717,13 +717,14 @@ entryPoint
 | Foreach.cs:24:10:24:11 | M4 | Foreach.cs:25:5:28:5 | {...} |
 | Foreach.cs:30:10:30:11 | M5 | Foreach.cs:31:5:34:5 | {...} |
 | Foreach.cs:36:10:36:11 | M6 | Foreach.cs:37:5:40:5 | {...} |
-| Initializers.cs:6:5:6:16 | Initializers | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:8:5:8:16 | Initializers | Initializers.cs:3:9:3:9 | this access |
-| Initializers.cs:10:10:10:10 | M | Initializers.cs:11:5:14:5 | {...} |
-| Initializers.cs:18:11:18:23 | NoConstructor | Initializers.cs:20:23:20:23 | this access |
-| Initializers.cs:29:9:29:11 | Sub | Initializers.cs:29:17:29:20 | call to constructor NoConstructor |
-| Initializers.cs:31:9:31:11 | Sub | Initializers.cs:31:22:31:25 | call to constructor Sub |
-| Initializers.cs:33:9:33:11 | Sub | Initializers.cs:20:23:20:23 | this access |
+| Initializers.cs:8:5:8:16 | Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:10:5:10:16 | Initializers | Initializers.cs:5:9:5:9 | this access |
+| Initializers.cs:12:10:12:10 | M | Initializers.cs:13:5:16:5 | {...} |
+| Initializers.cs:20:11:20:23 | NoConstructor | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:31:9:31:11 | Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |
+| Initializers.cs:33:9:33:11 | Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |
+| Initializers.cs:35:9:35:11 | Sub | Initializers.cs:22:23:22:23 | this access |
+| Initializers.cs:51:10:51:13 | Test | Initializers.cs:52:5:66:5 | {...} |
 | LoopUnrolling.cs:7:10:7:11 | M1 | LoopUnrolling.cs:8:5:13:5 | {...} |
 | LoopUnrolling.cs:15:10:15:11 | M2 | LoopUnrolling.cs:16:5:20:5 | {...} |
 | LoopUnrolling.cs:22:10:22:11 | M3 | LoopUnrolling.cs:23:5:27:5 | {...} |


### PR DESCRIPTION
Support for C# 6 initializers such as
```
new Dictionary<int, string>() { [0] = "Zero", [1] = "One", [2] = "Two" }
```
was [recently added](https://github.com/github/codeql/pull/3484). This PR adjusts the CFG logic by adding the missing indexer expressions (`0`, `1`, and `2` above).