### PR TITLE
JS: Remove timeout for node --version check

### DIFF
--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -203,7 +203,7 @@ public class TypeScriptParser {
             getNodeJsRuntimeInvocation("--version"), out, err, getParserWrapper().getParentFile());
     b.expectFailure(); // We want to do our own logging in case of an error.
 
-    int timeout = Env.systemEnv().getInt(TYPESCRIPT_TIMEOUT_VAR, 10000);
+    int timeout = Env.systemEnv().getInt(TYPESCRIPT_TIMEOUT_VAR, 0); // Default to no timeout.
     try {
       int r = b.execute(timeout);
       String stdout = new String(out.toByteArray());

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -203,7 +203,7 @@ public class TypeScriptParser {
             getNodeJsRuntimeInvocation("--version"), out, err, getParserWrapper().getParentFile());
     b.expectFailure(); // We want to do our own logging in case of an error.
 
-    int timeout = Env.systemEnv().getInt(TYPESCRIPT_TIMEOUT_VAR, 0); // Default to no timeout.
+    int timeout = Env.systemEnv().getInt(TYPESCRIPT_TIMEOUT_VAR, 10000);
     try {
       int r = b.execute(timeout);
       String stdout = new String(out.toByteArray());


### PR DESCRIPTION
Attempts to fix https://github.com/github/codeql-javascript-team/issues/120 by disabling the timeout for the call to
`node --version`.

I was able to verify that the timeout can be triggered if the parent process (Java) is suspended during the interval where `node` is booting up. In a cloud computing environment, my guess is that this suspension happens when the entire VM is paused for some reason, and that the initial `node` call can be slow enough for the pause to occur during that time (e.g. some lazy initialization might happen).

The believe the robust solution would be to wrap `node --version` in a retry loop, but I instead decided to just remove the timeout. The timeout seems unnecessary since we afterwards start a `node` process without a timeout anyway.