### PR TITLE
Java: add websocket reads as remote flow source.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
@@ -15,6 +15,7 @@ import semmle.code.java.frameworks.ApacheHttp
 import semmle.code.java.frameworks.android.XmlParsing
 import semmle.code.java.frameworks.android.WebView
 import semmle.code.java.frameworks.JaxWS
+import semmle.code.java.frameworks.javase.WebSocket
 import semmle.code.java.frameworks.android.Intent
 import semmle.code.java.frameworks.spring.SpringWeb
 import semmle.code.java.frameworks.spring.SpringController
@@ -153,6 +154,14 @@ private class ThriftIfaceParameterSource extends RemoteFlowSource {
   }
 
   override string getSourceType() { result = "Thrift Iface parameter" }
+}
+
+private class WebSocketMessageParameterSource extends RemoteFlowSource {
+  WebSocketMessageParameterSource() {
+    exists(WebsocketOnText t | t.getParameter(1) = this.asParameter())
+  }
+
+  override string getSourceType() { result = "Websocket onText parameter" }
 }
 
 /** Class for `tainted` user input. */

--- a/java/ql/src/semmle/code/java/frameworks/javase/WebSocket.qll
+++ b/java/ql/src/semmle/code/java/frameworks/javase/WebSocket.qll
@@ -1,0 +1,21 @@
+/**
+ * Provides classes for identifying methods called by the Java SE WebSocket package.
+ */
+
+import java
+
+/** The `java.net.http.Websocket.Listener` interface. */
+class WebsocketListener extends Interface {
+  WebsocketListener() { this.hasQualifiedName("java.net.http", "WebSocket$Listener") }
+}
+
+/** The method `onText` on a type that implements the `java.net.http.Websocket.Listener` interface. */
+class WebsocketOnText extends Method {
+  WebsocketOnText() {
+    exists(WebsocketListener l |
+      this.getDeclaringType().extendsOrImplements(l) and
+      // onText(WebSocket webSocket, CharSequence data, boolean last)
+      this.hasName("onText")
+    )
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/WebsocketXss.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/WebsocketXss.java
@@ -1,0 +1,27 @@
+// package test.cwe079.cwe.examples;
+
+// import java.net.http.HttpClient;
+// import java.net.http.WebSocket;
+// import java.net.URI;
+// import java.util.*;
+// import java.util.concurrent.*;
+
+// public class WebsocketXss {
+//     public static void main(String[] args) throws Exception {
+//         WebSocket.Listener listener = new WebSocket.Listener() {
+//             public CompletionStage<?> onText(WebSocket webSocket, CharSequence message, boolean last) {
+//                 try {
+//                     HttpClient client = HttpClient.newBuilder().build();
+//                     CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
+//                             .buildAsync(URI.create("ws://websocket.example.com"), null);
+//                     ws.get().sendText​(message, false);
+//                 } catch (Exception e) {
+//                     // TODO: handle exception
+//                 }
+
+//                 return null;
+//             };
+//         };
+
+//     }
+// }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/WebsocketXss.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/WebsocketXss.java
@@ -14,7 +14,7 @@
 //                     HttpClient client = HttpClient.newBuilder().build();
 //                     CompletableFuture<WebSocket> ws = client.newWebSocketBuilder()
 //                             .buildAsync(URI.create("ws://websocket.example.com"), null);
-//                     ws.get().sendText​(message, false);
+//                     ws.get().sendText(message, false);
 //                 } catch (Exception e) {
 //                     // TODO: handle exception
 //                 }


### PR DESCRIPTION
Currently, JAX-WS reads are considered as untrusted. However, `java.net.http.WebSocket` reads are not marked as such. This PR adds support for the same.