### PR TITLE
Java: CWE-273 Unsafe certificate trust

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.java
@@ -65,4 +65,37 @@ public static void main(String[] args) {
 			}
 		};
 	}
+
+	{
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		SSLEngine sslEngine = sslContext.createSSLEngine();
+		SSLParameters sslParameters = sslEngine.getSSLParameters();
+		sslParameters.setEndpointIdentificationAlgorithm("HTTPS"); //GOOD: Set a valid endpointIdentificationAlgorithm for SSL engine to trigger hostname verification
+		sslEngine.setSSLParameters(sslParameters);
+	}
+
+	{
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		SSLEngine sslEngine = sslContext.createSSLEngine();  //BAD: No endpointIdentificationAlgorithm set
+	}
+
+	{
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		final SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+		SSLSocket socket = (SSLSocket) socketFactory.createSocket("www.example.com", 443); 
+		SSLParameters sslParameters = sslEngine.getSSLParameters();
+		sslParameters.setEndpointIdentificationAlgorithm("HTTPS"); //GOOD: Set a valid endpointIdentificationAlgorithm for SSL socket to trigger hostname verification
+		socket.setSSLParameters(sslParameters);
+	}
+
+	{
+		com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+		connectionFactory.useSslProtocol();
+		connectionFactory.enableHostnameVerification();  //GOOD: Enable hostname verification for rabbitmq ConnectionFactory
+	}
+
+	{
+		com.rabbitmq.client.ConnectionFactory connectionFactory = new com.rabbitmq.client.ConnectionFactory();
+		connectionFactory.useSslProtocol(); //BAD: Hostname verification for rabbitmq ConnectionFactory is not enabled
+	}
 }

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.java
@@ -1,0 +1,68 @@
+public static void main(String[] args) {
+	{
+		HostnameVerifier verifier = new HostnameVerifier() {
+			@Override
+			public boolean verify(String hostname, SSLSession session) {
+				try { //GOOD: verify the certificate
+					Certificate[] certs = session.getPeerCertificates();
+					X509Certificate x509 = (X509Certificate) certs[0];
+					check(new String[]{host}, x509);
+					return true;
+				} catch (SSLException e) {
+					return false;
+				}
+			}
+		};
+		HttpsURLConnection.setDefaultHostnameVerifier(verifier);
+	}
+
+	{
+		HostnameVerifier verifier = new HostnameVerifier() {
+			@Override
+			public boolean verify(String hostname, SSLSession session) {
+				return true; // BAD: accept even if the hostname doesn't match
+			}
+		};
+		HttpsURLConnection.setDefaultHostnameVerifier(verifier);
+	}
+
+	{
+		X509TrustManager trustAllCertManager = new X509TrustManager() {
+			@Override
+			public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+			}
+
+			@Override
+			public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+				// BAD: trust any server cert
+			}
+
+			@Override
+			public X509Certificate[] getAcceptedIssuers() {
+				return null; //BAD: doesn't check cert issuer
+			}
+		};
+	}
+
+	{
+		X509TrustManager trustCertManager = new X509TrustManager() {
+			@Override
+			public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+			}
+
+			@Override
+			public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+				pkixTrustManager.checkServerTrusted(chain, authType); //GOOD: validate the server cert
+			}
+
+			@Override
+			public X509Certificate[] getAcceptedIssuers() {
+				return new X509Certificate[0]; //GOOD: Validate the cert issuer
+			}
+		};
+	}
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.qhelp
@@ -1,0 +1,33 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Java offers two mechanisms for SSL authentication - trust manager and hostname verifier. Trust manager validates the peer's certificate chain while hostname verification establishes that the hostname in the URL matches the hostname in the server's identification.</p>
+<p>Unsafe implementation of the interface X509TrustManager and HostnameVerifier ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.</p>
+<p>This query checks whether trust manager is set to trust all certificates or the hostname verifier is turned off.</p>
+</overview>
+
+<recommendation>
+<p>Validate SSL certificate in SSL authentication.</p>
+</recommendation>
+
+<example>
+<p>The following two examples show two ways of configuring X509 trust cert manager and hostname verifier. In the 'BAD' case,
+no validation is performed thus any certificate is trusted. In the 'GOOD' case, the proper validation is performed.</p>
+<sample src="UnsafeCertTrust.java" />
+</example>
+
+<references>
+<li>
+<a href="https://cwe.mitre.org/data/definitions/273.html">CWE-273</a>
+</li>
+<li>
+<a href="https://support.google.com/faqs/answer/6346016?hl=en">How to fix apps containing an unsafe implementation of TrustManager</a>
+</li>
+<li>
+<a href="https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md">Testing Endpoint Identify Verification (MSTG-NETWORK-3)</a>
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.qhelp
@@ -5,8 +5,9 @@
 
 <overview>
 <p>Java offers two mechanisms for SSL authentication - trust manager and hostname verifier. Trust manager validates the peer's certificate chain while hostname verification establishes that the hostname in the URL matches the hostname in the server's identification.</p>
