### PR TITLE
JavaScript: Turn on experimental language features for two tests.

### DIFF
--- a/javascript/ql/test/library-tests/HTML/HTMLElementAndHTMLAttribute/HTMLElement_getChild.expected
+++ b/javascript/ql/test/library-tests/HTML/HTMLElementAndHTMLAttribute/HTMLElement_getChild.expected
@@ -1,6 +1,6 @@
-| tst.html:2:1:13:7 | <html>...</> | 0 | tst.html:3:5:9:11 | <head>...</> |
-| tst.html:2:1:13:7 | <html>...</> | 1 | tst.html:10:5:12:11 | <body>...</> |
-| tst.html:3:5:9:11 | <head>...</> | 0 | tst.html:4:9:4:32 | <title>...</> |
-| tst.html:3:5:9:11 | <head>...</> | 1 | tst.html:5:9:5:43 | <script>...</> |
-| tst.html:3:5:9:11 | <head>...</> | 2 | tst.html:6:9:8:17 | <script>...</> |
-| tst.html:10:5:12:11 | <body>...</> | 0 | tst.html:11:9:11:64 | <a>...</> |
+| tst.html:2:1:13:7 | <html>...</> | 1 | tst.html:3:5:9:11 | <head>...</> |
+| tst.html:2:1:13:7 | <html>...</> | 3 | tst.html:10:5:12:11 | <body>...</> |
+| tst.html:3:5:9:11 | <head>...</> | 1 | tst.html:4:9:4:32 | <title>...</> |
+| tst.html:3:5:9:11 | <head>...</> | 3 | tst.html:5:9:5:43 | <script>...</> |
+| tst.html:3:5:9:11 | <head>...</> | 5 | tst.html:6:9:8:17 | <script>...</> |
+| tst.html:10:5:12:11 | <body>...</> | 1 | tst.html:11:9:11:64 | <a>...</> |

--- a/javascript/ql/test/library-tests/HTML/HTMLElementAndHTMLAttribute/options
+++ b/javascript/ql/test/library-tests/HTML/HTMLElementAndHTMLAttribute/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/SyntaxError.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/SyntaxError.expected
@@ -1,4 +1,4 @@
 | arrows.js:1:5:1:5 | Error: Argument name clash | Error: Argument name clash |
-| destructingPrivate.js:2:12:2:12 | Error: Unexpected token | Error: Unexpected token |
+| destructingPrivate.js:4:6:4:6 | Error: Unexpected token | Error: Unexpected token |
 | privateMethod.js:2:3:2:3 | Error: Only fields, not methods, can be declared private. | Error: Only fields, not methods, can be declared private. |
 | tst.js:2:12:2:12 | Error: Unterminated string constant | Error: Unterminated string constant |

--- a/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/options
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SyntaxError/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --tolerate-parse-errors
+semmle-extractor-options: --tolerate-parse-errors --experimental


### PR DESCRIPTION
All other tests already pass with experimental features turned on, so once this is merged we can do so by default.