### PR TITLE
Python: Handle fabric.api.execute in command injection

### DIFF
--- a/python/ql/src/Security/CWE-078/CommandInjection.ql
+++ b/python/ql/src/Security/CWE-078/CommandInjection.ql
@@ -32,6 +32,8 @@ class CommandInjectionConfiguration extends TaintTracking::Configuration {
 
     override predicate isExtension(TaintTracking::Extension extension) {
         extension instanceof FirstElementFlow
+        or
+        extension instanceof FabricExecuteExtension
     }
 }
 

--- a/python/ql/test/library-tests/security/fabric-v1-execute/Taint.qll
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/Taint.qll
@@ -1,6 +1,7 @@
 import python
 import semmle.python.dataflow.TaintTracking
 import semmle.python.security.strings.Untrusted
+import semmle.python.security.injection.Command
 
 class SimpleSource extends TaintSource {
     SimpleSource() { this.(NameNode).getId() = "TAINTED_STRING" }
@@ -8,4 +9,16 @@ class SimpleSource extends TaintSource {
     override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringKind }
 
     override string toString() { result = "taint source" }
+}
+
+class FabricExecuteTestConfiguration extends TaintTracking::Configuration {
+    FabricExecuteTestConfiguration() { this = "FabricExecuteTestConfiguration" }
+
+    override predicate isSource(TaintTracking::Source source) { source instanceof SimpleSource }
+
+    override predicate isSink(TaintTracking::Sink sink) { sink instanceof CommandSink }
+
+    override predicate isExtension(TaintTracking::Extension extension) {
+        extension instanceof FabricExecuteExtension
+    }
 }

--- a/python/ql/test/library-tests/security/fabric-v1-execute/Taint.qll
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/Taint.qll
@@ -1,0 +1,11 @@
+import python
+import semmle.python.dataflow.TaintTracking
+import semmle.python.security.strings.Untrusted
+
+class SimpleSource extends TaintSource {
+    SimpleSource() { this.(NameNode).getId() = "TAINTED_STRING" }
+
+    override predicate isSourceOf(TaintKind kind) { kind instanceof ExternalStringKind }
+
+    override string toString() { result = "taint source" }
+}

--- a/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.expected
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.expected
@@ -1,0 +1,10 @@
+| test.py:8 | fail | unsafe | cmd | <NO TAINT> |
+| test.py:8 | fail | unsafe | cmd2 | <NO TAINT> |
+| test.py:9 | ok   | unsafe | safe_arg | <NO TAINT> |
+| test.py:9 | ok   | unsafe | safe_optional | <NO TAINT> |
+| test.py:16 | fail | unsafe | cmd | <NO TAINT> |
+| test.py:16 | fail | unsafe | cmd2 | <NO TAINT> |
+| test.py:17 | ok   | unsafe | safe_arg | <NO TAINT> |
+| test.py:17 | ok   | unsafe | safe_optional | <NO TAINT> |
+| test.py:23 | ok   | some_http_handler | cmd | externally controlled string |
+| test.py:23 | ok   | some_http_handler | cmd2 | externally controlled string |

--- a/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.expected
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.expected
@@ -1,9 +1,9 @@
-| test.py:8 | fail | unsafe | cmd | <NO TAINT> |
-| test.py:8 | fail | unsafe | cmd2 | <NO TAINT> |
+| test.py:8 | ok   | unsafe | cmd | externally controlled string |
+| test.py:8 | ok   | unsafe | cmd2 | externally controlled string |
 | test.py:9 | ok   | unsafe | safe_arg | <NO TAINT> |
 | test.py:9 | ok   | unsafe | safe_optional | <NO TAINT> |
-| test.py:16 | fail | unsafe | cmd | <NO TAINT> |
-| test.py:16 | fail | unsafe | cmd2 | <NO TAINT> |
+| test.py:16 | ok   | unsafe | cmd | externally controlled string |
+| test.py:16 | ok   | unsafe | cmd2 | externally controlled string |
 | test.py:17 | ok   | unsafe | safe_arg | <NO TAINT> |
 | test.py:17 | ok   | unsafe | safe_optional | <NO TAINT> |
 | test.py:23 | ok   | some_http_handler | cmd | externally controlled string |