-<p>Unsafe implementation of the interface X509TrustManager and HostnameVerifier ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.</p>
-<p>This query checks whether trust manager is set to trust all certificates or the hostname verifier is turned off.</p>
+<p>And when SSLSocket or SSLEngine is created without a valid parameter of setEndpointIdentificationAlgorithm, hostname verification is disabled by default.</p>
+<p>Unsafe implementation of the interface X509TrustManager, HostnameVerifier, and SSLSocket/SSLEngine ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.</p>
+<p>This query checks whether trust manager is set to trust all certificates, the hostname verifier is turned off, or setEndpointIdentificationAlgorithm is missing. The query also covers a special implementation com.rabbitmq.client.ConnectionFactory.</p>
 </overview>
 
 <recommendation>
@@ -28,6 +29,18 @@ no validation is performed thus any certificate is trusted. In the 'GOOD' case, 
 </li>
 <li>
 <a href="https://github.com/OWASP/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md">Testing Endpoint Identify Verification (MSTG-NETWORK-3)</a>
+</li>
+<li>
+<a href="https://github.com/advisories/GHSA-xvch-r4wf-h8w9">CVE-2018-17187: Apache Qpid Proton-J transport issue with hostname verification</a>
+</li>
+<li>
+<a href="https://github.com/advisories/GHSA-46j3-r4pj-4835">CVE-2018-8034: Apache Tomcat - host name verification when using TLS with the WebSocket client</a>
+</li>
+<li>
+<a href="https://github.com/advisories/GHSA-w4g2-9hj6-5472">CVE-2018-11087: Pivotal Spring AMQP vulnerability due to lack of hostname validation</a>
+</li>
+<li>
+<a href="https://github.com/advisories/GHSA-m9w8-v359-9ffr">CVE-2018-11775: TLS hostname verification issue when using the Apache ActiveMQ Client</a>
 </li>
 </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -1,0 +1,95 @@
