### PR TITLE
Python: How to make TaintKinds for dict subclasses

### DIFF
--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -7,7 +7,4 @@
 | test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
 | test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |
 | test.py:36:18:36:33 | ATTR_BASED_FILES | AttrBasedDictKind | AttrBasedDictKind |
-| test.py:36:18:36:33 | ATTR_BASED_FILES | DictKind | {file[externally controlled string]} |
 | test.py:37:20:37:37 | ATTR_BASED_STRINGS | AttrBasedDictKind | AttrBasedDictKind |
-| test.py:37:20:37:37 | ATTR_BASED_STRINGS | ExternalStringDictKind | {externally controlled string} |
-| test.py:37:20:37:37 | ATTR_BASED_STRINGS | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -6,8 +6,8 @@
 | test.py:5:16:5:23 | BAR_DICT | BarDictKind | BarDictKind |
 | test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
 | test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |
-| test.py:30:18:30:33 | ATTR_BASED_FILES | AttrBasedDictKind | AttrBasedDictKind |
-| test.py:30:18:30:33 | ATTR_BASED_FILES | DictKind | {file[externally controlled string]} |
-| test.py:31:20:31:37 | ATTR_BASED_STRINGS | AttrBasedDictKind | AttrBasedDictKind |
-| test.py:31:20:31:37 | ATTR_BASED_STRINGS | ExternalStringDictKind | {externally controlled string} |
-| test.py:31:20:31:37 | ATTR_BASED_STRINGS | StringDictKind | {externally controlled string} |
+| test.py:36:18:36:33 | ATTR_BASED_FILES | AttrBasedDictKind | AttrBasedDictKind |
+| test.py:36:18:36:33 | ATTR_BASED_FILES | DictKind | {file[externally controlled string]} |
+| test.py:37:20:37:37 | ATTR_BASED_STRINGS | AttrBasedDictKind | AttrBasedDictKind |
+| test.py:37:20:37:37 | ATTR_BASED_STRINGS | ExternalStringDictKind | {externally controlled string} |
+| test.py:37:20:37:37 | ATTR_BASED_STRINGS | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -1,8 +1,8 @@
-| test.py:3:20:3:31 | TAINTED_DICT | DictPart | {externally controlled string} |
+| test.py:3:20:3:31 | TAINTED_DICT | ExternalStringDictKind | {externally controlled string} |
 | test.py:3:20:3:31 | TAINTED_DICT | StringDictKind | {externally controlled string} |
-| test.py:4:16:4:23 | FOO_DICT | DictPart | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | ExternalStringDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | FooDictKind | FooDictKind |
 | test.py:4:16:4:23 | FOO_DICT | StringDictKind | {externally controlled string} |
-| test.py:4:16:4:23 | FOO_DICT | SubclassSpecific | FooDictKind::SubclassSpecific |
 | test.py:5:16:5:23 | BAR_DICT | BarDictKind | BarDictKind |
-| test.py:5:16:5:23 | BAR_DICT | DictPart | {externally controlled string} |
+| test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
 | test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -6,3 +6,8 @@
 | test.py:5:16:5:23 | BAR_DICT | BarDictKind | BarDictKind |
 | test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
 | test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |
+| test.py:30:18:30:33 | ATTR_BASED_FILES | AttrBasedDictKind | AttrBasedDictKind |
+| test.py:30:18:30:33 | ATTR_BASED_FILES | DictKind | {file[externally controlled string]} |
+| test.py:31:20:31:37 | ATTR_BASED_STRINGS | AttrBasedDictKind | AttrBasedDictKind |
+| test.py:31:20:31:37 | ATTR_BASED_STRINGS | ExternalStringDictKind | {externally controlled string} |
+| test.py:31:20:31:37 | ATTR_BASED_STRINGS | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -1,0 +1,12 @@
+| test.py:3:20:3:31 | TAINTED_DICT | BarDictKind | {externally controlled string} |
+| test.py:3:20:3:31 | TAINTED_DICT | ExternalStringDictKind | {externally controlled string} |
+| test.py:3:20:3:31 | TAINTED_DICT | FooDictKind | {externally controlled string} |
+| test.py:3:20:3:31 | TAINTED_DICT | StringDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | BarDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | ExternalStringDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | FooDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | StringDictKind | {externally controlled string} |
+| test.py:5:16:5:23 | BAR_DICT | BarDictKind | {externally controlled string} |
+| test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
+| test.py:5:16:5:23 | BAR_DICT | FooDictKind | {externally controlled string} |
+| test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.expected
@@ -1,12 +1,8 @@
-| test.py:3:20:3:31 | TAINTED_DICT | BarDictKind | {externally controlled string} |
-| test.py:3:20:3:31 | TAINTED_DICT | ExternalStringDictKind | {externally controlled string} |
-| test.py:3:20:3:31 | TAINTED_DICT | FooDictKind | {externally controlled string} |
+| test.py:3:20:3:31 | TAINTED_DICT | DictPart | {externally controlled string} |
 | test.py:3:20:3:31 | TAINTED_DICT | StringDictKind | {externally controlled string} |
