### PR TITLE
CodeQL for Go: Edit AST reference

### DIFF
--- a/docs/language/learn-ql/go/ast-class-reference.rst
+++ b/docs/language/learn-ql/go/ast-class-reference.rst
@@ -1,5 +1,9 @@
-Abstract syntax tree classes for Go
-===================================
+Abstract syntax tree classes for working with Go programs
+=========================================================
+
+CodeQL has a large selection of classes for representing the abstract syntax tree of Go programs.
+
+.. include:: ../../reusables/abstract-syntax-tree.rst
 
 Statement classes
 -----------------
@@ -471,3 +475,9 @@ The following classes organize expressions by the kind of entity they refer to.
 +------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | `ValueExpr <https://help.semmle.com/qldoc/go/semmle/go/Expr.qll/type.Expr$BadExpr.html>`__           | an expression that can be evaluated to a value (as opposed to expressions that refer to a package, a type, or a statement label). This generalizes `ReferenceExpr <https://help.semmle.com/qldoc/go/semmle/go/Expr.qll/type.Expr$ReferenceExpr.html>`__ |
 +------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Further reading
+---------------
+
+.. include:: ../../reusables/go-further-reading.rst
+.. include:: ../../reusables/codeql-ref-tools-further-reading.rst

--- a/docs/language/learn-ql/go/ql-for-go.rst
+++ b/docs/language/learn-ql/go/ql-for-go.rst
@@ -13,4 +13,4 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`CodeQL library for Go <introduce-libraries-go>`: When you're analyzing a Go program, you can make use of the large collection of classes in the CodeQL library for Go.
 
--  :doc:`Abstract syntax tree classes for Go <ast-class-reference>`: CodeQL has a large selection of classes for representing the abstract syntax tree of Go programs.
+-  :doc:`Abstract syntax tree classes for working with Go programs <ast-class-reference>`: CodeQL has a large selection of classes for representing the abstract syntax tree of Go programs.


### PR DESCRIPTION
Follow-up to https://github.com/github/codeql/pull/3675. (Thanks for creating this new content @owen-mc!) 

Here are some minor peripheral changes to keep the AST class reference for Go consistent with our other docs. 