### PR TITLE
Python: Use proper import for semmle.python.dataflow.TaintTracking

### DIFF
--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -13,7 +13,7 @@
 
 import python
 import semmle.python.security.Paths
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 
 /** A TaintKind to represent open tarfile objects. That is, the result of calling `tarfile.open(...)` */

--- a/python/ql/src/Security/CWE-312/CleartextLogging.ql
+++ b/python/ql/src/Security/CWE-312/CleartextLogging.ql
@@ -14,7 +14,7 @@
 
 import python
 import semmle.python.security.Paths
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.SensitiveData
 import semmle.python.security.ClearText
 

--- a/python/ql/src/Security/CWE-312/CleartextStorage.ql
+++ b/python/ql/src/Security/CWE-312/CleartextStorage.ql
@@ -14,7 +14,7 @@
 
 import python
 import semmle.python.security.Paths
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.SensitiveData
 import semmle.python.security.ClearText
 

--- a/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
+++ b/python/ql/src/Security/CWE-798/HardcodedCredentials.ql
@@ -13,7 +13,7 @@
 
 import python
 import semmle.python.security.Paths
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.filters.Tests
 
 class HardcodedValue extends TaintKind {

--- a/python/ql/src/Variables/Undefined.qll
+++ b/python/ql/src/Variables/Undefined.qll
@@ -1,6 +1,6 @@
 import python
 import Loop
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 /** Marker for "uninitialized". */
 class Uninitialized extends TaintKind {

--- a/python/ql/src/semmle/python/dataflow/Configuration.qll
+++ b/python/ql/src/semmle/python/dataflow/Configuration.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 private import semmle.python.objects.ObjectInternal
 private import semmle.python.dataflow.Implementation
 

--- a/python/ql/src/semmle/python/dataflow/DataFlow.qll
+++ b/python/ql/src/semmle/python/dataflow/DataFlow.qll
@@ -1,1 +1,1 @@
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking

--- a/python/ql/src/semmle/python/dataflow/Files.qll
+++ b/python/ql/src/semmle/python/dataflow/Files.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 class OpenFile extends TaintKind {
     OpenFile() { this = "file.open" }

--- a/python/ql/src/semmle/python/dataflow/Legacy.qll
+++ b/python/ql/src/semmle/python/dataflow/Legacy.qll
@@ -1,4 +1,4 @@
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 private import semmle.python.objects.ObjectInternal
 import semmle.python.dataflow.Implementation
 

--- a/python/ql/src/semmle/python/security/ClearText.qll
+++ b/python/ql/src/semmle/python/security/ClearText.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.SensitiveData
 import semmle.python.dataflow.Files
 import semmle.python.web.Http

--- a/python/ql/src/semmle/python/security/Crypto.qll
+++ b/python/ql/src/semmle/python/security/Crypto.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 private import semmle.python.security.SensitiveData
 private import semmle.crypto.Crypto as CryptoLib
 

--- a/python/ql/src/semmle/python/security/Exceptions.qll
+++ b/python/ql/src/semmle/python/security/Exceptions.qll
@@ -4,7 +4,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 
 private Value traceback_function(string name) { result = Module::named("traceback").attr(name) }

--- a/python/ql/src/semmle/python/security/SQL.qll
+++ b/python/ql/src/semmle/python/security/SQL.qll
@@ -1,4 +1,4 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 abstract class SqlInjectionSink extends TaintSink { }

--- a/python/ql/src/semmle/python/security/SensitiveData.qll
+++ b/python/ql/src/semmle/python/security/SensitiveData.qll
@@ -10,7 +10,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.HttpRequest
 
 /**

--- a/python/ql/src/semmle/python/security/injection/Command.qll
+++ b/python/ql/src/semmle/python/security/injection/Command.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 /** Abstract taint sink that is potentially vulnerable to malicious shell commands. */

--- a/python/ql/src/semmle/python/security/injection/Deserialization.qll
+++ b/python/ql/src/semmle/python/security/injection/Deserialization.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 /** `pickle.loads(untrusted)` vulnerability. */
 abstract class DeserializationSink extends TaintSink {

--- a/python/ql/src/semmle/python/security/injection/Exec.qll
+++ b/python/ql/src/semmle/python/security/injection/Exec.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 /**

--- a/python/ql/src/semmle/python/security/injection/Marshal.qll
+++ b/python/ql/src/semmle/python/security/injection/Marshal.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 

--- a/python/ql/src/semmle/python/security/injection/Path.qll
+++ b/python/ql/src/semmle/python/security/injection/Path.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 /**

--- a/python/ql/src/semmle/python/security/injection/Pickle.qll
+++ b/python/ql/src/semmle/python/security/injection/Pickle.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 

--- a/python/ql/src/semmle/python/security/injection/Sql.qll
+++ b/python/ql/src/semmle/python/security/injection/Sql.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.SQL
 

--- a/python/ql/src/semmle/python/security/injection/Xml.qll
+++ b/python/ql/src/semmle/python/security/injection/Xml.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 

--- a/python/ql/src/semmle/python/security/injection/Yaml.qll
+++ b/python/ql/src/semmle/python/security/injection/Yaml.qll
@@ -7,7 +7,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.injection.Deserialization
 

--- a/python/ql/src/semmle/python/security/strings/Basic.qll
+++ b/python/ql/src/semmle/python/security/strings/Basic.qll
@@ -1,6 +1,6 @@
 import python
 private import Common
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 /** An extensible kind of taint representing any kind of string. */
 abstract class StringKind extends TaintKind {

--- a/python/ql/src/semmle/python/web/bottle/Redirect.qll
+++ b/python/ql/src/semmle/python/web/bottle/Redirect.qll
@@ -5,7 +5,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.bottle.General
 

--- a/python/ql/src/semmle/python/web/bottle/Request.qll
+++ b/python/ql/src/semmle/python/web/bottle/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.web.Http
 import semmle.python.web.bottle.General

--- a/python/ql/src/semmle/python/web/bottle/Response.qll
+++ b/python/ql/src/semmle/python/web/bottle/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.web.Http
 import semmle.python.web.bottle.General

--- a/python/ql/src/semmle/python/web/cherrypy/Request.qll
+++ b/python/ql/src/semmle/python/web/cherrypy/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 import semmle.python.web.cherrypy.General

--- a/python/ql/src/semmle/python/web/cherrypy/Response.qll
+++ b/python/ql/src/semmle/python/web/cherrypy/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.web.Http
 import semmle.python.web.cherrypy.General

--- a/python/ql/src/semmle/python/web/django/Model.qll
+++ b/python/ql/src/semmle/python/web/django/Model.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 import semmle.python.security.injection.Sql

--- a/python/ql/src/semmle/python/web/django/Redirect.qll
+++ b/python/ql/src/semmle/python/web/django/Redirect.qll
@@ -5,7 +5,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 private import semmle.python.web.django.Shared
 private import semmle.python.web.Http

--- a/python/ql/src/semmle/python/web/django/Request.qll
+++ b/python/ql/src/semmle/python/web/django/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.django.General
 

--- a/python/ql/src/semmle/python/web/django/Response.qll
+++ b/python/ql/src/semmle/python/web/django/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 private import semmle.python.web.django.Shared
 private import semmle.python.web.Http

--- a/python/ql/src/semmle/python/web/falcon/Request.qll
+++ b/python/ql/src/semmle/python/web/falcon/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.falcon.General
 import semmle.python.security.strings.External

--- a/python/ql/src/semmle/python/web/falcon/Response.qll
+++ b/python/ql/src/semmle/python/web/falcon/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.falcon.General
 import semmle.python.security.strings.External

--- a/python/ql/src/semmle/python/web/flask/Redirect.qll
+++ b/python/ql/src/semmle/python/web/flask/Redirect.qll
@@ -5,7 +5,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.flask.General
 

--- a/python/ql/src/semmle/python/web/flask/Request.qll
+++ b/python/ql/src/semmle/python/web/flask/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import semmle.python.web.flask.General
 

--- a/python/ql/src/semmle/python/web/flask/Response.qll
+++ b/python/ql/src/semmle/python/web/flask/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.flask.General
 

--- a/python/ql/src/semmle/python/web/pyramid/Redirect.qll
+++ b/python/ql/src/semmle/python/web/pyramid/Redirect.qll
@@ -5,7 +5,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 

--- a/python/ql/src/semmle/python/web/pyramid/Request.qll
+++ b/python/ql/src/semmle/python/web/pyramid/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 private import semmle.python.web.webob.Request
 private import semmle.python.web.pyramid.View

--- a/python/ql/src/semmle/python/web/pyramid/Response.qll
+++ b/python/ql/src/semmle/python/web/pyramid/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 private import semmle.python.web.pyramid.View

--- a/python/ql/src/semmle/python/web/stdlib/Request.qll
+++ b/python/ql/src/semmle/python/web/stdlib/Request.qll
@@ -4,7 +4,7 @@
  * (or subclasses) and form parsing using `cgi.FieldStorage`.
  */
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 
 /** Source of BaseHTTPRequestHandler instances. */

--- a/python/ql/src/semmle/python/web/stdlib/Response.qll
+++ b/python/ql/src/semmle/python/web/stdlib/Response.qll
@@ -3,7 +3,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 
 private predicate is_wfile(AttrNode wfile) {

--- a/python/ql/src/semmle/python/web/tornado/Redirect.qll
+++ b/python/ql/src/semmle/python/web/tornado/Redirect.qll
@@ -5,7 +5,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 import Tornado

--- a/python/ql/src/semmle/python/web/tornado/Request.qll
+++ b/python/ql/src/semmle/python/web/tornado/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import Tornado
 

--- a/python/ql/src/semmle/python/web/tornado/Response.qll
+++ b/python/ql/src/semmle/python/web/tornado/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 private import semmle.python.web.Http
 import Tornado

--- a/python/ql/src/semmle/python/web/tornado/Tornado.qll
+++ b/python/ql/src/semmle/python/web/tornado/Tornado.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 
 private ClassValue theTornadoRequestHandlerClass() {

--- a/python/ql/src/semmle/python/web/turbogears/Response.qll
+++ b/python/ql/src/semmle/python/web/turbogears/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Basic
 import semmle.python.web.Http
 import TurboGears

--- a/python/ql/src/semmle/python/web/turbogears/TurboGears.qll
+++ b/python/ql/src/semmle/python/web/turbogears/TurboGears.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 private ClassValue theTurboGearsControllerClass() { result = Value::named("tg.TGController") }
 

--- a/python/ql/src/semmle/python/web/twisted/Request.qll
+++ b/python/ql/src/semmle/python/web/twisted/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import Twisted
 

--- a/python/ql/src/semmle/python/web/twisted/Response.qll
+++ b/python/ql/src/semmle/python/web/twisted/Response.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 import semmle.python.security.strings.Basic
 import Twisted

--- a/python/ql/src/semmle/python/web/twisted/Twisted.qll
+++ b/python/ql/src/semmle/python/web/twisted/Twisted.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 private ClassValue theTwistedHttpRequestClass() {
     result = Value::named("twisted.web.http.Request")

--- a/python/ql/src/semmle/python/web/webob/Request.qll
+++ b/python/ql/src/semmle/python/web/webob/Request.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.Http
 
 abstract class BaseWebobRequest extends TaintKind {

--- a/python/ql/test/3/library-tests/taint/unpacking/Taint.qll
+++ b/python/ql/test/3/library-tests/taint/unpacking/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class SimpleSource extends TaintSource {

--- a/python/ql/test/3/library-tests/taint/unpacking/TestTaint.ql
+++ b/python/ql/test/3/library-tests/taint/unpacking/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/examples/custom-sanitizer/Taint.qll
+++ b/python/ql/test/library-tests/examples/custom-sanitizer/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class SimpleSource extends TaintSource {

--- a/python/ql/test/library-tests/examples/custom-sanitizer/TestTaint.ql
+++ b/python/ql/test/library-tests/examples/custom-sanitizer/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from

--- a/python/ql/test/library-tests/taint/collections/Taint.qll
+++ b/python/ql/test/library-tests/taint/collections/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class SimpleSource extends TaintSource {

--- a/python/ql/test/library-tests/taint/collections/TestStep.ql
+++ b/python/ql/test/library-tests/taint/collections/TestStep.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from TaintedNode n, TaintedNode s

--- a/python/ql/test/library-tests/taint/collections/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/collections/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/taint/config/RockPaperScissors.ql
+++ b/python/ql/test/library-tests/taint/config/RockPaperScissors.ql
@@ -3,7 +3,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 import semmle.python.security.Paths
 

--- a/python/ql/test/library-tests/taint/config/Simple.ql
+++ b/python/ql/test/library-tests/taint/config/Simple.ql
@@ -3,7 +3,7 @@
  */
 
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 import semmle.python.security.Paths
 

--- a/python/ql/test/library-tests/taint/config/TaintLib.qll
+++ b/python/ql/test/library-tests/taint/config/TaintLib.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 class SimpleTest extends TaintKind {
     SimpleTest() { this = "simple.test" }

--- a/python/ql/test/library-tests/taint/config/TaintedArgument.ql
+++ b/python/ql/test/library-tests/taint/config/TaintedArgument.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 import semmle.python.dataflow.Implementation
 

--- a/python/ql/test/library-tests/taint/config/TestNode.ql
+++ b/python/ql/test/library-tests/taint/config/TestNode.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.dataflow.Implementation
 import TaintLib
 

--- a/python/ql/test/library-tests/taint/config/TestSink.ql
+++ b/python/ql/test/library-tests/taint/config/TestSink.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from TestConfig config, DataFlow::Node sink, TaintKind kind

--- a/python/ql/test/library-tests/taint/config/TestSource.ql
+++ b/python/ql/test/library-tests/taint/config/TestSource.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from TestConfig config, DataFlow::Node source, TaintKind kind

--- a/python/ql/test/library-tests/taint/config/TestStep.ql
+++ b/python/ql/test/library-tests/taint/config/TestStep.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 import semmle.python.dataflow.Implementation
 

--- a/python/ql/test/library-tests/taint/example/Edges.ql
+++ b/python/ql/test/library-tests/taint/example/Edges.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.dataflow.Implementation
 import DilbertConfig
 

--- a/python/ql/test/library-tests/taint/example/Nodes.ql
+++ b/python/ql/test/library-tests/taint/example/Nodes.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.dataflow.Implementation
 import DilbertConfig
 

--- a/python/ql/test/library-tests/taint/extensions/ExtensionsLib.qll
+++ b/python/ql/test/library-tests/taint/extensions/ExtensionsLib.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 class SimpleTest extends TaintKind {
     SimpleTest() { this = "simple.test" }

--- a/python/ql/test/library-tests/taint/flowpath_regression/Config.qll
+++ b/python/ql/test/library-tests/taint/flowpath_regression/Config.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class FooSource extends TaintSource {

--- a/python/ql/test/library-tests/taint/general/ParamSource.ql
+++ b/python/ql/test/library-tests/taint/general/ParamSource.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 /* Standard library sink */
 import semmle.python.security.injection.Command
 

--- a/python/ql/test/library-tests/taint/general/TaintLib.qll
+++ b/python/ql/test/library-tests/taint/general/TaintLib.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 
 class SimpleTest extends TaintKind {
     SimpleTest() { this = "simple.test" }

--- a/python/ql/test/library-tests/taint/general/TestSanitizers.ql
+++ b/python/ql/test/library-tests/taint/general/TestSanitizers.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from Sanitizer s, TaintKind taint, PyEdgeRefinement test

--- a/python/ql/test/library-tests/taint/general/TestSink.ql
+++ b/python/ql/test/library-tests/taint/general/TestSink.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from TaintSource src, TaintSink sink, TaintKind srckind, TaintKind sinkkind

--- a/python/ql/test/library-tests/taint/general/TestSource.ql
+++ b/python/ql/test/library-tests/taint/general/TestSource.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from TaintSource src, TaintKind kind

--- a/python/ql/test/library-tests/taint/general/TestStep.ql
+++ b/python/ql/test/library-tests/taint/general/TestStep.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from TaintedNode n, TaintedNode s

--- a/python/ql/test/library-tests/taint/general/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/general/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import TaintLib
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/taint/namedtuple/Taint.qll
+++ b/python/ql/test/library-tests/taint/namedtuple/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class SimpleSource extends TaintSource {

--- a/python/ql/test/library-tests/taint/namedtuple/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/namedtuple/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/taint/strings/Taint.qll
+++ b/python/ql/test/library-tests/taint/strings/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 import semmle.python.security.Exceptions
 

--- a/python/ql/test/library-tests/taint/strings/TestStep.ql
+++ b/python/ql/test/library-tests/taint/strings/TestStep.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from TaintedNode n, TaintedNode s

--- a/python/ql/test/library-tests/taint/strings/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/strings/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/taint/unpacking/Taint.qll
+++ b/python/ql/test/library-tests/taint/unpacking/Taint.qll
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
 
 class SimpleSource extends TaintSource {

--- a/python/ql/test/library-tests/taint/unpacking/TestStep.ql
+++ b/python/ql/test/library-tests/taint/unpacking/TestStep.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from TaintedNode n, TaintedNode s

--- a/python/ql/test/library-tests/taint/unpacking/TestTaint.ql
+++ b/python/ql/test/library-tests/taint/unpacking/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import Taint
 
 from Call call, Expr arg, string taint_string

--- a/python/ql/test/library-tests/web/stdlib/TestTaint.ql
+++ b/python/ql/test/library-tests/web/stdlib/TestTaint.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import semmle.python.web.HttpRequest
 import semmle.python.security.strings.Untrusted
 

--- a/python/ql/test/query-tests/Security/CWE-327/TestNode.ql
+++ b/python/ql/test/query-tests/Security/CWE-327/TestNode.ql
@@ -1,5 +1,5 @@
 import python
-import semmle.python.security.TaintTracking
+import semmle.python.dataflow.TaintTracking
 import python
 import semmle.python.security.SensitiveData
 import semmle.python.security.Crypto


### PR DESCRIPTION
It was moved in 637677d515d1301b0818eac396a64ef72ee02274, but imports were not updated.