-| test.py:4:16:4:23 | FOO_DICT | BarDictKind | {externally controlled string} |
-| test.py:4:16:4:23 | FOO_DICT | ExternalStringDictKind | {externally controlled string} |
-| test.py:4:16:4:23 | FOO_DICT | FooDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | DictPart | {externally controlled string} |
 | test.py:4:16:4:23 | FOO_DICT | StringDictKind | {externally controlled string} |
-| test.py:5:16:5:23 | BAR_DICT | BarDictKind | {externally controlled string} |
-| test.py:5:16:5:23 | BAR_DICT | ExternalStringDictKind | {externally controlled string} |
-| test.py:5:16:5:23 | BAR_DICT | FooDictKind | {externally controlled string} |
+| test.py:4:16:4:23 | FOO_DICT | SubclassSpecific | FooDictKind::SubclassSpecific |
+| test.py:5:16:5:23 | BAR_DICT | BarDictKind | BarDictKind |
+| test.py:5:16:5:23 | BAR_DICT | DictPart | {externally controlled string} |
 | test.py:5:16:5:23 | BAR_DICT | StringDictKind | {externally controlled string} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.ql
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/CustomKinds.ql
@@ -1,0 +1,9 @@
+import python
+import Taint
+
+from TaintedNode tainted, AstNode ast
+where
+    ast = tainted.getAstNode() and
+    ast.getLocation().getFile().getShortName() = "test.py" and
+    not exists(Call call | call.contains(ast))
+select ast, tainted.getTaintKind().getAQlClass(), tainted.getTaintKind()

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
@@ -57,23 +57,44 @@ class BarDictSource extends TaintSource {
     }
 }
 
-
 /**
  * Kind for a custom dictionary class where `dict.key` is the same as `dict['key']`.
  * A real example is `bottle.FormsDict`.
 */
 class AttrBasedDictKind extends TaintKind {
 
-    // we _could_ add a `TaintKind valueKind` field, but then we need a way to disallow
-    // infinite recursion since `valueKind` could be `AttrBasedDictKind`. Essentially the
-    // same problem that CollectionKind, SequenceKind, and DictKind is dealing with :\
+    DictKind dict;
 
-    AttrBasedDictKind() { this = "AttrBasedDictKind" }
+    TaintKind getValue() { result = dict.(DictKind).getValue() }
 
-    // bindingset[name]
-    // override TaintKind getTaintOfAttribute(string name) {
-    //     result instanceof <TODO>
-    // }
+    AttrBasedDictKind() {
+        this = "AttrBasedDictKind"
+    }
+
+    bindingset[name]
+    override TaintKind getTaintOfAttribute(string name) {
+        result = getValue()
+    }
+
+    override TaintKind getTaintOfMethodResult(string name) {
+        result = dict.getTaintOfMethodResult(name)
+    }
+
+    override TaintKind getTaintForFlowStep(ControlFlowNode fromnode, ControlFlowNode tonode) {
+        result = dict.getTaintForFlowStep(fromnode, tonode)
+    }
+
+    override TaintKind getTaintForFlowStep(ControlFlowNode fromnode, ControlFlowNode tonode, string edgeLabel) {
+        result = dict.getTaintForFlowStep(fromnode, tonode, edgeLabel)
+    }
+
+    override TaintKind getTaintForIteration() {
+        result = dict.getTaintForIteration()
+    }
+
+    override predicate flowStep(DataFlow::Node fromnode, DataFlow::Node tonode, string edgeLabel) {
+        dict.flowStep(fromnode, tonode, edgeLabel)
+    }
 }
 
 class AttrBasedDictSource extends TaintSource {
@@ -89,8 +110,6 @@ class AttrBasedDictSource extends TaintSource {
     }
 
     override predicate isSourceOf(TaintKind kind) {
-        kind instanceof AttrBasedDictKind
-        or
-        kind.(DictKind).getValue() = valueKind
+        kind.(AttrBasedDictKind).getValue() = valueKind
     }
 }

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
@@ -21,12 +21,21 @@ class DictSource extends TaintSource {
     override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringDictKind }
 }
 
