### PR TITLE
JS: Introduce SharedTaintStep

### DIFF
--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -8,8 +8,8 @@ module ArrayTaintTracking {
   /**
    * A taint propagating data flow edge caused by the builtin array functions.
    */
-  private class ArrayFunctionTaintStep extends TaintTracking::SharedTaintStep {
-    override predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class ArrayFunctionTaintStep extends TaintTracking::ArrayStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       arrayFunctionTaintStep(pred, succ, _)
     }
   }

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -8,12 +8,9 @@ module ArrayTaintTracking {
   /**
    * A taint propagating data flow edge caused by the builtin array functions.
    */
-  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep,
-    DataFlow::CallNode {
-    ArrayFunctionTaintStep() { arrayFunctionTaintStep(_, _, this) }
-
+  private class ArrayFunctionTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      arrayFunctionTaintStep(pred, succ, this)
+      arrayFunctionTaintStep(pred, succ, _)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -9,7 +9,7 @@ module ArrayTaintTracking {
    * A taint propagating data flow edge caused by the builtin array functions.
    */
   private class ArrayFunctionTaintStep extends TaintTracking::SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
       arrayFunctionTaintStep(pred, succ, _)
     }
   }

--- a/javascript/ql/src/semmle/javascript/Base64.qll
+++ b/javascript/ql/src/semmle/javascript/Base64.qll
@@ -67,14 +67,12 @@ module Base64 {
    * Note that we currently do not model base64 encoding as a taint-propagating data flow edge
    * to avoid false positives.
    */
-  private class Base64DecodingStep extends TaintTracking::AdditionalTaintStep {
-    Decode dec;
-
-    Base64DecodingStep() { this = dec }
-
+  private class Base64DecodingStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = dec.getInput() and
-      succ = dec.getOutput()
+      exists(Decode dec |
+        pred = dec.getInput() and
+        succ = dec.getOutput()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Base64.qll
+++ b/javascript/ql/src/semmle/javascript/Base64.qll
@@ -67,7 +67,7 @@ module Base64 {
    * Note that we currently do not model base64 encoding as a taint-propagating data flow edge
    * to avoid false positives.
    */
-  private class Base64DecodingStep extends TaintTracking::SharedTaintStep {
+  private class Base64DecodingStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Decode dec |
         pred = dec.getInput() and

--- a/javascript/ql/src/semmle/javascript/Base64.qll
+++ b/javascript/ql/src/semmle/javascript/Base64.qll
@@ -67,7 +67,7 @@ module Base64 {
    * Note that we currently do not model base64 encoding as a taint-propagating data flow edge
    * to avoid false positives.
    */
-  private class Base64DecodingStep extends TaintTracking::GenericStep {
+  private class Base64DecodingStep extends TaintTracking::DecodingStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Decode dec |
         pred = dec.getInput() and

--- a/javascript/ql/src/semmle/javascript/Closure.qll
+++ b/javascript/ql/src/semmle/javascript/Closure.qll
@@ -154,7 +154,7 @@ module Closure {
 
     /**
      * Gets the top-level `exports` variable in this module, if this module is defined by
-     * a `good.module` call.
+     * a `goog.module` call.
      *
      * This variable denotes the object exported from this module.
      *

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -160,14 +160,12 @@ private class FunctionalExtendCallShallow extends ExtendCall {
  * A taint propagating data flow edge from the objects flowing into an extend call to its return value
  * and to the source of the destination object.
  */
-private class ExtendCallTaintStep extends TaintTracking::AdditionalTaintStep {
-  ExtendCall extend;
-
-  ExtendCallTaintStep() { this = extend }
-
+private class ExtendCallTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()
-    or
-    pred = extend.getAnOperand() and succ = extend
+    exists(ExtendCall extend |
+      pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()
+      or
+      pred = extend.getAnOperand() and succ = extend
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -160,7 +160,7 @@ private class FunctionalExtendCallShallow extends ExtendCall {
  * A taint propagating data flow edge from the objects flowing into an extend call to its return value
  * and to the source of the destination object.
  */
-private class ExtendCallTaintStep extends TaintTracking::SharedTaintStep {
+private class ExtendCallTaintStep extends TaintTracking::GenericStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ExtendCall extend |
       pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -160,7 +160,7 @@ private class FunctionalExtendCallShallow extends ExtendCall {
  * A taint propagating data flow edge from the objects flowing into an extend call to its return value
  * and to the source of the destination object.
  */
-private class ExtendCallTaintStep extends TaintTracking::GenericStep {
+private class ExtendCallTaintStep extends TaintTracking::HeapStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ExtendCall extend |
       pred = extend.getASourceOperand() and succ = extend.getDestinationOperand().getALocalSource()

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -612,14 +612,12 @@ private module ClosurePromise {
   /**
    * Taint steps through closure promise methods.
    */
-  private class ClosurePromiseTaintStep extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node pred;
-
-    ClosurePromiseTaintStep() {
+  private class ClosurePromiseTaintStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // static methods in goog.Promise
       exists(DataFlow::CallNode call, string name |
         call = Closure::moduleImport("goog.Promise." + name).getACall() and
-        this = call and
+        succ = call and
         pred = call.getAnArgument()
       |
         name = "all" or
@@ -631,11 +629,9 @@ private module ClosurePromise {
       // promise created through goog.promise.withResolver()
       exists(DataFlow::CallNode resolver |
         resolver = Closure::moduleImport("goog.Promise.withResolver").getACall() and
-        this = resolver.getAPropertyRead("promise") and
+        succ = resolver.getAPropertyRead("promise") and
         pred = resolver.getAMethodCall("resolve").getArgument(0)
       )
     }
-
-    override predicate step(DataFlow::Node src, DataFlow::Node dst) { src = pred and dst = this }
   }
 }

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -607,7 +607,7 @@ private module ClosurePromise {
   /**
    * Taint steps through closure promise methods.
    */
-  private class ClosurePromiseTaintStep extends TaintTracking::GenericStep {
+  private class ClosurePromiseTaintStep extends TaintTracking::PromiseStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // static methods in goog.Promise
       exists(DataFlow::CallNode call, string name |

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -473,8 +473,8 @@ private module PromiseFlow {
  */
 deprecated predicate promiseTaintStep = TaintTracking::promiseStep/2;
 
-private class PromiseTaintStep extends TaintTracking::SharedTaintStep {
-  override predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+private class PromiseTaintStep extends TaintTracking::PromiseStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     // from `x` to `new Promise((res, rej) => res(x))`
     pred = succ.(PromiseDefinition).getResolveParameter().getACall().getArgument(0)
     or
@@ -607,7 +607,7 @@ private module ClosurePromise {
   /**
    * Taint steps through closure promise methods.
    */
-  private class ClosurePromiseTaintStep extends TaintTracking::SharedTaintStep {
+  private class ClosurePromiseTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // static methods in goog.Promise
       exists(DataFlow::CallNode call, string name |

--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -518,13 +518,9 @@ predicate promiseTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
 /**
  * An additional taint step that involves promises.
  */
-private class PromiseTaintStep extends TaintTracking::AdditionalTaintStep {
-  DataFlow::Node source;
-
-  PromiseTaintStep() { promiseTaintStep(source, this) }
-
+private class PromiseTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = source and succ = this
+    promiseTaintStep(pred, succ)
   }
 }
 

--- a/javascript/ql/src/semmle/javascript/Regexp.qll
+++ b/javascript/ql/src/semmle/javascript/Regexp.qll
@@ -893,7 +893,7 @@ private DataFlow::Node regExpSource(DataFlow::Node re, DataFlow::TypeBackTracker
   exists(DataFlow::TypeBackTracker t2, DataFlow::Node succ | succ = regExpSource(re, t2) |
     t2 = t.smallstep(result, succ)
     or
-    any(TaintTracking::AdditionalTaintStep dts).step(result, succ) and
+    TaintTracking::sharedTaintStep(result, succ) and
     t = t2
   )
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -364,21 +364,15 @@ module TaintTracking {
    * taint to flow from `v` to any read of `c2.props.p`, where `c2`
    * also is an instance of `C`.
    */
-  private class ReactComponentPropsTaintStep extends AdditionalTaintStep, DataFlow::ValueNode {
-    DataFlow::Node source;
-
-    ReactComponentPropsTaintStep() {
+  private class ReactComponentPropsTaintStep extends SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, string name, DataFlow::PropRead prn |
         prn = c.getAPropRead(name) or
         prn = c.getAPreviousPropsSource().getAPropertyRead(name)
       |
-        source = c.getACandidatePropsValue(name) and
-        this = prn
+        pred = c.getACandidatePropsValue(name) and
+        succ = prn
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = source and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -319,7 +319,7 @@ module TaintTracking {
   }
 
   /**
-   * A class of taint-propagating data flow edges through through data serialization, such as `JSON.stringify`.
+   * A class of taint-propagating data flow edges through data serialization, such as `JSON.stringify`.
    */
   class SerializeStep extends SharedTaintStep {
     SerializeStep() { this = "SerializeStep" }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -647,11 +647,13 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from sorting.
    */
-  private class SortTaintStep extends AdditionalTaintStep, DataFlow::MethodCallNode {
-    SortTaintStep() { getMethodName() = "sort" }
-
+  private class SortTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getReceiver() and succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "sort" and
+        pred = call.getReceiver() and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -527,11 +527,13 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from JSON unparsing.
    */
-  private class JsonStringifyTaintStep extends AdditionalTaintStep, DataFlow::MethodCallNode {
-    JsonStringifyTaintStep() { this = DataFlow::globalVarRef("JSON").getAMemberCall("stringify") }
-
+  private class JsonStringifyTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and succ = this
+      exists(DataFlow::CallNode call |
+        call = DataFlow::globalVarRef("JSON").getAMemberCall("stringify") and
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -540,14 +540,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from JSON parsing.
    */
-  private class JsonParserTaintStep extends AdditionalTaintStep, DataFlow::CallNode {
-    JsonParserCall call;
-
-    JsonParserTaintStep() { this = call }
-
+  private class JsonParserTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = call.getInput() and
-      succ = call.getOutput()
+      exists(JsonParserCall call |
+        pred = call.getInput() and
+        succ = call.getOutput()
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -538,49 +538,6 @@ module TaintTracking {
   }
 
   /**
-   * A taint propagating data flow edge for assignments of the form `c1.state.p = v`,
-   * where `c1` is an instance of React component `C`; in this case, we consider
-   * taint to flow from `v` to any read of `c2.state.p`, where `c2`
-   * also is an instance of `C`.
-   */
-  private class ReactComponentStateTaintStep extends SharedTaintStep {
-    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
-        (
-          c.getACandidateStateSource().flowsTo(pwn.getBase()) or
-          c.getADirectStateAccess().flowsTo(pwn.getBase())
-        ) and
-        (
-          c.getAPreviousStateSource().flowsTo(prn.getBase()) or
-          c.getADirectStateAccess().flowsTo(prn.getBase())
-        )
-      |
-        prn.getPropertyName() = pwn.getPropertyName() and
-        succ = prn and
-        pred = pwn.getRhs()
-      )
-    }
-  }
-
-  /**
-   * A taint propagating data flow edge for assignments of the form `c1.props.p = v`,
-   * where `c1` is an instance of React component `C`; in this case, we consider
-   * taint to flow from `v` to any read of `c2.props.p`, where `c2`
-   * also is an instance of `C`.
-   */
-  private class ReactComponentPropsTaintStep extends SharedTaintStep {
-    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(ReactComponent c, string name, DataFlow::PropRead prn |
-        prn = c.getAPropRead(name) or
-        prn = c.getAPreviousPropsSource().getAPropertyRead(name)
-      |
-        pred = c.getACandidatePropsValue(name) and
-        succ = prn
-      )
-    }
-  }
-
-  /**
    * A taint propagating data flow edge arising from string concatenations.
    *
    * Note that since we cannot easily distinguish string append from addition,

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -312,26 +312,26 @@ module TaintTracking {
   cached
   private module Cached {
     /**
-    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-    * data flow edge, which doesn't fit into a more specific category.
-    */
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, which doesn't fit into a more specific category.
+     */
     cached
     predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(SharedTaintStep step).step(pred, succ)
     }
 
     /**
-    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-    * data flow edge, contribued by the heuristics library.
-    */
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, contribued by the heuristics library.
+     */
     cached
     predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(SharedTaintStep step).heuristicStep(pred, succ)
     }
 
     /**
-    * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
-    */
+     * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+     */
     cached
     predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
       any(AdditionalTaintStep step).step(pred, succ)
@@ -343,96 +343,97 @@ module TaintTracking {
     cached
     module Public {
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through a URI library function.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through a URI library function.
+       */
       cached
       predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).uriStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+       */
       cached
       predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).persistentStorageStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+       */
       cached
       predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).heapStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+       */
       cached
       predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).arrayStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through the
-      * properties of a view compenent, such as the `state` or `props` of a React component.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through the
+       * properties of a view compenent, such as the `state` or `props` of a React component.
+       */
       cached
       predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).viewComponentStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through string
-      * concatenation.
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through string
+       * concatenation.
+       */
       cached
       predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).stringConcatenationStep(pred, succ)
       }
 
       /**
-      * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
-      * (other than concatenation).
-      */
+       * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+       * (other than concatenation).
+       */
       cached
       predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).stringManipulationStep(pred, succ)
       }
 
       /**
-      *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data serialization, such as `JSON.stringify`.
-      */
+       *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through data serialization, such as `JSON.stringify`.
+       */
       cached
       predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).serializeStep(pred, succ)
       }
 
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data deserialization, such as `JSON.parse`.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through data deserialization, such as `JSON.parse`.
+       */
       cached
       predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).deserializeStep(pred, succ)
       }
 
       /**
-      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through a promise.
-      *
-      * These steps consider a promise object to tainted if it can resolve to
-      * a tainted value.
-      */
+       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+       * data flow edge through a promise.
+       *
+       * These steps consider a promise object to tainted if it can resolve to
+       * a tainted value.
+       */
       cached
       predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
         any(SharedTaintStep step).promiseStep(pred, succ)
       }
     }
   }
+
   import Cached::Public
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -480,17 +480,12 @@ module TaintTracking {
   /**
    * A taint propagating data flow edge arising from string formatting.
    */
-  private class StringFormattingTaintStep extends AdditionalTaintStep {
-    PrintfStyleCall call;
-
-    StringFormattingTaintStep() {
-      this = call and
-      call.returnsFormatted()
-    }
-
+  private class StringFormattingTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
-      (
+      exists(PrintfStyleCall call |
+        call.returnsFormatted() and
+        succ = call
+      |
         pred = call.getFormatString()
         or
         pred = call.getFormatArgument(_)

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -392,11 +392,8 @@ module TaintTracking {
    * A taint propagating data flow edge arising from string manipulation
    * functions defined in the standard library.
    */
-  private class StringManipulationTaintStep extends AdditionalTaintStep, DataFlow::ValueNode {
-    StringManipulationTaintStep() { stringManipulationStep(_, this) }
-
+  private class StringManipulationTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       stringManipulationStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -215,8 +215,12 @@ module TaintTracking {
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.
      */
-    cached
     predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
+  }
+
+  cached
+  private predicate sharedTaintStepInternal(DataFlow::Node pred, DataFlow::Node succ, SharedTaintStep kind) {
+    kind.step(pred, succ)
   }
 
   /**
@@ -346,21 +350,21 @@ module TaintTracking {
    * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
    */
   predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(PersistentStorageStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(PersistentStorageStep step))
   }
 
   /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
    */
   predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(HeapStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(HeapStep step))
   }
 
   /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
    */
   predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(ArrayStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(ArrayStep step))
   }
 
   /**
@@ -368,7 +372,7 @@ module TaintTracking {
    * properties of a view compenent, such as the `state` or `props` of a React component.
    */
   predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(ViewComponentStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(ViewComponentStep step))
   }
 
   /**
@@ -376,7 +380,7 @@ module TaintTracking {
    * concatenation.
    */
   predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(StringConcatenationStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(StringConcatenationStep step))
   }
 
   /**
@@ -384,7 +388,7 @@ module TaintTracking {
    * (other than concatenation).
    */
   predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(StringManipulationStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(StringManipulationStep step))
   }
 
   /**
@@ -392,7 +396,7 @@ module TaintTracking {
    * data flow edge through data serialization, such as `JSON.stringify`.
    */
   predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SerializeStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(SerializeStep step))
   }
 
   /**
@@ -400,7 +404,7 @@ module TaintTracking {
    * data flow edge through data deserialization, such as `JSON.parse`.
    */
   predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(DeserializeStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(DeserializeStep step))
   }
 
   /**
@@ -411,7 +415,7 @@ module TaintTracking {
    * a tainted value.
    */
   predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(PromiseStep step).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, any(PromiseStep step))
   }
 
   /**
@@ -428,7 +432,7 @@ module TaintTracking {
    */
   predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
     any(AdditionalTaintStep s).step(pred, succ) or
-    any(SharedTaintStep s).step(pred, succ)
+    sharedTaintStepInternal(pred, succ, _)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -219,7 +219,9 @@ module TaintTracking {
   }
 
   cached
-  private predicate sharedTaintStepInternal(DataFlow::Node pred, DataFlow::Node succ, SharedTaintStep kind) {
+  private predicate sharedTaintStepInternal(
+    DataFlow::Node pred, DataFlow::Node succ, SharedTaintStep kind
+  ) {
     kind.step(pred, succ)
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -255,6 +255,17 @@ module TaintTracking {
   }
 
   /**
+   * A class of taint-propagating data flow edges through file path manipulation,
+   * such as `path.join`.
+   *
+   * Does not include string operations that aren't specific to paths, such
+   * as concatenation and substring operations.
+   */
+  class FilePathStep extends SharedTaintStep {
+    FilePathStep() { this = "FilePathStep" }
+  }
+
+  /**
    * A class of taint-propagating data flow edges contributed by the heuristics library.
    *
    * Such steps are provided by the `semmle.javascript.heuristics` libraries
@@ -371,6 +382,14 @@ module TaintTracking {
    */
   predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
     sharedTaintStepInternal(pred, succ, any(UriStep step))
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through a library function manipulating file paths.
+   */
+  predicate filePathStep(DataFlow::Node pred, DataFlow::Node succ) {
+    sharedTaintStepInternal(pred, succ, any(FilePathStep step))
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -287,6 +287,15 @@ module TaintTracking {
      * data flow edge through data deserialization, such as `JSON.parse`.
      */
     predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through a promise.
+     *
+     * These steps consider a promise object to tainted if it can resolve to
+     * a tainted value.
+     */
+    predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -378,6 +387,18 @@ module TaintTracking {
   }
 
   /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data deserialization, such as `JSON.parse`.
+   *
+   * These steps consider a promise object to tainted if it can resolve to
+   * a tainted value.
+   */
+  cached
+  predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).promiseStep(pred, succ)
+  }
+
+  /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
    */
   pragma[inline]
@@ -408,7 +429,8 @@ module TaintTracking {
     stringConcatenationStep(pred, succ) or
     stringManipulationStep(pred, succ) or
     serializeStep(pred, succ) or
-    deserializeStep(pred, succ)
+    deserializeStep(pred, succ) or
+    promiseStep(pred, succ)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -207,6 +207,17 @@ module TaintTracking {
     override predicate sanitizes(boolean outcome, Expr e) { none() }
   }
 
+  /**
+   * A class of taint-propagating data flow edges that should be added to all taint tracking
+   * configurations in addition to standard data flow edges.
+   *
+   * This class should rarely be subclassed directly; prefer one of the specific subclasses
+   * such as `TaintTracking::HeapStep`.
+   *
+   * Note: For performance reasons, all subclasses of this class should be part
+   * of the standard library. Override `Configuration::isAdditionalTaintStep`
+   * for analysis-specific taint steps.
+   */
   abstract class SharedTaintStep extends string {
     bindingset[this]
     SharedTaintStep() { any() }
@@ -226,26 +237,15 @@ module TaintTracking {
   }
 
   /**
-   * A taint-propagating data flow edge that should be added to all taint tracking
-   * configurations in addition to standard data flow edges.
-   *
-   * This class is a singleton, and thus subclasses do not need to specify a characteristic predicate.
-   *
-   * Note: For performance reasons, all subclasses of this class should be part
-   * of the standard library. Override `Configuration::isAdditionalTaintStep`
-   * for analysis-specific taint steps.
-   *
-   * This class has multiple kinds of `step` predicates; these all have the same
-   * effect on taint-tracking configurations. However, the categorization of steps
-   * allows some data-flow configurations to opt in to specific kinds of taint steps.
+   * A class of taint-propagating data flow edges that don't belong to any of the more
+   * specific categories such as `TaintTracking::HeapStep`.
    */
   class GenericStep extends SharedTaintStep {
     GenericStep() { this = "GenericStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through URI manipulation.
+   * A class of taint-propagating data flow edges through URI manipulation.
    *
    * Does not include string operations that aren't specific to URIs, such
    * as concatenation and substring operations.
@@ -255,8 +255,7 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge contributed by the heuristics library.
+   * A class of taint-propagating data flow edges contributed by the heuristics library.
    *
    * Such steps are provided by the `semmle.javascript.heuristics` libraries
    * and will default to be being empty if those libraries are not imported.
@@ -266,77 +265,78 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through persistent storage.
+   * A class of taint-propagating data flow edges through persistent storage,
+   * such as cookies.
    */
   class PersistentStorageStep extends SharedTaintStep {
     PersistentStorageStep() { this = "PersistentStorageStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through the heap.
+   * A class of taint-propagating data flow edges through the heap.
+   *
+   * The general assumption made by these steps are:
+   * - A tainted object has tainted properties.
+   * - An object with a tainted property name is tainted.
+   *   - However, a tainted property _value_ is not generally enough to
+   *     consider the whole object tainted.
    */
   class HeapStep extends SharedTaintStep {
     HeapStep() { this = "HeapStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through arrays.
+   * A class of taint-propagating data flow edges through arrays.
    *
-   * These steps considers an array to be tainted if it contains tainted elements.
+   * The general assumption made by these steps are:
+   * - A tainted array has tainted array elements.
+   * - An array with a tainted element is tainted.
    */
   class ArrayStep extends SharedTaintStep {
     ArrayStep() { this = "ArrayStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through the `state` or `props` or a React component.
+   * A class of taint-propagating data flow edges through a view component,
+   * such as the `state` or `props` or a React component.
    */
   class ViewComponentStep extends SharedTaintStep {
     ViewComponentStep() { this = "ViewComponentStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through string concatenation.
+   * A class of taint-propagating data flow edges through string concatenation.
    */
   class StringConcatenationStep extends SharedTaintStep {
     StringConcatenationStep() { this = "StringConcatenationStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through string manipulation (other than concatenation).
+   * A class of taint-propagating data flow edges through string manipulation (other than concatenation).
    */
   class StringManipulationStep extends SharedTaintStep {
     StringManipulationStep() { this = "StringManipulationStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data serialization, such as `JSON.stringify`.
+   * A class of taint-propagating data flow edges through through data serialization, such as `JSON.stringify`.
    */
   class SerializeStep extends SharedTaintStep {
     SerializeStep() { this = "SerializeStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data deserialization, such as `JSON.parse`.
+   * A class of taint-propagating data flow edges through data deserialization, such as `JSON.parse`.
    */
   class DeserializeStep extends SharedTaintStep {
     DeserializeStep() { this = "DeserializeStep" }
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through a promise.
+   * A class of taint-propagating data flow edges through a promise.
    *
-   * These steps consider a promise object to tainted if it can resolve to
-   * a tainted value.
+   * The general assumption made by these steps are:
+   * - A promise object is tainted iff it can succeed with a tainted value.
    */
   class PromiseStep extends SharedTaintStep {
     PromiseStep() { this = "PromiseStep" }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -254,11 +254,9 @@ module TaintTracking {
    * A taint propagating data flow edge through object or array elements and
    * promises.
    */
-  private class HeapTaintStep extends AdditionalTaintStep {
-    HeapTaintStep() { heapStep(_, this) }
-
+  private class HeapTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      heapStep(pred, succ) and succ = this
+      heapStep(pred, succ)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -972,6 +972,6 @@ module TaintTracking {
    */
   predicate localTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
     DataFlow::localFlowStep(pred, succ) or
-    any(AdditionalTaintStep s).step(pred, succ)
+    sharedTaintStep(pred, succ)
   }
 }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -233,6 +233,15 @@ module TaintTracking {
      * data flow edge, in the URI category.
      */
     predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, in the heuristic category.
+     *
+     * Note that this set of steps will be empty unless libraries from
+     * `semmle.javascript.heuristics` are explicitly imported.
+     */
+    predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -242,6 +251,8 @@ module TaintTracking {
     any(SharedTaintStep step).step(pred, succ)
     or
     any(AdditionalTaintStep step).step(pred, succ)
+    or
+    any(SharedTaintStep step).heuristicStep(pred, succ)
     or
     uriStep(pred, succ)
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -317,11 +317,8 @@ module TaintTracking {
    * a map, not as a real object. In this case, it makes sense to consider the entire
    * map to be tainted as soon as one of its entries is.
    */
-  private class DictionaryTaintStep extends AdditionalTaintStep {
-    DictionaryTaintStep() { dictionaryTaintStep(_, this) }
-
+  private class DictionaryTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       dictionaryTaintStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -422,7 +422,7 @@ module TaintTracking {
 
       /**
       * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-      * data flow edge through data deserialization, such as `JSON.parse`.
+      * data flow edge through a promise.
       *
       * These steps consider a promise object to tainted if it can resolve to
       * a tainted value.

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -527,6 +527,12 @@ module TaintTracking {
     }
   }
 
+  pragma[nomagic]
+  private DataFlow::MethodCallNode execMethodCall() {
+    result.getMethodName() = "exec" and
+    result.getReceiver().analyze().getAType() = TTRegExp()
+  }
+
   /**
    * A taint-propagating data flow edge from the first (and only) argument in a call to
    * `RegExp.prototype.exec` to its result.
@@ -534,13 +540,18 @@ module TaintTracking {
   private class RegExpExecTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getReceiver().analyze().getAType() = TTRegExp() and
-        call.getMethodName() = "exec" and
+        call = execMethodCall() and
         call.getNumArgument() = 1 and
         pred = call.getArgument(0) and
         succ = call
       )
     }
+  }
+
+  pragma[nomagic]
+  private DataFlow::MethodCallNode matchMethodCall() {
+    result.getMethodName() = "match" and
+    result.getArgument(0).analyze().getAType() = TTRegExp()
   }
 
   /**
@@ -549,9 +560,8 @@ module TaintTracking {
   private class StringMatchTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getMethodName() = "match" and
+        call = matchMethodCall() and
         call.getNumArgument() = 1 and
-        call.getArgument(0).analyze().getAType() = TTRegExp() and
         pred = call.getReceiver() and
         succ = call
       )

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -660,9 +660,13 @@ module TaintTracking {
   /**
    * A taint step through an exception constructor, such as `x` to `new Error(x)`.
    */
-  class ErrorConstructorTaintStep extends AdditionalTaintStep, DataFlow::InvokeNode {
-    ErrorConstructorTaintStep() {
-      exists(string name | this = DataFlow::globalVarRef(name).getAnInvocation() |
+  class ErrorConstructorTaintStep extends SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::NewNode invoke, string name |
+        invoke = DataFlow::globalVarRef(name).getAnInvocation() and
+        pred = invoke.getArgument(0) and
+        succ = invoke
+        |
         name = "Error" or
         name = "EvalError" or
         name = "RangeError" or
@@ -671,11 +675,6 @@ module TaintTracking {
         name = "TypeError" or
         name = "URIError"
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -681,12 +681,13 @@ module TaintTracking {
   /**
    * A taint step through the Node.JS function `util.inspect(..)`.
    */
-  class UtilInspectTaintStep extends AdditionalTaintStep, DataFlow::InvokeNode {
-    UtilInspectTaintStep() { this = DataFlow::moduleImport("util").getAMemberCall("inspect") }
-
+  class UtilInspectTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
-      this.getAnArgument() = pred
+      exists(DataFlow::CallNode call |
+        call = DataFlow::moduleImport("util").getAMemberCall("inspect") and
+        call.getAnArgument() = pred and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -307,112 +307,133 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge, which doesn't fit into a more specific category.
+   * Module existing only to ensure all taint steps are cached as a single stage.
    */
   cached
-  private predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).step(pred, succ)
-  }
+  private module Cached {
+    /**
+    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+    * data flow edge, which doesn't fit into a more specific category.
+    */
+    cached
+    predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(SharedTaintStep step).step(pred, succ)
+    }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge, contribued by the heuristics library.
-   */
-  cached
-  private predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).heuristicStep(pred, succ)
-  }
+    /**
+    * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+    * data flow edge, contribued by the heuristics library.
+    */
+    cached
+    predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(SharedTaintStep step).heuristicStep(pred, succ)
+    }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through a URI library function.
-   */
-  cached
-  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).uriStep(pred, succ)
-  }
+    /**
+    * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+    */
+    cached
+    predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+      any(AdditionalTaintStep step).step(pred, succ)
+    }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-   */
-  cached
-  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).persistentStorageStep(pred, succ)
-  }
+    /**
+     * Public taint step relations.
+     */
+    cached
+    module Public {
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through a URI library function.
+      */
+      cached
+      predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).uriStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
-   */
-  cached
-  predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).heapStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+      */
+      cached
+      predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).persistentStorageStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
-   */
-  cached
-  predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).arrayStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+      */
+      cached
+      predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).heapStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through the
-   * properties of a view compenent, such as the `state` or `props` of a React component.
-   */
-  cached
-  predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).viewComponentStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+      */
+      cached
+      predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).arrayStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through string
-   * concatenation.
-   */
-  cached
-  predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).stringConcatenationStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through the
+      * properties of a view compenent, such as the `state` or `props` of a React component.
+      */
+      cached
+      predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).viewComponentStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
-   * (other than concatenation).
-   */
-  cached
-  predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).stringManipulationStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through string
+      * concatenation.
+      */
+      cached
+      predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).stringConcatenationStep(pred, succ)
+      }
 
-  /**
-   *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data serialization, such as `JSON.stringify`.
-   */
-  cached
-  predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).serializeStep(pred, succ)
-  }
+      /**
+      * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+      * (other than concatenation).
+      */
+      cached
+      predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).stringManipulationStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data deserialization, such as `JSON.parse`.
-   */
-  cached
-  predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).deserializeStep(pred, succ)
-  }
+      /**
+      *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data serialization, such as `JSON.stringify`.
+      */
+      cached
+      predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).serializeStep(pred, succ)
+      }
 
-  /**
-   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-   * data flow edge through data deserialization, such as `JSON.parse`.
-   *
-   * These steps consider a promise object to tainted if it can resolve to
-   * a tainted value.
-   */
-  cached
-  predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).promiseStep(pred, succ)
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data deserialization, such as `JSON.parse`.
+      */
+      cached
+      predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).deserializeStep(pred, succ)
+      }
+
+      /**
+      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+      * data flow edge through data deserialization, such as `JSON.parse`.
+      *
+      * These steps consider a promise object to tainted if it can resolve to
+      * a tainted value.
+      */
+      cached
+      predicate promiseStep(DataFlow::Node pred, DataFlow::Node succ) {
+        any(SharedTaintStep step).promiseStep(pred, succ)
+      }
+    }
   }
+  import Cached::Public
 
   /**
    * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
@@ -424,20 +445,12 @@ module TaintTracking {
   }
 
   /**
-   * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
-   */
-  cached
-  private predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(AdditionalTaintStep step).step(pred, succ)
-  }
-
-  /**
    * Holds if `pred -> succ` is an edge used by all taint-tracking configurations.
    */
   predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    legacyAdditionalTaintStep(pred, succ) or
-    genericStep(pred, succ) or
-    heuristicStep(pred, succ) or
+    Cached::legacyAdditionalTaintStep(pred, succ) or
+    Cached::genericStep(pred, succ) or
+    Cached::heuristicStep(pred, succ) or
     uriStep(pred, succ) or
     persistentStorageStep(pred, succ) or
     heapStep(pred, succ) or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -216,13 +216,23 @@ module TaintTracking {
    * Note: For performance reasons, all subclasses of this class should be part
    * of the standard library. Override `Configuration::isAdditionalTaintStep`
    * for analysis-specific taint steps.
+   *
+   * This class has multiple kinds of `step` predicates; these all have the same
+   * effect on taint-tracking configurations. However, the categorization of steps
+   * allows some data-flow configurations to opt in to specific kinds of taint steps.
    */
   class SharedTaintStep extends Unit {
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge.
      */
-    abstract predicate step(DataFlow::Node pred, DataFlow::Node succ);
+    predicate step(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge, in the URI category.
+     */
+    predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
   }
 
   /**
@@ -232,6 +242,12 @@ module TaintTracking {
     any(SharedTaintStep step).step(pred, succ)
     or
     any(AdditionalTaintStep step).step(pred, succ)
+    or
+    uriStep(pred, succ)
+  }
+
+  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).uriStep(pred, succ)
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -497,35 +497,30 @@ module TaintTracking {
    * A taint-propagating data flow edge from the first (and only) argument in a call to
    * `RegExp.prototype.exec` to its result.
    */
-  private class RegExpExecTaintStep extends AdditionalTaintStep {
-    DataFlow::MethodCallNode self;
-
-    RegExpExecTaintStep() {
-      this = self and
-      self.getReceiver().analyze().getAType() = TTRegExp() and
-      self.getMethodName() = "exec" and
-      self.getNumArgument() = 1
-    }
-
+  private class RegExpExecTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = self.getArgument(0) and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getReceiver().analyze().getAType() = TTRegExp() and
+        call.getMethodName() = "exec" and
+        call.getNumArgument() = 1 and
+        pred = call.getArgument(0) and
+        succ = call
+      )
     }
   }
 
   /**
    * A taint propagating data flow edge arising from calling `String.prototype.match()`.
    */
-  private class StringMatchTaintStep extends AdditionalTaintStep, DataFlow::MethodCallNode {
-    StringMatchTaintStep() {
-      this.getMethodName() = "match" and
-      this.getNumArgument() = 1 and
-      this.getArgument(0).analyze().getAType() = TTRegExp()
-    }
-
+  private class StringMatchTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getReceiver() and
-      succ = this
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "match" and
+        call.getNumArgument() = 1 and
+        call.getArgument(0).analyze().getAType() = TTRegExp() and
+        pred = call.getReceiver() and
+        succ = call
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -460,9 +460,6 @@ module TaintTracking {
           prop.isComputed() and f = prop.getNameExpr()
         )
         or
-        // awaiting a tainted expression gives a tainted result
-        e.(AwaitExpr).getOperand() = f
-        or
         // spreading a tainted object into an object literal gives a tainted object
         e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
         or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -255,9 +255,7 @@ module TaintTracking {
    * promises.
    */
   private class HeapTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      heapStep(pred, succ)
-    }
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { heapStep(pred, succ) }
   }
 
   /**
@@ -294,15 +292,24 @@ module TaintTracking {
   }
 
   /**
+   * DEPRECATED. Use the predicate `TaintTracking::persistentStorageStep` instead.
+   *
    * A taint propagating data flow edge through persistent storage.
    */
-  class PersistentStorageTaintStep extends SharedTaintStep {
+  deprecated class PersistentStorageTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(PersistentReadAccess read |
-        pred = read.getAWrite().getValue() and
-        succ = read
-      )
+      persistentStorageStep(pred, succ)
     }
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+   */
+  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(PersistentReadAccess read |
+      pred = read.getAWrite().getValue() and
+      succ = read
+    )
   }
 
   predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -230,35 +230,185 @@ module TaintTracking {
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-     * data flow edge, in the URI category.
+     * data flow edge through URI manipulation.
+     *
+     * Does not include string operations that aren't specific to URIs, such
+     * as concatenation and substring operations.
      */
     predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
-     * data flow edge, in the heuristic category.
+     * data flow edge contributed by the heuristics library.
      *
-     * Note that this set of steps will be empty unless libraries from
-     * `semmle.javascript.heuristics` are explicitly imported.
+     * Such steps are provided by the `semmle.javascript.heuristics` libraries
+     * and will default to be being empty if those libraries are not imported.
      */
     predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through persistent storage.
+     */
+    predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through the heap.
+     */
+    predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through the `state` or `props` or a React component.
+     */
+    predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through string concatenation.
+     */
+    predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through string manipulation (other than concatenation).
+     */
+    predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through data serialization, such as `JSON.stringify`.
+     */
+    predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through data deserialization, such as `JSON.parse`.
+     */
+    predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge, which doesn't fit into a more specific category.
+   */
+  cached
+  private predicate genericStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).step(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge, contribued by the heuristics library.
+   */
+  cached
+  private predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).heuristicStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through a URI library function.
+   */
+  cached
+  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).uriStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
+   */
+  cached
+  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).persistentStorageStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through the heap.
+   */
+  cached
+  predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).heapStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through the
+   * properties of a view compenent, such as the `state` or `props` of a React component.
+   */
+  cached
+  predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).viewComponentStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through string
+   * concatenation.
+   */
+  cached
+  predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).stringConcatenationStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through string manipulation
+   * (other than concatenation).
+   */
+  cached
+  predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).stringManipulationStep(pred, succ)
+  }
+
+  /**
+   *  Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data serialization, such as `JSON.stringify`.
+   */
+  cached
+  predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).serializeStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+   * data flow edge through data deserialization, such as `JSON.parse`.
+   */
+  cached
+  predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).deserializeStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through a string operation.
+   */
+  pragma[inline]
+  predicate stringStep(DataFlow::Node pred, DataFlow::Node succ) {
+    stringConcatenationStep(pred, succ) or
+    stringManipulationStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is an edge contributed by an `AdditionalTaintStep` instance.
+   */
+  cached
+  private predicate legacyAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(AdditionalTaintStep step).step(pred, succ)
   }
 
   /**
    * Holds if `pred -> succ` is an edge used by all taint-tracking configurations.
    */
