### PR TITLE
Fix Java code style of MagicConstants examples

### DIFF
--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstantsNumbers.java
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstantsNumbers.java
@@ -1,9 +1,9 @@
 // Problem version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
@@ -20,17 +20,16 @@ public class MagicConstants
 // Fixed version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
-	final static public int TIMEOUT = 60000;  // Magic number is replaced by named constant
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
+	public static final int TIMEOUT = 60000;  // Magic number is replaced by named constant
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-
 		new MagicConstants().serve(IP, PORT, USERNAME, TIMEOUT);  // Use 'TIMEOUT' constant
 	}
 }

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstantsString.java
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicConstantsString.java
@@ -1,9 +1,9 @@
 // Problem version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
@@ -20,17 +20,16 @@ public class MagicConstants
 // Fixed version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public int USERNAME = "test";  // Magic string is replaced by named constant
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final int USERNAME = "test";  // Magic string is replaced by named constant
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-
 		new MagicConstants().serve(IP, PORT, USERNAME, TIMEOUT);  // Use 'USERNAME' constant
 	}
 }

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicNumbersUseConstant.java
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicNumbersUseConstant.java
@@ -1,19 +1,19 @@
 // Problem version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-		int internal_port = 8080;  // AVOID: Magic number
+		int internalPort = 8080;  // AVOID: Magic number
 
-		new MagicConstants().serve(IP, internal_port, USERNAME, TIMEOUT);
+		new MagicConstants().serve(IP, internalPort, USERNAME, TIMEOUT);
 	}
 }
 
@@ -21,17 +21,16 @@ public class MagicConstants
 // Fixed version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-
 		new MagicConstants().serve(IP, PORT, USERNAME, TIMEOUT);  // Use 'PORT' constant
 	}
 }

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicNumbersUseConstant.qhelp
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicNumbersUseConstant.qhelp
@@ -35,7 +35,7 @@ update if the requirements change, because you have to update the number in only
 </recommendation>
 <example>
 
-<p>The following example shows a magic number <code>internal_port</code>. This should be replaced by  
+<p>The following example shows a magic number <code>internalPort</code>. This should be replaced by  
 the existing named constant, as shown in the fixed version.</p>
 
 <sample src="MagicNumbersUseConstant.java" />

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicStringsUseConstant.java
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicStringsUseConstant.java
@@ -1,19 +1,19 @@
 // Problem version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-		String internal_ip = "127.0.0.1";  // AVOID: Magic string
+		String internalIp = "127.0.0.1";  // AVOID: Magic string
 
-		new MagicConstants().serve(internal_ip, PORT, USERNAME, TIMEOUT);
+		new MagicConstants().serve(internalIp, PORT, USERNAME, TIMEOUT);
 	}
 }
 
@@ -21,17 +21,16 @@ public class MagicConstants
 // Fixed version
 public class MagicConstants
 {
-	final static public String IP = "127.0.0.1";
-	final static public int PORT = 8080;
-	final static public String USERNAME = "test";
-	final static public int TIMEOUT = 60000;
+	public static final String IP = "127.0.0.1";
+	public static final int PORT = 8080;
+	public static final String USERNAME = "test";
+	public static final int TIMEOUT = 60000;
 
 	public void serve(String ip, int port, String user, int timeout) {
 		// ...
 	}
 
 	public static void main(String[] args) {
-
 		new MagicConstants().serve(IP, PORT, USERNAME, TIMEOUT);  //Use 'IP' constant
 	}
 }

--- a/java/ql/src/Violations of Best Practice/Magic Constants/MagicStringsUseConstant.qhelp
+++ b/java/ql/src/Violations of Best Practice/Magic Constants/MagicStringsUseConstant.qhelp
@@ -35,7 +35,7 @@ update if the requirements change, because you have to update the string in only
 </recommendation>
 <example>
 
-<p>The following example shows a magic string <code>internal_ip</code>. This should be replaced by  
+<p>The following example shows a magic string <code>internalIp</code>. This should be replaced by  
 the existing named constant, as shown in the fixed version.</p>
 
 <sample src="MagicStringsUseConstant.java" />


### PR DESCRIPTION
- Use recommended ordering of modifiers
- Use recommended variable naming scheme