-class FooDictKind extends DictKind {
-    FooDictKind() { this.getValue() instanceof ExternalStringKind }
+abstract class FooDictKind extends TaintKind {
+    bindingset[this]
+    FooDictKind() { any() }
+}
 
-    override TaintKind getTaintOfAttribute(string name) {
-        name = "foo" and result instanceof ExternalFileObject
+private module FooDictKind {
+    class SubclassSpecific extends FooDictKind {
+        SubclassSpecific() { this = "FooDictKind::SubclassSpecific" }
+
+        override TaintKind getTaintOfAttribute(string name) {
+            name = "foo" and result instanceof ExternalFileObject
+        }
     }
+
+    class DictPart extends FooDictKind, ExternalStringDictKind { }
 }
 
 class FooDictSource extends TaintSource {
@@ -35,8 +44,8 @@ class FooDictSource extends TaintSource {
     override predicate isSourceOf(TaintKind kind) { kind instanceof FooDictKind }
 }
 
-class BarDictKind extends DictKind {
-    BarDictKind() { this.getValue() instanceof ExternalStringKind }
+class BarDictKind extends TaintKind {
+    BarDictKind() { this = "BarDictKind" }
 
     override TaintKind getTaintOfAttribute(string name) {
         name = "bar" and result instanceof ExternalFileObject
@@ -46,5 +55,9 @@ class BarDictKind extends DictKind {
 class BarDictSource extends TaintSource {
     BarDictSource() { this.(NameNode).getId() = "BAR_DICT" }
 
-    override predicate isSourceOf(TaintKind kind) { kind instanceof BarDictKind }
+    override predicate isSourceOf(TaintKind kind) {
+        kind instanceof BarDictKind
+        or
+        kind instanceof ExternalStringDictKind
+    }
 }

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
@@ -21,27 +21,22 @@ class DictSource extends TaintSource {
     override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringDictKind }
 }
 
-abstract class FooDictKind extends TaintKind {
-    bindingset[this]
-    FooDictKind() { any() }
-}
+class FooDictKind extends TaintKind {
+    FooDictKind() { this = "FooDictKind" }
 
-private module FooDictKind {
-    class SubclassSpecific extends FooDictKind {
-        SubclassSpecific() { this = "FooDictKind::SubclassSpecific" }
-
-        override TaintKind getTaintOfAttribute(string name) {
-            name = "foo" and result instanceof ExternalFileObject
-        }
+    override TaintKind getTaintOfAttribute(string name) {
+        name = "foo" and result instanceof ExternalFileObject
     }
-
-    class DictPart extends FooDictKind, ExternalStringDictKind { }
 }
 
 class FooDictSource extends TaintSource {
     FooDictSource() { this.(NameNode).getId() = "FOO_DICT" }
 
-    override predicate isSourceOf(TaintKind kind) { kind instanceof FooDictKind }
+    override predicate isSourceOf(TaintKind kind) {
+        kind instanceof FooDictKind
+        or
+        kind.(DictKind).getValue() instanceof ExternalStringKind
+    }
 }
 
 class BarDictKind extends TaintKind {
@@ -58,6 +53,6 @@ class BarDictSource extends TaintSource {
     override predicate isSourceOf(TaintKind kind) {
         kind instanceof BarDictKind
         or
-        kind instanceof ExternalStringDictKind
+        kind.(DictKind).getValue() instanceof ExternalStringKind
     }
 }

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
@@ -56,3 +56,41 @@ class BarDictSource extends TaintSource {
         kind.(DictKind).getValue() instanceof ExternalStringKind
     }
 }
+
+
+/**
+ * Kind for a custom dictionary class where `dict.key` is the same as `dict['key']`.
+ * A real example is `bottle.FormsDict`.
+*/
+class AttrBasedDictKind extends TaintKind {
+
+    // we _could_ add a `TaintKind valueKind` field, but then we need a way to disallow
+    // infinite recursion since `valueKind` could be `AttrBasedDictKind`. Essentially the
+    // same problem that CollectionKind, SequenceKind, and DictKind is dealing with :\
+
+    AttrBasedDictKind() { this = "AttrBasedDictKind" }
+
+    // bindingset[name]
+    // override TaintKind getTaintOfAttribute(string name) {
+    //     result instanceof <TODO>
+    // }
+}
+
+class AttrBasedDictSource extends TaintSource {
+
+    TaintKind valueKind;
+
+    AttrBasedDictSource() {
+        this.(NameNode).getId() = "ATTR_BASED_FILES" and
+        valueKind instanceof ExternalFileObject
+        or
+        this.(NameNode).getId() = "ATTR_BASED_STRINGS" and
+        valueKind instanceof ExternalStringKind
+    }
+
+    override predicate isSourceOf(TaintKind kind) {
+        kind instanceof AttrBasedDictKind
+        or
+        kind.(DictKind).getValue() = valueKind
+    }
+}

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/Taint.qll
@@ -1,0 +1,50 @@
+/**
+ * The idea of this test is that each of TAINTED_DICT, FOO_DICT, and BAR_DICT should give
+ * rise to one (and only one) TaintKind.
+ *
+ * With the current setup, the taint of FOO_DICT will give rise to the most-specific
+ * classes: FooDict, BarDict, ExternalStringDictKind, and StringDictKind.
+ *
+ * When modeling a python class that is a dictionary, but also provides custom attributes/methods,
+ * it's very useful to be able to define a TaintKind for that specific class. Obviously, such TaintKinds
+ * should not be able to influence each other :\
+ */
+
+import python
+import semmle.python.dataflow.TaintTracking
+import semmle.python.security.strings.External
+import semmle.python.security.strings.Untrusted
+
+class DictSource extends TaintSource {
+    DictSource() { this.(NameNode).getId() = "TAINTED_DICT" }
+
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringDictKind }
+}
+
+class FooDictKind extends DictKind {
+    FooDictKind() { this.getValue() instanceof ExternalStringKind }
+
+    override TaintKind getTaintOfAttribute(string name) {
+        name = "foo" and result instanceof ExternalFileObject
+    }
+}
+
+class FooDictSource extends TaintSource {
+    FooDictSource() { this.(NameNode).getId() = "FOO_DICT" }
+
+    override predicate isSourceOf(TaintKind kind) { kind instanceof FooDictKind }
+}
+
+class BarDictKind extends DictKind {
+    BarDictKind() { this.getValue() instanceof ExternalStringKind }
+
+    override TaintKind getTaintOfAttribute(string name) {
+        name = "bar" and result instanceof ExternalFileObject
+    }
+}
+
+class BarDictSource extends TaintSource {
+    BarDictSource() { this.(NameNode).getId() = "BAR_DICT" }
+
+    override predicate isSourceOf(TaintKind kind) { kind instanceof BarDictKind }
+}

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
@@ -10,7 +10,41 @@
 | test.py:27 | ok   | test_custom_kind | Attribute() | externally controlled string |
 | test.py:28 | ok   | test_custom_kind | Attribute | file[externally controlled string] |
 | test.py:31 | ok   | test_custom_kind | Attribute | <NO TAINT> |
-| test.py:40 | ok   | test_attr_based | Subscript | file[externally controlled string] |
-| test.py:41 | fail | test_attr_based | Attribute | <NO TAINT> |
-| test.py:45 | ok   | test_attr_based | Subscript | externally controlled string |
-| test.py:46 | fail | test_attr_based | Attribute | <NO TAINT> |
+| test.py:40 | fail | test_attr_based | Subscript | <NO TAINT> |
+| test.py:41 | ok   | test_attr_based | Attribute | AttrBasedDictKind |
+| test.py:41 | ok   | test_attr_based | Attribute | BarDictKind |
+| test.py:41 | ok   | test_attr_based | Attribute | FooDictKind |
+| test.py:41 | ok   | test_attr_based | Attribute | [AttrBasedDictKind] |
+| test.py:41 | ok   | test_attr_based | Attribute | [BarDictKind] |
+| test.py:41 | ok   | test_attr_based | Attribute | [FooDictKind] |
+| test.py:41 | ok   | test_attr_based | Attribute | [externally controlled string] |
+| test.py:41 | ok   | test_attr_based | Attribute | [file[externally controlled string]] |
+| test.py:41 | ok   | test_attr_based | Attribute | [json[externally controlled string]] |
+| test.py:41 | ok   | test_attr_based | Attribute | externally controlled string |
+| test.py:41 | ok   | test_attr_based | Attribute | file[externally controlled string] |
+| test.py:41 | ok   | test_attr_based | Attribute | json[externally controlled string] |
+| test.py:41 | ok   | test_attr_based | Attribute | {AttrBasedDictKind} |
+| test.py:41 | ok   | test_attr_based | Attribute | {BarDictKind} |
+| test.py:41 | ok   | test_attr_based | Attribute | {FooDictKind} |
+| test.py:41 | ok   | test_attr_based | Attribute | {externally controlled string} |
+| test.py:41 | ok   | test_attr_based | Attribute | {file[externally controlled string]} |
+| test.py:41 | ok   | test_attr_based | Attribute | {json[externally controlled string]} |
+| test.py:45 | fail | test_attr_based | Subscript | <NO TAINT> |
+| test.py:46 | ok   | test_attr_based | Attribute | AttrBasedDictKind |
+| test.py:46 | ok   | test_attr_based | Attribute | BarDictKind |
+| test.py:46 | ok   | test_attr_based | Attribute | FooDictKind |
+| test.py:46 | ok   | test_attr_based | Attribute | [AttrBasedDictKind] |
+| test.py:46 | ok   | test_attr_based | Attribute | [BarDictKind] |
+| test.py:46 | ok   | test_attr_based | Attribute | [FooDictKind] |
+| test.py:46 | ok   | test_attr_based | Attribute | [externally controlled string] |
+| test.py:46 | ok   | test_attr_based | Attribute | [file[externally controlled string]] |
+| test.py:46 | ok   | test_attr_based | Attribute | [json[externally controlled string]] |
+| test.py:46 | ok   | test_attr_based | Attribute | externally controlled string |
+| test.py:46 | ok   | test_attr_based | Attribute | file[externally controlled string] |
+| test.py:46 | ok   | test_attr_based | Attribute | json[externally controlled string] |
+| test.py:46 | ok   | test_attr_based | Attribute | {AttrBasedDictKind} |
+| test.py:46 | ok   | test_attr_based | Attribute | {BarDictKind} |
+| test.py:46 | ok   | test_attr_based | Attribute | {FooDictKind} |
+| test.py:46 | ok   | test_attr_based | Attribute | {externally controlled string} |
+| test.py:46 | ok   | test_attr_based | Attribute | {file[externally controlled string]} |
+| test.py:46 | ok   | test_attr_based | Attribute | {json[externally controlled string]} |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
@@ -1,0 +1,12 @@
+| test.py:8 | test_custom_kind | Subscript | externally controlled string |
+| test.py:9 | test_custom_kind | Attribute() | externally controlled string |
+| test.py:10 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:11 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:15 | test_custom_kind | Subscript | externally controlled string |
+| test.py:16 | test_custom_kind | Attribute() | externally controlled string |
+| test.py:17 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:18 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:22 | test_custom_kind | Subscript | externally controlled string |
+| test.py:23 | test_custom_kind | Attribute() | externally controlled string |
+| test.py:24 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:25 | test_custom_kind | Attribute | file[externally controlled string] |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
@@ -10,3 +10,7 @@
 | test.py:23 | test_custom_kind | Attribute() | externally controlled string |
 | test.py:24 | test_custom_kind | Attribute | NO TAINT |
 | test.py:25 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:34 | test_attr_based | Subscript | file[externally controlled string] |
+| test.py:35 | test_attr_based | Attribute | NO TAINT |
+| test.py:39 | test_attr_based | Subscript | externally controlled string |
+| test.py:40 | test_attr_based | Attribute | NO TAINT |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
@@ -1,12 +1,12 @@
 | test.py:8 | test_custom_kind | Subscript | externally controlled string |
 | test.py:9 | test_custom_kind | Attribute() | externally controlled string |
-| test.py:10 | test_custom_kind | Attribute | file[externally controlled string] |
-| test.py:11 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:10 | test_custom_kind | Attribute | NO TAINT |
+| test.py:11 | test_custom_kind | Attribute | NO TAINT |
 | test.py:15 | test_custom_kind | Subscript | externally controlled string |
 | test.py:16 | test_custom_kind | Attribute() | externally controlled string |
 | test.py:17 | test_custom_kind | Attribute | file[externally controlled string] |
-| test.py:18 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:18 | test_custom_kind | Attribute | NO TAINT |
 | test.py:22 | test_custom_kind | Subscript | externally controlled string |
 | test.py:23 | test_custom_kind | Attribute() | externally controlled string |
-| test.py:24 | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:24 | test_custom_kind | Attribute | NO TAINT |
 | test.py:25 | test_custom_kind | Attribute | file[externally controlled string] |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.expected
@@ -1,16 +1,16 @@
-| test.py:8 | test_custom_kind | Subscript | externally controlled string |
-| test.py:9 | test_custom_kind | Attribute() | externally controlled string |
-| test.py:10 | test_custom_kind | Attribute | NO TAINT |
-| test.py:11 | test_custom_kind | Attribute | NO TAINT |
-| test.py:15 | test_custom_kind | Subscript | externally controlled string |
-| test.py:16 | test_custom_kind | Attribute() | externally controlled string |
-| test.py:17 | test_custom_kind | Attribute | file[externally controlled string] |
-| test.py:18 | test_custom_kind | Attribute | NO TAINT |
-| test.py:22 | test_custom_kind | Subscript | externally controlled string |
-| test.py:23 | test_custom_kind | Attribute() | externally controlled string |
-| test.py:24 | test_custom_kind | Attribute | NO TAINT |
-| test.py:25 | test_custom_kind | Attribute | file[externally controlled string] |
-| test.py:34 | test_attr_based | Subscript | file[externally controlled string] |
-| test.py:35 | test_attr_based | Attribute | NO TAINT |
-| test.py:39 | test_attr_based | Subscript | externally controlled string |
-| test.py:40 | test_attr_based | Attribute | NO TAINT |
+| test.py:8 | ok   | test_custom_kind | Subscript | externally controlled string |
+| test.py:9 | ok   | test_custom_kind | Attribute() | externally controlled string |
+| test.py:12 | ok   | test_custom_kind | Attribute | <NO TAINT> |
+| test.py:13 | ok   | test_custom_kind | Attribute | <NO TAINT> |
+| test.py:17 | ok   | test_custom_kind | Subscript | externally controlled string |
+| test.py:18 | ok   | test_custom_kind | Attribute() | externally controlled string |
+| test.py:19 | ok   | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:22 | ok   | test_custom_kind | Attribute | <NO TAINT> |
+| test.py:26 | ok   | test_custom_kind | Subscript | externally controlled string |
+| test.py:27 | ok   | test_custom_kind | Attribute() | externally controlled string |
+| test.py:28 | ok   | test_custom_kind | Attribute | file[externally controlled string] |
+| test.py:31 | ok   | test_custom_kind | Attribute | <NO TAINT> |
+| test.py:40 | ok   | test_attr_based | Subscript | file[externally controlled string] |
+| test.py:41 | fail | test_attr_based | Attribute | <NO TAINT> |
+| test.py:45 | ok   | test_attr_based | Subscript | externally controlled string |
+| test.py:46 | fail | test_attr_based | Attribute | <NO TAINT> |

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.ql
@@ -1,18 +1,32 @@
 import python
+import semmle.python.security.TaintTracking
+import semmle.python.security.strings.Untrusted
 import Taint
 
-from Call call, Expr arg, string taint_string
+from
+    Call call, Expr arg, boolean expected_taint, boolean has_taint, string test_res,
+    string taint_string
 where
     call.getLocation().getFile().getShortName() = "test.py" and
-    call.getFunc().(Name).getId() = "test" and
+    (
+        call.getFunc().(Name).getId() = "ensure_tainted" and
+        expected_taint = true
+        or
+        call.getFunc().(Name).getId() = "ensure_not_tainted" and
+        expected_taint = false
+    ) and
     arg = call.getAnArg() and
     (
         not exists(TaintedNode tainted | tainted.getAstNode() = arg) and
-        taint_string = "NO TAINT"
+        taint_string = "<NO TAINT>" and
+        has_taint = false
         or
         exists(TaintedNode tainted | tainted.getAstNode() = arg |
             taint_string = tainted.getTaintKind().toString()
-        )
-    )
-select arg.getLocation().toString(), call.getScope().(Function).getName(), arg.toString(),
+        ) and
+        has_taint = true
+    ) and
+    if expected_taint = has_taint then test_res = "ok  " else test_res = "fail"
+// if expected_taint = has_taint then test_res = "✓" else test_res = "✕"
+select arg.getLocation().toString(), test_res, call.getScope().(Function).getName(), arg.toString(),
     taint_string

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/TestTaint.ql
@@ -1,0 +1,18 @@
+import python
+import Taint
+
+from Call call, Expr arg, string taint_string
+where
+    call.getLocation().getFile().getShortName() = "test.py" and
+    call.getFunc().(Name).getId() = "test" and
+    arg = call.getAnArg() and
+    (
+        not exists(TaintedNode tainted | tainted.getAstNode() = arg) and
+        taint_string = "NO TAINT"
+        or
+        exists(TaintedNode tainted | tainted.getAstNode() = arg |
+            taint_string = tainted.getTaintKind().toString()
+        )
+    )
+select arg.getLocation().toString(), call.getScope().(Function).getName(), arg.toString(),
+    taint_string

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
@@ -1,0 +1,26 @@
+def test_custom_kind():
+    # see CustomKinds.ql for explanation
+    tainted_dict = TAINTED_DICT
+    foo_dict = FOO_DICT
+    bar_dict = BAR_DICT
+
+    test(
+        tainted_dict['key'],
+        tainted_dict.get('key'),
+        tainted_dict.foo,
+        tainted_dict.bar,
+    )
+
+    test(
+        foo_dict['key'],
+        foo_dict.get('key'),
+        foo_dict.foo,
+        foo_dict.bar,
+    )
+
+    test(
+        bar_dict['key'],
+        bar_dict.get('key'),
+        bar_dict.foo,
+        bar_dict.bar,
+    )

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
@@ -4,25 +4,31 @@ def test_custom_kind():
     foo_dict = FOO_DICT
     bar_dict = BAR_DICT
 
-    test(
+    ensure_tainted(
         tainted_dict['key'],
         tainted_dict.get('key'),
+    )
+    ensure_not_tainted(
         tainted_dict.foo,
         tainted_dict.bar,
     )
 
-    test(
+    ensure_tainted(
         foo_dict['key'],
         foo_dict.get('key'),
         foo_dict.foo,
+    )
+    ensure_not_tainted(
         foo_dict.bar,
     )
 
-    test(
+    ensure_tainted(
         bar_dict['key'],
         bar_dict.get('key'),
-        bar_dict.foo,
         bar_dict.bar,
+    )
+    ensure_not_tainted(
+        bar_dict.foo,
     )
 
 def test_attr_based():
@@ -30,12 +36,12 @@ def test_attr_based():
     attr_files = ATTR_BASED_FILES
     attr_strings = ATTR_BASED_STRINGS
 
-    test(
+    ensure_tainted(
         attr_files['key'],
         attr_files.key,
     )
 
-    test(
+    ensure_tainted(
         attr_strings['key'],
         attr_strings.key,
     )

--- a/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
+++ b/python/ql/test/library-tests/taint/collections/custom-dictkind/test.py
@@ -1,5 +1,5 @@
 def test_custom_kind():
-    # see CustomKinds.ql for explanation
+    # see Taint.qll for explanation
     tainted_dict = TAINTED_DICT
     foo_dict = FOO_DICT
     bar_dict = BAR_DICT
@@ -23,4 +23,19 @@ def test_custom_kind():
         bar_dict.get('key'),
         bar_dict.foo,
         bar_dict.bar,
+    )
+
+def test_attr_based():
+    """representing a dictionary where `dict.key` is the same as `dict['key']` -- bottle.FormsDict"""
+    attr_files = ATTR_BASED_FILES
+    attr_strings = ATTR_BASED_STRINGS
+
+    test(
+        attr_files['key'],
+        attr_files.key,
+    )
+
+    test(
+        attr_strings['key'],
+        attr_strings.key,
     )


### PR DESCRIPTION
For https://github.com/github/codeql/pull/3267 and https://github.com/github/codeql/pull/3485 I needed to model Python subclasses of dict -- and that turned out to be a bit more tricky than I had anticipated (see example in 2d8627c). The core of the problem is that currently, you can't make QL subclasses of `DictKind` that are non-overlapping.

This PR is recording my progress in trying to solve this problem. It is currently a draft, since I still don't have a good solution.

---

My initial example was a bit too simple, so I _thought_ I had found a usable work-around solution, but with an example where the TaintKind of the elements is not static (508e6e199), both original work-around solutions fell short :confused:

The third solution with using a delegate inside the custom TaintKind also had problems. It can work, but is not as expressive as I would like it to be.

So now I'm off to give it a go with IPA types.

## Solutions that didn't work

### Didn't work 1: Abstract `FooDictKind`, with 2 subclasses


```codeql
abstract class FooDictKind extends TaintKind {
    bindingset[this]
    FooDictKind() { any() }
}

private module FooDictKind {
    class SubclassSpecific extends FooDictKind {
        SubclassSpecific() { this = "FooDictKind::SubclassSpecific" }

        override TaintKind getTaintOfAttribute(string name) {
            name = "foo" and result instanceof ExternalFileObject
        }
    }

    class DictPart extends FooDictKind, ExternalStringDictKind { }
}

class FooDictSource extends TaintSource {
    FooDictSource() { this.(NameNode).getId() = "FOO_DICT" }

    override predicate isSourceOf(TaintKind kind) {
        kind instanceof FooDictKind
    }
}
```

However, this is not general enough. If we can't determine the value-type ahead-of-time, we will have to make a definition like so:

```codeql
private module FooDictKind {
    class DictPart extends FooDictKind, DictKind { }
}
```

usually we would restrict the actual TainKind inside the dict in the source, as such:

```codeql
override predicate isSourceOf(TaintKind kind) {
    kind.(FooDictKind).getValue() instanceof ExternalStringKind
}
```

but we can't, since `FooDictKind` is _not_ a `DictKind`, we can't access the `.getValue` :( so IT HAS TO BE

```codeql
override predicate isSourceOf(TaintKind kind) {
    kind instanceof FooDictKind
}
```

and that is simply not good enough :|


### Didn't work 2: source uses `or`

What is currently used in the code of this PR. Isn't expressive enough, as shown by `AttrBasedDictKind` :\

```codeql
/** The subclass specific part of BarDict */
class BarDictKind extends TaintKind {
    BarDictKind() { this = "BarDictKind" }

    override TaintKind getTaintOfAttribute(string name) {
        name = "bar" and result instanceof ExternalFileObject
    }
}

class BarDictSource extends TaintSource {
    BarDictSource() { this.(NameNode).getId() = "BAR_DICT" }

    override predicate isSourceOf(TaintKind kind) {
        kind instanceof BarDictKind
        or
        kind.(DictKind).getValue() instanceof ExternalStringKind
    }
}
```

This has the problem that if your Python subclass overwrites the behavior of `__iter__`, you _can_ override `getTaintForIteration` in the subclass specific part, but there is no way to prevent the `getTaintForIteration` from `DictKind` to also be used (not as much a problem for DictKind right now, but it would be for a subclass of `list` and `SequenceKind`).

### Didn't work 3: Using delegation

When I talked with `@aschackmull` about how to handle this, we discussed the idea of using a delegate.

I imagined it would be something like

```codeql
class FooDictKind extends TaintKind {
    DictKind dict;

    TaintKind getValue() { result = dict.getValue() }

    FooDictKind() { this = "FooDictKind" }

    override TaintKind getTaintOfAttribute(string name) {
        result = dict.getTaintOfAttribute(name)
        or
        name = "foo" and result instanceof ExternalFileObject
    }

    override TaintKind getTaintOfMethodResult(string name) {
        result = dict.getTaintOfMethodResult(name)
    }

    override TaintKind getTaintForFlowStep(ControlFlowNode fromnode, ControlFlowNode tonode) {
        result = dict.getTaintForFlowStep(fromnode, tonode)
    }

    // ...
}

class FooDictSource extends TaintSource {
    FooDictSource() { this.(NameNode).getId() = "FOO_DICT" }

    override predicate isSourceOf(TaintKind kind) {
        kind.(FooDictKind).getValue() instanceof ExternalStringKind
    }
}
```

and while this _could_ work, there is a major problem: Since we don't restrict the relation between the `dict` field and `this`, the snippet `kind.(FooDictKind).getValue() instanceof ExternalStringKind` doesn't do what we really want it to -- se condensed example in https://lgtm.com/query/6077904279195063093/.

An obvious solution is to change the char-pred to do `this = "FooDictKind" + dict`; however, since a FooDictKind can be the value inside a dict, we end up with infinite recursion :confused

If we know all the possible kinds we could want our dict to contain beforehand, we could change the char-pred to do

```codeql
FooDictKind() {
    exists(TaintKind valueKind | valueKind in [KindA, KindB]
    |
        dict.getValue() = valueKind and
        this = "FooDictKind" + dict
    )
}
```

and while that is sort of annoying having to do, it could make this trick work.

Well, actually there will be _one_ problem, since our taint-tracking implementation code only handles dictionary lookups (with subscripts) when the TaintKind is a CollectionKind (and our new `FooDictKind` isn't). See

- https://github.com/github/codeql/blob/727cde31c99dae7e9b1cd7b267a16644be5b1d96/python/ql/src/semmle/python/dataflow/Implementation.qll#L333-L335
- https://github.com/github/codeql/blob/2fad5e8e32aed7f777ea9a570f38efc4e671e7c2/python/ql/src/semmle/python/dataflow/TaintTracking.qll#L321-L323

I'm not 100% sure why we have this `flowToMember`/`flowFromMember` setup instead of just using `getTaintForFlowStep`, but this is the way it is today :|

## Bad solutions

### Bad solution 1

Add class-specific suffix to the string defining the TaintKind. So we could define our classes as
```codeql
class FooDictKind extends DictKind {
    FooDictKind() { this = "{" + this.getValue() + "!" + "FooDictKind" }
}

class BarDictKind extends DictKind {
    BarDictKind() { this = "{" + this.getValue() + "!" + "BarDictKind" }
}
```
This requires a change to the char-pred of DictKind to only look at the prefix, such as:
```codeql
DictKind() { this.indexOf("{" + valueKind) = 0 }
```
### Bad solution 2

Duplicate the code for DictKind for FooDictKind, BarDictKind, and any new dict subclass.