-  cached predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).step(pred, succ)
-    or
-    any(AdditionalTaintStep step).step(pred, succ)
-    or
-    any(SharedTaintStep step).heuristicStep(pred, succ)
-    or
-    uriStep(pred, succ)
-  }
-
-  predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-    any(SharedTaintStep step).uriStep(pred, succ)
+  predicate sharedTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    legacyAdditionalTaintStep(pred, succ) or
+    genericStep(pred, succ) or
+    heuristicStep(pred, succ) or
+    uriStep(pred, succ) or
+    persistentStorageStep(pred, succ) or
+    heapStep(pred, succ) or
+    viewComponentStep(pred, succ) or
+    stringConcatenationStep(pred, succ) or
+    stringManipulationStep(pred, succ) or
+    serializeStep(pred, succ) or
+    deserializeStep(pred, succ)
   }
 
   /**
@@ -282,40 +432,35 @@ module TaintTracking {
    * promises.
    */
   private class HeapTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { heapStep(pred, succ) }
-  }
-
-  /**
-   * Holds if there is taint propagation through the heap from `pred` to `succ`.
-   */
-  private predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
-      exists(Property prop | e.(ObjectExpr).getAProperty() = prop |
-        prop.isComputed() and f = prop.getNameExpr()
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
+        exists(Property prop | e.(ObjectExpr).getAProperty() = prop |
+          prop.isComputed() and f = prop.getNameExpr()
+        )
+        or
+        // awaiting a tainted expression gives a tainted result
+        e.(AwaitExpr).getOperand() = f
+        or
+        // spreading a tainted object into an object literal gives a tainted object
+        e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
+        or
+        // spreading a tainted value into an array literal gives a tainted array
+        e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
       )
       or
