### PR TITLE
C++: QLDoc for the remaining elements in the controlflow directory

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/DefinitionsAndUses.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides classes and predicates for reasoning about definitions and uses of variables.
+ */
+
 import cpp
 private import semmle.code.cpp.controlflow.StackVariableReachability
 private import semmle.code.cpp.dataflow.EscapesTree
@@ -135,6 +139,7 @@ library class DefOrUse extends ControlFlowNodeBase {
   }
 }
 
+/** A definition of a stack variable. */
 library class Def extends DefOrUse {
   Def() { definition(_, this) }
 
@@ -149,6 +154,7 @@ private predicate parameterIsOverwritten(Function f, Parameter p) {
   definitionBarrier(p, _)
 }
 
+/** A definition of a parameter. */
 library class ParameterDef extends DefOrUse {
   ParameterDef() {
     // Optimization: parameters that are not overwritten do not require
@@ -162,6 +168,7 @@ library class ParameterDef extends DefOrUse {
   }
 }
 
+/** A use of a stack variable. */
 library class Use extends DefOrUse {
   Use() { useOfVar(_, this) }
 

--- a/cpp/ql/src/semmle/code/cpp/controlflow/Dereferenced.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Dereferenced.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides predicates for detecting whether an expression dereferences a pointer.
+ */
+
 import cpp
 import Nullness
 

--- a/cpp/ql/src/semmle/code/cpp/controlflow/Guards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Guards.qll
@@ -1,3 +1,8 @@
+/**
+ * Provides classes and predicates for reasoning about guards and the control
+ * flow elements controlled by those guards.
+ */
+
 import cpp
 import semmle.code.cpp.controlflow.BasicBlocks
 import semmle.code.cpp.controlflow.SSA

--- a/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
@@ -1,3 +1,8 @@
+/**
+ * Provides classes and predicates for reasoning about guards and the control
+ * flow elements controlled by those guards.
+ */
+
 import cpp
 import semmle.code.cpp.ir.IR
 
@@ -32,7 +37,7 @@ class GuardCondition extends Expr {
   }
 
   /**
-   * Holds if this condition controls `block`, meaning that `block` is only
+   * Holds if this condition controls `controlled`, meaning that `controlled` is only
    * entered if the value of this condition is `testIsTrue`.
    *
    * Illustration:
@@ -253,7 +258,7 @@ class IRGuardCondition extends Instruction {
   IRGuardCondition() { branch = get_branch_for_condition(this) }
 
   /**
-   * Holds if this condition controls `block`, meaning that `block` is only
+   * Holds if this condition controls `controlled`, meaning that `controlled` is only
    * entered if the value of this condition is `testIsTrue`.
    *
    * Illustration:
@@ -290,6 +295,10 @@ class IRGuardCondition extends Instruction {
     )
   }
 
+  /**
+   * Holds if the control-flow edge `(pred, succ)` may be taken only if
+   * the value of this condition is `testIsTrue`.
+   */
   cached
   predicate controlsEdge(IRBlock pred, IRBlock succ, boolean testIsTrue) {
     pred.getASuccessor() = succ and

--- a/cpp/ql/src/semmle/code/cpp/controlflow/Nullness.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/Nullness.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides classes and predicates for working with null values and checks for nullness.
+ */
+
 import cpp
 import DefinitionsAndUses
 

--- a/cpp/ql/src/semmle/code/cpp/controlflow/SSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/SSA.qll
@@ -1,7 +1,15 @@
+/**
+ * Provides classes and predicates for SSA representation (Static Single Assignment form).
+ */
+
 import cpp
 import semmle.code.cpp.controlflow.Dominance
 import SSAUtils
 
+/**
+ * The SSA logic comes in two versions: the standard SSA and range-analysis RangeSSA.
+ * This class provides the standard SSA logic.
+ */
 library class StandardSSA extends SSAHelper {
   StandardSSA() { this = 0 }
 }
@@ -50,11 +58,13 @@ class SsaDefinition extends ControlFlowNodeBase {
    */
   ControlFlowNode getDefinition() { result = this }
 
+  /** Gets the `BasicBlock` containing this definition. */
   BasicBlock getBasicBlock() { result.contains(getDefinition()) }
 
   /** Holds if this definition is a phi node for variable `v`. */
   predicate isPhiNode(StackVariable v) { exists(StandardSSA x | x.phi_node(v, this.(BasicBlock))) }
 
+  /** Gets the location of this definition. */
   Location getLocation() { result = this.(ControlFlowNode).getLocation() }
 
   /** Holds if the SSA variable `(this, p)` is defined by parameter `p`. */

--- a/cpp/ql/src/semmle/code/cpp/controlflow/SSAUtils.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/SSAUtils.qll
@@ -1,3 +1,7 @@
+/**
+ * Provides classes and predicates for use in the SSA library.
+ */
+
 import cpp
 import semmle.code.cpp.controlflow.Dominance
 import semmle.code.cpp.controlflow.SSA // must be imported for proper caching of SSAHelper

--- a/cpp/ql/src/semmle/code/cpp/controlflow/StackVariableReachability.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/StackVariableReachability.qll
@@ -1,3 +1,8 @@
+/**
+ * Provides a library for working with local (intra-procedural) control-flow
+ * reachability involving stack variables.
+ */
+
 import cpp
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/controlflow/SubBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/SubBasicBlocks.qll
@@ -168,6 +168,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
   /** Gets the first control-flow node in this `SubBasicBlock`. */
   ControlFlowNode getStart() { result = this }
 
+  /** Gets the function that contains this `SubBasicBlock`. */
   pragma[noinline]
   Function getEnclosingFunction() { result = this.getStart().getControlFlowScope() }
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll
@@ -168,6 +168,7 @@ class SubBasicBlock extends ControlFlowNodeBase {
   /** Gets the first control-flow node in this `SubBasicBlock`. */
   ControlFlowNode getStart() { result = this }
 
+  /** Gets the function that contains this `SubBasicBlock`. */
   pragma[noinline]
   Function getEnclosingFunction() { result = this.getStart().getControlFlowScope() }
 }


### PR DESCRIPTION
Part of https://github.com/github/codeql-c-analysis-team/issues/40.

I've shamelessly stolen the file comment on `Guards.qll` and `IRGuards.qll` from https://github.com/github/codeql/blob/master/java/ql/src/semmle/code/java/controlflow/Guards.qll. I don't know if I agree with the hyphenation, though. But I'll leave this as it is and avoid dragging in the Java team.

I also fixed a comment on `GuardCondition::controls` in `IRGuards.qll` that referred to the the parameter `controlled` as `block`. I _think_ that was the intention of the comment.