+/**
+ * @id java/unsafe-cert-trust
+ * @name Unsafe implementation of trusting any certificate in SSL configuration
+ * @description Unsafe implementation of the interface X509TrustManager and HostnameVerifier ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.
+ * @kind problem
+ * @tags security
+ *       external/cwe-273
+ */
+
+import java
+import semmle.code.java.security.Encryption
+import semmle.code.java.dataflow.DataFlow
+import DataFlow
+
+/**
+ * X509TrustManager class that blindly trusts all certificates in server SSL authentication
+ */
+class X509TrustAllManager extends RefType {
+  X509TrustAllManager() {
+    this.getASupertype*() instanceof X509TrustManager and
+    exists(Method m1 |
+      m1.getDeclaringType() = this and
+      m1.hasName("checkServerTrusted") and
+      m1.getBody().getNumStmt() = 0
+    ) and
+    exists(Method m2, ReturnStmt rt2 |
+      m2.getDeclaringType() = this and
+      m2.hasName("getAcceptedIssuers") and
+      rt2.getEnclosingCallable() = m2 and
+      rt2.getResult() instanceof NullLiteral
+    )
+  }
+}
+
+/**
+ * The init method of SSLContext with the trust all manager, which is sslContext.init(..., serverTMs, ...)
+ */
+class X509TrustAllManagerInit extends MethodAccess {
+  X509TrustAllManagerInit() {
+    this.getMethod().hasName("init") and
+    this.getMethod().getDeclaringType() instanceof SSLContext and //init method of SSLContext
+    (
+      exists(ArrayInit ai |
+        ai.getInit(0).(VarAccess).getVariable().getInitializer().getType().(Class).getASupertype*()
+          instanceof X509TrustAllManager //Scenario of context.init(null, new TrustManager[] { TRUST_ALL_CERTIFICATES }, null);
+      )
+      or
+      exists(Variable v, ArrayInit ai |
+        this.getArgument(1).(VarAccess).getVariable() = v and
+        ai.getParent() = v.getAnAccess().getVariable().getAnAssignedValue() and
+        ai.getInit(0).getType().(Class).getASupertype*() instanceof X509TrustAllManager //Scenario of context.init(null, serverTMs, null);
+      )
+    )
+  }
+}
+
+/**
+ * HostnameVerifier class that allows a certificate whose CN (Common Name) does not match the host name in the URL
+ */
+class TrustAllHostnameVerifier extends RefType {
+  TrustAllHostnameVerifier() {
+    this.getASupertype*() instanceof HostnameVerifier and
+    exists(Method m, ReturnStmt rt |
+      m.getDeclaringType() = this and
+      m.hasName("verify") and
+      rt.getEnclosingCallable() = m and
+      rt.getResult().(BooleanLiteral).getBooleanValue() = true
+    )
+  }
+}
+
+/**
+ * The setDefaultHostnameVerifier method of HttpsURLConnection with the trust all configuration
+ */
+class TrustAllHostnameVerify extends MethodAccess {
+  TrustAllHostnameVerify() {
+    this.getMethod().hasName("setDefaultHostnameVerifier") and
+    this.getMethod().getDeclaringType() instanceof HttpsURLConnection and //httpsURLConnection.setDefaultHostnameVerifier method
+    (
+      exists(NestedClass nc |
+        nc.getASupertype*() instanceof TrustAllHostnameVerifier and
+        this.getArgument(0).getType() = nc  //Scenario of HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {...});
+      )
+      or
+      exists(Variable v |
+        this.getArgument(0).(VarAccess).getVariable() = v.getAnAccess().getVariable() and
+        v.getInitializer().getType() instanceof TrustAllHostnameVerifier //Scenario of HttpsURLConnection.setDefaultHostnameVerifier(verifier);
+      )
+    )
+  }
+}
+
+from MethodAccess aa
+where aa instanceof TrustAllHostnameVerify or aa instanceof X509TrustAllManagerInit
+select aa, "Unsafe configuration of trusted certificates"

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -1,8 +1,8 @@
 /**
- * @id java/unsafe-cert-trust
  * @name Unsafe implementation of trusting any certificate or missing hostname verification in SSL configuration
  * @description Unsafe implementation of the interface X509TrustManager, HostnameVerifier, and SSLSocket/SSLEngine ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks.
  * @kind problem
+ * @id java/unsafe-cert-trust
  * @tags security
  *       external/cwe-273
  */
@@ -226,3 +226,4 @@ where
   aa instanceof SSLEndpointIdentificationNotSet or
   aa instanceof RabbitMQEnableHostnameVerificationNotSet
 select aa, "Unsafe configuration of trusted certificates"
+

--- a/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql
@@ -226,4 +226,3 @@ where
   aa instanceof SSLEndpointIdentificationNotSet or
   aa instanceof RabbitMQEnableHostnameVerificationNotSet
 select aa, "Unsafe configuration of trusted certificates"
