### PR TITLE
JS: Avoid string coercion in JSXName.getValue

### DIFF
--- a/javascript/ql/src/semmle/javascript/JSX.qll
+++ b/javascript/ql/src/semmle/javascript/JSX.qll
@@ -196,7 +196,7 @@ class JSXName extends Expr {
     )
     or
     exists(JSXQualifiedName qual | qual = this |
-      result = qual.getNamespace() + ":" + qual.getName()
+      result = qual.getNamespace().getName() + ":" + qual.getName().getName()
     )
   }
 }


### PR DESCRIPTION
Removes an accidental toString-coercion. I've used QL4QL to verify that there are no other accidental coercions.

Evaluations:
- [XSS/Smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/avoid-accidental-string-coercion_1590498911101) looks fine
- Running security/smoke-test as well, just to be safe.