### PR TITLE
[Java] CWE-295 - Incorrect Hostname Verification

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-295/AlwaysTrueHostnameVerifier.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/AlwaysTrueHostnameVerifier.java
@@ -1,0 +1,6 @@
+HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        return true; // BAD, verifies anything as correct
+    }
+};

--- a/java/ql/src/experimental/Security/CWE/CWE-295/AndroidHostnameVerifier.LICENSE
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/AndroidHostnameVerifier.LICENSE
@@ -1,0 +1,38 @@
+// Licensed under Apache 2.0 per https://developer.android.com/license
+/*
+Copyright 2020 Android/Android
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Create an HostnameVerifier that hardwires the expected hostname.
+// Note that is different than the URL's hostname:
+// example.com versus example.org
+HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        HostnameVerifier hv =
+            HttpsURLConnection.getDefaultHostnameVerifier();
+        return hv.verify("example.com", session); // OKAY-ISH: verify that the certificate matches
+        // example.com and only accept example.com as an alternative to example.org
+        // BETTER: fix the underlying configuration problem that causes example.org to present the certificate for the wrong domain.
+    }
+};
+
+// Tell the URLConnection to use our HostnameVerifier
+URL url = new URL("https://example.org/");
+HttpsURLConnection urlConnection =
+    (HttpsURLConnection)url.openConnection();
+urlConnection.setHostnameVerifier(hostnameVerifier);
+InputStream in = urlConnection.getInputStream();

--- a/java/ql/src/experimental/Security/CWE/CWE-295/AndroidHostnameVerifier.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/AndroidHostnameVerifier.java
@@ -1,0 +1,20 @@
+// Create an HostnameVerifier that hardwires the expected hostname.
+// Note that is different than the URL's hostname:
+// example.com versus example.org
+HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        HostnameVerifier hv =
+            HttpsURLConnection.getDefaultHostnameVerifier();
+        return hv.verify("example.com", session); // OKAY-ISH: verify that the certificate matches
+        // example.com and only accept example.com as an alternative to example.org
+        // BETTER: fix the underlying configuration problem that causes example.org to present the certificate for the wrong domain.
+    }
+};
+
+// Tell the URLConnection to use our HostnameVerifier
+URL url = new URL("https://example.org/");
+HttpsURLConnection urlConnection =
+    (HttpsURLConnection)url.openConnection();
+urlConnection.setHostnameVerifier(hostnameVerifier);
+InputStream in = urlConnection.getInputStream();

--- a/java/ql/src/experimental/Security/CWE/CWE-295/EverythingAcceptingHostnameVerifier.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/EverythingAcceptingHostnameVerifier.qhelp
@@ -1,0 +1,46 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+If a HostnameVerifier always returns <code>true</code> it will not verify the hostname at all.
+This allows an attacker to perform a man-in-the-middle attack on the application therefore breaking any security Transport Layer Security (TLS) gives.
+
+An Attack would look like this:
+1. The program connects to <code>https://example.com</code>.
+2. The attacker intercepts this connection and presents one of their valid certificates they control, for example one from Let's Encrypt.
+3. Java verifies that the certificate has been issued by a trusted certificate authority.
+4. Java verifies that the certificate has been issued for the host <code>example.com</code>, which will fail because the certificate has been issued for <code>malicious.domain</code>.
+5. Java wants to reject the certificate because the hostname does not match. Before doing this it checks whether there exists a <code>HostnameVerifier</code>.
+6. Your <code>HostnameVerifier</code> is called which returns <code>true</code> for any certificate so also for this one.
+7. Java proceeds with the connection since your <code>HostnameVerifier</code> accepted it.
+8. The attacker can now read the data (Man-in-the-middle) your program sends to <code>https://example.com</code> while the program thinks the connection is secure.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Do NOT use an unverifying HostnameVerifier!
+<li>If you use an unverifying verifier to solve a configuration problem with TLS/HTTPS you should solve the configuration problem instead.
+</li>
+<li>If you use an unverifying verifier to connect to a local host you should instead create a self-signed certificate for your local host and import that certificate to the java key store</li>
+If you do not verify the hostname, you allow any attacker to perform a man-in-the-middle attack.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+In the first example, the <code>HostnameVerifier</code> always returns <code>true</code>.
+This allows an attacker to perform a man-in-the-middle attack, because any certificate is accepted despite an incorrect hostname.
+</p>
+<sample src="AlwaysTrueHostnameVerifier.java" />
+</example>
+
+<references>
+<li><a href="https://developer.android.com/training/articles/security-ssl">Android Security Guide for TLS/HTTPS</a>.</li>
+<li><a href="https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/">Further Information on Hostname Verification</a>.</li>
+<li>OWASP: <a href="https://cwe.mitre.org/data/definitions/295.html">CWE-295</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-295/EverythingAcceptingHostnameVerifier.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/EverythingAcceptingHostnameVerifier.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Disabled hostname verification
+ * @description Accepting any certificate as valid for a host allows an attacker to perform a man-in-the-middle attack.
+ * @kind alert
+ * @problem.severity error
+ * @precision high
+ * @id java/everything-accepting-hostname-verifier
+ * @tags security
+ *       external/cwe/cwe-295
+ */
+
+import java
+import HostnameValidation
+
+from AlwaysAcceptingVerifyMethod m
+where not m.getDeclaringType() instanceof TestClass
+select m, "$@ accepts any certificate as valid for a host.", m, "This method"

