### PR TITLE
C#: Fix extracted type for nested object initializers

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
@@ -69,9 +69,18 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
                 if (assignment != null)
                 {
-                    var assignmentEntity = new Expression(new ExpressionNodeInfo(cx, init, this, child++).SetKind(ExprKind.SIMPLE_ASSIGN));
-
-                    CreateFromNode(new ExpressionNodeInfo(cx, assignment.Right, assignmentEntity, 0));
+                    var assignmentInfo = new ExpressionNodeInfo(cx, init, this, child++).SetKind(ExprKind.SIMPLE_ASSIGN);
+                    var assignmentEntity = new Expression(assignmentInfo);
+                    var typeInfoRight = cx.GetTypeInfo(assignment.Right);
+                    if (typeInfoRight.Type is null)
+                        // The type may be null for nested initializers such as
+                        // ```
+                        // new ClassWithArrayField() { As = { [0] = a } }
+                        // ```
+                        // In this case we take the type from the assignment
+                        // `As = { [0] = a }` instead
+                        typeInfoRight = assignmentInfo.TypeInfo;
+                    CreateFromNode(new ExpressionNodeInfo(cx, assignment.Right, assignmentEntity, 0, typeInfoRight));
 
                     var target = cx.GetSymbolInfo(assignment.Left);
 

--- a/csharp/ql/test/library-tests/csharp6/MemberInitializer.expected
+++ b/csharp/ql/test/library-tests/csharp6/MemberInitializer.expected
@@ -76,3 +76,12 @@ initializers
 | csharp6.cs:77:29:77:56 | { ..., ... } | 1 | csharp6.cs:77:44:77:54 | ... = ... |
 | csharp6.cs:78:30:78:59 | { ..., ... } | 0 | csharp6.cs:78:32:78:43 | ... = ... |
 | csharp6.cs:78:30:78:59 | { ..., ... } | 1 | csharp6.cs:78:46:78:57 | ... = ... |
+initializerType
+| csharp6.cs:68:50:68:91 | { ..., ... } | Dictionary<Int32, String> |
+| csharp6.cs:72:9:79:9 | { ..., ... } | Compound |
+| csharp6.cs:73:31:73:72 | { ..., ... } | null |
+| csharp6.cs:74:34:74:76 | { ..., ... } | null |
+| csharp6.cs:75:26:75:54 | { ..., ... } | null |
+| csharp6.cs:76:27:76:56 | { ..., ... } | null |
+| csharp6.cs:77:29:77:56 | { ..., ... } | null |
+| csharp6.cs:78:30:78:59 | { ..., ... } | null |

--- a/csharp/ql/test/library-tests/csharp6/MemberInitializer.expected
+++ b/csharp/ql/test/library-tests/csharp6/MemberInitializer.expected
@@ -79,9 +79,9 @@ initializers
 initializerType
 | csharp6.cs:68:50:68:91 | { ..., ... } | Dictionary<Int32, String> |
 | csharp6.cs:72:9:79:9 | { ..., ... } | Compound |
-| csharp6.cs:73:31:73:72 | { ..., ... } | null |
-| csharp6.cs:74:34:74:76 | { ..., ... } | null |
-| csharp6.cs:75:26:75:54 | { ..., ... } | null |
-| csharp6.cs:76:27:76:56 | { ..., ... } | null |
-| csharp6.cs:77:29:77:56 | { ..., ... } | null |
-| csharp6.cs:78:30:78:59 | { ..., ... } | null |
+| csharp6.cs:73:31:73:72 | { ..., ... } | Dictionary<Int32, String> |
+| csharp6.cs:74:34:74:76 | { ..., ... } | Dictionary<Int32, String> |
+| csharp6.cs:75:26:75:54 | { ..., ... } | String[] |
+| csharp6.cs:76:27:76:56 | { ..., ... } | String[,] |
+| csharp6.cs:77:29:77:56 | { ..., ... } | String[] |
+| csharp6.cs:78:30:78:59 | { ..., ... } | String[,] |

--- a/csharp/ql/test/library-tests/csharp6/MemberInitializer.ql
+++ b/csharp/ql/test/library-tests/csharp6/MemberInitializer.ql
@@ -22,3 +22,7 @@ query predicate arrayQualifiers(ElementAccess access, Expr qualifier) {
 query predicate initializers(ObjectInitializer init, int item, Expr expr) {
   expr = init.getMemberInitializer(item)
 }
+
+query predicate initializerType(ObjectInitializer init, string type) {
+  type = init.getType().toStringWithTypes()
+}


### PR DESCRIPTION
Follow-up on https://github.com/github/codeql/pull/3484.