### PR TITLE
JS: extend support for yargs for js/indirect-command-line-injection

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
@@ -62,20 +62,16 @@ module IndirectCommandInjection {
   private DataFlow::SourceNode yargs() {
     result = DataFlow::moduleImport("yargs")
     or
-    result =
-      // script used to generate list of chained methods: https://gist.github.com/erik-krogh/f8afe952c0577f4b563a993e613269ba
-      yargs()
-          .getAMethodCall(["middleware", "scriptName", "reset", "resetOptions", "boolean", "array",
-                "number", "normalize", "count", "string", "requiresArg", "skipValidation", "nargs",
-                "choices", "alias", "defaults", "default", "describe", "demandOption", "coerce",
-                "config", "example", "require", "required", "demand", "demandCommand",
-                "deprecateOption", "implies", "conflicts", "usage", "epilog", "epilogue", "fail",
-                "onFinishCommand", "check", "global", "pkgConf", "options", "option", "positional",
-                "group", "env", "wrap", "strict", "strictCommands", "parserConfiguration",
-                "version", "help", "addHelpOpt", "showHidden", "addShowHiddenOpt", "hide",
-                "showHelpOnFail", "exitProcess", "completion", "updateLocale", "updateStrings",
-                "detectLocale", "recommendCommands", "getValidationInstance", "command",
-                "commandDir", "showHelp", "showCompletionScript"])
+    // script used to generate list of chained methods: https://gist.github.com/erik-krogh/f8afe952c0577f4b563a993e613269ba
+    exists(string method |
+      not method =
+        // the methods that does not return a chained `yargs` object.
+        ["getContext", "getDemandedOptions", "getDemandedCommands", "getDeprecatedOptions",
+            "_getParseContext", "getOptions", "getGroups", "getStrict", "getStrictCommands",
+            "getExitProcess", "locale", "getUsageInstance", "getCommandInstance"]
+    |
+      result = yargs().getAMethodCall(method)
+    )
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandInjectionCustomizations.qll
@@ -50,11 +50,43 @@ module IndirectCommandInjection {
       // `require('minimist')(...)` => `{ _: [], a: ... b: ... }`
       this = DataFlow::moduleImport("minimist").getACall()
       or
-      // `require('yargs').argv` => `{ _: [], a: ... b: ... }`
-      this = DataFlow::moduleMember("yargs", "argv")
-      or
       // `require('optimist').argv` => `{ _: [], a: ... b: ... }`
       this = DataFlow::moduleMember("optimist", "argv")
+    }
+  }
+
+  /**
+   * Gets an instance of `yargs`.
+   * Either directly imported as a module, or through some chained method call.
+   */
+  private DataFlow::SourceNode yargs() {
+    result = DataFlow::moduleImport("yargs")
+    or
+    result =
+      // script used to generate list of chained methods: https://gist.github.com/erik-krogh/f8afe952c0577f4b563a993e613269ba
+      yargs()
+          .getAMethodCall(["middleware", "scriptName", "reset", "resetOptions", "boolean", "array",
+                "number", "normalize", "count", "string", "requiresArg", "skipValidation", "nargs",
+                "choices", "alias", "defaults", "default", "describe", "demandOption", "coerce",
+                "config", "example", "require", "required", "demand", "demandCommand",
+                "deprecateOption", "implies", "conflicts", "usage", "epilog", "epilogue", "fail",
+                "onFinishCommand", "check", "global", "pkgConf", "options", "option", "positional",
+                "group", "env", "wrap", "strict", "strictCommands", "parserConfiguration",
+                "version", "help", "addHelpOpt", "showHidden", "addShowHiddenOpt", "hide",
+                "showHelpOnFail", "exitProcess", "completion", "updateLocale", "updateStrings",
+                "detectLocale", "recommendCommands", "getValidationInstance", "command",
+                "commandDir", "showHelp", "showCompletionScript"])
+  }
+
+  /**
+   * An array of command line arguments (`argv`) parsed by the `yargs` libary.
+   */
+  class YargsArgv extends Source {
+    YargsArgv() {
+      this = yargs().getAPropertyRead("argv")
+      or
+      this = yargs().getAMethodCall("parse") and
+      this.(DataFlow::MethodCallNode).getNumArgument() = 0
     }
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection.expected
@@ -68,6 +68,17 @@ nodes
 | command-line-parameter-command-injection.js:33:21:33:44 | require ... ").argv |
 | command-line-parameter-command-injection.js:33:21:33:44 | require ... ").argv |
 | command-line-parameter-command-injection.js:33:21:33:48 | require ... rgv.foo |
+| command-line-parameter-command-injection.js:36:6:39:7 | args |
+| command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv |
+| command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv |
+| command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args |
+| command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args |
+| command-line-parameter-command-injection.js:41:22:41:25 | args |
+| command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo |
+| command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo |
+| command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() |
+| command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() |
+| command-line-parameter-command-injection.js:43:22:43:62 | require ... e().foo |
 edges
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv |
 | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line-parameter-command-injection.js:8:22:8:36 | process.argv[2] |
@@ -129,6 +140,15 @@ edges
 | command-line-parameter-command-injection.js:33:21:33:44 | require ... ").argv | command-line-parameter-command-injection.js:33:21:33:48 | require ... rgv.foo |
 | command-line-parameter-command-injection.js:33:21:33:48 | require ... rgv.foo | command-line-parameter-command-injection.js:33:9:33:48 | "cmd.sh ... rgv.foo |
 | command-line-parameter-command-injection.js:33:21:33:48 | require ... rgv.foo | command-line-parameter-command-injection.js:33:9:33:48 | "cmd.sh ... rgv.foo |
+| command-line-parameter-command-injection.js:36:6:39:7 | args | command-line-parameter-command-injection.js:41:22:41:25 | args |
+| command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv | command-line-parameter-command-injection.js:36:6:39:7 | args |
+| command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv | command-line-parameter-command-injection.js:36:6:39:7 | args |
+| command-line-parameter-command-injection.js:41:22:41:25 | args | command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args |
+| command-line-parameter-command-injection.js:41:22:41:25 | args | command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args |
+| command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() | command-line-parameter-command-injection.js:43:22:43:62 | require ... e().foo |
+| command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() | command-line-parameter-command-injection.js:43:22:43:62 | require ... e().foo |
+| command-line-parameter-command-injection.js:43:22:43:62 | require ... e().foo | command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo |
+| command-line-parameter-command-injection.js:43:22:43:62 | require ... e().foo | command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo |
 #select
 | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:4:10:4:21 | process.argv | command-line argument |
 | command-line-parameter-command-injection.js:8:10:8:36 | "cmd.sh ... argv[2] | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line-parameter-command-injection.js:8:10:8:36 | "cmd.sh ... argv[2] | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:8:22:8:33 | process.argv | command-line argument |
@@ -144,3 +164,5 @@ edges
 | command-line-parameter-command-injection.js:31:9:31:45 | "cmd.sh ... )().foo | command-line-parameter-command-injection.js:31:21:31:41 | require ... ist")() | command-line-parameter-command-injection.js:31:9:31:45 | "cmd.sh ... )().foo | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:31:21:31:41 | require ... ist")() | command-line argument |
 | command-line-parameter-command-injection.js:32:9:32:45 | "cmd.sh ... rgv.foo | command-line-parameter-command-injection.js:32:21:32:41 | require ... ").argv | command-line-parameter-command-injection.js:32:9:32:45 | "cmd.sh ... rgv.foo | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:32:21:32:41 | require ... ").argv | command-line argument |
 | command-line-parameter-command-injection.js:33:9:33:48 | "cmd.sh ... rgv.foo | command-line-parameter-command-injection.js:33:21:33:44 | require ... ").argv | command-line-parameter-command-injection.js:33:9:33:48 | "cmd.sh ... rgv.foo | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:33:21:33:44 | require ... ").argv | command-line argument |
