### PR TITLE
Improves RedundantNullCheckSimple

### DIFF
--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -74,16 +74,16 @@ predicate isCheckedInstruction(Instruction unchecked, Instruction checked, Value
 }
 
 pragma[noinline]
-predicate candidateResultDeref(LoadInstruction unchecked, ValueNumber value, IRBlock dominator) {
+predicate candidateResultDeref(LoadInstruction unchecked, ValueNumber value) {
   value.getAnInstruction() = unchecked and
   derefInstruction(unchecked, _) and
-  not isCheckedInstruction(unchecked, _, value) and
-  not dominator.dominates(unchecked.getBlock())
+  not isCheckedInstruction(unchecked, _, value)
 }
 
 from LoadInstruction checked, LoadInstruction deref, ValueNumber sourceValue, IRBlock dominator
 where
   candidateResult(checked, sourceValue, dominator) and
-  candidateResultDeref(deref, sourceValue, dominator)
+  candidateResultDeref(deref, sourceValue) and
+  not dominator.dominates(deref.getBlock())
 select checked, "This null check is redundant because the value is $@ in any case", deref,
   "dereferenced here"

--- a/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
+++ b/cpp/ql/src/Likely Bugs/RedundantNullCheckSimple.ql
@@ -50,9 +50,11 @@ predicate explicitNullTestOfInstruction(Instruction checked, Instruction bool) {
 }
 
 pragma[noinline]
-predicate candidateResultChecked(LoadInstruction checked, ValueNumber value) {
+predicate candidateResult(LoadInstruction checked, ValueNumber value, IRBlock dominator) {
   explicitNullTestOfInstruction(checked, _) and
-  value.getAnInstruction() = checked
+  not checked.getAST().isInMacroExpansion() and
+  value.getAnInstruction() = checked and
+  checked.getBlock() = dominator
 }
 
 predicate derefInstruction(Instruction checked, Instruction bool) {
@@ -79,9 +81,9 @@ predicate candidateResultDeref(LoadInstruction unchecked, ValueNumber value, IRB
   not dominator.dominates(unchecked.getBlock())
 }
 
-from LoadInstruction checked, LoadInstruction deref, ValueNumber sourceValue
+from LoadInstruction checked, LoadInstruction deref, ValueNumber sourceValue, IRBlock dominator
 where
-  candidateResultChecked(checked, sourceValue) and
-  candidateResultDeref(deref, sourceValue, checked.getBlock())
+  candidateResult(checked, sourceValue, dominator) and
+  candidateResultDeref(deref, sourceValue, dominator)
 select checked, "This null check is redundant because the value is $@ in any case", deref,
   "dereferenced here"


### PR DESCRIPTION
## CVE ID(s)

*List the CVE ID(s) associated with this vulnerability. GitHub will automatically link CVE IDs to the [GitHub Advisory Database](https://github.com/advisories).*

- CVE-2020-10957

## Report

A potential NULL dereference (or redundant NULL check) may happen if a pointer is checked once against NULL in a function but not every time.

This improvement to RedundantNullCheckSimple, in addition to finding the NULL dereference from CVE-2020-10957 also finds the redundant null checks from :
- https://github.com/dovecot/core/commit/cab34492c2d681d59b2da30d0ca06431d2137c26
- https://hackerone.com/bugs?report_id=883606&subject=user

I am still getting one (and only one) false positive with this code :
```
static void
dcrypt_openssl_private_to_public_key(struct dcrypt_private_key *priv_key,
				     struct dcrypt_public_key **pub_key_r)
{
	i_assert(priv_key != NULL && pub_key_r != NULL);
...
	*pub_key_r = i_new(struct dcrypt_public_key, 1);
}
```

There seems to be performance to improve as well

- [X] Are you planning to discuss this vulnerability submission publicly? (Blog Post, social networks, etc). *We would love to have you spread the word about the good work you are doing*
