### PR TITLE
C#: Add call-sensitivity to data-flow call resolution

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Unification.qll
+++ b/csharp/ql/src/semmle/code/csharp/Unification.qll
@@ -685,7 +685,7 @@ module Unification {
   private import Cached
 
   /**
-   * Holds if types `t1` and `t2` are unifiable. That is, is it possible to replace
+   * Holds if types `t1` and `t2` are unifiable. That is, it is possible to replace
    * all type parameters in `t1` and `t2` with some (other) types to make the two
    * substituted terms equal.
    *
@@ -722,7 +722,7 @@ module Unification {
   }
 
   /**
-   * Holds if type `t1` subsumes type `t2`. That is, is it possible to replace all
+   * Holds if type `t1` subsumes type `t2`. That is, it is possible to replace all
    * type parameters in `t1` with some (other) types to make the two types equal.
    *
    * The same limitations that apply to the predicate `unifiable()` apply to this

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -118,22 +118,51 @@ private module Cached {
   }
 
   /**
+   * Holds if the set of viable implementations that can be called by `call`
+   * might be improved by knowing the call context. This is the case if the
+   * call is a delegate call, or if the qualifier accesses a parameter of
+   * the enclosing callable `c` (including the implicit `this` parameter).
+   */
+  private predicate mayBenefitFromCallContext(DataFlowCall call, Callable c) {
+    c = call.getEnclosingCallable() and
+    (
+      exists(CallContext cc | exists(viableDelegateCallable(call, cc)) |
+        not cc instanceof EmptyCallContext
+      )
+      or
+      call.(NonDelegateDataFlowCall).getDispatchCall().mayBenefitFromCallContext()
+    )
+  }
+
+  /**
    * Holds if the call context `ctx` reduces the set of viable run-time
    * targets of call `call` in `c`.
    */
   cached
   predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
-    c = viableImpl(ctx) and
-    c = call.getEnclosingCallable() and
-    exists(CallContext cc | exists(viableDelegateCallable(call, cc)) |
-      not cc instanceof EmptyCallContext
+    exists(int tgts, int ctxtgts |
+      mayBenefitFromCallContext(call, c) and
+      c = viableCallable(ctx) and
+      ctxtgts = count(viableImplInCallContext(call, ctx)) and
+      tgts = strictcount(viableImpl(call)) and
+      ctxtgts < tgts
     )
   }
 
+  /**
+   * Gets a viable dispatch target of `call` in the context `ctx`. This is
+   * restricted to those `call`s for which a context might make a difference.
+   */
   private DotNet::Callable viableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
     exists(ArgumentCallContext cc | result = viableDelegateCallable(call, cc) |
       cc.isArgument(ctx.getExpr(), _)
     )
+    or
+    result =
+      call
+          .(NonDelegateDataFlowCall)
+          .getDispatchCall()
+          .getADynamicTargetInCallContext(ctx.(NonDelegateDataFlowCall).getDispatchCall())
   }
 
   /**
@@ -155,9 +184,10 @@ private module Cached {
   cached
   predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
     exists(int tgts, int ctxtgts |
+      mayBenefitFromCallContext(call, _) and
       c = viableImpl(call) and
-      ctxtgts = strictcount(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
-      tgts = strictcount(DataFlowCall ctx | viableImpl(ctx) = call.getEnclosingCallable()) and
+      ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
+      tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
       ctxtgts < tgts
     )
   }
@@ -277,6 +307,9 @@ class NonDelegateDataFlowCall extends DataFlowCall, TNonDelegateCall {
   private DispatchCall dc;
 
   NonDelegateDataFlowCall() { this = TNonDelegateCall(cfn, dc) }
+
+  /** Gets the underlying call. */
+  DispatchCall getDispatchCall() { result = dc }
 
   override DotNet::Callable getARuntimeTarget() {
     result = getCallableForDataFlow(dc.getADynamicTarget())

--- a/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/Dispatch.qll
@@ -30,6 +30,26 @@ class DispatchCall extends Internal::TDispatchCall {
 
   /** Gets a dynamic (run-time) target of this call, if any. */
   RuntimeCallable getADynamicTarget() { result = Internal::getADynamicTarget(this) }
+
+  /**
+   * Holds if a call context may limit the set of viable source declaration
+   * run-time targets of this call.
+   *
+   * This is the case if the qualifier is either a `this` access or a parameter
+   * access, as the corresponding qualifier/argument in the call context may
+   * have a more precise type.
+   */
+  predicate mayBenefitFromCallContext() { Internal::mayBenefitFromCallContext(this) }
+
+  /**
+   * Gets a dynamic (run-time) target of this call in call context `ctx`, if any.
+   *
+   * This predicate is restricted to calls for which `mayBenefitFromCallContext()`
+   * holds.
+   */
+  RuntimeCallable getADynamicTargetInCallContext(DispatchCall ctx) {
+    result = Internal::getADynamicTargetInCallContext(this, ctx)
+  }
 }
 
 /** Internal implementation details. */
@@ -40,6 +60,7 @@ private module Internal {
   private import semmle.code.csharp.dataflow.internal.Steps
   private import semmle.code.csharp.frameworks.System
   private import semmle.code.csharp.frameworks.system.Reflection
+  private import semmle.code.csharp.dataflow.internal.BaseSSA
 
   cached
   private module Cached {
@@ -89,6 +110,16 @@ private module Internal {
     cached
     RuntimeCallable getADynamicTarget(DispatchCall dc) {
       result = dc.(DispatchCallImpl).getADynamicTarget()
+    }
+
+    cached
+    predicate mayBenefitFromCallContext(DispatchMethodOrAccessorCall dc) {
+      dc.mayBenefitFromCallContext(_, _)
+    }
+
+    cached
+    RuntimeCallable getADynamicTargetInCallContext(DispatchMethodOrAccessorCall dc, DispatchCall ctx) {
+      result = dc.getADynamicTargetInCallContext(ctx)
     }
   }
 
@@ -190,6 +221,17 @@ private module Internal {
     abstract RuntimeCallable getADynamicTarget();
   }
 
+  /** A non-constructed overridable callable. */
+  private class NonConstructedOverridableCallable extends OverridableCallable {
+    NonConstructedOverridableCallable() { not this instanceof ConstructedMethod }
+
+    OverridableCallable getAConstructingCallableOrSelf() {
+      result = this
+      or
+      result = this.(UnboundGenericMethod).getAConstructedGeneric()
+    }
+  }
+
   pragma[noinline]
   private predicate hasOverrider(OverridableCallable oc, ValueOrRefType t) {
     exists(oc.getAnOverrider(t))
@@ -249,14 +291,244 @@ private module Internal {
 
   abstract private class DispatchMethodOrAccessorCall extends DispatchCallImpl {
     pragma[nomagic]
-    predicate hasQualifierTypeInherited(SourceDeclarationType t) {
-      t = getAPossibleType(this.getQualifier(), _).getSourceDeclaration()
-    }
+    predicate hasQualifierTypeInherited(Type t) { t = getAPossibleType(this.getQualifier(), _) }
 
     pragma[nomagic]
     predicate hasQualifierTypeOverridden(ValueOrRefType t, OverridableCallable c) {
       hasQualifierTypeOverridden0(t, this) and
       hasCallable(any(OverridableCallable oc | hasQualifierTypeOverridden1(oc, this)), t, c)
+    }
+
+    /**
+     * Holds if a call context may limit the set of viable source declaration
+     * run-time targets of this call.
+     *
+     * This is the case if the qualifier is either a `this` access or a parameter
+     * access, as the corresponding qualifier/argument in the call context may
+     * have a more precise type.
+     */
+    predicate mayBenefitFromCallContext(Callable c, int i) {
+      1 < strictcount(this.getADynamicTarget().getSourceDeclaration()) and
+      c = this.getCall().getEnclosingCallable().getSourceDeclaration() and
+      (
+        exists(AssignableDefinitions::ImplicitParameterDefinition pdef, Parameter p |
+          this.getQualifier() = BaseSsa::getARead(pdef, p) and
+          p.getPosition() = i and
+          c.getAParameter() = p and
+          not p.isParams()
+        )
+        or
+        i = -1 and
+        this.getQualifier() instanceof ThisAccess
+      )
+    }
+
+    /**
+     * Holds if the call `ctx` might act as a context that improves the set of
+     * dispatch targets of this call, which occurs in a viable target of `ctx`.
+     */
+    pragma[nomagic]
+    private predicate relevantContext(DispatchCall ctx, int i) {
+      this.mayBenefitFromCallContext(ctx.getADynamicTarget().getSourceDeclaration(), i)
+    }
+
+    /**
+     * Holds if the `i`th argument of `ctx` has type `t` and `ctx` is a relevant
+     * call context.
+     */
+    private predicate contextArgHasType(DispatchCall ctx, Type t, boolean isExact) {
+      exists(Expr arg, int i |
+        this.relevantContext(ctx, i) and
+        t = getAPossibleType(arg, isExact)
+      |
+        ctx.getArgument(i) = arg
+        or
+        ctx.getQualifier() = arg and
+        i = -1
+      )
+    }
+
+    pragma[nomagic]
+    private Callable getASubsumedStaticTarget0(Type t) {
+      exists(Callable staticTarget, Type declType |
+        staticTarget = this.getAStaticTarget() and
+        declType = staticTarget.getDeclaringType() and
+        result = staticTarget.getSourceDeclaration() and
+        Unification::subsumes(declType, t)
+      )
+    }
+
+    /**
+     * Gets a callable whose source declaration matches the source declaration of
+     * some static target `target`, and whose declaring type is subsumed by the
+     * declaring type of `target`.
+     */
+    pragma[nomagic]
+    private Callable getASubsumedStaticTarget() {
+      result = this.getAStaticTarget()
+      or
+      result.getSourceDeclaration() = this.getASubsumedStaticTarget0(result.getDeclaringType())
+    }
+
+    /**
+     * Gets a callable inherited by (or defined in) the qualifier type of this
+     * call that overrides (or equals) a static target of this call.
+     *
+     * Example:
+     *
+     * ```csharp
+     * class A {
+     *   public virtual void M() { }
+     * }
+     *
+     * class B : A {
+     *   public override void M() { }
+     * }
+     *
+     * class C : B { }
+     *
+     * class D {
+     *   void CallM() {
+     *     A x = new A();
+     *     x.M();
+     *     x = new B();
+     *     x.M();
+     *     x = new C();
+     *     x.M();
+     *   }
+     * }
+     * ```
+     *
+     * The static target is `A.M` in all three calls on lines 14, 16, and 18,
+     * but the methods inherited by the actual qualifier types are `A.M`,
+     * `B.M`, and `B.M`, respectively.
+     */
+    private RuntimeCallable getAViableInherited() {
+      exists(NonConstructedOverridableCallable c, Type t | this.hasQualifierTypeInherited(t) |
+        this.getASubsumedStaticTarget() = c.getAConstructingCallableOrSelf() and
+        result = c.getInherited(t)
+        or
+        t instanceof TypeParameter and
+        this.getAStaticTarget() = c.getAConstructingCallableOrSelf() and
+        result = c
+      )
+    }
+
+    /**
+     * Gets a callable that is defined in a subtype of the qualifier type of this
+     * call, and which overrides a static target of this call.
+     *
+     * Example:
+     *
+     * ```csharp
+     * class A {
+     *   public virtual void M() { }
+     * }
+     *
+     * class B : A {
+     *   public override void M() { }
+     * }
+     *
+     * class C : B {
+     *   public override void M() { }
+     * }
+     *
+     * class D {
+     *   void CallM() {
+     *     A x = new A();
+     *     x.M();
+     *     x = new B();
+     *     x.M();
+     *     x = new C();
+     *     x.M();
+     *   }
+     * }
+     * ```
+     *
+     * The static target is `A.M` in all three calls on lines 16, 18, and 20,
+     * but the methods overriding the static targets in subtypes of the actual
+     * qualifier types are `B.M` and `C.M`, `C.M`, and none, respectively.
+     */
+    private RuntimeCallable getAViableOverrider() {
+      exists(ValueOrRefType t, NonConstructedOverridableCallable c |
+        this.hasQualifierTypeOverridden(t, c.getAConstructingCallableOrSelf()) and
+        result = c.getAnOverrider(t)
+      )
+    }
+
+    override RuntimeCallable getADynamicTarget() {
+      result = getAViableInherited()
+      or
+      result = getAViableOverrider()
+      or
+      // Simple case: target method cannot be overridden
+      result = getAStaticTarget() and
+      not result instanceof OverridableCallable
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableInheritedInCallContext0(ValueOrRefType t) {
+      this.contextArgHasType(_, t, _) and
+      result = this.getADynamicTarget()
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableInheritedInCallContext1(
+      NonConstructedOverridableCallable c, ValueOrRefType t
+    ) {
+      result = this.getAViableInheritedInCallContext0(t) and
+      result = c.getInherited(t)
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableInheritedInCallContext(DispatchCall ctx) {
+      exists(Type t, NonConstructedOverridableCallable c | this.contextArgHasType(ctx, t, _) |
+        this.getASubsumedStaticTarget() = c.getAConstructingCallableOrSelf() and
+        result = this.getAViableInheritedInCallContext1(c, t)
+        or
+        t instanceof TypeParameter and
+        this.getAStaticTarget() = c.getAConstructingCallableOrSelf() and
+        result = c
+      )
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableOverriderInCallContext0(
+      NonConstructedOverridableCallable c, ValueOrRefType t
+    ) {
+      result = this.getAViableOverrider() and
+      this.contextArgHasType(_, _, false) and
+      result = c.getAnOverrider(t)
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableOverriderInCallContext1(
+      NonConstructedOverridableCallable c, DispatchCall ctx
+    ) {
+      exists(ValueOrRefType t |
+        result = this.getAViableOverriderInCallContext0(c, t) and
+        exists(Type t0 | this.contextArgHasType(ctx, t0, false) |
+          t = t0
+          or
+          Unification::subsumes(t0, t)
+          or
+          t = t0.(Unification::UnconstrainedTypeParameter).getAnUltimatelySuppliedType()
+        )
+      )
+    }
+
+    pragma[nomagic]
+    private RuntimeCallable getAViableOverriderInCallContext(DispatchCall ctx) {
+      exists(NonConstructedOverridableCallable c |
+        result = this.getAViableOverriderInCallContext1(c, ctx) and
+        this.getAStaticTarget() = c.getAConstructingCallableOrSelf()
+      )
+    }
+
+    RuntimeCallable getADynamicTargetInCallContext(DispatchCall ctx) {
+      result = this.getAViableInheritedInCallContext(ctx)
+      or
+      result = this.getAViableOverriderInCallContext(ctx)
     }
   }
 
@@ -386,6 +658,8 @@ private module Internal {
               .getQualifier()
         or
         this = any(DispatchCallImpl c).getQualifier()
+        or
+        this = any(DispatchCallImpl c).getArgument(_)
       }
 
       Source getASource() { stepTC(this, result) }
@@ -430,108 +704,7 @@ private module Internal {
     override Expr getQualifier() { result = getCall().getQualifier() }
 
     override Method getAStaticTarget() { result = getCall().getTarget() }
-
-    override RuntimeMethod getADynamicTarget() {
-      result = getViableInherited()
-      or
-      result = getAViableOverrider()
-      or
-      // Simple case: target method cannot be overridden
-      result = getAStaticTarget() and
-      not result instanceof OverridableMethod
-    }
-
-    /**
-     * Gets the (unique) instance method inherited by (or defined in) the
-     * qualifier type of this call that overrides (or equals) the static
-     * target of this call.
-     *
-     * Example:
-     *
-     * ```
-     * class A {
-     *   public virtual void M() { }
-     * }
-     *
-     * class B : A {
-     *   public override void M() { }
-     * }
-     *
-     * class C : B { }
-     *
-     * class D {
-     *   void CallM() {
-     *     A x = new A();
-     *     x.M();
-     *     x = new B();
-     *     x.M();
-     *     x = new C();
-     *     x.M();
-     *   }
-     * }
-     * ```
-     *
-     * The static target is `A.M` in all three calls on lines 14, 16, and 18,
-     * but the methods inherited by the actual qualifier types are `A.M`,
-     * `B.M`, and `B.M`, respectively.
-     */
-    private RuntimeInstanceMethod getViableInherited() {
-      exists(NonConstructedOverridableMethod m, SourceDeclarationType t |
-        this.getAStaticTarget() = m.getAConstructingMethodOrSelf() and
-        this.hasQualifierTypeInherited(t)
-      |
-        result = m.getInherited(t)
-        or
-        t instanceof TypeParameter and
-        result = m
-      )
-    }
-
-    /**
-     * Gets an instance method that is defined in a subtype of the qualifier
-     * type of this call, and which overrides the static target of this call.
-     *
-     * Example:
-     *
-     * ```
-     * class A {
-     *   public virtual void M() { }
-     * }
-     *
-     * class B : A {
-     *   public override void M() { }
-     * }
-     *
-     * class C : B {
-     *   public override void M() { }
-     * }
-     *
-     * class D {
-     *   void CallM() {
-     *     A x = new A();
-     *     x.M();
-     *     x = new B();
-     *     x.M();
-     *     x = new C();
-     *     x.M();
-     *   }
-     * }
-     * ```
-     *
-     * The static target is `A.M` in all three calls on lines 16, 18, and 20,
-     * but the methods overriding the static targets in subtypes of the actual
-     * qualifier types are `B.M` and `C.M`, `C.M`, and none, respectively.
-     */
-    private RuntimeInstanceMethod getAViableOverrider() {
-      exists(ValueOrRefType t, NonConstructedOverridableMethod m |
-        this.hasQualifierTypeOverridden(t, m.getAConstructingMethodOrSelf()) and
-        result = m.getAnOverrider(t)
-      )
-    }
   }
-
-  /** A non-constructed overridable method. */
-  private class NonConstructedOverridableMethod extends OverridableMethod, NonConstructedMethod { }
 
   /**
    * A call to an accessor.
@@ -549,7 +722,7 @@ private module Internal {
     override Accessor getAStaticTarget() { result = getCall().getTarget() }
 
     override RuntimeAccessor getADynamicTarget() {
-      result = getADynamicTargetCandidate() and
+      result = DispatchMethodOrAccessorCall.super.getADynamicTarget() and
       // Calls to accessors may have `dynamic` expression arguments,
       // so we need to check that the types match
       forall(Type argumentType, int i | hasDynamicArg(i, argumentType) |
@@ -557,106 +730,11 @@ private module Internal {
       )
     }
 
-    private RuntimeAccessor getADynamicTargetCandidate() {
-      result = getViableInherited()
-      or
-      result = getAViableOverrider()
-      or
-      // Simple case: target accessor cannot be overridden
-      result = getAStaticTarget() and
-      not result instanceof OverridableAccessor
-    }
-
     private predicate hasDynamicArg(int i, Type argumentType) {
       exists(Expr argument |
         argument = getArgument(i) and
         argument.stripImplicitCasts().getType() instanceof DynamicType and
         argumentType = getAPossibleType(argument, _)
-      )
-    }
-
-    /**
-     * Gets the (unique) accessor inherited by (or defined in) the qualifier
-     * type of this call that overrides (or equals) the static target of this
-     * call.
-     *
-     * Example:
-     *
-     * ```
-     * class A {
-     *   public virtual int P { get => 0; }
-     * }
-     *
-     * class B : A {
-     *   public override int P { get => 1; }
-     * }
-     *
-     * class C : B { }
-     *
-     * class D {
-     *   void CallM() {
-     *     A x = new A();
-     *     x.P;
-     *     x = new B();
-     *     x.P;
-     *     x = new C();
-     *     x.P;
-     *   }
-     * }
-     * ```
-     *
-     * The static target is `A.get_P` in all three calls on lines 14, 16, and 18,
-     * but the accessors inherited by the actual qualifier types are `A.get_P`,
-     * `B.get_P`, and `B.get_P`, respectively.
-     */
-    private RuntimeAccessor getViableInherited() {
-      exists(OverridableAccessor a, SourceDeclarationType t |
-        this.getAStaticTarget() = a and
-        this.hasQualifierTypeInherited(t) and
-        result = a.getInherited(t)
-      )
-    }
-
-    /**
-     * Gets an accessor that is defined in a subtype of the qualifier type of
-     * this call, and which overrides the static target of this call.
-     *
-     * Example:
-     *
-     * ```
-     * class A {
-     *   public virtual int P { get => 0; }
-     * }
-     *
-     * class B : A {
-     *   public override int P { get => 1; }
-     * }
-     *
-     * class C : B {
-     *   public override int P { get => 2; }
-     * }
-     *
-     * class D {
-     *   void CallM() {
-     *     A x = new A();
-     *     x.P;
-     *     x = new B();
-     *     x.P;
-     *     x = new C();
-     *     x.P;
-     *   }
-     * }
-     * ```
-     *
-     * The static target is `A.get_P` in all three calls on lines 16, 18, and 20,
-     * but the accessors overriding the static targets in subtypes of the actual
-     * qualifier types are `B.get_P` and `C.get_P`, `C.get_P`, and none,
-     * respectively.
-     */
-    private RuntimeAccessor getAViableOverrider() {
-      exists(ValueOrRefType t, OverridableAccessor a |
-        this.hasQualifierTypeOverridden(t, a) and
-        result = a.getAnOverrider(t)
       )
     }
   }

--- a/csharp/ql/src/semmle/code/csharp/dispatch/OverridableCallable.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/OverridableCallable.qll
@@ -134,10 +134,9 @@ class OverridableCallable extends Callable {
    * - `C2.M = C2.M.getInherited(C2)`, and
    * - `C2.M = C2.M.getInherited(C3)`.
    */
-  Callable getInherited(SourceDeclarationType t) {
-    exists(Callable sourceDecl | result = this.getInherited2(t, sourceDecl) |
-      hasSourceDeclarationCallable(t, sourceDecl)
-    )
+  Callable getInherited(ValueOrRefType t) {
+    result = this.getInherited1(t) and
+    t.hasCallable(result)
   }
 
   private Callable getInherited0(ValueOrRefType t) {
@@ -150,19 +149,11 @@ class OverridableCallable extends Callable {
     exists(ValueOrRefType mid | result = this.getInherited0(mid) | t = mid.getASubType())
   }
 
-  private Callable getInherited1(SourceDeclarationType t) {
-    exists(ValueOrRefType t0 | result = getInherited0(t0) | t = t0.getSourceDeclaration())
+  private Callable getInherited1(ValueOrRefType t) {
+    result = getInherited0(t)
     or
     // An interface implementation
-    exists(ValueOrRefType s |
-      result = getAnImplementorSubType(s) and
-      t = s.getSourceDeclaration()
-    )
-  }
-
-  private Callable getInherited2(SourceDeclarationType t, Callable sourceDecl) {
-    result = this.getInherited1(t) and
-    sourceDecl = result.getSourceDeclaration()
+    result = getAnImplementorSubType(t)
   }
 
   pragma[noinline]
@@ -218,11 +209,6 @@ class OverridableCallable extends Callable {
   }
 }
 
-pragma[noinline]
-private predicate hasSourceDeclarationCallable(ValueOrRefType t, Callable sourceDecl) {
-  exists(Callable c | t.hasCallable(c) | sourceDecl = c.getSourceDeclaration())
-}
-
 /** An overridable method. */
 class OverridableMethod extends Method, OverridableCallable {
   override Method getAnOverrider() { result = Method.super.getAnOverrider() }
@@ -231,7 +217,7 @@ class OverridableMethod extends Method, OverridableCallable {
 
   override Method getAnUltimateImplementor() { result = Method.super.getAnUltimateImplementor() }
 
-  override Method getInherited(SourceDeclarationType t) {
+  override Method getInherited(ValueOrRefType t) {
     result = OverridableCallable.super.getInherited(t)
   }
 
@@ -278,7 +264,7 @@ class OverridableAccessor extends Accessor, OverridableCallable {
     )
   }
 
-  override Accessor getInherited(SourceDeclarationType t) {
+  override Accessor getInherited(ValueOrRefType t) {
     result = OverridableCallable.super.getInherited(t)
   }
 

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
@@ -163,7 +163,12 @@ public class A2
 
     public virtual void M(object o)
     {
-        Sink(o); // no flow here
+        Sink(o);
+    }
+
+    public static void CallM(A2 a2, object o)
+    {
+        a2.M(o);
     }
 
     public void Callsite(InterfaceB intF)
@@ -172,7 +177,10 @@ public class A2
         // in both possible implementations of foo, this callsite is relevant
         // in IntA, it improves virtual dispatch,
         // and in IntB, it improves the dataflow analysis.
-        intF.Foo(b, new object(), false);
+        intF.Foo(b, new object(), false); // no flow to `Sink()` via `A2.M()`, but flow via `IntA.Foo()`
+
+        CallM(b, new object()); // no flow to `Sink()`
+        CallM(this, new object());  // flow to `Sink()`
     }
 
     public class B : A2

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
@@ -163,7 +163,7 @@ public class A2
 
     public virtual void M(object o)
     {
-        Sink(o); // no flow here [FALSE POSITIVE]
+        Sink(o); // no flow here
     }
 
     public void Callsite(InterfaceB intF)

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.cs
@@ -161,9 +161,9 @@ public class A2
     {
     }
 
-    public void M()
+    public virtual void M(object o)
     {
-
+        Sink(o); // no flow here [FALSE POSITIVE]
     }
 
     public void Callsite(InterfaceB intF)
@@ -175,25 +175,25 @@ public class A2
         intF.Foo(b, new object(), false);
     }
 
-    private class B : A2
+    public class B : A2
     {
-        public void M()
+        public override void M(object o)
         {
 
         }
     }
 
-    private class IntA : InterfaceB
+    public class IntA : InterfaceB
     {
 
         public void Foo(A2 obj, object o, bool cond)
         {
-            obj.M();
+            obj.M(o);
             Sink(o);
         }
     }
 
-    private class IntB : InterfaceB
+    public class IntB : InterfaceB
     {
 
         public void Foo(A2 obj, object o, bool cond)

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -26,8 +26,12 @@ edges
 | CallSensitivityFlow.cs:124:43:124:43 | o : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o |
 | CallSensitivityFlow.cs:133:44:133:44 | o : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 |
-| CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:189:40:189:40 | o : Object |
-| CallSensitivityFlow.cs:189:40:189:40 | o : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o |
+| CallSensitivityFlow.cs:164:34:164:34 | o : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o |
+| CallSensitivityFlow.cs:169:44:169:44 | o : Object | CallSensitivityFlow.cs:171:14:171:14 | access to parameter o : Object |
+| CallSensitivityFlow.cs:171:14:171:14 | access to parameter o : Object | CallSensitivityFlow.cs:164:34:164:34 | o : Object |
+| CallSensitivityFlow.cs:180:21:180:32 | object creation of type Object : Object | CallSensitivityFlow.cs:197:40:197:40 | o : Object |
+| CallSensitivityFlow.cs:183:21:183:32 | object creation of type Object : Object | CallSensitivityFlow.cs:169:44:169:44 | o : Object |
+| CallSensitivityFlow.cs:197:40:197:40 | o : Object | CallSensitivityFlow.cs:200:18:200:18 | access to parameter o |
 nodes
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | semmle.label | access to parameter o |
@@ -66,9 +70,14 @@ nodes
 | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | semmle.label | access to local variable o3 |
-| CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
-| CallSensitivityFlow.cs:189:40:189:40 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | semmle.label | access to parameter o |
+| CallSensitivityFlow.cs:164:34:164:34 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | semmle.label | access to parameter o |
+| CallSensitivityFlow.cs:169:44:169:44 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:171:14:171:14 | access to parameter o : Object | semmle.label | access to parameter o : Object |
+| CallSensitivityFlow.cs:180:21:180:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| CallSensitivityFlow.cs:183:21:183:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| CallSensitivityFlow.cs:197:40:197:40 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:200:18:200:18 | access to parameter o | semmle.label | access to parameter o |
 #select
 | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | $@ | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:79:25:79:36 | object creation of type Object : Object | CallSensitivityFlow.cs:79:25:79:36 | object creation of type Object : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | $@ | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | access to parameter o |
@@ -87,4 +96,5 @@ nodes
 | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | $@ | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | $@ | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | $@ | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | access to local variable o3 |
-| CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | $@ | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | access to parameter o |
+| CallSensitivityFlow.cs:180:21:180:32 | object creation of type Object : Object | CallSensitivityFlow.cs:180:21:180:32 | object creation of type Object : Object | CallSensitivityFlow.cs:200:18:200:18 | access to parameter o | $@ | CallSensitivityFlow.cs:200:18:200:18 | access to parameter o | access to parameter o |
+| CallSensitivityFlow.cs:183:21:183:32 | object creation of type Object : Object | CallSensitivityFlow.cs:183:21:183:32 | object creation of type Object : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | $@ | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | access to parameter o |

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -26,11 +26,8 @@ edges
 | CallSensitivityFlow.cs:124:43:124:43 | o : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o |
 | CallSensitivityFlow.cs:133:44:133:44 | o : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 |
-| CallSensitivityFlow.cs:164:34:164:34 | o : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:189:40:189:40 | o : Object |
-| CallSensitivityFlow.cs:189:40:189:40 | o : Object | CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object |
 | CallSensitivityFlow.cs:189:40:189:40 | o : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o |
-| CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object | CallSensitivityFlow.cs:164:34:164:34 | o : Object |
 nodes
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | semmle.label | access to parameter o |
@@ -69,11 +66,8 @@ nodes
 | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | semmle.label | access to local variable o3 |
-| CallSensitivityFlow.cs:164:34:164:34 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | CallSensitivityFlow.cs:189:40:189:40 | o : Object | semmle.label | o : Object |
-| CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | semmle.label | access to parameter o |
 #select
 | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | $@ | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | access to parameter o |
@@ -93,5 +87,4 @@ nodes
 | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | $@ | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | $@ | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | $@ | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | access to local variable o3 |
-| CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | $@ | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | $@ | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | access to parameter o |

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -26,8 +26,11 @@ edges
 | CallSensitivityFlow.cs:124:43:124:43 | o : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o |
 | CallSensitivityFlow.cs:133:44:133:44 | o : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 |
+| CallSensitivityFlow.cs:164:34:164:34 | o : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:189:40:189:40 | o : Object |
+| CallSensitivityFlow.cs:189:40:189:40 | o : Object | CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object |
 | CallSensitivityFlow.cs:189:40:189:40 | o : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o |
+| CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object | CallSensitivityFlow.cs:164:34:164:34 | o : Object |
 nodes
 | CallSensitivityFlow.cs:19:39:19:39 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | semmle.label | access to parameter o |
@@ -66,8 +69,11 @@ nodes
 | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:142:49:142:49 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | semmle.label | access to local variable o3 |
+| CallSensitivityFlow.cs:164:34:164:34 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | semmle.label | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | CallSensitivityFlow.cs:189:40:189:40 | o : Object | semmle.label | o : Object |
+| CallSensitivityFlow.cs:191:19:191:19 | access to parameter o : Object | semmle.label | access to parameter o : Object |
 | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | semmle.label | access to parameter o |
 #select
 | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | $@ | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | access to parameter o |
@@ -87,4 +93,5 @@ nodes
 | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:117:26:117:37 | object creation of type Object : Object | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | $@ | CallSensitivityFlow.cs:128:22:128:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:118:27:118:38 | object creation of type Object : Object | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | $@ | CallSensitivityFlow.cs:137:22:137:22 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:119:32:119:43 | object creation of type Object : Object | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | $@ | CallSensitivityFlow.cs:152:18:152:19 | access to local variable o3 | access to local variable o3 |
+| CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | $@ | CallSensitivityFlow.cs:166:14:166:14 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | $@ | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | access to parameter o |

--- a/csharp/ql/test/library-tests/dispatch/CallContext.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.expected
@@ -1,0 +1,25 @@
+getADynamicTargetInCallContext
+| TypeFlow.cs:33:9:33:18 | call to method Method | TypeFlow.cs:12:29:12:34 | Method | TypeFlow.cs:7:7:7:23 | call to method Run |
+| TypeFlow.cs:33:9:33:18 | call to method Method | TypeFlow.cs:17:30:17:35 | Method | TypeFlow.cs:7:7:7:23 | call to method Run |
+mayBenefitFromCallContext
+| TypeFlow.cs:33:9:33:18 | call to method Method |
+| ViableCallable.cs:12:9:12:28 | call to method M |
+| ViableCallable.cs:14:9:14:15 | access to property Prop |
+| ViableCallable.cs:14:19:14:25 | access to property Prop |
+| ViableCallable.cs:16:9:16:23 | access to indexer |
+| ViableCallable.cs:16:27:16:41 | access to indexer |
+| ViableCallable.cs:18:9:18:16 | access to event Event |
+| ViableCallable.cs:19:9:19:16 | access to event Event |
+| ViableCallable.cs:22:9:22:30 | call to method M |
+| ViableCallable.cs:24:9:24:15 | access to property Prop |
+| ViableCallable.cs:24:19:24:25 | access to property Prop |
+| ViableCallable.cs:26:9:26:23 | access to indexer |
+| ViableCallable.cs:26:27:26:41 | access to indexer |
+| ViableCallable.cs:28:9:28:16 | access to event Event |
+| ViableCallable.cs:29:9:29:16 | access to event Event |
+| ViableCallable.cs:235:9:235:15 | call to method M |
+| ViableCallable.cs:284:9:284:15 | call to method M |
+| ViableCallable.cs:287:9:287:20 | call to method M |
+| ViableCallable.cs:412:9:412:18 | call to method M |
+| ViableCallable.cs:456:9:456:30 | call to method M2 |
+| ViableCallable.cs:462:9:462:30 | call to method M2 |

--- a/csharp/ql/test/library-tests/dispatch/CallContext.ql
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.ql
@@ -1,0 +1,10 @@
+import csharp
+import semmle.code.csharp.dispatch.Dispatch
+
+query predicate getADynamicTargetInCallContext(
+  DispatchCall call, Callable callable, DispatchCall ctx
+) {
+  callable = call.getADynamicTargetInCallContext(ctx)
+}
+
+query predicate mayBenefitFromCallContext(DispatchCall call) { call.mayBenefitFromCallContext() }

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -438,7 +438,7 @@ class C17 : C16<string, int>
         // Viable callables: C16<string, int>.M1()
         this.M1("");
 
-        // Viable callables: C16<string, int>.M2<int>()
+        // Viable callables: C17.M2<int>()
         this.M2(() => i);
     }
 


### PR DESCRIPTION
This PR is the first step in being able to [increase the access path restriction](https://github.com/github/codeql/blob/master/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll#L1669) for C#.

Call contexts are used to restrict the set of viable dispatch targets, when the context may improve precision. Context-sensitivity is implemented for calls where the qualifier accesses a parameter (including the implicit `this` parameter), as the context may provide a more precise type:
```csharp
class A
{
    public virtual void M();

    public void CallM1()
        => this.M(); // Without a call context, this can target both `A.M()` and `B.M()`

    public static void CallM2(A a)
        => a.M(); // Without a call context, this can target both `A.M()` and `B.M()`
}

class B
{
    public override void M();

    public static void Run()
    {
        this.CallM1(); // This call context restricts the targets in `CallM1` to `B.M()`
        CallM2(this); // This call context restricts the targets in `CallM2` to `B.M()`
    }
}
```

`CSharp-Difference` job [here](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/199/).