-      // awaiting a tainted expression gives a tainted result
-      e.(AwaitExpr).getOperand() = f
+      // arrays with tainted elements and objects with tainted property names are tainted
+      succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
+      not any(PromiseAllCreation call).getArrayNode() = succ
       or
-      // spreading a tainted object into an object literal gives a tainted object
-      e.(ObjectExpr).getAProperty().(SpreadProperty).getInit().(SpreadElement).getOperand() = f
+      // reading from a tainted object yields a tainted result
+      succ.(DataFlow::PropRead).getBase() = pred
       or
-      // spreading a tainted value into an array literal gives a tainted array
-      e.(ArrayExpr).getAnElement().(SpreadElement).getOperand() = f
-    )
-    or
-    // arrays with tainted elements and objects with tainted property names are tainted
-    succ.(DataFlow::ArrayCreationNode).getAnElement() = pred and
-    not any(PromiseAllCreation call).getArrayNode() = succ
-    or
-    // reading from a tainted object yields a tainted result
-    succ.(DataFlow::PropRead).getBase() = pred
-    or
-    // iterating over a tainted iterator taints the loop variable
-    exists(ForOfStmt fos |
-      pred = DataFlow::valueNode(fos.getIterationDomain()) and
-      succ = DataFlow::lvalueNode(fos.getLValue())
-    )
+      // iterating over a tainted iterator taints the loop variable
+      exists(ForOfStmt fos |
+        pred = DataFlow::valueNode(fos.getIterationDomain()) and
+        succ = DataFlow::lvalueNode(fos.getLValue())
+      )
+    }
   }
 
   /**
@@ -324,19 +469,12 @@ module TaintTracking {
    * A taint propagating data flow edge through persistent storage.
    */
   deprecated class PersistentStorageTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      persistentStorageStep(pred, succ)
