### PR TITLE
C++: Don't give alerts from TooFewArguments.ql on ambiguous declarations

### DIFF
--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
@@ -19,20 +19,21 @@ private predicate hasDefiniteNumberOfParameters(FunctionDeclarationEntry fde) {
   fde.isDefinition()
 }
 
-// True if function was ()-declared, but not (void)-declared or K&R-defined
+/* Holds if function was ()-declared, but not (void)-declared or K&R-defined. */
 private predicate hasZeroParamDecl(Function f) {
   exists(FunctionDeclarationEntry fde | fde = f.getADeclarationEntry() |
     not hasDefiniteNumberOfParameters(fde)
   )
 }
 
-// True if this file (or header) was compiled as a C file
+/* Holds if this file (or header) was compiled as a C file. */
 private predicate isCompiledAsC(File f) {
   f.compiledAsC()
   or
   exists(File src | isCompiledAsC(src) | src.getAnIncludedFile() = f)
 }
 
+/** Holds if `fc` is a call to `f` with too few arguments. */
 predicate tooFewArguments(FunctionCall fc, Function f) {
   f = fc.getTarget() and
   not f.isVarargs() and

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.qll
@@ -6,10 +6,23 @@
 
 import cpp
 
+/**
+ * Holds if `fde` has a parameter declaration that's clear on the minimum
+ * number of parameters. This is essentially true for everything except
+ * `()`-declarations.
+ */
+private predicate hasDefiniteNumberOfParameters(FunctionDeclarationEntry fde) {
+  fde.hasVoidParamList()
+  or
+  fde.getNumberOfParameters() > 0
+  or
+  fde.isDefinition()
+}
+
 // True if function was ()-declared, but not (void)-declared or K&R-defined
 private predicate hasZeroParamDecl(Function f) {
   exists(FunctionDeclarationEntry fde | fde = f.getADeclarationEntry() |
-    not fde.hasVoidParamList() and fde.getNumberOfParameters() = 0 and not fde.isDefinition()
+    not hasDefiniteNumberOfParameters(fde)
   )
 }
 
@@ -24,11 +37,18 @@ predicate tooFewArguments(FunctionCall fc, Function f) {
   f = fc.getTarget() and
   not f.isVarargs() and
   not f instanceof BuiltInFunction and
+  // This query should only have results on C (not C++) functions that have a
+  // `()` parameter list somewhere. If it has results on other functions, then
+  // it's probably because the extractor only saw a partial compilation.
   hasZeroParamDecl(f) and
   isCompiledAsC(f.getFile()) and
-  // There is an explicit declaration of the function whose parameter count is larger
-  // than the number of call arguments
-  exists(FunctionDeclarationEntry fde | fde = f.getADeclarationEntry() |
+  // Produce an alert when all declarations that are authoritative on the
+  // parameter count specify a parameter count larger than the number of call
+  // arguments.
+  forex(FunctionDeclarationEntry fde |
+    fde = f.getADeclarationEntry() and
+    hasDefiniteNumberOfParameters(fde)
+  |
     fde.getNumberOfParameters() > fc.getNumberOfArguments()
   )
 }


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/3535. 

I've tested at https://lgtm.com/query/6768520683527548147/ that this removes the FPs on racket/racket.