### PR TITLE
Java: CWE-523 Insecure HSTS configuration

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.expected
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.expected
@@ -1,0 +1,1 @@
+| insecure-hsts-web.xml:0:0:0:0 | insecure-hsts-web.xml | HSTS shall be enabled in web.xml to help mitigate MITM and protocol downgrade attacks |

--- a/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.qhelp
@@ -16,7 +16,7 @@
 <example>
 <p>The following two examples show two ways of HSTS configuration. In the 'BAD' case, HSTS is not enabled or is incorrectly configured. In the 'GOOD' case, HSTS is enabled for all requests.</p>
 <sample src="insecure-hsts-web.xml" />
-<sample src="secure-hsts-web.xml" />
+<sample src="secure-hsts-web.xml.good" />
 </example>
 
 <references>

--- a/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.qhelp
@@ -1,0 +1,28 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>HSTS is a web security policy mechanism that helps to protect websites against man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking. HSTS is specified in RFC 6797 and is supported by all major browsers and web servers.</p>
+<p> Missing or incorrect configuration allows unprotected transport of credentials.</p>
+<p>The query detects insecure configuration by checking web.xml. To reduce false positives, application source code and server configuration can be further analyzed to check whether it allows both HTTP/HTTPS URLs and processes sensitive information.</p>
+</overview>
+
+<recommendation>
+<p>Enable HSTS when a website handles sensitive information, especially when the website allows both HTTP and HTTPS protocols.</p>
+</recommendation>
+
+<example>
+<p>The following two examples show two ways of HSTS configuration. In the 'BAD' case, HSTS is not enabled or is incorrectly configured. In the 'GOOD' case, HSTS is enabled for all requests.</p>
+<sample src="insecure-hsts-web.xml" />
+<sample src="secure-hsts-web.xml" />
+</example>
+
+<references>
+<li>
+<a href="https://cwe.mitre.org/data/definitions/523.html">CWE-523: Unprotected Transport of Credentials</a>
+<a href="https://portswigger.net/kb/issues/01000300_strict-transport-security-not-enforced">Strict transport security not enforced</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.ql
@@ -1,5 +1,5 @@
 /**
- * @id java/leak-without-hsts
+ * @id java/insecure-hsts
  * @name Unprotected transport of credentials without HTTP Strict Transport Security (HSTS)
  * @description HSTS is a web security policy mechanism that helps to protect websites against man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking.  HSTS is specified in RFC 6797 and is supported by all major browsers and web servers. Missing or incorrect configuration allows unprotected transport of credentials.
  *     This query covers three scenarios of insecure Tomcat configuration:

--- a/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/InsecureHstsConfig.ql
@@ -1,0 +1,79 @@
+/**
+ * @id java/leak-without-hsts
+ * @name Unprotected transport of credentials without HTTP Strict Transport Security (HSTS)
+ * @description HSTS is a web security policy mechanism that helps to protect websites against man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking.  HSTS is specified in RFC 6797 and is supported by all major browsers and web servers. Missing or incorrect configuration allows unprotected transport of credentials.
+ *     This query covers three scenarios of insecure Tomcat configuration:
+ *     1. HttpHeaderSecurityFilter not configured
+ *     2. Filter is configured but is explicitly disabled
+ *     3. Filter is not mapped to all resources
+ * @kind problem
+ * @tags security
+ *       external/cwe-523
+ */
+
+import java
+import semmle.code.xml.WebXML
+
+/**
+ * A `<filter>` element in a `web.xml` file configured for HSTS.
+ */
+private class HstsFilter extends WebFilter {
+  HstsFilter() {
+    this.getAChild("filter-class").getTextValue() =
+      "org.apache.catalina.filters.HttpHeaderSecurityFilter" //Tomcat HSTS filter
+  }
+
+  string getFilterName() { result = this.getAChild("filter-name").getTextValue() }
+  //string getFilterClass() { result = this.getAChild("filter-class").getTextValue() }
+}
+
+/**
+ * A `<init-param>` element in a `web.xml` file, nested under a `<filter>` element.
+ */
+class HstsFilterInitParam extends WebXMLElement {
+  HstsFilterInitParam() { getName() = "init-param" and getParent() instanceof HstsFilter }
+
+  /**
+   * Gets the `<param-name>` element of this `<init-param>` for the `<filter>`.
+   */
+  string getParamName() { result = this.getAChild("param-name").getTextValue() }
+
+  /**
+   * Gets the `<param-value>` element of this `<init-param>` for the `<filter>`.
+   */
+  string getParamValue() { result = this.getAChild("param-value").getTextValue() }
+}
+
+/**
+ * A `<filter-mapping>` element in a `web.xml` file.
+ */
+class WebFilterMapping extends WebXMLElement {
+  WebFilterMapping() { getName() = "filter-mapping" }
+
+  /**
+   * Gets the `<filter-name>` element of this `<filter-mapping>`.
+   */
+  string getFilterName() { result = getAChild("filter-name").getTextValue() }
+
+  /**
+   * Gets the `<url-pattern>` element of this `<filter-mapping>`.
+   */
+  string getUrlPattern() { result = getAChild("url-pattern").getTextValue() }
+}
+
+from WebXMLFile webXml
+where
+  not exists(HstsFilter filter)
+  or
+  exists(HstsFilter filter, WebFilterMapping filterMapping |
+    filter.getFilterName() = filterMapping.getFilterName() and
+    (
+      exists(HstsFilterInitParam initparam |
+        initparam.getParamName() = "hstsEnabled" and initparam.getParamValue() = "false" //hstsEnabled is default to true for the HSTS filter
+      )
+      or
+      filterMapping.getUrlPattern() != "/*" //Filter is not applied to all URLs
+    )
+  )
+select webXml,
+  "HSTS shall be enabled in web.xml to help mitigate MITM and protocol downgrade attacks"