--- a/java/ql/src/experimental/Security/CWE/CWE-295/HostnameValidation.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/HostnameValidation.qll
@@ -1,0 +1,183 @@
+import java
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.DataFlow
+import semmle.code.java.security.Encryption
+
+/** A method that overrides the `javax.net.ssl.HostnameVerifier.verify` method. */
+class OverridenVerifyMethod extends HostnameVerifierVerify {
+  OverridenVerifyMethod() { this instanceof HostnameVerifierVerify }
+
+  /**
+   * The `hostname` parameter of this method.
+   */
+  Parameter getHostnameParameter() { result = getParameter(0) }
+
+  /**
+   * The `session` parameter of this method.
+   */
+  Parameter getSessionParameter() { result = getParameter(1) }
+}
+
+/** A return statement that returns `true`. */
+class TrueReturnStmt extends ReturnStmt {
+  TrueReturnStmt() { getResult().(CompileTimeConstantExpr).getBooleanValue() = true }
+}
+
+/**
+ * Holds if `m` always returns `true` ignoring any exceptional flow.
+ */
+private predicate alwaysReturnsTrue(OverridenVerifyMethod m) {
+  forex(ReturnStmt rs | rs.getEnclosingCallable() = m | rs instanceof TrueReturnStmt)
+}
+
+/** A method that overrides the `javax.net.ssl.HostnameVerifier.verify` method in a dangerous way. */
+abstract class DangerousVerifyMethod extends OverridenVerifyMethod {
+  /** A `Stmt` that makes this `HostnameVerifier` dangerous. */
+  abstract Stmt getADangerousStmt();
+}
+
+/**
+ * A method that overrides the `javax.net.ssl.HostnameVerifier.verify` method and **always** returns `true`, thus
+ * accepting any certificate despite a hostname mismatch.
+ */
+class AlwaysAcceptingVerifyMethod extends DangerousVerifyMethod {
+  AlwaysAcceptingVerifyMethod() { alwaysReturnsTrue(this) }
+
+  override Stmt getADangerousStmt() {
+    exists(TrueReturnStmt r | r.getEnclosingCallable() = this | result = r)
+  }
+}
+
+/** An access to any method whose name starts with `equals` and which is defined in the `String` class. */
+class StringEqualsMethodAccess extends MethodAccess {
+  StringEqualsMethodAccess() {
+    getMethod().getName().matches("equals%") and
+    getMethod().getDeclaringType() instanceof TypeString
+  }
+
+  // TODO there is probably a better name for "anEqualityPart" but I don't know any right now
+  /** Returns a part of this equality check, i.e. in the case of `foo.equals(bar)` this returns `foo` and `bar`. */
+  Expr getAnEqualityPart() { result = getQualifier() or result = getArgument(0) }
+}
+
+/**
+ * Get the nearest enclosing if statement, if there exists one.
+ * For example consider this case:
+ * ````
+ * if(foo) {
+ *   if(bar) {
+ *     stmt
+ *   }
+ * }
+ * ````
+ * This query would then return the `bar` if statement and **not** the `foo` if statement.
+ */
+private IfStmt getNearestEnclosingIfStmt(Stmt stmt) {
+  //result = getNerestEnclosingIfStmtRecursive(stmt) and result != stmt
+  exists(IfStmt ifStmt |
+    result = ifStmt and
+    (
+      ifStmt.getElse().getAChild*() = stmt and
+      /*
+       * Ensure that the `IfStmt` we found does not contain another `IfStmt`.
+       * If it contains one, the result can not be the nearest enclosing `IfStmt`.
+       */
+
+      not any(ifStmt.getElse().getAChild*()) instanceof IfStmt
+      or
+      ifStmt.getThen().getAChild*() = stmt and
+      /*
+       * Ensure that the `IfStmt` we found does not contain another `IfStmt`.
+       * If it contains one, the result can not be the nearest enclosing `IfStmt`.
+       */
+
+      not any(ifStmt.getThen().getAChild*()) instanceof IfStmt
+    )
+  )
+}
+
+/** The `javax.net.ssl.SSLSession.getPeerHost` method. */
+private class SSLSessionGetPeerHostMethodAccess extends MethodAccess {
+  SSLSessionGetPeerHostMethodAccess() {
+    getMethod().hasName("getPeerHost") and
+    getMethod().getDeclaringType() instanceof SSLSession
+  }
+}
+
+/**
+ * A `TaintTracking::Configuration` where the `source` is a parameter.
+ * This configuration considers any getter on `SSLSession` as being tainted, but ignores any calls to `SSLSession.getPeerHost`.
+ */
+private class ParameterTaintTracking extends TaintTracking::Configuration {
+  ParameterTaintTracking() { this = "ParameterTaintTracking" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof DataFlow::ExprNode }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    node1.asExpr().getType() instanceof SSLSession and
+    exists(MethodAccess ma | ma.getMethod().getName().matches("get%") | node2.asExpr() = ma)
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.asExpr() instanceof SSLSessionGetPeerHostMethodAccess
+  }
+}
+
+/** Holds if `e` is derived from `parameter`. This is approximated by checking whether `e` gets tainted by `parameter`. */
+private predicate isDerivedFromParameter(Parameter parameter, Expr e) {
+  exists(ParameterTaintTracking t, DataFlow::ExprNode sink, DataFlow::ParameterNode source |
+    source = DataFlow::parameterNode(parameter) and sink = DataFlow::exprNode(e)
+  |
+    t.hasFlow(source, sink)
+  )
+}
+
+/**
+ * A (dangerous) `StringEqualsMethodAccess` where the equality does:
+ * 1. not depend on a expression that is derived from the `session` parameter of the `verify` method.
+ * 2. depend on a expression that is derived from the `hostname` parameter of the `verify` method.
+ */
+class SSLSessionParameterIgnoringStringEqualsMethodAccess extends StringEqualsMethodAccess {
+  SSLSessionParameterIgnoringStringEqualsMethodAccess() {
+    exists(Expr hostname, Expr other, Parameter hostnameParameter, Parameter sessionParameter |
+      hostnameParameter = getEnclosingCallable().(OverridenVerifyMethod).getHostnameParameter() and
+      sessionParameter = getEnclosingCallable().(OverridenVerifyMethod).getSessionParameter() and
+      getAnEqualityPart() = hostname and
+      getAnEqualityPart() = other and
+      hostname != other
+    |
+      not isDerivedFromParameter(sessionParameter, other) and
+      isDerivedFromParameter(hostnameParameter, hostname)
+    )
+  }
+}
+
+/**
+ * A `verify` method that does not verify the `hostname` correctly. It is incorrect
+ * because it does not validate the `hostname` against any expression that is derived from the `session` parameter of the `verify` method.
+ */
+class IncorrectHostnameVerifyMethod extends DangerousVerifyMethod {
+  Stmt dangerousStmt;
+
+  IncorrectHostnameVerifyMethod() {
+    /* We return `true` based on an if statement that verifies the `hostname` incorrectly.*/
+    exists(TrueReturnStmt r, IfStmt i |
+      getBody().getAChild*() = r and i = getNearestEnclosingIfStmt(r)
+    |
+      i.getCondition().getAChildExpr*() instanceof
+        SSLSessionParameterIgnoringStringEqualsMethodAccess and
+      dangerousStmt = i
+    )
+    or
+    /* We return the result of an `equals` call that verifies the `hostname` incorrectly.*/
+    exists(ReturnStmt r | getBody().getAChild*() = r |
+      not r.getResult() instanceof BooleanLiteral and
+      r.getResult().getAChildExpr*() instanceof SSLSessionParameterIgnoringStringEqualsMethodAccess and
+      dangerousStmt = r
+    )
+  }
+
+  override Stmt getADangerousStmt() { result = dangerousStmt }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-295/IncorrectHostnameVerifier.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/IncorrectHostnameVerifier.qhelp
@@ -1,0 +1,80 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+If a <code>HostnameVerifier</code> incorrectly verifies the hostname it might not verify the hostname at all.
+This allows an attacker to perform a man-in-the-middle attack on the application therefore breaking any security Transport Layer Security (TLS) gives.
+</p>
+</overview>
+
+<recommendation>
+<p>
+Do NOT use an incorrect <code>HostnameVerifier</code>!
+A <code>HostnameVerifier</code> is typically used for either an <code>URL</code>/<code>HttpsURLConnection</code> or a raw <code>SSLSocket</code>.
+A raw <code>SSLSocket</code> does not do any hostname verification so a working hostname verification is important.
+When you use an <code>URL</code>/<code>HttpsURLConnection</code>:
+<p>
+<li>If you use a verifier to solve a configuration problem with TLS/HTTPS you should solve the configuration problem instead.
+</li>
+<li>If you use a verifier to connect to a local host you should instead create a self-signed certificate for your local host and import that certificate to the java key store</li>
+</p>
+
+When you use a raw <code>SSLSocket</code>:
+<p>
+<li>Use <code>SSLParameters.setEndpointIdentificationAlgorithm("HTTPS")</code> to enable hostname verification. This is available starting with Java 7 and Android Api Level 24.</li>
+<li>Before Android Api Level 24 you should use the <code>HostnameVerifier</code> from <code>HttpsURLConnection.getDefaultHostnameVerifier()</code> to verify the hostname.</li>
+If you do not verify the hostname, you allow any attacker to perform a man-in-the-middle attack.
+</p>
+
+</recommendation>
+
+<example>
+<p>
+In the first example, the <code>HostnameVerifier</code> verifies the <code>hostname</code> against <code>session.getPeerHost()</code>.
+This allows an attacker to perform a man-in-the-middle attack, because <code>getPeerHost() is not authenticated and will always be equal to the hostname.
+</p>
+<sample src="PeerHostHostnameVerifier.java" />
+
+<p>
+In the second example, the <code>HostnameVerifier</code> verifies the <code>hostname</code> against different local hosts.
+Comparing <code>hostname</code> against <code>localhost</code> does not verify the certificate. In theory traffic to <code>localhost</code>
+should never leave the host. In practice this may not always be the case due to misconfigurations.
+Comparing <code>hostname</code> against <code>127.0.0.1</code> or <code>::1</code> does not verify the certificate. These adresses are loopback adresses and traffic
+MUST never leave the host. So this SHOULD be safe, but nevertheless it would be better to use a proper self-signed certificate.
+</p>
+<sample src="LocalhostHostnameverifier.java" />
+
+<p>
+In the third example, we want to connect to the <code>example.org</code> host, but the host presents a certificate for example.com.
+Assuming that <code>example.org</code> and <code>example.com</code> are under our control (and only then this is ok) we can use the default <code>HostnameVerifier</code>
+to verify that the certificate belongs to <code>example.com</code>.
+Note that you should really fix the configuration problem that causes <code>example.org</code> to present the certificate for <code>example.com</code> instead of using this method.
+This method **only** works on Android, on (OpenJDK) Java the default <code>HostnameVerifier</code> will always return <code>false</code>.
+On (OpenJDK) Java you can use <a href="https://github.com/AsyncHttpClient/async-http-client/commit/3c9152e">this implementation</a> of a working
+hostname verifier instead of the default <code>HostnameVerifier</code>.
+</p>
+<sample src="AndroidHostnameVerifier.java" />
+
+<p>
+In the fourth example, we properly use a raw <code>SSLSocket</code> with enabled <code>SSLParameters.setEndpointIdentificationAlgorithm("HTTPS")</code>, thus verifying hostnames correctly.
+Note that this method is only available with Java 7 and Android Api Level 24.
+The next example shows an alternative for Android Api Levels before 24.
+</p>
+<sample src="RawSSLSocketHostnameEndpointIdentification.java" />
+
+<p>
+In the fifth example, we properly use a raw <code>SSLSocket</code> and verify the hostname using the <code>HostnameVerifier</code> from <code>HttpsURLConnection.getDefaultHostnameVerifier()</code>.
+Note that this is also works on Android Api Levels before 24.
+But also note that this will **not** work on (OpenJDK) Java, because the default <code>HostnameVerifier</code> will always return <code>false</code>.
+</p>
+<sample src="RawSSLSocketHostnameEndpointIdentification.java" />
+</example>
+
+<references>
+<li><a href="https://developer.android.com/training/articles/security-ssl">Android Security Guide for TLS/HTTPS</a>.</li>
+<li><a href="https://tersesystems.com/blog/2014/03/23/fixing-hostname-verification/">Further Information on Hostname Verification</a>.</li>
+<li>OWASP: <a href="https://cwe.mitre.org/data/definitions/295.html">CWE-295</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-295/IncorrectHostnameVerifier.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/IncorrectHostnameVerifier.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Incorrect hostname verification
+ * @description Incorrectly verifying a hostname allows an attacker to perform a man-in-the-middle attack.
+ * @kind alert
+ * @problem.severity error
+ * @precision high
+ * @id java/incorrect-hostname-verifier
+ * @tags security
+ *       external/cwe/cwe-295
+ */
+
+import java
+import HostnameValidation
+
+from IncorrectHostnameVerifyMethod m, Stmt dangerousStmt
+where dangerousStmt = m.getADangerousStmt() and not m.getDeclaringType() instanceof TestClass
+select dangerousStmt, "$@ incorrectly verifies the hostname.", dangerousStmt, "This statement"

--- a/java/ql/src/experimental/Security/CWE/CWE-295/LocalhostHostnameVerifier.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/LocalhostHostnameVerifier.java
@@ -1,0 +1,23 @@
+HostnameVerifier localHostHostnameVerifier = new HostnameVerifier() {
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        if (hostname.equals("localhost")) { // BAD, does not verify the certificate. In theory traffic to
+                                            // "localhost" should never leave the host. In practice this may not
+                                            // always be the case due to misconfigurations.
+            return true;
+        } else if (hostname.equals("127.0.0.1")) { // BAD, does not verify the certificate [Debatable Security
+                                                    // Impact]. "127.0.0.1" is the IPv4 loopback adress and traffic
+                                                    // MUST never leave the host. So this SHOULD be safe, but
+                                                    // nevertheless it would be better to use a proper self-signed
+                                                    // certificate.
+            return true;
+        } else if (hostname.equals("::1")) { // BAD, does not verify the certificate [Debatable Security Impact].
+                                                // "::1" is the IPv6 loopback adress and traffic MUST never leave
+                                                // the host. So this SHOULD be safe, but nevertheless it would be
+                                                // better to use a proper self-signed certificate.
+            return true;
+        }
+        return false;
+
+    }
+};

