### PR TITLE
C++: Speed up IRGuardCondition::controlsBlock

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
@@ -407,11 +407,7 @@ class IRGuardCondition extends Instruction {
     not isUnreachedBlock(controlled) and
     exists(IRBlock branchBlock | branchBlock.getAnInstruction() = branch |
       exists(IRBlock succ |
-        testIsTrue = true and succ.getFirstInstruction() = branch.getTrueSuccessor()
-        or
-        testIsTrue = false and succ.getFirstInstruction() = branch.getFalseSuccessor()
-      |
-        branch.getCondition() = this and
+        this.hasBranchEdge(succ, testIsTrue) and
         succ.dominates(controlled) and
         forall(IRBlock pred | pred.getASuccessor() = succ |
           pred = branchBlock or succ.dominates(pred) or not pred.isReachableFromFunctionEntry()

--- a/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/src/semmle/code/cpp/controlflow/IRGuards.qll
@@ -466,6 +466,12 @@ class IRGuardCondition extends Instruction {
       branchBlock.getASuccessor() = succ and
       forall(IRBlock pred | pred = succ.getAPredecessor() and pred != branchBlock |
         succ.dominates(pred)
+        or
+        // An unreachable `pred` is vacuously dominated by `succ` since all
+        // paths from the entry to `pred` go through `succ`. Such vacuous
+        // dominance is not included in the `dominates` predicate since that
+        // could cause quadratic blow-up.
+        not pred.isReachableFromFunctionEntry()
       )
     )
   }


### PR DESCRIPTION
This PR is a port of @aschackmull's implementation of Java guardedness to the C++ IR, giving us a performance boost that makes a big difference on kamailio/kamailio. See commit message of the second commit for details.

As evidence for the correctness of this PR, I've checked that the row count of `IRGuards::IRGuardCondition::controlsBlock_dispred#fff` is exactly the same before and after: 11,261,160 rows on the kamailio/kamailio snapshot I got from lgtm.com.