### PR TITLE
Java: Improve qldoc for JavadocTag.

### DIFF
--- a/java/ql/src/semmle/code/java/Javadoc.qll
+++ b/java/ql/src/semmle/code/java/Javadoc.qll
@@ -79,7 +79,7 @@ abstract class JavadocElement extends @javadocElement, Top {
   abstract string getText();
 }
 
-/** A Javadoc tag. */
+/** A Javadoc block tag. This does not include inline tags. */
 class JavadocTag extends JavadocElement, JavadocParent, @javadocTag {
   /** Gets the name of this Javadoc tag. */
   string getTagName() { javadocTag(this, result, _, _) }


### PR DESCRIPTION
Clarify that `JavadocTag` doesn't include inline tags.

https://github.com/github/codeql/issues/3647