--- a/java/ql/src/experimental/Security/CWE/CWE-295/PeerHostHostnameVerifier.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/PeerHostHostnameVerifier.java
@@ -1,0 +1,7 @@
+HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+    @Override
+    public boolean verify(String hostname, SSLSession session) {
+        return hostname.equals(session.getPeerHost()); // BAD, getPeerHost() is not authenticated
+        // and will always be equal to the hostname, therefore trusting ALL hostnames
+    }
+};

--- a/java/ql/src/experimental/Security/CWE/CWE-295/RawSSLSocketEndpointIdentification.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/RawSSLSocketEndpointIdentification.java
@@ -1,0 +1,9 @@
+// Open SSLSocket directly to example.org.
+SocketFactory sf = SSLSocketFactory.getDefault();
+SSLSocket socket = (SSLSocket) sf.createSocket("example.org", 443);
+SSLParameters sslParams = new SSLParameters();
+sslParams.setEndpointIdentificationAlgorithm("HTTPS"); // GOOD, enable hostname verification using the `HTTPS`
+                                                        // verification algorithm.
+socket.setSSLParameters(sslParams);
+
+// Hostname verification has been performed and we can proceed.

--- a/java/ql/src/experimental/Security/CWE/CWE-295/RawSSLSocketHostnameVerifierAndroid.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-295/RawSSLSocketHostnameVerifierAndroid.java
@@ -1,0 +1,14 @@
+// Open SSLSocket directly to example.org.
+SocketFactory sf = SSLSocketFactory.getDefault();
+SSLSocket socket = (SSLSocket) sf.createSocket("example.org", 443);
+HostnameVerifier hv = HttpsURLConnection.getDefaultHostnameVerifier();
+SSLSession s = socket.getSession();
+
+// Verify that the certificate matches the hostname.
+if (!hv.verify(s.getPeerHost(), s)) { // GOOD
+    // We use the default hostname verifier from Android to verify that the
+    // certificate matches.
+    throw new SSLHandshakeException("Expected <" + s.getPeerHost() + ">, but " + "found " + s.getPeerPrincipal());
+}
+
+// Hostname verification has been performed and we can proceed.

