### PR TITLE
C++: Performance tweak for 1-field struct loads

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -564,10 +564,11 @@ private predicate simpleInstructionLocalFlowStep(Instruction iFrom, Instruction 
   or
   // Flow from stores to structs with a single field to a load of that field.
   iTo.(LoadInstruction).getSourceValueOperand().getAnyDef() = iFrom and
-  exists(int size, Type type |
+  exists(int size, Type type, Class cTo |
     type = iFrom.getResultType() and
-    iTo.getResultType().getSize() = size and
-    getFieldSizeOfClass(iTo.getResultType(), type, size)
+    cTo = iTo.getResultType() and
+    cTo.getSize() = size and
+    getFieldSizeOfClass(cTo, type, size)
   )
   or
   // Flow through modeled functions


### PR DESCRIPTION
See the main commit for details.

A more idealistic solution may be to use `unique` at appropriate points in the IR construction, but I don't want to make deep IR changes before #3612 is merged.