### PR TITLE
Python: Handle Python 3.8 `Enum._convert`

### DIFF
--- a/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/getACall.expected
+++ b/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/getACall.expected
@@ -1,0 +1,1 @@
+| test.py:6:5:6:22 | Function Foo.foo | test.py:9:1:9:11 | ControlFlowNode for Attribute() |

--- a/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/getACall.ql
+++ b/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/getACall.ql
@@ -1,0 +1,4 @@
+import python
+
+from PythonFunctionValue func
+select func, func.getACall()

--- a/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/test.py
+++ b/python/ql/test/library-tests/PointsTo/regressions/missing/metaclass/test.py
@@ -1,0 +1,25 @@
+# Simple classmethod
+
+class Foo(object):
+
+    @classmethod
+    def foo(cls, arg):
+        print(cls, arg)
+
+Foo.foo(42)
+
+
+# classmethod defined by metaclass
+
+class BarMeta(type):
+
+    def bar(cls, arg):
+        print(cls, arg)
+
+class Bar(metaclass=BarMeta):
+    pass
+
+Bar.bar(42) # TODO: No points-to
+
+# If this is solved, please update python/ql/src/Variables/UndefinedExport.ql which has a
+# work-around for this behavior


### PR DESCRIPTION
It's hard to show in a test, but the following test gave results for `Maybe` and `Maybe_not` under Python 3.8, saying that they `is exported by __all__ but is not defined.`

https://github.com/github/codeql/blob/52ddd79cab6cae2e0c7b3c3691655829b58c8bca/python/ql/test/3/query-tests/Variables/undefined/enum_convert.py#L1-L8

This PR fixes the problem, and adds a case of points-to regression that caused the query to not just work out of the box.