### PR TITLE
C++: Add a test case for CWE-114 involving pointers and references.

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/UncontrolledProcessOperation.expected
@@ -7,6 +7,22 @@ edges
 | test.cpp:42:18:42:34 | (const char *)... | test.cpp:24:30:24:36 | command |
 | test.cpp:43:18:43:23 | call to getenv | test.cpp:29:30:29:36 | command |
 | test.cpp:43:18:43:34 | (const char *)... | test.cpp:29:30:29:36 | command |
+| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | (const char *)... |
+| test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer |
+| test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | (const char *)... |
+| test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | (const char *)... |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:62:10:62:15 | buffer |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | (const char *)... |
+| test.cpp:56:12:56:17 | fgets output argument | test.cpp:63:10:63:13 | data |
+| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | (const char *)... |
+| test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer |
+| test.cpp:76:12:76:17 | buffer | test.cpp:79:10:79:13 | (const char *)... |
+| test.cpp:76:12:76:17 | buffer | test.cpp:79:10:79:13 | data |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | (const char *)... |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:78:10:78:15 | buffer |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:79:10:79:13 | (const char *)... |
+| test.cpp:76:12:76:17 | fgets output argument | test.cpp:79:10:79:13 | data |
 nodes
 | test.cpp:24:30:24:36 | command | semmle.label | command |
 | test.cpp:26:10:26:16 | command | semmle.label | command |
@@ -20,6 +36,26 @@ nodes
 | test.cpp:42:18:42:34 | (const char *)... | semmle.label | (const char *)... |
 | test.cpp:43:18:43:23 | call to getenv | semmle.label | call to getenv |
 | test.cpp:43:18:43:34 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:56:12:56:17 | buffer | semmle.label | buffer |
+| test.cpp:56:12:56:17 | fgets output argument | semmle.label | fgets output argument |
+| test.cpp:62:10:62:15 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:62:10:62:15 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:62:10:62:15 | buffer | semmle.label | buffer |
+| test.cpp:63:10:63:13 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:63:10:63:13 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:63:10:63:13 | data | semmle.label | data |
+| test.cpp:76:12:76:17 | buffer | semmle.label | buffer |
+| test.cpp:76:12:76:17 | fgets output argument | semmle.label | fgets output argument |
+| test.cpp:78:10:78:15 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:78:10:78:15 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:78:10:78:15 | buffer | semmle.label | buffer |
+| test.cpp:79:10:79:13 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:79:10:79:13 | (const char *)... | semmle.label | (const char *)... |
+| test.cpp:79:10:79:13 | data | semmle.label | data |
 #select
 | test.cpp:26:10:26:16 | command | test.cpp:42:18:42:23 | call to getenv | test.cpp:26:10:26:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:42:18:42:23 | call to getenv | call to getenv |
 | test.cpp:31:10:31:16 | command | test.cpp:43:18:43:23 | call to getenv | test.cpp:31:10:31:16 | command | The value of this argument may come from $@ and is being passed to system | test.cpp:43:18:43:23 | call to getenv | call to getenv |
+| test.cpp:62:10:62:15 | buffer | test.cpp:56:12:56:17 | buffer | test.cpp:62:10:62:15 | buffer | The value of this argument may come from $@ and is being passed to system | test.cpp:56:12:56:17 | buffer | buffer |
+| test.cpp:63:10:63:13 | data | test.cpp:56:12:56:17 | buffer | test.cpp:63:10:63:13 | data | The value of this argument may come from $@ and is being passed to system | test.cpp:56:12:56:17 | buffer | buffer |
+| test.cpp:78:10:78:15 | buffer | test.cpp:76:12:76:17 | buffer | test.cpp:78:10:78:15 | buffer | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |
+| test.cpp:79:10:79:13 | data | test.cpp:76:12:76:17 | buffer | test.cpp:79:10:79:13 | data | The value of this argument may come from $@ and is being passed to system | test.cpp:76:12:76:17 | buffer | buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-114/semmle/UncontrolledProcessOperation/test.cpp
@@ -42,3 +42,42 @@ void testMyDerived()
 	md2->doCommand2(getenv("varname"));
 	md3->doCommand3(getenv("varname"));
 }
+
+// ---
+
+typedef struct {} FILE;
+char *fgets(char *s, int n, FILE *stream);
+FILE *stdin;
+
+void testReferencePointer1()
+{
+	char buffer[1024];
+
+	if (fgets(buffer, 1024, stdin) != 0)
+	{
+		char *data = buffer;
+		char *&dataref = data;
+		char *data2 = dataref;
+
+		system(buffer); // BAD
+		system(data); // BAD
+		system(dataref); // BAD [NOT DETECTED]
+		system(data2); // BAD [NOT DETECTED]
+	}
+}
+
+void testReferencePointer2()
+{
+	char buffer[1024];
+	char *data = buffer;
+	char *&dataref = data;
+	char *data2 = dataref;
+
+	if (fgets(buffer, 1024, stdin) != 0)
+	{
+		system(buffer); // BAD
+		system(data); // BAD
+		system(dataref); // BAD [NOT DETECTED]
+		system(data2); // BAD [NOT DETECTED]
+	}
+}


### PR DESCRIPTION
I'm trying to track down one of the samate regressions since we moved to DefaultTaintTracking (for https://github.com/github/codeql-c-analysis-team/issues/27).  This one is in CWE-114, and has to do with references to pointers to tainted data.

I spend a bit of time last week looking into what's happening and what's supposed to happen.  Mostly this was an exercise in learning how the IR and dataflow are constructed and debugged (I still don't really understand how the SSA layers do what they do) and I didn't make much progress on the actual issue here.  I might be able to answer some questions though.

@dbartol @MathiasVP do you have any feelings about this?  I'd like to either link it to an existing ticket or create a new ticket to fix whatever's caused this regression.