+| command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args | command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv | command-line-parameter-command-injection.js:41:10:41:25 | "cmd.sh " + args | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:36:13:39:7 | require ... \\t\\t.argv | command-line argument |
+| command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo | command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() | command-line-parameter-command-injection.js:43:10:43:62 | "cmd.sh ... e().foo | This command depends on an unsanitized $@. | command-line-parameter-command-injection.js:43:22:43:58 | require ... parse() | command-line argument |

--- a/javascript/ql/test/query-tests/Security/CWE-078/command-line-parameter-command-injection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/command-line-parameter-command-injection.js
@@ -31,3 +31,27 @@ cp.exec("cmd.sh " + require("get-them-args")().foo); // NOT OK
 cp.exec("cmd.sh " + require("minimist")().foo); // NOT OK
 cp.exec("cmd.sh " + require("yargs").argv.foo); // NOT OK
 cp.exec("cmd.sh " + require("optimist").argv.foo); // NOT OK
+
+(function () {
+	var args = require('yargs') // eslint-disable-line
+		.command('serve [port]', 'start the server', (yargs) => { })
+		.option('verbose', { foo: "bar" })
+		.argv
+
+	cp.exec("cmd.sh " + args); // NOT OK
+
+	cp.exec("cmd.sh " + require("yargs").array("foo").parse().foo); // NOT OK
+});
+
+(function () {
+	const {
+		argv: {
+			...args
+		},
+	} = yargs
+		.usage('Usage: foo bar')
+		.command();
+
+	cp.exec("cmd.sh " + args); // NOT OK - but not flagged yet. 
+});
+

--- a/javascript/ql/test/query-tests/Security/CWE-078/command-line-parameter-command-injection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/command-line-parameter-command-injection.js
@@ -48,7 +48,7 @@ cp.exec("cmd.sh " + require("optimist").argv.foo); // NOT OK
 		argv: {
 			...args
 		},
-	} = yargs
+	} = require('yargs')
 		.usage('Usage: foo bar')
 		.command();
 


### PR DESCRIPTION
Flags the source in CVE-2020-8149. 

The is still some missing flow related to destructuring assignments that I couldn't figure out. There is a test-case for the missing flow. 

TODO: (post sprint)
 - [ ] performance evaluation
 - [ ] change-note