-

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
@@ -1,7 +1,7 @@
-| UnsafeCertTrustTest.java:26:4:26:74 | init(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:41:4:41:38 | init(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:54:3:59:4 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:72:3:72:57 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:123:25:123:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:134:25:134:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:143:34:143:83 | createSocket(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:27:4:27:74 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:42:4:42:38 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:55:3:60:4 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:73:3:73:57 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:124:25:124:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:135:25:135:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:144:34:144:83 | createSocket(...) | Unsafe configuration of trusted certificates |

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
@@ -1,4 +1,7 @@
-| UnsafeCertTrustTest.java:19:4:19:74 | init(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:34:4:34:38 | init(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:47:3:52:4 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
-| UnsafeCertTrustTest.java:65:3:65:57 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:26:4:26:74 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:41:4:41:38 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:54:3:59:4 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:72:3:72:57 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:123:25:123:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:134:25:134:52 | createSSLEngine(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:143:34:143:83 | createSocket(...) | Unsafe configuration of trusted certificates |

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.expected
@@ -1,0 +1,4 @@
+| UnsafeCertTrustTest.java:19:4:19:74 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:34:4:34:38 | init(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:47:3:52:4 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |
+| UnsafeCertTrustTest.java:65:3:65:57 | setDefaultHostnameVerifier(...) | Unsafe configuration of trusted certificates |

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrust.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-273/UnsafeCertTrust.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
@@ -1,0 +1,110 @@
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public class UnsafeCertTrustTest {
+
+	/**
+	 * Test the implementation of trusting all server certs as a variable
+	 */
+	public SSLSocketFactory testTrustAllCertManager() {
+		try {
+			final SSLContext context = SSLContext.getInstance("SSL");
+			context.init(null, new TrustManager[] { TRUST_ALL_CERTIFICATES }, null);
+			final SSLSocketFactory socketFactory = context.getSocketFactory();
+			return socketFactory;
+		} catch (final Exception x) {
+			throw new RuntimeException(x);
+		}
+	}
+
+	/**
+	 * Test the implementation of trusting all server certs as an anonymous class
+	 */
+	public SSLSocketFactory testTrustAllCertManagerOfVariable() {
+		try {
+			SSLContext context = SSLContext.getInstance("SSL");
+			TrustManager[] serverTMs = new TrustManager[] { new X509TrustAllManager() };
+			context.init(null, serverTMs, null);
+
+			final SSLSocketFactory socketFactory = context.getSocketFactory();
+			return socketFactory;
+		} catch (final Exception x) {
+			throw new RuntimeException(x);
+		}
+	}
+
+	/**
+	 * Test the implementation of trusting all hostnames as an anonymous class
+	 */
+	public void testTrustAllHostnameOfAnonymousClass() {
+		HttpsURLConnection.setDefaultHostnameVerifier(new HostnameVerifier() {
+			@Override
+			public boolean verify(String hostname, SSLSession session) {
+				return true; // Noncompliant
+			}
+		});
+	}
+
+	/**
+	 * Test the implementation of trusting all hostnames as a variable
+	 */
+	public void testTrustAllHostnameOfVariable() {
+		HostnameVerifier verifier = new HostnameVerifier() {
+			@Override
+			public boolean verify(String hostname, SSLSession session) {
+				return true; // Noncompliant
+			}
+		};
+		HttpsURLConnection.setDefaultHostnameVerifier(verifier);
+	}
+
+	private static final X509TrustManager TRUST_ALL_CERTIFICATES = new X509TrustManager() {
+		@Override
+		public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+		}
+
+		@Override
+		public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+			// Noncompliant
+		}
+
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return null; // Noncompliant
+		}
+	};
+
+	private class X509TrustAllManager implements X509TrustManager {
+		@Override
+		public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+		}
+
+		@Override
+		public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+				throws CertificateException {
+			// Noncompliant
+		}
+
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return null; // Noncompliant
+		}
+	};
+
+	public static final HostnameVerifier ALLOW_ALL_HOSTNAME_VERIFIER = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return true; // Noncompliant
+		}
+	};
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
@@ -10,6 +10,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import java.net.Socket;
+import javax.net.SocketFactory;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
@@ -126,7 +127,7 @@ public class UnsafeCertTrustTest {
 		sslEngine.setSSLParameters(sslParameters);
 	}
 
-		/**
+	/**
 	 * Test the endpoint identification of SSL engine is not set
 	 */
 	public void testSSLEngineEndpointIdNotSet() {
@@ -143,11 +144,19 @@ public class UnsafeCertTrustTest {
 		SSLSocket socket = (SSLSocket) socketFactory.createSocket("www.example.com", 443);
 	}
 
+	/**
+	 * Test the endpoint identification of regular socket is not set
+	 */
+	public void testSocketEndpointIdNotSet() {
+		SocketFactory socketFactory = SocketFactory.getDefault();
+		Socket socket = socketFactory.createSocket("www.example.com", 80);
+	}
+
 	// /**
-	//  * Test the enableHostnameVerification of RabbitMQConnectionFactory is not set
-	//  */
+	// * Test the enableHostnameVerification of RabbitMQConnectionFactory is not set
+	// */
 	// public void testEnableHostnameVerificationOfRabbitMQFactoryNotSet() {
-	// 	ConnectionFactory connectionFactory = new ConnectionFactory();
-	// 	connectionFactory.useSslProtocol();
+	// ConnectionFactory connectionFactory = new ConnectionFactory();
+	// connectionFactory.useSslProtocol();
 	// }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-273/UnsafeCertTrustTest.java
@@ -1,12 +1,19 @@
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import java.net.Socket;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+
+//import com.rabbitmq.client.ConnectionFactory;
 
 public class UnsafeCertTrustTest {
 
@@ -15,7 +22,7 @@ public class UnsafeCertTrustTest {
 	 */
 	public SSLSocketFactory testTrustAllCertManager() {
 		try {
-			final SSLContext context = SSLContext.getInstance("SSL");
+			final SSLContext context = SSLContext.getInstance("TLS");
 			context.init(null, new TrustManager[] { TRUST_ALL_CERTIFICATES }, null);
 			final SSLSocketFactory socketFactory = context.getSocketFactory();
 			return socketFactory;
@@ -29,7 +36,7 @@ public class UnsafeCertTrustTest {
 	 */
 	public SSLSocketFactory testTrustAllCertManagerOfVariable() {
 		try {
-			SSLContext context = SSLContext.getInstance("SSL");
+			SSLContext context = SSLContext.getInstance("TLS");
 			TrustManager[] serverTMs = new TrustManager[] { new X509TrustAllManager() };
 			context.init(null, serverTMs, null);
 
@@ -107,4 +114,40 @@ public class UnsafeCertTrustTest {
 			return true; // Noncompliant
 		}
 	};
+
+	/**
+	 * Test the endpoint identification of SSL engine is set to null
+	 */
+	public void testSSLEngineEndpointIdSetNull() {
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		SSLEngine sslEngine = sslContext.createSSLEngine();
+		SSLParameters sslParameters = sslEngine.getSSLParameters();
+		sslParameters.setEndpointIdentificationAlgorithm(null);
+		sslEngine.setSSLParameters(sslParameters);
+	}
+
+		/**
+	 * Test the endpoint identification of SSL engine is not set
+	 */
+	public void testSSLEngineEndpointIdNotSet() {
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		SSLEngine sslEngine = sslContext.createSSLEngine();
+	}
+
+	/**
+	 * Test the endpoint identification of SSL socket is not set
+	 */
+	public void testSSLSocketEndpointIdNotSet() {
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		final SSLSocketFactory socketFactory = sslContext.getSocketFactory();
+		SSLSocket socket = (SSLSocket) socketFactory.createSocket("www.example.com", 443);
+	}
+
+	// /**
+	//  * Test the enableHostnameVerification of RabbitMQConnectionFactory is not set
+	//  */
+	// public void testEnableHostnameVerificationOfRabbitMQFactoryNotSet() {
+	// 	ConnectionFactory connectionFactory = new ConnectionFactory();
+	// 	connectionFactory.useSslProtocol();
+	// }
 }


### PR DESCRIPTION
Java offers two mechanisms for SSL authentication - trust manager and hostname verifier. Trust manager validates the peer's certificate chain while hostname verification establishes that the hostname in the URL matches the hostname in the server's identification.

Unsafe implementation of the interface X509TrustManager and HostnameVerifier ignores all SSL certificate validation errors when establishing an HTTPS connection, thereby making the app vulnerable to man-in-the-middle attacks. This is a very common issue with web development. 

The query checks whether trust manager is set to trust all certificates or the hostname verifier is turned off. I've tested it against some GitHub projects, and a test case has been created.

Please consider to merge the PR. Thanks.