--- a/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.ql
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/TestTaint.ql
@@ -1,0 +1,34 @@
+import python
+import semmle.python.security.TaintTracking
+import semmle.python.web.HttpRequest
+import semmle.python.security.strings.Untrusted
+
+import Taint
+
+from
+    Call call, Expr arg, boolean expected_taint, boolean has_taint, string test_res,
+    string taint_string
+where
+    call.getLocation().getFile().getShortName() = "test.py" and
+    (
+        call.getFunc().(Name).getId() = "ensure_tainted" and
+        expected_taint = true
+        or
+        call.getFunc().(Name).getId() = "ensure_not_tainted" and
+        expected_taint = false
+    ) and
+    arg = call.getAnArg() and
+    (
+        not exists(TaintedNode tainted | tainted.getAstNode() = arg) and
+        taint_string = "<NO TAINT>" and
+        has_taint = false
+        or
+        exists(TaintedNode tainted | tainted.getAstNode() = arg |
+            taint_string = tainted.getTaintKind().toString()
+        ) and
+        has_taint = true
+    ) and
+    if expected_taint = has_taint then test_res = "ok  " else test_res = "fail"
+// if expected_taint = has_taint then test_res = "✓" else test_res = "✕"
+select arg.getLocation().toString(), test_res, call.getScope().(Function).getName(), arg.toString(),
+    taint_string

--- a/python/ql/test/library-tests/security/fabric-v1-execute/options
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --max-import-depth=2 -p ../../../query-tests/Security/lib/

--- a/python/ql/test/library-tests/security/fabric-v1-execute/test.py
+++ b/python/ql/test/library-tests/security/fabric-v1-execute/test.py
@@ -1,0 +1,28 @@
+"""Test that shows fabric.api.execute propagates taint"""
+
+from fabric.api import run, execute
+
+
+def unsafe(cmd, safe_arg, cmd2=None, safe_optional=5):
+    run('./venv/bin/activate && {}'.format(cmd))
+    ensure_tainted(cmd, cmd2)
+    ensure_not_tainted(safe_arg, safe_optional)
+
+
+class Foo(object):
+
+    def unsafe(self, cmd, safe_arg, cmd2=None, safe_optional=5):
+        run('./venv/bin/activate && {}'.format(cmd))
+        ensure_tainted(cmd, cmd2)
+        ensure_not_tainted(safe_arg, safe_optional)
+
+
+def some_http_handler():
+    cmd = TAINTED_STRING
+    cmd2 = TAINTED_STRING
+    ensure_tainted(cmd, cmd2)
+
+    execute(unsafe, cmd=cmd, safe_arg='safe_arg', cmd2=cmd2)
+
+    foo = Foo()
+    execute(foo.unsafe, cmd, 'safe_arg', cmd2)

--- a/python/ql/test/query-tests/Security/lib/fabric/api.py
+++ b/python/ql/test/query-tests/Security/lib/fabric/api.py
@@ -23,3 +23,7 @@ def sudo(command, shell=True, pty=True, combine_stderr=None, user=None,
     quiet=False, warn_only=False, stdout=None, stderr=None, group=None,
     timeout=None, shell_escape=None, capture_buffer_size=None):
     pass
+
+# https://github.com/fabric/fabric/blob/1.14/fabric/tasks.py#L281
+def execute(task, *args, **kwargs):
+    pass


### PR DESCRIPTION
Fixes https://github.com/github/codeql-python-team/issues/53

Closing https://github.com/github/codeql/pull/3164 which was my initial attempt at figuring out how to do this. In this PR I made use of a `DataFlowExtension`, which seems like a better (and more modular) way of implementing this, than changing `isAdditionalFlowStep` of the configuration.. at least this approach made it very simple to test my changes :+1:.