### PR TITLE
JS: Track functions through props and returns

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -80,7 +80,8 @@ module CallGraph {
     imprecision = 0 and
     shouldTrackFunction(function) and
     exists(DataFlow::TypeTracker t2 |
-      result = getAFunctionReference(function, imprecision, t2).track(t2, t)
+      result = getAFunctionReference(function, imprecision, t2).track(t2, t) and
+      t.hasCall() = false
     )
   }
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -66,7 +66,8 @@ query predicate missingCallee(AnnotatedCall call, AnnotatedFunction target, int 
 
 query predicate badAnnotation(string name) {
   name = any(AnnotatedCall cl).getCallTargetName() and
-  not name = any(AnnotatedFunction cl).getCalleeName()
+  not name = any(AnnotatedFunction cl).getCalleeName() and
+  name != "NONE"
   or
   not name = any(AnnotatedCall cl).getCallTargetName() and
   name = any(AnnotatedFunction cl).getCalleeName()

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
@@ -21,3 +21,12 @@ let r2 = r1();
 
 /** calls:curry3 */
 r2();
+
+function callback(f) {
+    // Call graph should not include callback invocations.
+    /** calls:NONE */
+    f();
+}
+
+let w1 = callback(curry1);
+callback(() => {});

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
@@ -1,0 +1,23 @@
+import 'dummy';
+
+/** name:curry1 */
+function curry1() {
+    /** name:curry2 */
+    function curry2(x) {
+        /** name:curry3 */
+        function curry3(y) {
+
+        }
+        return curry3;
+    }
+    return curry2;
+};
+
+/** calls:curry1 */
+let r1 = curry1();
+
+/** calls:curry2 */
+let r2 = r1();
+
+/** calls:curry3 */
+r2();


### PR DESCRIPTION
Addresses https://github.com/github/codeql-javascript-team/issues/18 by tracking functions through properties and returns, but not into calls (to avoid FPs from callbacks).

We avoid tracking anything that's a class member as those are tracked via the class instead. We also omit functions in externs for purely speculated performance reasons.

Evaluations:
- [Security/smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/track-all-the-functions_1591618282785) looks interesting, about 1% slowdown but with a surprising number of new call edges.
- [Security/nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/track-all-the-functions-fixed-reruns) also shows a lot of new call edges, but runtime was too flaky to be conclusive, even with the reruns it looks a little fishy.
- [Security/big-apps](https://git.semmle.com/asger/dist-compare-reports/tree/js/track-all-the-functions_1591826878303) times out on gecko.

TODO
- [ ] Investigate the TP rate of these call edges
- [ ] Larger evaluation