### PR TITLE
Python: Fix filename example

### DIFF
--- a/python/ql/examples/snippets/filename.ql
+++ b/python/ql/examples/snippets/filename.ql
@@ -8,5 +8,5 @@
 import python
 
 from File f
-where f.getName() = "spam.py"
+where f.getShortName() = "spam.py"
 select f


### PR DESCRIPTION
I got my eyes on this one since it was using a deprecated method, BUT it was also doing the thing, since File.getName() is the same as File.getAbsolutePath(), and that doesn't match the description :\