### PR TITLE
JavaScript: Track `require` through local data flow.

### DIFF
--- a/javascript/ql/test/library-tests/NodeJS/Require.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Require.expected
@@ -11,6 +11,8 @@
 | d.js:7:1:7:14 | require('foo') |
 | e.js:5:1:5:18 | require("process") |
 | f.js:2:1:2:7 | r("fs") |
+| g.js:1:1:1:96 | (proces ... https") |
+| g.js:1:43:1:61 | require("electron") |
 | index.js:1:12:1:26 | require('path') |
 | index.js:2:1:2:41 | require ... b.js")) |
 | mjs-files/require-from-js.js:1:12:1:36 | require ... on-me') |

--- a/javascript/ql/test/library-tests/NodeJS/g.js
+++ b/javascript/ql/test/library-tests/NodeJS/g.js
@@ -1,0 +1,1 @@
+(process && "renderer" === process.type ? require("electron").remote.require : require)("https");


### PR DESCRIPTION
Occasionally helpful, though an [evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/master/js/require-flow/report.md) on nightly doesn't show any changes in results. Performance is also unchanged.
