### PR TITLE
JS: Restrict domValueRef to known DOM properties

### DIFF
--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -309,6 +309,8 @@ module DOM {
           not read.mayHavePropertyName(_)
           or
           read.mayHavePropertyName(getADomPropertyName())
+          or
+          read.mayHavePropertyName(any(string s | exists(s.toInt())))
         )
         or
         this = domElementCreationOrQuery()

--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -291,11 +291,25 @@ module DOM {
      */
     abstract class Range extends DataFlow::Node { }
 
+    private string getADomPropertyName() {
+      exists(ExternalInstanceMemberDecl decl |
+        result = decl.getName() and
+        isDomRootType(decl.getDeclaringType().getASupertype*())
+      )
+    }
+
     private class DefaultRange extends Range {
       DefaultRange() {
         this.asExpr().(VarAccess).getVariable() instanceof DOMGlobalVariable
         or
-        this = domValueRef().getAPropertyRead()
+        exists(DataFlow::PropRead read |
+          this = read and
+          read = domValueRef().getAPropertyRead()
+        |
+          not read.mayHavePropertyName(_)
+          or
+          read.mayHavePropertyName(getADomPropertyName())
+        )
         or
         this = domElementCreationOrQuery()
         or

--- a/javascript/ql/test/library-tests/DOM/Customizations.expected
+++ b/javascript/ql/test/library-tests/DOM/Customizations.expected
@@ -4,3 +4,9 @@ test_locationRef
 | customization.js:3:3:3:14 | doc.location |
 test_domValueRef
 | customization.js:4:3:4:28 | doc.get ... 'test') |
+| tst.js:45:8:45:7 | this |
+| tst.js:46:7:46:12 | this.x |
+| tst.js:49:3:49:8 | window |
+| tst.js:50:3:50:8 | window |
+| tst.js:50:3:50:14 | window.myApp |
+| tst.js:50:3:50:18 | window.myApp.foo |

--- a/javascript/ql/test/library-tests/DOM/Customizations.expected
+++ b/javascript/ql/test/library-tests/DOM/Customizations.expected
@@ -4,9 +4,5 @@ test_locationRef
 | customization.js:3:3:3:14 | doc.location |
 test_domValueRef
 | customization.js:4:3:4:28 | doc.get ... 'test') |
-| tst.js:45:8:45:7 | this |
-| tst.js:46:7:46:12 | this.x |
 | tst.js:49:3:49:8 | window |
 | tst.js:50:3:50:8 | window |
-| tst.js:50:3:50:14 | window.myApp |
-| tst.js:50:3:50:18 | window.myApp.foo |

--- a/javascript/ql/test/library-tests/DOM/externs/externs.js
+++ b/javascript/ql/test/library-tests/DOM/externs/externs.js
@@ -1,0 +1,10 @@
+/** @externs */
+
+/**
+ * @constructor
+ * @name EventTarget
+ */
+function EventTarget() {}
+
+/** @type {EventTarget} */
+var window;

--- a/javascript/ql/test/library-tests/DOM/tst.js
+++ b/javascript/ql/test/library-tests/DOM/tst.js
@@ -39,3 +39,13 @@
     factory2();
 
 })();
+
+(function pollute() {
+  class C {
+    foo() {
+      this.x; // Should not be a domValueRef
+    }
+  }
+  window.myApp = new C();
+  window.myApp.foo();
+})();

--- a/javascript/ql/test/query-tests/Security/CWE-079/externs.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/externs.js
@@ -25,6 +25,24 @@
 function EventTarget() {}
 
 /**
- * @type {!EventTarget}
+ * Stub for the DOM hierarchy.
+ *
+ * @constructor
+ * @extends {EventTarget}
+ */
+function DomObjectStub() {}
+
+/**
+ * @type {!DomObjectStub}
+ */
+DomObjectStub.prototype.body;
+
+/**
+ * @type {!DomObjectStub}
+ */
+DomObjectStub.prototype.value;
+
+/**
+ * @type {!DomObjectStub}
  */
 var document;


### PR DESCRIPTION
`domValueRef` steps through all property reads, which means once an object is spuriously classified as a DOM value ref, it can escalate quickly.

A concrete example where this happened is for code like this:
```js
  class C {
    foo() {
      this.x; // Accidentally seen as domValueRef
    }
  }
  window.myApp = new C();
  window.myApp.foo(); // 'window.myApp' propagates into 'this'
```
