### PR TITLE
Python: Fix ClassValue.isSequence() and isMapping()

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -517,7 +517,14 @@ class ClassValue extends Value {
     /** Holds if this class is a container(). That is, does it have a __getitem__ method. */
     predicate isContainer() { exists(this.lookup("__getitem__")) }
 
-    /** Holds if this class is probably a sequence. */
+    /**
+     * Holds if this class is a sequence. Mutually exclusive with `isMapping()`.
+     *
+     * Following the definition from
+     * https://docs.python.org/3/glossary.html#term-sequence.
+     * We don't look at the keys accepted by `__getitem__, but default to treating a class
+     * as a sequence (so might treat some mappings as sequences).
+     */
     predicate isSequence() {
         /*
          * To determine whether something is a sequence or a mapping is not entirely clear,
@@ -538,16 +545,26 @@ class ClassValue extends Value {
         or
         major_version() = 3 and this.getASuperType() = Value::named("collections.abc.Sequence")
         or
-        /* Does it have an index or __reversed__ method? */
-        this.isContainer() and
-        (
-            this.hasAttribute("index") or
-            this.hasAttribute("__reversed__")
-        )
+        this.hasAttribute("__getitem__") and
+        this.hasAttribute("__len__") and
+        not this.getASuperType() = ClassValue::dict() and
+        not this.getASuperType() = Value::named("collections.Mapping") and
+        not this.getASuperType() = Value::named("collections.abc.Mapping")
     }
 
-    /** Holds if this class is a mapping. */
+    /**
+     * Holds if this class is a mapping. Mutually exclusive with `isSequence()`.
+     *
+     * Although a class will satisfy the requirement by the definition in
+     * https://docs.python.org/3.8/glossary.html#term-mapping, we don't look at the keys
+     * accepted by `__getitem__, but default to treating a class as a sequence (so might
+     * treat some mappings as sequences).
+     */
     predicate isMapping() {
+        major_version() = 2 and this.getASuperType() = Value::named("collections.Mapping")
+        or
+        major_version() = 3 and this.getASuperType() = Value::named("collections.abc.Mapping")
+        or
         this.hasAttribute("__getitem__") and
         not this.isSequence()
     }

--- a/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
+++ b/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
@@ -1,3 +1,4 @@
+| mapping | class MySequenceImpl |
 | neither sequence nor mapping | builtin-class set |
 | sequence | builtin-class bytes |
 | sequence | builtin-class collections.OrderedDict |
@@ -6,4 +7,7 @@
 | sequence | builtin-class list |
 | sequence | builtin-class str |
 | sequence | builtin-class tuple |
+| sequence | class MyDictSubclass |
+| sequence | class MyMappingABC |
+| sequence | class MySequenceABC |
 | sequence | class OrderedDict |

--- a/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
+++ b/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
@@ -1,0 +1,9 @@
+| mapping | builtin-class collections.defaultdict |
+| mapping | builtin-class dict |
+| neither sequence nor mapping | builtin-class set |
+| sequence | builtin-class bytes |
+| sequence | builtin-class collections.OrderedDict |
+| sequence | builtin-class list |
+| sequence | builtin-class str |
+| sequence | builtin-class tuple |
+| sequence | class OrderedDict |

--- a/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
+++ b/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
@@ -1,13 +1,13 @@
-| mapping | class MySequenceImpl |
+| mapping | builtin-class collections.OrderedDict |
+| mapping | builtin-class collections.defaultdict |
+| mapping | builtin-class dict |
+| mapping | class MyDictSubclass |
+| mapping | class MyMappingABC |
+| mapping | class OrderedDict |
 | neither sequence nor mapping | builtin-class set |
 | sequence | builtin-class bytes |
-| sequence | builtin-class collections.OrderedDict |
-| sequence | builtin-class collections.defaultdict |
-| sequence | builtin-class dict |
 | sequence | builtin-class list |
 | sequence | builtin-class str |
 | sequence | builtin-class tuple |
-| sequence | class MyDictSubclass |
-| sequence | class MyMappingABC |
 | sequence | class MySequenceABC |
-| sequence | class OrderedDict |
+| sequence | class MySequenceImpl |

--- a/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
+++ b/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.expected
@@ -1,8 +1,8 @@
-| mapping | builtin-class collections.defaultdict |
-| mapping | builtin-class dict |
 | neither sequence nor mapping | builtin-class set |
 | sequence | builtin-class bytes |
 | sequence | builtin-class collections.OrderedDict |
+| sequence | builtin-class collections.defaultdict |
+| sequence | builtin-class dict |
 | sequence | builtin-class list |
 | sequence | builtin-class str |
 | sequence | builtin-class tuple |

--- a/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.ql
+++ b/python/ql/test/library-tests/PointsTo/class_properties/ClassValues.ql
@@ -1,0 +1,20 @@
+import python
+
+from ClassValue cls, string res
+where
+    exists(CallNode call |
+        call.getFunction().(NameNode).getId() = "test" and
+        call.getAnArg().pointsTo(cls)
+    ) and
+    (
+        cls.isSequence() and
+        cls.isMapping() and
+        res = "IS BOTH. SHOULD NOT HAPPEN. THEY ARE MUTUALLY EXCLUSIVE."
+        or
+        cls.isSequence() and not cls.isMapping() and res = "sequence"
+        or
+        not cls.isSequence() and cls.isMapping() and res = "mapping"
+        or
+        not cls.isSequence() and not cls.isMapping() and res = "neither sequence nor mapping"
+    )
+select res, cls.toString()

--- a/python/ql/test/library-tests/PointsTo/class_properties/options
+++ b/python/ql/test/library-tests/PointsTo/class_properties/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --max-import-depth=2

--- a/python/ql/test/library-tests/PointsTo/class_properties/test.py
+++ b/python/ql/test/library-tests/PointsTo/class_properties/test.py
@@ -1,0 +1,27 @@
+from collections import OrderedDict, defaultdict
+import collections.abc
+
+def test(*args):
+    pass
+
+test(
+    list,
+    tuple,
+    str,
+    bytes,
+    set,
+    dict,
+    OrderedDict,
+    defaultdict,
+)
+
+for seq_cls in (list, tuple, str, bytes):
+    assert issubclass(seq_cls, collections.abc.Sequence)
+    assert not issubclass(seq_cls, collections.abc.Mapping)
+
+for map_cls in (dict, OrderedDict, defaultdict):
+    assert not issubclass(map_cls, collections.abc.Sequence)
+    assert issubclass(map_cls, collections.abc.Mapping)
+
+assert not issubclass(set, collections.abc.Sequence)
+assert not issubclass(set, collections.abc.Mapping)

--- a/python/ql/test/library-tests/PointsTo/class_properties/test.py
+++ b/python/ql/test/library-tests/PointsTo/class_properties/test.py
@@ -4,15 +4,35 @@ import collections.abc
 def test(*args):
     pass
 
+class MySequenceABC(collections.abc.Sequence):
+    pass
+
+class MyMappingABC(collections.abc.Mapping):
+    pass
+
+class MySequenceImpl(object):
+    def __getitem__(self, key):
+        pass
+
+    def __len__(self):
+        pass
+
+class MyDictSubclass(dict):
+    pass
+
 test(
     list,
     tuple,
     str,
     bytes,
+    MySequenceABC,
+    MySequenceImpl,
     set,
     dict,
     OrderedDict,
     defaultdict,
+    MyMappingABC,
+    MyDictSubclass,
 )
 
 for seq_cls in (list, tuple, str, bytes):


### PR DESCRIPTION
Required some reading on whether we where talking about 

- the [sequence protocol](https://docs.python.org/3/c-api/sequence.html) and [mapping protocol](https://docs.python.org/3/c-api/mapping.html)
- the abstract base classes [`collections.abc.Sequence`](https://docs.python.org/3.8/library/collections.abc.html#collections.abc.Sequence) and [`collections.abc.Mapping`](https://docs.python.org/3.8/library/collections.abc.html#collections.abc.Mapping) -- and the methods they require, which is listed in the table [here](https://docs.python.org/3.8/library/collections.abc.html#collections-abstract-base-classes)
- the terms [sequence](https://docs.python.org/3/glossary.html#term-sequence) and [mapping](https://docs.python.org/3.8/glossary.html#term-mapping) as defined in the glossary

Although the original implementation in [protocols.qll](https://github.com/github/codeql/blob/f77f486c6b17ee595d31e72a59cbb2c9f101998a/python/ql/src/semmle/python/protocols.qll) might have aimed for what the protocols in the C API did, what we effectively have implemented is closer to the definition in the glossary. I have adjusted our implementation to fit what the definition in the glossary actually says (`__getitem__` and `__len__` is requried).