### PR TITLE
JS: Use newer format for yarn.lock

### DIFF
--- a/javascript/extractor/lib/typescript/yarn.lock
+++ b/javascript/extractor/lib/typescript/yarn.lock
@@ -4,31 +4,31 @@
 
 "@types/node@12.7.11":
   version "12.7.11"
-  resolved "node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
+  resolved node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446
 
 ansi-regex@^2.0.0:
   version "2.1.1"
-  resolved "ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  resolved ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df
 
 ansi-styles@^2.2.1:
   version "2.2.1"
-  resolved "ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  resolved ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe
 
 ansi-styles@^3.1.0:
   version "3.2.0"
-  resolved "ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  resolved ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88
   dependencies:
     color-convert "^1.9.0"
 
 argparse@^1.0.7:
   version "1.0.9"
-  resolved "argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  resolved argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86
   dependencies:
     sprintf-js "~1.0.2"
 
 babel-code-frame@^6.22.0:
   version "6.26.0"
-  resolved "babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  resolved babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
@@ -36,22 +36,22 @@ babel-code-frame@^6.22.0:
 
 balanced-match@^1.0.0:
   version "1.0.0"
-  resolved "balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  resolved balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767
 
 brace-expansion@^1.1.7:
   version "1.1.8"
-  resolved "brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  resolved brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 builtin-modules@^1.1.1:
   version "1.1.1"
-  resolved "builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  resolved builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f
 
 chalk@^1.1.3:
   version "1.1.3"
-  resolved "chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  resolved chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98
   dependencies:
     ansi-styles "^2.2.1"
     escape-string-regexp "^1.0.2"
@@ -61,7 +61,7 @@ chalk@^1.1.3:
 
 chalk@^2.3.0:
   version "2.3.0"
-  resolved "chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  resolved chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -69,45 +69,45 @@ chalk@^2.3.0:
 
 color-convert@^1.9.0:
   version "1.9.1"
-  resolved "color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
+  resolved color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed
   dependencies:
     color-name "^1.1.1"
 
 color-name@^1.1.1:
   version "1.1.3"
-  resolved "color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  resolved color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25
 
 commander@^2.12.1:
   version "2.13.0"
-  resolved "commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  resolved commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c
 
 concat-map@0.0.1:
   version "0.0.1"
-  resolved "concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  resolved concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b
 
 diff@^3.2.0:
   version "3.4.0"
-  resolved "diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+  resolved diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
-  resolved "escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  resolved escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4
 
 esprima@^4.0.0:
   version "4.0.0"
-  resolved "esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+  resolved esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804
 
 esutils@^2.0.2:
   version "2.0.2"
-  resolved "esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+  resolved esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b
 
 fs.realpath@^1.0.0:
   version "1.0.0"
-  resolved "fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  resolved fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f
 
 glob@^7.1.1:
   version "7.1.2"
-  resolved "glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  resolved glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -118,93 +118,93 @@ glob@^7.1.1:
 
 has-ansi@^2.0.0:
   version "2.0.0"
-  resolved "has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  resolved has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91
   dependencies:
     ansi-regex "^2.0.0"
 
 has-flag@^2.0.0:
   version "2.0.0"
-  resolved "has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  resolved has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51
 
 inflight@^1.0.4:
   version "1.0.6"
-  resolved "inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  resolved inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9
   dependencies:
     once "^1.3.0"
     wrappy "1"
 
 inherits@2:
   version "2.0.3"
-  resolved "inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  resolved inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de
 
 js-tokens@^3.0.2:
   version "3.0.2"
-  resolved "js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  resolved js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b
 
 js-yaml@^3.7.0:
   version "3.10.0"
-  resolved "js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+  resolved js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 minimatch@^3.0.4:
   version "3.0.4"
-  resolved "minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  resolved minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083
   dependencies:
     brace-expansion "^1.1.7"
 
 once@^1.3.0:
   version "1.4.0"
-  resolved "once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  resolved once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1
   dependencies:
     wrappy "1"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
-  resolved "path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  resolved path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f
 
 path-parse@^1.0.5:
   version "1.0.5"
-  resolved "path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  resolved path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1
 
 resolve@^1.3.2:
   version "1.5.0"
-  resolved "resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  resolved resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36
   dependencies:
     path-parse "^1.0.5"
 
 semver@^5.3.0:
   version "5.5.0"
-  resolved "semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  resolved semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab
 
 sprintf-js@~1.0.2:
   version "1.0.3"
-  resolved "sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  resolved sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c
 
 strip-ansi@^3.0.0:
   version "3.0.1"
-  resolved "strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  resolved strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf
   dependencies:
     ansi-regex "^2.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
-  resolved "supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  resolved supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7
 
 supports-color@^4.0.0:
   version "4.5.0"
-  resolved "supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  resolved supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b
   dependencies:
     has-flag "^2.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
-  resolved "tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+  resolved tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8
 
 tslint@^5.9.1:
   version "5.9.1"
-  resolved "tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+  resolved tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -221,14 +221,14 @@ tslint@^5.9.1:
 
 tsutils@^2.12.1:
   version "2.19.1"
-  resolved "tsutils-2.19.1.tgz#76d7ebdea9d7a7bf4a05f50ead3701b0168708d7"
+  resolved tsutils-2.19.1.tgz#76d7ebdea9d7a7bf4a05f50ead3701b0168708d7
   dependencies:
     tslib "^1.8.1"
 
 typescript@3.9.2:
   version "3.9.2"
-  resolved "typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  resolved typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9
 
 wrappy@1:
   version "1.0.2"
-  resolved "wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  resolved wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f


### PR DESCRIPTION
For a long time we've maintained a yarn.lock file that was backward compatible with older versions of yarn, but this isn't sustainable. People will have to update.

This PR regenerates the yarn.lock using version 1.21.1.

Some versions I've tested:
- Works with 1.21.1 (obviously)
- Works with 1.3.2
- Works with 0.28.4
- Does not work with 0.20.4