--- a/java/ql/src/semmle/code/java/security/Encryption.qll
+++ b/java/ql/src/semmle/code/java/security/Encryption.qll
@@ -21,6 +21,10 @@ class SSLSocketFactory extends RefType {
   SSLSocketFactory() { this.hasQualifiedName("javax.net.ssl", "SSLSocketFactory") }
 }
 
+class SSLSession extends RefType {
+  SSLSession() { hasQualifiedName("javax.net.ssl", "SSLSession") }
+}
+
 class SSLContext extends RefType {
   SSLContext() { hasQualifiedName("javax.net.ssl", "SSLContext") }
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.expected
@@ -1,0 +1,1 @@
+| EverythingAcceptingHostnameVerifier.java:7:18:7:23 | verify | $@ accepts any certificate as valid for a host. | EverythingAcceptingHostnameVerifier.java:7:18:7:23 | verify | This method |

--- a/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.java
@@ -1,0 +1,21 @@
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+public class EverythingAcceptingHostnameVerifier {
+	HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return true; // BAD, always returns true, accepts everything
+		}
+	};
+
+	HostnameVerifier hostnameVerifier2 = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			if (hostname.equals("localhost")) {
+				return true; // BAD [Should not be detected by `EverythingAcceptingHostnameVerifier.ql`]
+			}
+			return false;
+		}
+	};
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/EverythingAcceptingHostnameVerifier.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-295/EverythingAcceptingHostnameVerifier.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.expected
@@ -1,0 +1,7 @@
+| EverythingAcceptingHostnameVerifier.java:15:4:15:36 | stmt | $@ incorrectly verifies the hostname. | EverythingAcceptingHostnameVerifier.java:15:4:15:36 | stmt | This statement |
+| IncorrectHostnameVerifier.java:9:4:9:49 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:9:4:9:49 | stmt | This statement |
+| IncorrectHostnameVerifier.java:18:4:18:40 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:18:4:18:40 | stmt | This statement |
+| IncorrectHostnameVerifier.java:26:4:26:36 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:26:4:26:36 | stmt | This statement |
+| IncorrectHostnameVerifier.java:30:11:30:43 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:30:11:30:43 | stmt | This statement |
+| IncorrectHostnameVerifier.java:36:11:36:37 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:36:11:36:37 | stmt | This statement |
+| IncorrectHostnameVerifier.java:97:4:97:46 | stmt | $@ incorrectly verifies the hostname. | IncorrectHostnameVerifier.java:97:4:97:46 | stmt | This statement |

