### PR TITLE
JS: cache Expr::getStringValue

### DIFF
--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -108,7 +108,8 @@ class Expr extends @expr, ExprOrStmt, ExprOrType, AST::ValueNode {
   int getIntValue() { none() }
 
   /** Gets the constant string value this expression evaluates to, if any. */
-  cached string getStringValue() { none() }
+  cached
+  string getStringValue() { none() }
 
   /** Holds if this expression is impure, that is, its evaluation could have side effects. */
   predicate isImpure() { any() }

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -108,7 +108,7 @@ class Expr extends @expr, ExprOrStmt, ExprOrType, AST::ValueNode {
   int getIntValue() { none() }
 
   /** Gets the constant string value this expression evaluates to, if any. */
-  string getStringValue() { none() }
+  cached string getStringValue() { none() }
 
   /** Holds if this expression is impure, that is, its evaluation could have side effects. */
   predicate isImpure() { any() }


### PR DESCRIPTION
I noticed that `Expr::getStringValue` took a long time to compute on some benchmarks.  
And it was computed multiple times across stages.

So I tried to see what would happen if i `cached` the predicate.

[Turns out we get a 3% performance boost.](https://docs.google.com/spreadsheets/d/1zzArzx7dba1ZGw5iXNb5B_3X-Pq8m3KNeB7lUoMXSWQ/edit?usp=sharing)   
(Evaluation done on my laptop, so no Azure wobble). 