### PR TITLE
Java: Fix CompileTimeConstantExpr qldoc and add char cast case.

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -305,10 +305,6 @@ class CompileTimeConstantExpr extends Expr {
   /**
    * Gets the integer value of this expression, where possible.
    *
-   * All computations are performed on QL 32-bit `int`s, so no
-   * truncation is performed in the case of overflow within `byte` or `short`:
-   * `((byte)127)+((byte)1)` evaluates to 128 rather than to -128.
-   *
    * Note that this does not handle the following cases:
    *
    * - values of type `long`,
@@ -332,7 +328,10 @@ class CompileTimeConstantExpr extends Expr {
         else
           if cast.getType().hasName("short")
           then result = (val + 32768).bitAnd(65535) - 32768
-          else result = val
+          else
+            if cast.getType().hasName("char")
+            then result = val.bitAnd(65535)
+            else result = val
       )
       or
       result = this.(PlusExpr).getExpr().(CompileTimeConstantExpr).getIntValue()


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/3632

I think this should handle the last case where the predicate might have given a different value than  actual Java evaluation.  The deleted qldoc comment should be irrelevant since Java also performs its arithmetic in 32-bit ints (and the deleted example was clearly wrong as noted in the issue).