### PR TITLE
Java: Add check for J2EE server directory listing

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.qhelp
@@ -1,0 +1,25 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>Enabling directory listing in J2EE application servers introduces the vulnerability of filename and path disclosure, which could allow an attacker to read arbitrary files in the server web directory. This includes application source code and data, as well as credentials for back-end systems.</p>
+    <p>The query detects insecure configuration by validating its web configuration.</p>
+  </overview>
+
+  <recommendation>
+    <p>Always disabling directory listing in the production environment.</p>
+  </recommendation>
+
+  <example>
+    <p>The following two examples show two ways of directory listing configuration. In the 'BAD' case, it is enabled. In the 'GOOD' case, it is disabled.</p>
+    <sample src="web.xml" />
+  </example>
+
+  <references>
+    <li>
+      <a href="https://cwe.mitre.org/data/definitions/548.html">CWE-548: Exposure of Information Through Directory Listing</a>
+      <a href="https://portswigger.net/kb/issues/00600100_directory-listing">Directory listing</a>
+      <a href="https://portswigger.net/web-security/file-path-traversal">Directory traversal</a>
+    </li>
+  </references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -1,0 +1,42 @@
+/**
+ * @id java/j2ee-server-directory-listing
+ * @name Inappropriately exposed directories and files yielding sensitive information like source code and credentials to attackers.
+ * @description A directory listing provides an attacker with the complete index of all the resources located inside of the complete web directory.
+ * @kind problem
+ * @tags security
+ *       external/cwe-548
+ */
+
+import java
+import semmle.code.xml.WebXML
+
+/**
+ * The default `<servlet-class>` element in a `web.xml` file.
+ */
+private class DefaultTomcatServlet extends WebServletClass {
+  DefaultTomcatServlet() {
+    this.getTextValue() = "org.apache.catalina.servlets.DefaultServlet" //Default servlet of Tomcat and other servlet containers derived from Tomcat like Glassfish
+  }
+}
+
+/**
+ * The `<init-param>` element in a `web.xml` file, nested under a `<servlet>` element controlling directory listing.
+ */
+class DirectoryListingInitParam extends WebXMLElement {
+  DirectoryListingInitParam() {
+    getName() = "init-param" and
+    getAChild("param-name").getTextValue() = "listings" and
+    exists(WebServlet servlet |
+      getParent() = servlet and servlet.getAChild("servlet-class") instanceof DefaultTomcatServlet
+    )
+  }
+
+  /**
+   * Check the `<param-value>` element (true - enabled, false - disabled)
+   */
+  predicate isListingEnabled() { getAChild("param-value").getTextValue().toLowerCase() = "true" }
+}
+
+from DirectoryListingInitParam initp
+where initp.isListingEnabled()
+select initp, "Directory listing should be disabled to mitigate filename and path disclosure"

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -1,8 +1,8 @@
 /**
- * @name Inappropriately exposed directories and files yielding sensitive information like source code and credentials to attackers.
- * @description A directory listing provides an attacker with the complete index of all the resources located inside of the complete web directory.
+ * @name Directories and files exposure
+ * @description A directory listing provides an attacker with the complete index of all the resources located inside of the complete web directory, which could yield files containing sensitive information like source code and credentials to the attacker.
  * @kind problem
- * @id java/dir-listing
+ * @id java/server-directory-listing
  * @tags security
  *       external/cwe-548
  */

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -40,4 +40,3 @@ class DirectoryListingInitParam extends WebXMLElement {
 from DirectoryListingInitParam initp
 where initp.isListingEnabled()
 select initp, "Directory listing should be disabled to mitigate filename and path disclosure"
-

--- a/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql
@@ -1,8 +1,8 @@
 /**
- * @id java/j2ee-server-directory-listing
  * @name Inappropriately exposed directories and files yielding sensitive information like source code and credentials to attackers.
  * @description A directory listing provides an attacker with the complete index of all the resources located inside of the complete web directory.
  * @kind problem
+ * @id java/dir-listing
  * @tags security
  *       external/cwe-548
  */
@@ -40,3 +40,4 @@ class DirectoryListingInitParam extends WebXMLElement {
 from DirectoryListingInitParam initp
 where initp.isListingEnabled()
 select initp, "Directory listing should be disabled to mitigate filename and path disclosure"
+

--- a/java/ql/src/experimental/Security/CWE/CWE-548/web.xml
+++ b/java/ql/src/experimental/Security/CWE/CWE-548/web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd" version="4.0">
+
+    <!-- The default servlet for all web applications, that serves static     -->
+    <!-- resources.  It processes all requests that are not mapped to other   -->
+    <!-- servlets with servlet mappings (defined either here or in your own   -->
+    <!-- web.xml file).                                                       -->
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+        <init-param>
+            <param-name>listings</param-name>
+            <!-- GOOD: Don't allow directory listing -->
+            <param-value>false</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+        <init-param>
+            <param-name>listings</param-name>
+            <!-- BAD: Allow directory listing -->
+            <param-value>true</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+</web-app>

--- a/java/ql/test/experimental/query-tests/security/CWE-548/InsecureDirectoryConfig.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-548/InsecureDirectoryConfig.expected
@@ -1,0 +1,1 @@
+| insecure-web.xml:16:9:19:22 | init-param | Directory listing should be disabled to mitigate filename and path disclosure |

--- a/java/ql/test/experimental/query-tests/security/CWE-548/InsecureDirectoryConfig.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-548/InsecureDirectoryConfig.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-548/InsecureDirectoryConfig.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-548/insecure-web.xml
+++ b/java/ql/test/experimental/query-tests/security/CWE-548/insecure-web.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd" version="4.0">
+
+    <!-- The default servlet for all web applications, that serves static     -->
+    <!-- resources.  It processes all requests that are not mapped to other   -->
+    <!-- servlets with servlet mappings (defined either here or in your own   -->
+    <!-- web.xml file).                                                       -->
+    <servlet>
+        <servlet-name>default</servlet-name>
+        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <init-param>
+            <param-name>listings</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <!-- The mapping for the default servlet -->
+    <servlet-mapping>
+        <servlet-name>default</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
Enabling directory listing in J2EE application servers introduces the vulnerability of filename and path disclosure, which could allow an attacker to read arbitrary files in the server web directory. This includes application source code and data, as well as credentials for back-end systems.

Directory listing can be enabled via web.xml configuration of J2EE application servers:
```
    <servlet>
        <servlet-name>default</servlet-name>
        <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
        <init-param>
            <param-name>listings</param-name>
            <param-value>true</param-value>
        </init-param>
    </servlet>
```

This PR adds a CodeQL query to find all insecure web.xml with the listing property set to true. 