### PR TITLE
C#: Fix performance issue in unification library

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Unification.qll
+++ b/csharp/ql/src/semmle/code/csharp/Unification.qll
@@ -474,7 +474,8 @@ module Gvn {
         sourceDecl = any(GenericType t).getSourceDeclaration() and
         not sourceDecl instanceof PointerType and
         not sourceDecl instanceof NullableType and
-        not sourceDecl instanceof ArrayType
+        not sourceDecl instanceof ArrayType and
+        not sourceDecl instanceof TupleType
       }
 
     cached


### PR DESCRIPTION
This fixes a performance regression introduced on https://github.com/github/codeql/pull/3351. `CSharp-Differences` job [here](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/189/).