### PR TITLE
Python: Fix (upcoming) deprecation compiler-warnings

### DIFF
--- a/python/ql/src/Variables/UndefinedExport.ql
+++ b/python/ql/src/Variables/UndefinedExport.ql
@@ -59,7 +59,7 @@ predicate contains_unknown_import_star(ModuleValue m) {
 from ModuleValue m, StrConst name, string exported_name
 where
     declaredInAll(m.getScope(), name) and
-    exported_name = name.strValue() and
+    exported_name = name.getText() and
     not m.hasAttribute(exported_name) and
     not is_exported_submodule_name(m, exported_name) and
     not contains_unknown_import_star(m) and

--- a/python/ql/src/semmle/python/Exprs.qll
+++ b/python/ql/src/semmle/python/Exprs.qll
@@ -597,7 +597,7 @@ class StrConst extends Str_, ImmutableLiteral {
         this.getEnclosingModule().hasFromFuture("unicode_literals")
     }
 
-    override string strValue() { result = this.getS() }
+    deprecated override string strValue() { result = this.getS() }
 
     override Expr getASubExpression() { none() }
 

--- a/python/ql/src/semmle/python/types/ModuleObject.qll
+++ b/python/ql/src/semmle/python/types/ModuleObject.qll
@@ -118,7 +118,7 @@ class BuiltinModuleObject extends ModuleObject {
 
     override predicate hasAttribute(string name) { exists(this.asBuiltin().getMember(name)) }
 
-    override predicate exportsComplete() { any() }
+    deprecated override predicate exportsComplete() { any() }
 }
 
 class PythonModuleObject extends ModuleObject {
@@ -132,7 +132,7 @@ class PythonModuleObject extends ModuleObject {
 
     override Container getPath() { result = this.getModule().getFile() }
 
-    override predicate exportsComplete() {
+    deprecated override predicate exportsComplete() {
         exists(Module m | m = this.getModule() |
             not exists(Call modify, Attribute attr, GlobalVariable all |
                 modify.getScope() = m and
@@ -196,7 +196,7 @@ class PackageObject extends ModuleObject {
         )
     }
 
-    override predicate exportsComplete() {
+    deprecated override predicate exportsComplete() {
         not exists(this.getInitModule())
         or
         this.getInitModule().exportsComplete()


### PR DESCRIPTION
In a near-future release overriding a deprecated predicate without making as deprecated would give a compiler warning.

Not fixing the XML one. [I can see that this shouldn't be reported anymore](https://github.com/github/codeql/pull/3520#issuecomment-631552943), and it's not safe to remove since it was only marked as deprecated in e6425bb4cf1b7b00f1b6ff592a1956de0fc0a8b6.

/cc @ginsbach 