### PR TITLE
Java: Backport missing CFG edge fix for switch expressions

### DIFF
--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -578,6 +578,8 @@ private module ControlFlowGraphImpl {
     n instanceof Stmt and
     not n instanceof PostOrderNode and
     not n instanceof SynchronizedStmt
+    or
+    result = n and n instanceof SwitchExpr
   }
 
   /**


### PR DESCRIPTION
This cherry-picks the CFG bug fix from https://github.com/github/codeql/pull/3473