+    override predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(PersistentReadAccess read |
+        pred = read.getAWrite().getValue() and
+        succ = read
+      )
     }
-  }
-
-  /**
-   * Holds if `pred -> succ` is a taint propagating data flow edge through persistent storage.
-   */
-  predicate persistentStorageStep(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(PersistentReadAccess read |
-      pred = read.getAWrite().getValue() and
-      succ = read
-    )
   }
 
   predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
@@ -352,19 +490,15 @@ module TaintTracking {
    * map to be tainted as soon as one of its entries is.
    */
   private class DictionaryTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      dictionaryTaintStep(pred, succ)
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(AssignExpr assgn, IndexExpr idx, DataFlow::ObjectLiteralNode obj |
+        assgn.getTarget() = idx and
+        obj.flowsToExpr(idx.getBase()) and
+        not exists(idx.getPropertyName()) and
+        pred = DataFlow::valueNode(assgn.getRhs()) and
+        succ = obj
+      )
     }
-  }
-
-  /** Holds if there is a step `pred -> succ` used by `DictionaryTaintStep`. */
-  private predicate dictionaryTaintStep(DataFlow::Node pred, DataFlow::ObjectLiteralNode succ) {
-    exists(AssignExpr assgn, IndexExpr idx |
-      assgn.getTarget() = idx and
-      succ.flowsToExpr(idx.getBase()) and
-      not exists(idx.getPropertyName()) and
-      pred = DataFlow::valueNode(assgn.getRhs())
-    )
   }
 
   /**
@@ -374,7 +508,7 @@ module TaintTracking {
    * also is an instance of `C`.
    */
   private class ReactComponentStateTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
         (
           c.getACandidateStateSource().flowsTo(pwn.getBase()) or
@@ -399,7 +533,7 @@ module TaintTracking {
    * also is an instance of `C`.
    */
   private class ReactComponentPropsTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(ReactComponent c, string name, DataFlow::PropRead prn |
         prn = c.getAPropRead(name) or
         prn = c.getAPreviousPropsSource().getAPropertyRead(name)
@@ -417,7 +551,7 @@ module TaintTracking {
    * we consider any `+` operation to propagate taint.
    */
   class StringConcatenationTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringConcatenationStep(DataFlow::Node pred, DataFlow::Node succ) {
       StringConcatenation::taintStep(pred, succ)
     }
   }
@@ -427,95 +561,90 @@ module TaintTracking {
    * functions defined in the standard library.
    */
   private class StringManipulationTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      stringManipulationStep(pred, succ)
-    }
-  }
-
-  /**
-   * Holds if taint can propagate from `pred` to `succ` with a step related to string manipulation.
-   */
-  private predicate stringManipulationStep(DataFlow::Node pred, DataFlow::ValueNode succ) {
-    // string operations that propagate taint
-    exists(string name | name = succ.getAstNode().(MethodCallExpr).getMethodName() |
-      pred.asExpr() = succ.getAstNode().(MethodCallExpr).getReceiver() and
-      (
-        // sorted, interesting, properties of String.prototype
-        name = "anchor" or
-        name = "big" or
-        name = "blink" or
-        name = "bold" or
-        name = "concat" or
-        name = "fixed" or
-        name = "fontcolor" or
-        name = "fontsize" or
-        name = "italics" or
-        name = "link" or
-        name = "padEnd" or
-        name = "padStart" or
-        name = "repeat" or
-        name = "replace" or
-        name = "slice" or
-        name = "small" or
-        name = "split" or
-        name = "strike" or
-        name = "sub" or
-        name = "substr" or
-        name = "substring" or
-        name = "sup" or
-        name = "toLocaleLowerCase" or
-        name = "toLocaleUpperCase" or
-        name = "toLowerCase" or
-        name = "toUpperCase" or
-        name = "trim" or
-        name = "trimLeft" or
-        name = "trimRight" or
-        // sorted, interesting, properties of Object.prototype
-        name = "toString" or
-        name = "valueOf" or
-        // sorted, interesting, properties of Array.prototype
-        name = "join"
-      )
-      or
-      exists(int i | pred.asExpr() = succ.getAstNode().(MethodCallExpr).getArgument(i) |
-        name = "concat"
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node target) {
+      exists(DataFlow::ValueNode succ | target = succ |
+        // string operations that propagate taint
+        exists(string name | name = succ.getAstNode().(MethodCallExpr).getMethodName() |
+          pred.asExpr() = succ.getAstNode().(MethodCallExpr).getReceiver() and
+          (
+            // sorted, interesting, properties of String.prototype
+            name = "anchor" or
+            name = "big" or
+            name = "blink" or
+            name = "bold" or
+            name = "concat" or
+            name = "fixed" or
+            name = "fontcolor" or
+            name = "fontsize" or
+            name = "italics" or
+            name = "link" or
+            name = "padEnd" or
+            name = "padStart" or
+            name = "repeat" or
+            name = "replace" or
+            name = "slice" or
+            name = "small" or
+            name = "split" or
+            name = "strike" or
+            name = "sub" or
+            name = "substr" or
+            name = "substring" or
+            name = "sup" or
+            name = "toLocaleLowerCase" or
+            name = "toLocaleUpperCase" or
+            name = "toLowerCase" or
+            name = "toUpperCase" or
+            name = "trim" or
+            name = "trimLeft" or
+            name = "trimRight" or
+            // sorted, interesting, properties of Object.prototype
+            name = "toString" or
+            name = "valueOf" or
+            // sorted, interesting, properties of Array.prototype
+            name = "join"
+          )
+          or
+          exists(int i | pred.asExpr() = succ.getAstNode().(MethodCallExpr).getArgument(i) |
+            name = "concat"
+            or
+            name = "replace" and i = 1
+          )
+        )
         or
-        name = "replace" and i = 1
+        // standard library constructors that propagate taint: `RegExp` and `String`
+        exists(DataFlow::InvokeNode invk, string gv | gv = "RegExp" or gv = "String" |
+          succ = invk and
+          invk = DataFlow::globalVarRef(gv).getAnInvocation() and
+          pred = invk.getArgument(0)
+        )
+        or
+        // String.fromCharCode and String.fromCodePoint
+        exists(int i, MethodCallExpr mce |
+          mce = succ.getAstNode() and
+          pred.asExpr() = mce.getArgument(i) and
+          (mce.getMethodName() = "fromCharCode" or mce.getMethodName() = "fromCodePoint")
+        )
+        or
+        // `(encode|decode)URI(Component)?` propagate taint
+        exists(DataFlow::CallNode c, string name |
+          succ = c and
+          c = DataFlow::globalVarRef(name).getACall() and
+          pred = c.getArgument(0)
+        |
+          name = "encodeURI" or
+          name = "decodeURI" or
+          name = "encodeURIComponent" or
+          name = "decodeURIComponent"
+        )
       )
-    )
-    or
-    // standard library constructors that propagate taint: `RegExp` and `String`
-    exists(DataFlow::InvokeNode invk, string gv | gv = "RegExp" or gv = "String" |
-      succ = invk and
-      invk = DataFlow::globalVarRef(gv).getAnInvocation() and
-      pred = invk.getArgument(0)
-    )
-    or
-    // String.fromCharCode and String.fromCodePoint
-    exists(int i, MethodCallExpr mce |
-      mce = succ.getAstNode() and
-      pred.asExpr() = mce.getArgument(i) and
-      (mce.getMethodName() = "fromCharCode" or mce.getMethodName() = "fromCodePoint")
-    )
-    or
-    // `(encode|decode)URI(Component)?` propagate taint
-    exists(DataFlow::CallNode c, string name |
-      succ = c and
-      c = DataFlow::globalVarRef(name).getACall() and
-      pred = c.getArgument(0)
-    |
-      name = "encodeURI" or
-      name = "decodeURI" or
-      name = "encodeURIComponent" or
-      name = "decodeURIComponent"
-    )
+    }
   }
 
   /**
    * A taint propagating data flow edge arising from string formatting.
    */
   private class StringFormattingTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(PrintfStyleCall call |
         call.returnsFormatted() and
         succ = call
@@ -538,7 +667,7 @@ module TaintTracking {
    * `RegExp.prototype.exec` to its result.
    */
   private class RegExpExecTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call = execMethodCall() and
         call.getNumArgument() = 1 and
@@ -558,7 +687,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from calling `String.prototype.match()`.
    */
   private class StringMatchTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate stringManipulationStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call = matchMethodCall() and
         call.getNumArgument() = 1 and
@@ -572,7 +701,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from JSON unparsing.
    */
   private class JsonStringifyTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate serializeStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call |
         call = DataFlow::globalVarRef("JSON").getAMemberCall("stringify") and
         pred = call.getArgument(0) and
@@ -585,7 +714,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from JSON parsing.
    */
   private class JsonParserTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate deserializeStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(JsonParserCall call |
         pred = call.getInput() and
         succ = call.getOutput()
@@ -692,7 +821,7 @@ module TaintTracking {
    * A taint propagating data flow edge arising from sorting.
    */
   private class SortTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
         call.getMethodName() = "sort" and
         pred = call.getReceiver() and
@@ -705,12 +834,12 @@ module TaintTracking {
    * A taint step through an exception constructor, such as `x` to `new Error(x)`.
    */
   class ErrorConstructorTaintStep extends SharedTaintStep {
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::NewNode invoke, string name |
         invoke = DataFlow::globalVarRef(name).getAnInvocation() and
         pred = invoke.getArgument(0) and
         succ = invoke
-        |
+      |
         name = "Error" or
         name = "EvalError" or
         name = "RangeError" or

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -260,6 +260,14 @@ module TaintTracking {
 
     /**
      * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
+     * data flow edge through arrays.
+     *
+     * These steps considers an array to be tainted if it contains tainted elements.
+     */
+    predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
+
+    /**
+     * Holds if `pred` &rarr; `succ` should be considered a taint-propagating
      * data flow edge through the `state` or `props` or a React component.
      */
     predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) { none() }
@@ -339,6 +347,14 @@ module TaintTracking {
   cached
   predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
     any(SharedTaintStep step).heapStep(pred, succ)
+  }
+
+  /**
+   * Holds if `pred -> succ` is a taint propagating data flow edge through an array.
+   */
+  cached
+  predicate arrayStep(DataFlow::Node pred, DataFlow::Node succ) {
+    any(SharedTaintStep step).arrayStep(pred, succ)
   }
 
   /**
@@ -425,6 +441,7 @@ module TaintTracking {
     uriStep(pred, succ) or
     persistentStorageStep(pred, succ) or
     heapStep(pred, succ) or
+    arrayStep(pred, succ) or
     viewComponentStep(pred, succ) or
     stringConcatenationStep(pred, succ) or
     stringManipulationStep(pred, succ) or
@@ -496,7 +513,7 @@ module TaintTracking {
     }
   }
 
-  predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
+  deprecated predicate arrayFunctionTaintStep = ArrayTaintTracking::arrayFunctionTaintStep/3;
 
   /**
    * A taint propagating data flow edge for assignments of the form `o[k] = v`, where

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -382,11 +382,8 @@ module TaintTracking {
    * Note that since we cannot easily distinguish string append from addition,
    * we consider any `+` operation to propagate taint.
    */
-  class StringConcatenationTaintStep extends AdditionalTaintStep {
-    StringConcatenationTaintStep() { StringConcatenation::taintStep(_, this) }
-
+  class StringConcatenationTaintStep extends SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      succ = this and
       StringConcatenation::taintStep(pred, succ)
     }
   }

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/Unit.qll
@@ -1,0 +1,8 @@
+private newtype TUnit = MkUnit()
+
+/**
+ * A class with only one instance.
+ */
+class Unit extends TUnit {
+  final string toString() { result = "Unit" }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
@@ -150,7 +150,7 @@ module AsyncPackage {
    *
    * For example: `data -> item` in `async.each(data, (item, cb) => {})`.
    */
-  private class IterationInputTaintStep extends TaintTracking::GenericStep {
+  private class IterationInputTaintStep extends TaintTracking::ArrayStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::FunctionNode iteratee, IterationCall call |
         iteratee = call.getIteratorCallback() and // Require a closure to avoid spurious call/return mismatch.
@@ -166,7 +166,7 @@ module AsyncPackage {
    *
    * For example: `item + taint()` -> result` in `async.map(data, (item, cb) => cb(null, item + taint()), (err, result) => {})`.
    */
-  private class IterationOutputTaintStep extends TaintTracking::GenericStep {
+  private class IterationOutputTaintStep extends TaintTracking::ArrayStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(
         DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call
@@ -190,7 +190,7 @@ module AsyncPackage {
    *
    * For example: `data -> result` in `async.sortBy(data, orderingFn, (err, result) => {})`.
    */
-  private class IterationPreserveTaintStep extends TaintTracking::GenericStep {
+  private class IterationPreserveTaintStep extends TaintTracking::ArrayStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::FunctionNode final, IterationCall call |
         final = call.getFinalCallback() and // Require a closure to avoid spurious call/return mismatch.

--- a/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
@@ -150,7 +150,7 @@ module AsyncPackage {
    *
    * For example: `data -> item` in `async.each(data, (item, cb) => {})`.
    */
-  private class IterationInputTaintStep extends TaintTracking::SharedTaintStep {
+  private class IterationInputTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::FunctionNode iteratee, IterationCall call |
         iteratee = call.getIteratorCallback() and // Require a closure to avoid spurious call/return mismatch.
@@ -166,7 +166,7 @@ module AsyncPackage {
    *
    * For example: `item + taint()` -> result` in `async.map(data, (item, cb) => cb(null, item + taint()), (err, result) => {})`.
    */
-  private class IterationOutputTaintStep extends TaintTracking::SharedTaintStep {
+  private class IterationOutputTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(
         DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call
@@ -190,7 +190,7 @@ module AsyncPackage {
    *
    * For example: `data -> result` in `async.sortBy(data, orderingFn, (err, result) => {})`.
    */
-  private class IterationPreserveTaintStep extends TaintTracking::SharedTaintStep {
+  private class IterationPreserveTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::FunctionNode final, IterationCall call |
         final = call.getFinalCallback() and // Require a closure to avoid spurious call/return mismatch.

--- a/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/AsyncPackage.qll
@@ -168,12 +168,14 @@ module AsyncPackage {
    */
   private class IterationOutputTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call |
+      exists(
+        DataFlow::FunctionNode iteratee, DataFlow::FunctionNode final, int i, IterationCall call
+      |
         iteratee = call.getIteratorCallback().getALocalSource() and
         final = call.getFinalCallback() and // Require a closure to avoid spurious call/return mismatch.
         pred = getLastParameter(iteratee).getACall().getArgument(i) and
         succ = final.getParameter(i) and
-        exists (string name | name = call.getName() |
+        exists(string name | name = call.getName() |
           name = "concat" or
           name = "map" or
           name = "reduce" or

--- a/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
@@ -7,7 +7,7 @@ import javascript
 module ClosureLibrary {
   private import DataFlow
 
-  private class StringStep extends TaintTracking::GenericStep {
+  private class StringStep extends TaintTracking::StringManipulationStep {
     override predicate step(Node pred, Node succ) {
       exists(string name, CallNode call |
         call = Closure::moduleImport("goog.string." + name).getACall() and succ = call

--- a/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
@@ -7,7 +7,7 @@ import javascript
 module ClosureLibrary {
   private import DataFlow
 
-  private class StringStep extends TaintTracking::SharedTaintStep {
+  private class StringStep extends TaintTracking::GenericStep {
     override predicate step(Node pred, Node succ) {
       exists(string name, CallNode call |
         call = Closure::moduleImport("goog.string." + name).getACall() and succ = call

--- a/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClosureLibrary.qll
@@ -7,12 +7,12 @@ import javascript
 module ClosureLibrary {
   private import DataFlow
 
-  private class StringStep extends TaintTracking::AdditionalTaintStep, CallNode {
-    Node pred;
-
-    StringStep() {
-      exists(string name | this = Closure::moduleImport("goog.string." + name).getACall() |
-        pred = getAnArgument() and
+  private class StringStep extends TaintTracking::SharedTaintStep {
+    override predicate step(Node pred, Node succ) {
+      exists(string name, CallNode call |
+        call = Closure::moduleImport("goog.string." + name).getACall() and succ = call
+      |
+        pred = call.getAnArgument() and
         (
           name = "canonicalizeNewlines" or
           name = "capitalize" or
@@ -39,18 +39,13 @@ module ClosureLibrary {
           name = "whitespaceEscape"
         )
         or
-        pred = getArgument(0) and
+        pred = call.getArgument(0) and
         (
           name = "truncate" or
           name = "truncateMiddle" or
           name = "unescapeEntitiesWithDocument"
         )
       )
-    }
-
-    override predicate step(Node src, Node dst) {
-      src = pred and
-      dst = this
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -28,21 +28,16 @@ private class ComposedFunction extends DataFlow::CallNode {
 /**
  * A taint step for a composed function.
  */
-private class ComposedFunctionTaintStep extends TaintTracking::AdditionalTaintStep {
-  ComposedFunction composed;
-  DataFlow::CallNode call;
-
-  ComposedFunctionTaintStep() {
-    call = composed.getACall() and
-    this = call
-  }
-
+private class ComposedFunctionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(int fnIndex, DataFlow::FunctionNode fn | fn = composed.getFunction(fnIndex) |
+    exists(int fnIndex, DataFlow::FunctionNode fn, ComposedFunction composed, DataFlow::CallNode call |
+      fn = composed.getFunction(fnIndex) and
+      call = composed.getACall()
+    |
       // flow out of the composed call
       fnIndex = composed.getNumArgument() - 1 and
       pred = fn.getAReturn() and
-      succ = this
+      succ = call
       or
       if fnIndex = 0
       then

--- a/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -28,7 +28,7 @@ private class ComposedFunction extends DataFlow::CallNode {
 /**
  * A taint step for a composed function.
  */
-private class ComposedFunctionTaintStep extends TaintTracking::SharedTaintStep {
+private class ComposedFunctionTaintStep extends TaintTracking::GenericStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(
       int fnIndex, DataFlow::FunctionNode fn, ComposedFunction composed, DataFlow::CallNode call

--- a/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ComposedFunctions.qll
@@ -30,7 +30,9 @@ private class ComposedFunction extends DataFlow::CallNode {
  */
 private class ComposedFunctionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    exists(int fnIndex, DataFlow::FunctionNode fn, ComposedFunction composed, DataFlow::CallNode call |
+    exists(
+      int fnIndex, DataFlow::FunctionNode fn, ComposedFunction composed, DataFlow::CallNode call
+    |
       fn = composed.getFunction(fnIndex) and
       call = composed.getACall()
     |

--- a/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Firebase.qll
@@ -275,7 +275,7 @@ module Firebase {
       result.hasUnderlyingType("firebase", "database.DataSnapshot")
     )
     or
-    promiseTaintStep(snapshot(t), result)
+    TaintTracking::promiseStep(snapshot(t), result)
     or
     exists(DataFlow::TypeTracker t2 | result = snapshot(t2).track(t2, t))
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -324,16 +324,16 @@ module NodeJSLib {
   /**
    * A model of taint propagation through `new Buffer` and `Buffer.from`.
    */
-  private class BufferTaintStep extends TaintTracking::AdditionalTaintStep, DataFlow::InvokeNode {
-    BufferTaintStep() {
-      this = DataFlow::globalVarRef("Buffer").getAnInstantiation()
-      or
-      this = DataFlow::globalVarRef("Buffer").getAMemberInvocation("from")
-    }
-
+  private class BufferTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = getArgument(0) and
-      succ = this
+      exists(DataFlow::InvokeNode invoke |
+        invoke = DataFlow::globalVarRef("Buffer").getAnInstantiation()
+        or
+        invoke = DataFlow::globalVarRef("Buffer").getAMemberInvocation("from")
+      |
+        pred = invoke.getArgument(0) and
+        succ = invoke
+      )
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -275,7 +275,7 @@ module NodeJSLib {
   /**
    * A call to a path-module method that preserves taint.
    */
-  private class PathFlowStep extends TaintTracking::SharedTaintStep {
+  private class PathFlowStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = NodeJSLib::Path::moduleMember(methodName).getACall() and
@@ -305,7 +305,7 @@ module NodeJSLib {
   /**
    * A call to a fs-module method that preserves taint.
    */
-  private class FsFlowStep extends TaintTracking::SharedTaintStep {
+  private class FsFlowStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = FS::moduleMember(methodName).getACall()
@@ -324,7 +324,7 @@ module NodeJSLib {
   /**
    * A model of taint propagation through `new Buffer` and `Buffer.from`.
    */
-  private class BufferTaintStep extends TaintTracking::SharedTaintStep {
+  private class BufferTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::InvokeNode invoke |
         invoke = DataFlow::globalVarRef("Buffer").getAnInstantiation()

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -275,33 +275,30 @@ module NodeJSLib {
   /**
    * A call to a path-module method that preserves taint.
    */
-  private class PathFlowTarget extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    DataFlow::Node tainted;
-
-    PathFlowTarget() {
-      exists(string methodName | this = NodeJSLib::Path::moduleMember(methodName).getACall() |
+  private class PathFlowStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::CallNode call, string methodName |
+        call = NodeJSLib::Path::moduleMember(methodName).getACall() and
+        succ = call
+      |
         // getters
-        methodName = "basename" and tainted = getArgument(0)
+        methodName = "basename" and pred = call.getArgument(0)
         or
-        methodName = "dirname" and tainted = getArgument(0)
+        methodName = "dirname" and pred = call.getArgument(0)
         or
-        methodName = "extname" and tainted = getArgument(0)
+        methodName = "extname" and pred = call.getArgument(0)
         or
         // transformers
-        methodName = "join" and tainted = getAnArgument()
+        methodName = "join" and pred = call.getAnArgument()
         or
-        methodName = "normalize" and tainted = getArgument(0)
+        methodName = "normalize" and pred = call.getArgument(0)
         or
-        methodName = "relative" and tainted = getArgument([0 .. 1])
+        methodName = "relative" and pred = call.getArgument([0 .. 1])
         or
-        methodName = "resolve" and tainted = getAnArgument()
+        methodName = "resolve" and pred = call.getAnArgument()
         or
-        methodName = "toNamespacedPath" and tainted = getArgument(0)
+        methodName = "toNamespacedPath" and pred = call.getArgument(0)
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = tainted and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -275,7 +275,7 @@ module NodeJSLib {
   /**
    * A call to a path-module method that preserves taint.
    */
-  private class PathFlowStep extends TaintTracking::GenericStep {
+  private class PathFlowStep extends TaintTracking::FilePathStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = NodeJSLib::Path::moduleMember(methodName).getACall() and
@@ -305,7 +305,7 @@ module NodeJSLib {
   /**
    * A call to a fs-module method that preserves taint.
    */
-  private class FsFlowStep extends TaintTracking::GenericStep {
+  private class FsFlowStep extends TaintTracking::FilePathStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = FS::moduleMember(methodName).getACall()

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -324,7 +324,7 @@ module NodeJSLib {
   /**
    * A model of taint propagation through `new Buffer` and `Buffer.from`.
    */
-  private class BufferTaintStep extends TaintTracking::GenericStep {
+  private class BufferTaintStep extends TaintTracking::EncodingStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::InvokeNode invoke |
         invoke = DataFlow::globalVarRef("Buffer").getAnInstantiation()

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -305,25 +305,19 @@ module NodeJSLib {
   /**
    * A call to a fs-module method that preserves taint.
    */
-  private class FsFlowTarget extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node tainted;
-
-    FsFlowTarget() {
+  private class FsFlowStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string methodName |
         call = FS::moduleMember(methodName).getACall()
       |
         methodName = "realpathSync" and
-        tainted = call.getArgument(0) and
-        this = call
+        pred = call.getArgument(0) and
+        succ = call
         or
         methodName = "realpath" and
-        tainted = call.getArgument(0) and
-        this = call.getCallback(1).getParameter(1)
+        pred = call.getArgument(0) and
+        succ = call.getCallback(1).getParameter(1)
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = tainted and succ = this
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
@@ -131,7 +131,7 @@ private class SimplePropertyProjection extends PropertyProjection::Range {
 /**
  * A taint step for a property projection.
  */
-private class PropertyProjectionTaintStep extends TaintTracking::GenericStep {
+private class PropertyProjectionTaintStep extends TaintTracking::HeapStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     // reading from a tainted object yields a tainted result
     exists(PropertyProjection projection |

--- a/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
@@ -131,7 +131,7 @@ private class SimplePropertyProjection extends PropertyProjection::Range {
 /**
  * A taint step for a property projection.
  */
-private class PropertyProjectionTaintStep extends TaintTracking::SharedTaintStep {
+private class PropertyProjectionTaintStep extends TaintTracking::GenericStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     // reading from a tainted object yields a tainted result
     exists(PropertyProjection projection |

--- a/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/PropertyProjection.qll
@@ -131,14 +131,12 @@ private class SimplePropertyProjection extends PropertyProjection::Range {
 /**
  * A taint step for a property projection.
  */
-private class PropertyProjectionTaintStep extends TaintTracking::AdditionalTaintStep {
-  PropertyProjection projection;
-
-  PropertyProjectionTaintStep() { projection = this }
-
+private class PropertyProjectionTaintStep extends TaintTracking::SharedTaintStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     // reading from a tainted object yields a tainted result
-    this = succ and
-    pred = projection.getObject()
+    exists(PropertyProjection projection |
+      pred = projection.getObject() and
+      succ = projection
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -48,6 +48,12 @@ abstract class ReactComponent extends ASTNode {
   abstract DataFlow::SourceNode getAComponentCreatorReference();
 
   /**
+   * Gets a reference to an instance of this component.
+   */
+  pragma[noinline]
+  DataFlow::SourceNode getAnInstanceReference() { result = ref() }
+
+  /**
    * Gets a reference to this component.
    */
   DataFlow::Node ref() { result.analyze().getAValue() = getAbstractComponent() }
@@ -68,20 +74,19 @@ abstract class ReactComponent extends ASTNode {
    * Gets an access to the `state` object of this component.
    */
   DataFlow::SourceNode getADirectStateAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "state")
+    result = getAnInstanceReference().getAPropertyReference("state")
   }
 
   /**
    * Gets a data flow node that reads a prop of this component.
    */
-  DataFlow::PropRead getAPropRead() { getADirectPropsAccess().flowsTo(result.getBase()) }
+  DataFlow::PropRead getAPropRead() { result = getADirectPropsAccess().getAPropertyRead() }
 
   /**
    * Gets a data flow node that reads prop `name` of this component.
    */
   DataFlow::PropRead getAPropRead(string name) {
-    result = getAPropRead() and
-    result.getPropertyName() = name
+    result = getADirectPropsAccess().getAPropertyRead(name)
   }
 
   /**
@@ -91,7 +96,7 @@ abstract class ReactComponent extends ASTNode {
   DataFlow::SourceNode getAStateAccess() {
     result = getADirectStateAccess()
     or
-    exists(DataFlow::PropRef prn | result = prn | getAStateAccess().flowsTo(prn.getBase()))
+    result = getAStateAccess().getAPropertyReference()
   }
 
   /**
@@ -114,18 +119,17 @@ abstract class ReactComponent extends ASTNode {
   /**
    * Gets a call to method `name` on this component.
    */
-  DataFlow::MethodCallNode getAMethodCall(string name) { result.calls(ref(), name) }
+  DataFlow::MethodCallNode getAMethodCall(string name) {
+    result = getAnInstanceReference().getAMethodCall(name)
+  }
 
   /**
    * Gets a value that will become (part of) the state
    * object of this component, for example an assignment to `this.state`.
    */
   DataFlow::SourceNode getACandidateStateSource() {
-    exists(DataFlow::PropWrite pwn, DataFlow::Node rhs |
-      // a direct definition: `this.state = o`
-      result.flowsTo(rhs) and
-      pwn.writes(ref(), "state", rhs)
-    )
+    // a direct definition: `this.state = o`
+    result = getAnInstanceReference().getAPropertySource("state")
     or
     exists(DataFlow::MethodCallNode mce, DataFlow::SourceNode arg0 |
       mce = getAMethodCall("setState") or
@@ -312,7 +316,8 @@ abstract private class SharedReactPreactClassComponent extends ReactComponent, C
   }
 
   override DataFlow::SourceNode getADirectPropsAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "props") or
+    result = getAnInstanceReference().getAPropertyRead("props")
+    or
     result = DataFlow::parameterNode(getConstructor().getBody().getParameter(0))
   }
 
@@ -435,7 +440,7 @@ class ES5Component extends ReactComponent, ObjectExpr {
   override Function getStaticMethod(string name) { none() }
 
   override DataFlow::SourceNode getADirectPropsAccess() {
-    result.(DataFlow::PropRef).accesses(ref(), "props")
+    result = getAnInstanceReference().getAPropertyRead("props")
   }
 
   override AbstractValue getAbstractComponent() { result = TAbstractObjectLiteral(this) }

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -560,8 +560,8 @@ private class ReactJSXElement extends JSXElement {
  * taint to flow from `v` to any read of `c2.state.p`, where `c2`
  * also is an instance of `C`.
  */
-private class StateTaintStep extends TaintTracking::SharedTaintStep {
-  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+private class StateTaintStep extends TaintTracking::ViewComponentStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
       (
         c.getACandidateStateSource().flowsTo(pwn.getBase()) or
@@ -585,8 +585,8 @@ private class StateTaintStep extends TaintTracking::SharedTaintStep {
  * taint to flow from `v` to any read of `c2.props.p`, where `c2`
  * also is an instance of `C`.
  */
-private class PropsTaintStep extends TaintTracking::SharedTaintStep {
-  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+private class PropsTaintStep extends TaintTracking::ViewComponentStep {
+  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(ReactComponent c, string name, DataFlow::PropRead prn |
       prn = c.getAPropRead(name) or
       prn = c.getAPreviousPropsSource().getAPropertyRead(name)

--- a/javascript/ql/src/semmle/javascript/frameworks/React.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/React.qll
@@ -553,3 +553,46 @@ private class ReactJSXElement extends JSXElement {
    */
   ReactComponent getComponent() { result = component }
 }
+
+/**
+ * A taint propagating data flow edge for assignments of the form `c1.state.p = v`,
+ * where `c1` is an instance of React component `C`; in this case, we consider
+ * taint to flow from `v` to any read of `c2.state.p`, where `c2`
+ * also is an instance of `C`.
+ */
+private class StateTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(ReactComponent c, DataFlow::PropRead prn, DataFlow::PropWrite pwn |
+      (
+        c.getACandidateStateSource().flowsTo(pwn.getBase()) or
+        c.getADirectStateAccess().flowsTo(pwn.getBase())
+      ) and
+      (
+        c.getAPreviousStateSource().flowsTo(prn.getBase()) or
+        c.getADirectStateAccess().flowsTo(prn.getBase())
+      )
+    |
+      prn.getPropertyName() = pwn.getPropertyName() and
+      succ = prn and
+      pred = pwn.getRhs()
+    )
+  }
+}
+
+/**
+ * A taint propagating data flow edge for assignments of the form `c1.props.p = v`,
+ * where `c1` is an instance of React component `C`; in this case, we consider
+ * taint to flow from `v` to any read of `c2.props.p`, where `c2`
+ * also is an instance of `C`.
+ */
+private class PropsTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate viewComponentStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(ReactComponent c, string name, DataFlow::PropRead prn |
+      prn = c.getAPropRead(name) or
+      prn = c.getAPreviousPropsSource().getAPropertyRead(name)
+    |
+      pred = c.getACandidatePropsValue(name) and
+      succ = prn
+    )
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
@@ -126,7 +126,7 @@ module Typeahead {
   /**
    * A taint step that models that a function in the `source` of typeahead.js is used to determine the input to the suggestion function.
    */
-  private class TypeaheadSourceTaintStep extends TaintTracking::SharedTaintStep {
+  private class TypeaheadSourceTaintStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // Matches `$(...).typeahead({..}, {source: function(q, cb) {..;cb(<pred>);..}, templates: { suggestion: function(<succ>) {} } })`.
       exists(TypeaheadSource typeahead |

--- a/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
@@ -126,11 +126,13 @@ module Typeahead {
   /**
    * A taint step that models that a function in the `source` of typeahead.js is used to determine the input to the suggestion function.
    */
-  private class TypeaheadSourceTaintStep extends TypeaheadSource, TaintTracking::AdditionalTaintStep {
+  private class TypeaheadSourceTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // Matches `$(...).typeahead({..}, {source: function(q, cb) {..;cb(<pred>);..}, templates: { suggestion: function(<succ>) {} } })`.
-      pred = this.getAFunctionValue().getParameter([1 .. 2]).getACall().getAnArgument() and
-      succ = this.getASuggestion()
+      exists(TypeaheadSource typeahead |
+        pred = typeahead.getAFunctionValue().getParameter([1 .. 2]).getACall().getAnArgument() and
+        succ = typeahead.getASuggestion()
+      )
     }
   }
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Typeahead.qll
@@ -126,7 +126,7 @@ module Typeahead {
   /**
    * A taint step that models that a function in the `source` of typeahead.js is used to determine the input to the suggestion function.
    */
-  private class TypeaheadSourceTaintStep extends TaintTracking::GenericStep {
+  private class TypeaheadSourceTaintStep extends TaintTracking::StringManipulationStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // Matches `$(...).typeahead({..}, {source: function(q, cb) {..;cb(<pred>);..}, templates: { suggestion: function(<succ>) {} } })`.
       exists(TypeaheadSource typeahead |

--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -5,7 +5,7 @@
 import javascript
 
 /**
- * DEPRECATED. Use `TaintTracking::SharedTaintStep` or `TaintTracking::uriStep` instead.
+ * DEPRECATED. Use `TaintTracking::UriStep` or `TaintTracking::uriStep` instead.
  *
  * A taint propagating data flow edge arising from an operation in a URI library.
  */
@@ -59,8 +59,8 @@ module urijs {
   /**
    * A taint step in the urijs library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       // flow through "constructors" (`new` is optional)
       exists(DataFlow::InvokeNode invk | invk = succ and invk = invocation() |
         pred = invk.getAnArgument()
@@ -92,8 +92,8 @@ module uridashjs {
   /**
    * A taint step in the urijs library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "parse" or
         name = "serialize" or
@@ -122,8 +122,8 @@ module punycode {
   /**
    * A taint step in the punycode library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "decode" or
         name = "encode" or
@@ -155,8 +155,8 @@ module urlParse {
   /**
    * A taint step in the url-parse library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call | succ = call |
         // parse(pred)
         call = call() and
@@ -189,8 +189,8 @@ module querystringify {
   /**
    * A taint step in the querystringify library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "parse" or
         name = "stringify"
@@ -217,8 +217,8 @@ module querydashstring {
   /**
    * A taint step in the query-string library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "parse" or
         name = "extract" or
@@ -245,8 +245,8 @@ module url {
   /**
    * A taint step in the url library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "parse" or
         name = "format" or
@@ -274,8 +274,8 @@ module querystring {
   /**
    * A taint step in the querystring library.
    */
-  private class Step extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class Step extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(string name, DataFlow::CallNode call |
         name = "escape" or
         name = "unescape" or
@@ -297,8 +297,8 @@ private module ClosureLibraryUri {
   /**
    * Taint step from an argument of a `goog.Uri` call to the return value.
    */
-  private class ArgumentStep extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class ArgumentStep extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::InvokeNode invoke, int arg |
         pred = invoke.getArgument(arg) and succ = invoke
       |
@@ -374,8 +374,8 @@ private module ClosureLibraryUri {
   }
 
   /** A taint step derived from a setter call on a `goog.Uri` object. */
-  private class SetterCallStep extends TaintTracking::SharedTaintStep {
-    override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+  private class SetterCallStep extends TaintTracking::UriStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(SetterCall call |
         pred = call.getReceiver() and succ = call
         or
@@ -393,8 +393,8 @@ private module ClosureLibraryUri {
     /**
      * A taint step in the path module.
      */
-    private class Step extends TaintTracking::SharedTaintStep {
-      override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
+    private class Step extends TaintTracking::UriStep {
+      override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
         exists(DataFlow::SourceNode ref, DataFlow::CallNode call |
           ref = NodeJSLib::Path::moduleMember("parse") or
           // a ponyfill: https://www.npmjs.com/package/path-parse

--- a/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/UriLibraries.qll
@@ -9,7 +9,8 @@ import javascript
  *
  * A taint propagating data flow edge arising from an operation in a URI library.
  */
-deprecated abstract class UriLibraryStep extends DataFlow::ValueNode, TaintTracking::AdditionalTaintStep { }
+abstract deprecated class UriLibraryStep extends DataFlow::ValueNode,
+  TaintTracking::AdditionalTaintStep { }
 
 /**
  * Provides classes for working with [urijs](http://medialize.github.io/URI.js/) code.
@@ -298,7 +299,9 @@ private module ClosureLibraryUri {
    */
   private class ArgumentStep extends TaintTracking::SharedTaintStep {
     override predicate uriStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(DataFlow::InvokeNode invoke, int arg | pred = invoke.getArgument(arg) and succ = invoke |
+      exists(DataFlow::InvokeNode invoke, int arg |
+        pred = invoke.getArgument(arg) and succ = invoke
+      |
         // goog.Uri constructor
         invoke = Closure::moduleImport("goog.Uri").getAnInstantiation() and arg = 0
         or

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -395,7 +395,7 @@ module Vue {
   /**
    * A taint propagating data flow edge through a Vue instance property.
    */
-  class InstanceHeapStep extends TaintTracking::GenericStep {
+  class InstanceHeapStep extends TaintTracking::ViewComponentStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Instance i, string name, DataFlow::FunctionNode bound |
         bound.flowsTo(i.getABoundFunction()) and
@@ -430,7 +430,7 @@ module Vue {
    * of `inst = new Vue({ ..., data: { prop: source } })`, if the
    * `div` element is part of the template for `inst`.
    */
-  class VHtmlSourceWrite extends TaintTracking::GenericStep {
+  class VHtmlSourceWrite extends TaintTracking::ViewComponentStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Vue::Instance instance, string expr, VHtmlAttribute attr |
         attr.getAttr().getRoot() =

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -216,7 +216,12 @@ module Vue {
     private DataFlow::PropWrite getAPropertyValueWrite(string name) {
       result = getData().getALocalSource().getAPropertyWrite(name)
       or
-      result = getABoundFunction().getALocalSource().(DataFlow::FunctionNode).getReceiver().getAPropertyWrite(name)
+      result =
+        getABoundFunction()
+            .getALocalSource()
+            .(DataFlow::FunctionNode)
+            .getReceiver()
+            .getAPropertyWrite(name)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -212,19 +212,18 @@ module Vue {
       result = getALifecycleHook(_)
     }
 
+    pragma[noinline]
+    private DataFlow::PropWrite getAPropertyValueWrite(string name) {
+      result = getData().getALocalSource().getAPropertyWrite(name)
+      or
+      result = getABoundFunction().getALocalSource().(DataFlow::FunctionNode).getReceiver().getAPropertyWrite(name)
+    }
+
     /**
      * Gets a node for the value for property `name` of this instance.
      */
     DataFlow::Node getAPropertyValue(string name) {
-      exists(DataFlow::SourceNode obj | obj.getAPropertyWrite(name).getRhs() = result |
-        obj.flowsTo(getData())
-        or
-        exists(DataFlow::FunctionNode bound |
-          bound.flowsTo(getABoundFunction()) and
-          not bound.getFunction() instanceof ArrowFunctionExpr and
-          obj = bound.getReceiver()
-        )
-      )
+      result = getAPropertyValueWrite(name).getRhs()
       or
       exists(DataFlow::FunctionNode getter |
         getter.flowsTo(getAccessor(name, "get")) and

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -402,6 +402,49 @@ module Vue {
     }
   }
 
+  /**
+   * A Vue `v-html` attribute.
+   */
+  class VHtmlAttribute extends DataFlow::Node {
+    HTML::Attribute attr;
+
+    VHtmlAttribute() {
+      this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html"
+    }
+
+    /**
+     * Gets the HTML attribute of this sink.
+     */
+    HTML::Attribute getAttr() { result = attr }
+  }
+
+  /**
+   * A taint propagating data flow edge through a string interpolation of a
+   * Vue instance property to a `v-html` attribute.
+   *
+   * As an example, `<div v-html="prop"/>` reads the `prop` property
+   * of `inst = new Vue({ ..., data: { prop: source } })`, if the
+   * `div` element is part of the template for `inst`.
+   */
+  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
+    VHtmlAttribute attr;
+
+    VHtmlSourceWrite() {
+      exists(Vue::Instance instance, string expr |
+        attr.getAttr().getRoot() =
+          instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
+        expr = attr.getAttr().getValue() and
+        // only support for simple identifier expressions
+        expr.regexpMatch("(?i)[a-z0-9_]+") and
+        this = instance.getAPropertyValue(expr)
+      )
+    }
+
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      pred = this and succ = attr
+    }
+  }
+
   /*
    * Provides classes for working with Vue templates.
    */

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -426,22 +426,17 @@ module Vue {
    * of `inst = new Vue({ ..., data: { prop: source } })`, if the
    * `div` element is part of the template for `inst`.
    */
-  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
-    VHtmlAttribute attr;
-
-    VHtmlSourceWrite() {
-      exists(Vue::Instance instance, string expr |
+  class VHtmlSourceWrite extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(Vue::Instance instance, string expr, VHtmlAttribute attr |
         attr.getAttr().getRoot() =
           instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
         expr = attr.getAttr().getValue() and
         // only support for simple identifier expressions
         expr.regexpMatch("(?i)[a-z0-9_]+") and
-        this = instance.getAPropertyValue(expr)
+        pred = instance.getAPropertyValue(expr) and
+        succ = attr
       )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this and succ = attr
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -391,19 +391,15 @@ module Vue {
   /**
    * A taint propagating data flow edge through a Vue instance property.
    */
-  class InstanceHeapStep extends TaintTracking::AdditionalTaintStep {
-    DataFlow::Node src;
-
-    InstanceHeapStep() {
+  class InstanceHeapStep extends TaintTracking::SharedTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Instance i, string name, DataFlow::FunctionNode bound |
         bound.flowsTo(i.getABoundFunction()) and
         not bound.getFunction() instanceof ArrowFunctionExpr and
-        bound.getReceiver().getAPropertyRead(name) = this and
-        src = i.getAPropertyValue(name)
+        succ = bound.getReceiver().getAPropertyRead(name) and
+        pred = i.getAPropertyValue(name)
       )
     }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) { pred = src and succ = this }
   }
 
   /*

--- a/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Vue.qll
@@ -390,7 +390,7 @@ module Vue {
   /**
    * A taint propagating data flow edge through a Vue instance property.
    */
-  class InstanceHeapStep extends TaintTracking::SharedTaintStep {
+  class InstanceHeapStep extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Instance i, string name, DataFlow::FunctionNode bound |
         bound.flowsTo(i.getABoundFunction()) and
@@ -425,7 +425,7 @@ module Vue {
    * of `inst = new Vue({ ..., data: { prop: source } })`, if the
    * `div` element is part of the template for `inst`.
    */
-  class VHtmlSourceWrite extends TaintTracking::SharedTaintStep {
+  class VHtmlSourceWrite extends TaintTracking::GenericStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(Vue::Instance instance, string expr, VHtmlAttribute attr |
         attr.getAttr().getRoot() =

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -12,9 +12,7 @@ import javascript
  * The target of a heuristic additional flow step in a security query.
  */
 deprecated class HeuristicAdditionalTaintStep extends DataFlow::Node {
-  HeuristicAdditionalTaintStep() {
-    any(TaintTracking::SharedTaintStep step).heuristicStep(_, this)
-  }
+  HeuristicAdditionalTaintStep() { any(TaintTracking::SharedTaintStep step).heuristicStep(_, this) }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes that heuristically increase the extent of `TaintTracking::AdditionalTaintStep`.
+ * Provides classes that heuristically increase the extent of `TaintTracking::SharedTaintStep`.
  *
  * Note: This module should not be a permanent part of the standard library imports.
  */

--- a/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
+++ b/javascript/ql/src/semmle/javascript/heuristics/AdditionalTaintSteps.qll
@@ -7,18 +7,25 @@
 import javascript
 
 /**
- * A heuristic additional flow step in a security query.
+ * DEPRECATED.
+ *
+ * The target of a heuristic additional flow step in a security query.
  */
-abstract class HeuristicAdditionalTaintStep extends DataFlow::ValueNode { }
+deprecated class HeuristicAdditionalTaintStep extends DataFlow::Node {
+  HeuristicAdditionalTaintStep() {
+    any(TaintTracking::SharedTaintStep step).heuristicStep(_, this)
+  }
+}
 
 /**
  * A call to `tainted.replace(x, y)` that preserves taint.
  */
-private class HeuristicStringManipulationTaintStep extends HeuristicAdditionalTaintStep,
-  TaintTracking::AdditionalTaintStep, DataFlow::MethodCallNode {
-  HeuristicStringManipulationTaintStep() { getMethodName() = "replace" }
-
-  override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-    pred = getReceiver() and succ = this
+private class HeuristicStringManipulationTaintStep extends TaintTracking::SharedTaintStep {
+  override predicate heuristicStep(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(DataFlow::MethodCallNode call |
+      call.getMethodName() = "replace" and
+      pred = call.getReceiver() and
+      succ = call
+    )
   }
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
@@ -52,7 +52,7 @@ private DataFlow::SourceNode argumentList(SystemCommandExecution sys, DataFlow::
     result = pred.backtrack(t2, t)
     or
     t = t2.continue() and
-    TaintTracking::arrayFunctionTaintStep(any(DataFlow::Node n | result.flowsTo(n)), pred, _)
+    TaintTracking::arrayStep(any(DataFlow::Node n | result.flowsTo(n)), pred)
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -645,7 +645,7 @@ module TaintedPath {
     or
     promiseTaintStep(src, dst) and srclabel = dstlabel
     or
-    any(TaintTracking::PersistentStorageTaintStep st).step(src, dst) and srclabel = dstlabel
+    TaintTracking::persistentStorageStep(src, dst) and srclabel = dstlabel
     or
     exists(DataFlow::PropRead read | read = dst |
       src = read.getBase() and

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -633,7 +633,7 @@ module TaintedPath {
     srclabel instanceof Label::PosixPath and
     dstlabel instanceof Label::PosixPath and
     (
-      any(UriLibraryStep step).step(src, dst)
+      TaintTracking::uriStep(src, dst)
       or
       exists(DataFlow::CallNode decode |
         decode.getCalleeName() = "decodeURIComponent" or decode.getCalleeName() = "decodeURI"

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -643,7 +643,7 @@ module TaintedPath {
       )
     )
     or
-    promiseTaintStep(src, dst) and srclabel = dstlabel
+    TaintTracking::promiseStep(src, dst) and srclabel = dstlabel
     or
     TaintTracking::persistentStorageStep(src, dst) and srclabel = dstlabel
     or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -245,45 +245,7 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends DomBasedXss::Sink {
-    HTML::Attribute attr;
-
-    VHtmlSink() {
-      this.(DataFlow::HtmlAttributeNode).getAttribute() = attr and attr.getName() = "v-html"
-    }
-
-    /**
-     * Gets the HTML attribute of this sink.
-     */
-    HTML::Attribute getAttr() { result = attr }
-  }
-
-  /**
-   * A taint propagating data flow edge through a string interpolation of a
-   * Vue instance property to a `v-html` attribute.
-   *
-   * As an example, `<div v-html="prop"/>` reads the `prop` property
-   * of `inst = new Vue({ ..., data: { prop: source } })`, if the
-   * `div` element is part of the template for `inst`.
-   */
-  class VHtmlSourceWrite extends TaintTracking::AdditionalTaintStep {
-    VHtmlSink attr;
-
-    VHtmlSourceWrite() {
-      exists(Vue::Instance instance, string expr |
-        attr.getAttr().getRoot() =
-          instance.getTemplateElement().(Vue::Template::HtmlElement).getElement() and
-        expr = attr.getAttr().getValue() and
-        // only support for simple identifier expressions
-        expr.regexpMatch("(?i)[a-z0-9_]+") and
-        this = instance.getAPropertyValue(expr)
-      )
-    }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this and succ = attr
-    }
-  }
+  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink {}
 
   /**
    * A property read from a safe property is considered a sanitizer.

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -245,7 +245,7 @@ module DomBasedXss {
   /**
    * A Vue `v-html` attribute, viewed as an XSS sink.
    */
-  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink {}
+  class VHtmlSink extends Vue::VHtmlAttribute, DomBasedXss::Sink { }
 
   /**
    * A property read from a safe property is considered a sanitizer.

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.expected
@@ -1,67 +1,67 @@
-| closureUri.js:5:11:5:20 | new Uri(x) | closureUri.js:5:19:5:19 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:6:1:6:12 | Uri.parse(x) | closureUri.js:6:11:6:11 | x | closureUri.js:6:1:6:12 | Uri.parse(x) |
-| closureUri.js:7:1:7:17 | Uri.resolve(x, y) | closureUri.js:7:13:7:13 | x | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
-| closureUri.js:7:1:7:17 | Uri.resolve(x, y) | closureUri.js:7:16:7:16 | y | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:12:8:17 | scheme | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:26:8:31 | domain | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:8:1:8:57 | Uri.cre ... , frag) | closureUri.js:8:40:8:43 | path | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
-| closureUri.js:10:1:10:16 | uri.setScheme(x) | closureUri.js:10:1:10:3 | uri | closureUri.js:10:1:10:16 | uri.setScheme(x) |
-| closureUri.js:10:1:10:16 | uri.setScheme(x) | closureUri.js:10:15:10:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:11:1:11:18 | uri.setUserInfo(x) | closureUri.js:11:1:11:3 | uri | closureUri.js:11:1:11:18 | uri.setUserInfo(x) |
-| closureUri.js:12:1:12:16 | uri.setDomain(x) | closureUri.js:12:1:12:3 | uri | closureUri.js:12:1:12:16 | uri.setDomain(x) |
-| closureUri.js:12:1:12:16 | uri.setDomain(x) | closureUri.js:12:15:12:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:13:1:13:14 | uri.setPort(x) | closureUri.js:13:1:13:3 | uri | closureUri.js:13:1:13:14 | uri.setPort(x) |
-| closureUri.js:14:1:14:14 | uri.setPath(x) | closureUri.js:14:1:14:3 | uri | closureUri.js:14:1:14:14 | uri.setPath(x) |
-| closureUri.js:14:1:14:14 | uri.setPath(x) | closureUri.js:14:13:14:13 | x | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:15:1:15:15 | uri.setQuery(x) | closureUri.js:15:1:15:3 | uri | closureUri.js:15:1:15:15 | uri.setQuery(x) |
-| closureUri.js:16:1:16:18 | uri.setFragment(x) | closureUri.js:16:1:16:3 | uri | closureUri.js:16:1:16:18 | uri.setFragment(x) |
-| closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:3 | uri | closureUri.js:18:1:18:15 | uri.setQuery(x) |
-| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:26 | uri.set ... Path(y) |
-| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:25:18:25 | y | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:18:1:18:39 | uri.set ... heme(z) | closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:39 | uri.set ... heme(z) |
-| closureUri.js:18:1:18:39 | uri.set ... heme(z) | closureUri.js:18:38:18:38 | z | closureUri.js:5:11:5:20 | new Uri(x) |
-| closureUri.js:22:1:22:25 | utils.a ... uri, z) | closureUri.js:22:19:22:21 | uri | closureUri.js:22:1:22:25 | utils.a ... uri, z) |
-| closureUri.js:23:1:23:18 | utils.getPath(uri) | closureUri.js:23:15:23:17 | uri | closureUri.js:23:1:23:18 | utils.getPath(uri) |
-| closureUri.js:27:1:27:23 | stringU ... code(x) | closureUri.js:27:22:27:22 | x | closureUri.js:27:1:27:23 | stringU ... code(x) |
-| closureUri.js:28:1:28:23 | stringU ... code(x) | closureUri.js:28:22:28:22 | x | closureUri.js:28:1:28:23 | stringU ... code(x) |
-| path-parse.js:4:1:4:13 | path.parse(x) | path-parse.js:4:12:4:12 | x | path-parse.js:4:1:4:13 | path.parse(x) |
-| path-parse.js:5:1:5:13 | path_parse(x) | path-parse.js:5:12:5:12 | x | path-parse.js:5:1:5:13 | path_parse(x) |
-| path-parse.js:6:1:6:19 | path.posix.parse(x) | path-parse.js:6:18:6:18 | x | path-parse.js:6:1:6:19 | path.posix.parse(x) |
-| path-parse.js:7:1:7:19 | path_parse.posix(x) | path-parse.js:7:18:7:18 | x | path-parse.js:7:1:7:19 | path_parse.posix(x) |
-| path-parse.js:8:1:8:19 | path.win32.parse(x) | path-parse.js:8:18:8:18 | x | path-parse.js:8:1:8:19 | path.win32.parse(x) |
-| path-parse.js:9:1:9:19 | path_parse.win32(x) | path-parse.js:9:18:9:18 | x | path-parse.js:9:1:9:19 | path_parse.win32(x) |
-| punycode.js:3:9:3:26 | punycode.decode(x) | punycode.js:3:25:3:25 | x | punycode.js:3:9:3:26 | punycode.decode(x) |
-| punycode.js:5:5:5:22 | punycode.encode(x) | punycode.js:5:21:5:21 | x | punycode.js:5:5:5:22 | punycode.encode(x) |
-| punycode.js:7:5:7:25 | punycod ... code(x) | punycode.js:7:24:7:24 | x | punycode.js:7:5:7:25 | punycod ... code(x) |
-| punycode.js:9:5:9:23 | punycode.toASCII(x) | punycode.js:9:22:9:22 | x | punycode.js:9:5:9:23 | punycode.toASCII(x) |
-| query-string.js:3:9:3:28 | queryString.parse(x) | query-string.js:3:27:3:27 | x | query-string.js:3:9:3:28 | queryString.parse(x) |
-| query-string.js:5:5:5:26 | querySt ... ract(x) | query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
-| query-string.js:7:5:7:27 | querySt ... eUrl(x) | query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
-| query-string.js:9:5:9:28 | querySt ... gify(x) | query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
-| query-string_import.js:3:1:3:8 | parse(x) | query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
-| querystring.js:3:9:3:29 | queryst ... cape(x) | querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
-| querystring.js:5:5:5:24 | querystring.parse(x) | querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
-| querystring.js:7:5:7:28 | queryst ... gify(x) | querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |
-| querystring.js:9:5:9:27 | queryst ... cape(x) | querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
-| querystringify.js:3:9:3:31 | queryst ... arse(x) | querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
-| querystringify.js:5:5:5:31 | queryst ... gify(x) | querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
-| uri-js.js:3:9:3:20 | URI.parse(x) | uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
-| uri-js.js:5:5:5:20 | URI.serialize(x) | uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
-| uri-js.js:7:5:7:18 | URI.resolve(x) | uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
-| uri-js.js:9:5:9:20 | URI.normalize(x) | uri-js.js:9:19:9:19 | x | uri-js.js:9:5:9:20 | URI.normalize(x) |
-| urijs.js:12:9:12:18 | new URI(x) | urijs.js:12:17:12:17 | x | urijs.js:12:9:12:18 | new URI(x) |
-| urijs.js:14:5:14:17 | u.username(x) | urijs.js:14:5:14:5 | u | urijs.js:14:5:14:17 | u.username(x) |
-| urijs.js:14:5:14:17 | u.username(x) | urijs.js:14:16:14:16 | x | urijs.js:14:5:14:17 | u.username(x) |
-| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:16:5 | u | urijs.js:16:5:17:16 | u\\n    .username(x) |
-| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:17:15:17:15 | x | urijs.js:16:5:17:16 | u\\n    .username(x) |
-| urijs.js:16:5:18:11 | u\\n    . ... .tld(x) | urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
-| urijs.js:16:5:18:11 | u\\n    . ... .tld(x) | urijs.js:18:10:18:10 | x | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
-| urijs.js:20:9:20:26 | u.normalizeQuery() | urijs.js:20:9:20:9 | u | urijs.js:20:9:20:26 | u.normalizeQuery() |
-| url-parse.js:3:9:3:19 | parse(x, y) | url-parse.js:3:15:3:15 | x | url-parse.js:3:9:3:19 | parse(x, y) |
-| url-parse.js:3:9:3:19 | parse(x, y) | url-parse.js:3:18:3:18 | y | url-parse.js:3:9:3:19 | parse(x, y) |
-| url-parse.js:4:5:4:19 | r.set('foo', x) | url-parse.js:4:5:4:5 | r | url-parse.js:4:5:4:19 | r.set('foo', x) |
-| url-parse.js:4:5:4:19 | r.set('foo', x) | url-parse.js:4:18:4:18 | x | url-parse.js:4:5:4:19 | r.set('foo', x) |
-| url.js:3:9:3:20 | url.parse(x) | url.js:3:19:3:19 | x | url.js:3:9:3:20 | url.parse(x) |
-| url.js:5:5:5:17 | url.format(x) | url.js:5:16:5:16 | x | url.js:5:5:5:17 | url.format(x) |
-| url.js:7:5:7:21 | url.resolve(x, y) | url.js:7:17:7:17 | x | url.js:7:5:7:21 | url.resolve(x, y) |
-| url.js:7:5:7:21 | url.resolve(x, y) | url.js:7:20:7:20 | y | url.js:7:5:7:21 | url.resolve(x, y) |
+| closureUri.js:5:19:5:19 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:6:11:6:11 | x | closureUri.js:6:1:6:12 | Uri.parse(x) |
+| closureUri.js:7:13:7:13 | x | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:7:16:7:16 | y | closureUri.js:7:1:7:17 | Uri.resolve(x, y) |
+| closureUri.js:8:12:8:17 | scheme | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:26:8:31 | domain | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:8:40:8:43 | path | closureUri.js:8:1:8:57 | Uri.cre ... , frag) |
+| closureUri.js:10:1:10:3 | uri | closureUri.js:10:1:10:16 | uri.setScheme(x) |
+| closureUri.js:10:15:10:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:11:1:11:3 | uri | closureUri.js:11:1:11:18 | uri.setUserInfo(x) |
+| closureUri.js:12:1:12:3 | uri | closureUri.js:12:1:12:16 | uri.setDomain(x) |
+| closureUri.js:12:15:12:15 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:13:1:13:3 | uri | closureUri.js:13:1:13:14 | uri.setPort(x) |
+| closureUri.js:14:1:14:3 | uri | closureUri.js:14:1:14:14 | uri.setPath(x) |
+| closureUri.js:14:13:14:13 | x | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:15:1:15:3 | uri | closureUri.js:15:1:15:15 | uri.setQuery(x) |
+| closureUri.js:16:1:16:3 | uri | closureUri.js:16:1:16:18 | uri.setFragment(x) |
+| closureUri.js:18:1:18:3 | uri | closureUri.js:18:1:18:15 | uri.setQuery(x) |
+| closureUri.js:18:1:18:15 | uri.setQuery(x) | closureUri.js:18:1:18:26 | uri.set ... Path(y) |
+| closureUri.js:18:1:18:26 | uri.set ... Path(y) | closureUri.js:18:1:18:39 | uri.set ... heme(z) |
+| closureUri.js:18:25:18:25 | y | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:18:38:18:38 | z | closureUri.js:5:11:5:20 | new Uri(x) |
+| closureUri.js:22:19:22:21 | uri | closureUri.js:22:1:22:25 | utils.a ... uri, z) |
+| closureUri.js:23:15:23:17 | uri | closureUri.js:23:1:23:18 | utils.getPath(uri) |
+| closureUri.js:27:22:27:22 | x | closureUri.js:27:1:27:23 | stringU ... code(x) |
+| closureUri.js:28:22:28:22 | x | closureUri.js:28:1:28:23 | stringU ... code(x) |
+| path-parse.js:4:12:4:12 | x | path-parse.js:4:1:4:13 | path.parse(x) |
+| path-parse.js:5:12:5:12 | x | path-parse.js:5:1:5:13 | path_parse(x) |
+| path-parse.js:6:18:6:18 | x | path-parse.js:6:1:6:19 | path.posix.parse(x) |
+| path-parse.js:7:18:7:18 | x | path-parse.js:7:1:7:19 | path_parse.posix(x) |
+| path-parse.js:8:18:8:18 | x | path-parse.js:8:1:8:19 | path.win32.parse(x) |
+| path-parse.js:9:18:9:18 | x | path-parse.js:9:1:9:19 | path_parse.win32(x) |
+| punycode.js:3:25:3:25 | x | punycode.js:3:9:3:26 | punycode.decode(x) |
+| punycode.js:5:21:5:21 | x | punycode.js:5:5:5:22 | punycode.encode(x) |
+| punycode.js:7:24:7:24 | x | punycode.js:7:5:7:25 | punycod ... code(x) |
+| punycode.js:9:22:9:22 | x | punycode.js:9:5:9:23 | punycode.toASCII(x) |
+| query-string.js:3:27:3:27 | x | query-string.js:3:9:3:28 | queryString.parse(x) |
+| query-string.js:5:25:5:25 | x | query-string.js:5:5:5:26 | querySt ... ract(x) |
+| query-string.js:7:26:7:26 | x | query-string.js:7:5:7:27 | querySt ... eUrl(x) |
+| query-string.js:9:27:9:27 | x | query-string.js:9:5:9:28 | querySt ... gify(x) |
+| query-string_import.js:3:7:3:7 | x | query-string_import.js:3:1:3:8 | parse(x) |
+| querystring.js:3:28:3:28 | x | querystring.js:3:9:3:29 | queryst ... cape(x) |
+| querystring.js:5:23:5:23 | x | querystring.js:5:5:5:24 | querystring.parse(x) |
+| querystring.js:7:27:7:27 | x | querystring.js:7:5:7:28 | queryst ... gify(x) |
+| querystring.js:9:26:9:26 | x | querystring.js:9:5:9:27 | queryst ... cape(x) |
+| querystringify.js:3:30:3:30 | x | querystringify.js:3:9:3:31 | queryst ... arse(x) |
+| querystringify.js:5:30:5:30 | x | querystringify.js:5:5:5:31 | queryst ... gify(x) |
+| uri-js.js:3:19:3:19 | x | uri-js.js:3:9:3:20 | URI.parse(x) |
+| uri-js.js:5:19:5:19 | x | uri-js.js:5:5:5:20 | URI.serialize(x) |
+| uri-js.js:7:17:7:17 | x | uri-js.js:7:5:7:18 | URI.resolve(x) |
+| uri-js.js:9:19:9:19 | x | uri-js.js:9:5:9:20 | URI.normalize(x) |
+| urijs.js:12:17:12:17 | x | urijs.js:12:9:12:18 | new URI(x) |
+| urijs.js:14:5:14:5 | u | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:14:16:14:16 | x | urijs.js:14:5:14:17 | u.username(x) |
+| urijs.js:16:5:16:5 | u | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:16:5:17:16 | u\\n    .username(x) | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:17:15:17:15 | x | urijs.js:16:5:17:16 | u\\n    .username(x) |
+| urijs.js:18:10:18:10 | x | urijs.js:16:5:18:11 | u\\n    . ... .tld(x) |
+| urijs.js:20:9:20:9 | u | urijs.js:20:9:20:26 | u.normalizeQuery() |
+| url-parse.js:3:15:3:15 | x | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:3:18:3:18 | y | url-parse.js:3:9:3:19 | parse(x, y) |
+| url-parse.js:4:5:4:5 | r | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url-parse.js:4:18:4:18 | x | url-parse.js:4:5:4:19 | r.set('foo', x) |
+| url.js:3:19:3:19 | x | url.js:3:9:3:20 | url.parse(x) |
+| url.js:5:16:5:16 | x | url.js:5:5:5:17 | url.format(x) |
+| url.js:7:17:7:17 | x | url.js:7:5:7:21 | url.resolve(x, y) |
+| url.js:7:20:7:20 | y | url.js:7:5:7:21 | url.resolve(x, y) |

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
@@ -2,4 +2,4 @@ import javascript
 
 from UriLibraryStep step, DataFlow::Node pred, DataFlow::Node succ
 where step.step(pred, succ)
-select step, pred, succ
+select pred, succ

--- a/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
+++ b/javascript/ql/test/library-tests/frameworks/UriLibraries/UriLibraryStep.ql
@@ -1,5 +1,5 @@
 import javascript
 
-from UriLibraryStep step, DataFlow::Node pred, DataFlow::Node succ
-where step.step(pred, succ)
+from DataFlow::Node pred, DataFlow::Node succ
+where TaintTracking::uriStep(pred, succ)
 select pred, succ


### PR DESCRIPTION
Adds the `SharedTaintStep` class as discussed in https://github.com/github/codeql-javascript-team/issues/110.

This PR first bases it on a unit type, and then towards the end changes it to a string type. The categorization of steps is then evolved a bit more at the end.

[Performance](https://git.semmle.com/asger/dist-compare-reports/tree/js/string-taint-step2_1591071280201) is OK.

Some previous experimental results that are not quite up-to-date with this PR or the performance PRs that landed separately in the meantime.
- The unit type was slightly faster (without changes to the optimizer)
- The `FlowLabel.isSharedStep` trick reduced tuple counts but caused a regression in real time anyway.

Some points to discuss:
- Is this the right degree of categorization? I have feeling that I went slightly overboard with it.
- Is it worth all the boilerplate?