--- a/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.java
@@ -1,0 +1,100 @@
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.HttpsURLConnection;
+
+public class IncorrectHostnameVerifier {
+	HostnameVerifier peerHostHostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return hostname.equals(session.getPeerHost()); // BAD, getPeerHost() is not authenticated and will always be
+															// equal to the hostname, therefore trusting ALL hostnames.
+		}
+	};
+
+	HostnameVerifier peerHostHostnameVerifier2 = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			String peerHostname = session.getPeerHost();
+			return hostname.equals(peerHostname); // BAD, getPeerHost() is not authenticated and will always be equal to
+													// the hostname, therefore trusting ALL hostnames.
+		}
+	};
+
+	HostnameVerifier localHostHostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			if (hostname.equals("localhost")) { // BAD, does not verify the certificate. In theory traffic to
+												// "localhost" should never leave the host. In practice this may not
+												// always be the case due to misconfigurations.
+				return true;
+			} else if (hostname.equals("127.0.0.1")) { // BAD, does not verify the certificate [Debatable Security
+														// Impact]. "127.0.0.1" is the IPv4 loopback adress and traffic
+														// MUST never leave the host. So this SHOULD be safe, but
+														// nevertheless it would be better to use a proper self-signed
+														// certificate.
+				return true;
+			} else if (hostname.equals("::1")) { // BAD, does not verify the certificate [Debatable Security Impact].
+													// "::1" is the IPv6 loopback adress and traffic MUST never leave
+													// the host. So this SHOULD be safe, but nevertheless it would be
+													// better to use a proper self-signed certificate.
+				return true;
+			}
+			return false;
+
+		}
+	};
+
+	HostnameVerifier delegatingHostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			HostnameVerifier verifier = HttpsURLConnection.getDefaultHostnameVerifier();
+			if (hostname.equals("example.com")) {
+				return verifier.verify("example.org", session); // "GOOD-ISH", if and only if this holds:
+				// We want to make a connection to `https://example.com`, but the webserver is
+				// misconfigured and wrongly returns the certificate for `https://example.org`.
+				// IF we control BOTH example.com and example.org we accept an certificate for
+				// `example.org` as valid for `example.com`.
+				// NOTE: It's STRONGLY suggested to fix the certificate problem instead.
+				// NOTE: This will only work on Android, on (OpenJDK) Java the default
+				// `HostnameVerifier` always returns false!
+			}
+			return false;
+		}
+	};
+
+	HostnameVerifier externalMethodHostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return checkHostname(hostname); // BAD [NOT DETECTED], only the implementation of `verify` method is
+											// checked. If the `verify` method calls other methods we can not reason
+											// about them. A simple implementation would be to detect that the external
+											// method only checks `hostname` and not a value derived from `session`.
+		}
+
+		private boolean checkHostname(String hostname) {
+			return hostname.equals("example.com"); // BAD [NOT DETECTED], does not verify the certificate.
+		}
+	};
+
+	HostnameVerifier externalMethodHostnameVerifier2 = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return check(hostname, session); // BAD [NOT DETECTED], only the implementation of the `verify` method is
+												// checked. If the `verify` method calls other methods we can not reason
+												// about them. The simple implementation from above
+												// (`externalMethodHostnameVerifier`) (if implemented) should not detect
+												// this.
+		}
+
+		private boolean check(String hostname, SSLSession session) {
+			return hostname.equals("example.com"); // BAD [NOT DETECTED], does not verify the certificate.
+		}
+	};
+
+	HostnameVerifier hostSpecificHostnameVerifier = new HostnameVerifier() {
+		@Override
+		public boolean verify(String hostname, SSLSession session) {
+			return hostname.equals("host.example.org"); // BAD, does not verify the certificate for `host.example.org`.
+		}
+	};
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-295/IncorrectHostnameVerifier.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-295/IncorrectHostnameVerifier.ql


### PR DESCRIPTION
Hostname verification is an essential part of Transport Layer Security (TLS) and HTTPS.

When a TLS connection is established there are two important steps:
First, the chain of trust is verified that means it is checked whether the certificate has been issued by a trusted certificate authority.
Second, the hostname (that is being connected to) needs to be verified against the certificate.
That means it is checked whether the certificate is actually for the hostname.

If the hostname is not verified an attacker could present any certificate with a valid chain of trust, but that is **not** issued for the hostname at all.

Many posts tell developers that have problems with hostname verification to accept any certificate as valid in the case of a mismatch.
These problems usually are configuration problems that should be fixed instead.

Java verifies HTTPS hostname by default when using `URL`/`HttpsUrlConnection`.
But when a protocol uses TLS (SSLEngine/SSLSocket) directly, the hostname is not verified by default.
That's where the second part of my query (IncorrectHostnameVerifier.ql) comes into play.

**[This PR and PR description is WIP]**
[I've also noticed #3550, which seems to focus on the chain of trust vaildation]