### PR TITLE
Revert "C++: Properly deprecate objc.qll and default.qll"

### DIFF
--- a/cpp/ql/src/default.qll
+++ b/cpp/ql/src/default.qll
@@ -1,7 +1,1 @@
-/**
- * DEPRECATED: use `import cpp` instead of `import default`.
- *
- * Provides classes and predicates for working with C/C++ code.
- */
-
 import cpp

--- a/cpp/ql/src/objc.qll
+++ b/cpp/ql/src/objc.qll
@@ -1,7 +1,1 @@
-/**
- * DEPRECATED: Objective C is no longer supported.
- *
- * Import `cpp` instead of `objc`.
- */
-
 import cpp

--- a/cpp/ql/test/header-variant-tests/deduplication/classes.ql
+++ b/cpp/ql/test/header-variant-tests/deduplication/classes.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 
 from Class c, string n
 where n = count(Class x | x.getName() = c.getName()) + " distinct class(es) called " + c.getName()

--- a/cpp/ql/test/library-tests/allocators/allocators.ql
+++ b/cpp/ql/test/library-tests/allocators/allocators.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 import semmle.code.cpp.models.implementations.Allocation
 
 query predicate newExprs(

--- a/cpp/ql/test/library-tests/conversions/conversions.ql
+++ b/cpp/ql/test/library-tests/conversions/conversions.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 
 string getValueCategoryString(Expr expr) {
   if expr.isLValueCategory()

--- a/cpp/ql/test/library-tests/ir/constant_func/constant_func.ql
+++ b/cpp/ql/test/library-tests/ir/constant_func/constant_func.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.implementation.aliased_ssa.constant.ConstantAnalysis
 import semmle.code.cpp.ir.internal.IntegerConstant

--- a/cpp/ql/test/library-tests/ir/escape/escape.ql
+++ b/cpp/ql/test/library-tests/ir/escape/escape.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 import semmle.code.cpp.ir.implementation.unaliased_ssa.internal.AliasAnalysis
 import semmle.code.cpp.ir.implementation.raw.IR
 import semmle.code.cpp.ir.implementation.UseSoundEscapeAnalysis

--- a/cpp/ql/test/library-tests/ir/escape/ssa_escape.ql
+++ b/cpp/ql/test/library-tests/ir/escape/ssa_escape.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 import semmle.code.cpp.ir.implementation.aliased_ssa.internal.AliasAnalysis
 import semmle.code.cpp.ir.implementation.aliased_ssa.internal.AliasConfiguration
 import semmle.code.cpp.ir.implementation.unaliased_ssa.IR

--- a/cpp/ql/test/library-tests/literals/uuidof/uuidof.ql
+++ b/cpp/ql/test/library-tests/literals/uuidof/uuidof.ql
@@ -1,4 +1,4 @@
-import cpp
+import default
 
 query predicate classUuids(Class cls, string uuid) {
   if exists(cls.getUuid()) then uuid = cls.getUuid() else uuid = ""


### PR DESCRIPTION
Reverts github/codeql#3558