### PR TITLE
C++: Remove TInitializeThisValueNumber from IR value numbering

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -56,8 +56,6 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -7,7 +7,6 @@ newtype TValueNumber =
   TInitializeParameterValueNumber(IRFunction irFunc, Language::AST var) {
     initializeParameterValueNumber(_, irFunc, var)
   } or
-  TInitializeThisValueNumber(IRFunction irFunc) { initializeThisValueNumber(_, irFunc) } or
   TConstantValueNumber(IRFunction irFunc, IRType type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
@@ -79,8 +78,6 @@ private predicate numberableInstruction(Instruction instr) {
   or
   instr instanceof InitializeParameterInstruction
   or
-  instr instanceof InitializeThisInstruction
-  or
   instr instanceof ConstantInstruction
   or
   instr instanceof StringConstantInstruction
@@ -130,10 +127,6 @@ private predicate initializeParameterValueNumber(
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
   instr.getIRVariable().getAST() = var
-}
-
-private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {
-  instr.getEnclosingIRFunction() = irFunc
 }
 
 private predicate constantValueNumber(
@@ -267,9 +260,6 @@ private TValueNumber nonUniqueValueNumber(Instruction instr) {
         initializeParameterValueNumber(instr, irFunc, var) and
         result = TInitializeParameterValueNumber(irFunc, var)
       )
-      or
-      initializeThisValueNumber(instr, irFunc) and
-      result = TInitializeThisValueNumber(irFunc)
       or
       exists(string value, IRType type |
         constantValueNumber(instr, irFunc, type, value) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -56,8 +56,6 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -7,7 +7,6 @@ newtype TValueNumber =
   TInitializeParameterValueNumber(IRFunction irFunc, Language::AST var) {
     initializeParameterValueNumber(_, irFunc, var)
   } or
-  TInitializeThisValueNumber(IRFunction irFunc) { initializeThisValueNumber(_, irFunc) } or
   TConstantValueNumber(IRFunction irFunc, IRType type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
@@ -79,8 +78,6 @@ private predicate numberableInstruction(Instruction instr) {
   or
   instr instanceof InitializeParameterInstruction
   or
-  instr instanceof InitializeThisInstruction
-  or
   instr instanceof ConstantInstruction
   or
   instr instanceof StringConstantInstruction
@@ -130,10 +127,6 @@ private predicate initializeParameterValueNumber(
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
   instr.getIRVariable().getAST() = var
-}
-
-private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {
-  instr.getEnclosingIRFunction() = irFunc
 }
 
 private predicate constantValueNumber(
@@ -267,9 +260,6 @@ private TValueNumber nonUniqueValueNumber(Instruction instr) {
         initializeParameterValueNumber(instr, irFunc, var) and
         result = TInitializeParameterValueNumber(irFunc, var)
       )
-      or
-      initializeThisValueNumber(instr, irFunc) and
-      result = TInitializeThisValueNumber(irFunc)
       or
       exists(string value, IRType type |
         constantValueNumber(instr, irFunc, type, value) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -56,8 +56,6 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -7,7 +7,6 @@ newtype TValueNumber =
   TInitializeParameterValueNumber(IRFunction irFunc, Language::AST var) {
     initializeParameterValueNumber(_, irFunc, var)
   } or
-  TInitializeThisValueNumber(IRFunction irFunc) { initializeThisValueNumber(_, irFunc) } or
   TConstantValueNumber(IRFunction irFunc, IRType type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
@@ -79,8 +78,6 @@ private predicate numberableInstruction(Instruction instr) {
   or
   instr instanceof InitializeParameterInstruction
   or
-  instr instanceof InitializeThisInstruction
-  or
   instr instanceof ConstantInstruction
   or
   instr instanceof StringConstantInstruction
@@ -130,10 +127,6 @@ private predicate initializeParameterValueNumber(
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
   instr.getIRVariable().getAST() = var
-}
-
-private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {
-  instr.getEnclosingIRFunction() = irFunc
 }
 
 private predicate constantValueNumber(
@@ -267,9 +260,6 @@ private TValueNumber nonUniqueValueNumber(Instruction instr) {
         initializeParameterValueNumber(instr, irFunc, var) and
         result = TInitializeParameterValueNumber(irFunc, var)
       )
-      or
-      initializeThisValueNumber(instr, irFunc) and
-      result = TInitializeThisValueNumber(irFunc)
       or
       exists(string value, IRType type |
         constantValueNumber(instr, irFunc, type, value) and

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
@@ -84,8 +84,6 @@ class GVN extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -56,8 +56,6 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -7,7 +7,6 @@ newtype TValueNumber =
   TInitializeParameterValueNumber(IRFunction irFunc, Language::AST var) {
     initializeParameterValueNumber(_, irFunc, var)
   } or
-  TInitializeThisValueNumber(IRFunction irFunc) { initializeThisValueNumber(_, irFunc) } or
   TConstantValueNumber(IRFunction irFunc, IRType type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
@@ -79,8 +78,6 @@ private predicate numberableInstruction(Instruction instr) {
   or
   instr instanceof InitializeParameterInstruction
   or
-  instr instanceof InitializeThisInstruction
-  or
   instr instanceof ConstantInstruction
   or
   instr instanceof StringConstantInstruction
@@ -130,10 +127,6 @@ private predicate initializeParameterValueNumber(
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
   instr.getIRVariable().getAST() = var
-}
-
-private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {
-  instr.getEnclosingIRFunction() = irFunc
 }
 
 private predicate constantValueNumber(
@@ -267,9 +260,6 @@ private TValueNumber nonUniqueValueNumber(Instruction instr) {
         initializeParameterValueNumber(instr, irFunc, var) and
         result = TInitializeParameterValueNumber(irFunc, var)
       )
-      or
-      initializeThisValueNumber(instr, irFunc) and
-      result = TInitializeThisValueNumber(irFunc)
       or
       exists(string value, IRType type |
         constantValueNumber(instr, irFunc, type, value) and

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -56,8 +56,6 @@ class ValueNumber extends TValueNumber {
     or
     this instanceof TInitializeParameterValueNumber and result = "InitializeParameter"
     or
-    this instanceof TInitializeThisValueNumber and result = "InitializeThis"
-    or
     this instanceof TStringConstantValueNumber and result = "StringConstant"
     or
     this instanceof TFieldAddressValueNumber and result = "FieldAddress"

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingInternal.qll
@@ -7,7 +7,6 @@ newtype TValueNumber =
   TInitializeParameterValueNumber(IRFunction irFunc, Language::AST var) {
     initializeParameterValueNumber(_, irFunc, var)
   } or
-  TInitializeThisValueNumber(IRFunction irFunc) { initializeThisValueNumber(_, irFunc) } or
   TConstantValueNumber(IRFunction irFunc, IRType type, string value) {
     constantValueNumber(_, irFunc, type, value)
   } or
@@ -79,8 +78,6 @@ private predicate numberableInstruction(Instruction instr) {
   or
   instr instanceof InitializeParameterInstruction
   or
-  instr instanceof InitializeThisInstruction
-  or
   instr instanceof ConstantInstruction
   or
   instr instanceof StringConstantInstruction
@@ -130,10 +127,6 @@ private predicate initializeParameterValueNumber(
   // `IRVariable` to work around a problem where a variable or expression with
   // multiple types gives rise to multiple `IRVariable`s.
   instr.getIRVariable().getAST() = var
-}
-
-private predicate initializeThisValueNumber(InitializeThisInstruction instr, IRFunction irFunc) {
-  instr.getEnclosingIRFunction() = irFunc
 }
 
 private predicate constantValueNumber(
@@ -267,9 +260,6 @@ private TValueNumber nonUniqueValueNumber(Instruction instr) {
         initializeParameterValueNumber(instr, irFunc, var) and
         result = TInitializeParameterValueNumber(irFunc, var)
       )
-      or
-      initializeThisValueNumber(instr, irFunc) and
-      result = TInitializeThisValueNumber(irFunc)
       or
       exists(string value, IRType type |
         constantValueNumber(instr, irFunc, type, value) and


### PR DESCRIPTION
We stopped generating `InitializeThisInstruction` as of https://github.com/github/codeql/pull/3571, so the value numbering case for `TInitializeThisValueNumber` is now subsumed by `TInitializeParameterValueNumber`.

Now the QL compiler doesn't complain when I remove `InitializeThisInstruction` from `Instruction.qll`, so that's probably something we should do at some point. I prefer to keep that out of this PR, though.