### PR TITLE
Fix incorrect java.util.regex.Pattern name in specification

### DIFF
--- a/docs/language/ql-handbook/language.rst
+++ b/docs/language/ql-handbook/language.rst
@@ -1760,7 +1760,7 @@ The following built-in predicates are members of type ``string``:
 | ``trim``             | string      |                  | The result is the receiver with all whitespace removed from the beginning and end of the string.                                                                                                                                                                                                                                                                                       |
 +----------------------+-------------+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Regular expressions are as defined by ``java.util.Pattern`` in Java.
+Regular expressions are as defined by ``java.util.regex.Pattern`` in Java.
 
 Evaluation
 ----------

--- a/docs/language/ql-handbook/language.rst
+++ b/docs/language/ql-handbook/language.rst
@@ -1761,6 +1761,7 @@ The following built-in predicates are members of type ``string``:
 +----------------------+-------------+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Regular expressions are as defined by ``java.util.regex.Pattern`` in Java.
+For more information, see the `Java API Documentation <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html>`__.
 
 Evaluation
 ----------


### PR DESCRIPTION
The class has the name [<code>java.util.<b>regex.</b>Pattern</code>](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html).

Also, it would probably be good to link to the [javadoc](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html) (for the respective Java version which is used) because people not familiar with Java might not be able to find the documentation that easily. However, I am not familiar enough with reStructuredText to add a link to text formatted as inline code.