--- a/java/ql/src/experimental/Security/CWE/CWE-523/insecure-hsts-web.xml
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/insecure-hsts-web.xml
@@ -1,0 +1,26 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd" version="4.0">
+  <!-- BAD: no httpHeaderSecurity filter is set (the filter and filter-mapping elements are commented out, which is not shown here);
+    or the filter is not mapped to all incoming requests;
+    or the init-param hstsEnabled is explicitly set to false -->
+  <filter>
+    <filter-name>httpHeaderSecurity</filter-name>
+    <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+    <async-supported>true</async-supported>
+    <init-param>
+      <param-name>hstsEnabled</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <init-param>
+      <param-name>hstsMaxAgeSeconds</param-name>
+      <param-value>31536000</param-value>
+    </init-param>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>httpHeaderSecurity</filter-name>
+    <url-pattern>/sub/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+  </filter-mapping>
+
+</web-app>

--- a/java/ql/src/experimental/Security/CWE/CWE-523/secure-hsts-web.xml.good
+++ b/java/ql/src/experimental/Security/CWE/CWE-523/secure-hsts-web.xml.good
@@ -1,0 +1,18 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd" version="4.0">
+  <!-- GOOD: httpHeaderSecurity filter is mapped to all incoming requests -->
+  <filter>
+    <filter-name>httpHeaderSecurity</filter-name>
+    <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+    <async-supported>true</async-supported>
+    <init-param>
+      <param-name>hstsMaxAgeSeconds</param-name>
+      <param-value>31536000</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>httpHeaderSecurity</filter-name>
+    <url-pattern>/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+  </filter-mapping>
+</web-app>


### PR DESCRIPTION
HSTS (HTTP Strict Transport Security) is a web security policy mechanism that helps to protect websites against man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking.  HSTS is specified in RFC 6797 and is supported by all major browsers and web servers. Missing or incorrect configuration allows unprotected transport of credentials.
 
HSTS started to be widely accepted and configured in recent years.

This query covers three scenarios of insecure Tomcat configuration:
  1. The filter HttpHeaderSecurityFilter is not configured
  2. The filter is configured but is explicitly disabled
  3. The filter is not mapped to all resources thus doesn't protect all resources

I've tested the query against some GitHub projects, and a test case has been created.

Please consider to merge the PR. Thanks.

@luchua-bc 