### PR TITLE
C++: Fix missing case in ValueNumber::getKind

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -58,6 +58,8 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeThisValueNumber and result = "InitializeThis"
     or
+    this instanceof TConstantValueNumber and result = "Constant"
+    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -58,6 +58,8 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeThisValueNumber and result = "InitializeThis"
     or
+    this instanceof TConstantValueNumber and result = "Constant"
+    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -58,6 +58,8 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeThisValueNumber and result = "InitializeThis"
     or
+    this instanceof TConstantValueNumber and result = "Constant"
+    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -58,6 +58,8 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeThisValueNumber and result = "InitializeThis"
     or
+    this instanceof TConstantValueNumber and result = "Constant"
+    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -58,6 +58,8 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeThisValueNumber and result = "InitializeThis"
     or
+    this instanceof TConstantValueNumber and result = "Constant"
+    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"


### PR DESCRIPTION
The `getKind` predicate on the IR value numbering class was missing a case for `TConstantValueNumber`.