### PR TITLE
C++: Add test for differences between AST and IR field flow

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/Nodes.qll
+++ b/cpp/ql/test/library-tests/dataflow/fields/Nodes.qll
@@ -1,0 +1,41 @@
+private import semmle.code.cpp.ir.dataflow.DataFlow as IR
+private import semmle.code.cpp.dataflow.DataFlow as AST
+private import cpp
+
+private newtype TNode =
+  TASTNode(AST::DataFlow::Node n) or
+  TIRNode(IR::DataFlow::Node n)
+
+class Node extends TNode {
+  string toString() { none() }
+
+  IR::DataFlow::Node asIR() { none() }
+
+  AST::DataFlow::Node asAST() { none() }
+
+  Location getLocation() { none() }
+}
+
+class ASTNode extends Node, TASTNode {
+  AST::DataFlow::Node n;
+
+  ASTNode() { this = TASTNode(n) }
+
+  override string toString() { result = n.toString() }
+
+  override AST::DataFlow::Node asAST() { result = n }
+
+  override Location getLocation() { result = n.getLocation() }
+}
+
+class IRNode extends Node, TIRNode {
+  IR::DataFlow::Node n;
+
+  IRNode() { this = TIRNode(n) }
+
+  override string toString() { result = n.toString() }
+
+  override IR::DataFlow::Node asIR() { result = n }
+
+  override Location getLocation() { result = n.getLocation() }
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
@@ -1,0 +1,62 @@
+| A.cpp:41:15:41:21 | new | A.cpp:43:10:43:12 | & ... | AST only |
+| A.cpp:47:12:47:18 | new | A.cpp:49:13:49:13 | c | AST only |
+| A.cpp:55:12:55:19 | new | A.cpp:56:13:56:15 | call to get | AST only |
+| A.cpp:57:17:57:23 | new | A.cpp:57:28:57:30 | call to get | AST only |
+| A.cpp:64:21:64:28 | new | A.cpp:66:14:66:14 | c | AST only |
+| A.cpp:73:25:73:32 | new | A.cpp:75:14:75:14 | c | AST only |
+| A.cpp:98:12:98:18 | new | A.cpp:120:16:120:16 | a | AST only |
+| A.cpp:126:12:126:18 | new | A.cpp:132:13:132:13 | c | AST only |
+| A.cpp:142:14:142:20 | new | A.cpp:153:16:153:16 | c | AST only |
+| A.cpp:143:25:143:31 | new | A.cpp:152:13:152:13 | b | AST only |
+| A.cpp:150:12:150:18 | new | A.cpp:152:13:152:13 | b | AST only |
+| A.cpp:159:12:159:18 | new | A.cpp:165:26:165:29 | head | AST only |
+| A.cpp:159:12:159:18 | new | A.cpp:169:15:169:18 | head | AST only |
+| B.cpp:6:15:6:24 | new | B.cpp:9:20:9:24 | elem1 | AST only |
+| B.cpp:15:15:15:27 | new | B.cpp:19:20:19:24 | elem2 | AST only |
+| C.cpp:22:12:22:21 | new | C.cpp:29:10:29:11 | s1 | AST only |
+| C.cpp:24:16:24:25 | new | C.cpp:31:10:31:11 | s3 | AST only |
+| D.cpp:28:15:28:24 | new | D.cpp:22:25:22:31 | call to getElem | AST only |
+| D.cpp:35:15:35:24 | new | D.cpp:22:25:22:31 | call to getElem | AST only |
+| D.cpp:42:15:42:24 | new | D.cpp:22:25:22:31 | call to getElem | AST only |
+| D.cpp:49:15:49:24 | new | D.cpp:22:25:22:31 | call to getElem | AST only |
+| D.cpp:56:15:56:24 | new | D.cpp:64:25:64:28 | elem | AST only |
+| E.cpp:28:21:28:23 | ref arg raw | E.cpp:31:10:31:12 | raw | AST only |
+| E.cpp:29:24:29:29 | ref arg buffer | E.cpp:32:13:32:18 | buffer | AST only |
+| E.cpp:30:28:30:33 | ref arg buffer | E.cpp:21:18:21:23 | buffer | AST only |
+| aliasing.cpp:37:13:37:22 | call to user_input | aliasing.cpp:38:11:38:12 | m1 | IR only |
+| aliasing.cpp:42:11:42:20 | call to user_input | aliasing.cpp:43:13:43:14 | m1 | IR only |
+| aliasing.cpp:79:11:79:20 | call to user_input | aliasing.cpp:80:12:80:13 | m1 | IR only |
+| aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | IR only |
+| by_reference.cpp:50:17:50:26 | call to user_input | by_reference.cpp:51:10:51:20 | call to getDirectly | AST only |
+| by_reference.cpp:56:19:56:28 | call to user_input | by_reference.cpp:57:10:57:22 | call to getIndirectly | AST only |
+| by_reference.cpp:62:25:62:34 | call to user_input | by_reference.cpp:63:10:63:28 | call to getThroughNonMember | AST only |
+| by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:111:25:111:25 | a | AST only |
+| by_reference.cpp:84:14:84:23 | call to user_input | by_reference.cpp:115:27:115:27 | a | AST only |
+| by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:131:25:131:25 | a | AST only |
+| by_reference.cpp:88:13:88:22 | call to user_input | by_reference.cpp:135:27:135:27 | a | AST only |
+| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:132:14:132:14 | a | AST only |
+| by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:136:16:136:16 | a | AST only |
+| complex.cpp:62:19:62:28 | call to user_input | complex.cpp:51:18:51:18 | call to a | AST only |
+| complex.cpp:62:19:62:28 | call to user_input | complex.cpp:52:18:52:18 | call to b | AST only |
+| complex.cpp:63:19:63:28 | call to user_input | complex.cpp:51:18:51:18 | call to a | AST only |
+| complex.cpp:63:19:63:28 | call to user_input | complex.cpp:52:18:52:18 | call to b | AST only |
+| complex.cpp:64:19:64:28 | call to user_input | complex.cpp:51:18:51:18 | call to a | AST only |
+| complex.cpp:64:19:64:28 | call to user_input | complex.cpp:52:18:52:18 | call to b | AST only |
+| complex.cpp:65:19:65:28 | call to user_input | complex.cpp:51:18:51:18 | call to a | AST only |
+| complex.cpp:65:19:65:28 | call to user_input | complex.cpp:52:18:52:18 | call to b | AST only |
+| constructors.cpp:34:11:34:20 | call to user_input | constructors.cpp:28:12:28:12 | call to a | AST only |
+| constructors.cpp:35:14:35:23 | call to user_input | constructors.cpp:29:12:29:12 | call to b | AST only |
+| constructors.cpp:36:11:36:20 | call to user_input | constructors.cpp:28:12:28:12 | call to a | AST only |
+| constructors.cpp:36:25:36:34 | call to user_input | constructors.cpp:29:12:29:12 | call to b | AST only |
+| qualifiers.cpp:22:27:22:36 | call to user_input | qualifiers.cpp:23:23:23:23 | a | AST only |
+| qualifiers.cpp:27:28:27:37 | call to user_input | qualifiers.cpp:28:23:28:23 | a | AST only |
+| qualifiers.cpp:32:35:32:44 | call to user_input | qualifiers.cpp:33:23:33:23 | a | AST only |
+| qualifiers.cpp:37:38:37:47 | call to user_input | qualifiers.cpp:38:23:38:23 | a | AST only |
+| qualifiers.cpp:42:29:42:38 | call to user_input | qualifiers.cpp:43:23:43:23 | a | AST only |
+| qualifiers.cpp:47:31:47:40 | call to user_input | qualifiers.cpp:48:23:48:23 | a | AST only |
+| simple.cpp:39:12:39:21 | call to user_input | simple.cpp:28:12:28:12 | call to a | AST only |
+| simple.cpp:40:12:40:21 | call to user_input | simple.cpp:29:12:29:12 | call to b | AST only |
+| simple.cpp:41:12:41:21 | call to user_input | simple.cpp:28:12:28:12 | call to a | AST only |
+| simple.cpp:42:12:42:21 | call to user_input | simple.cpp:29:12:29:12 | call to b | AST only |
+| struct_init.c:20:20:20:29 | call to user_input | struct_init.c:33:25:33:25 | a | AST only |
+| struct_init.c:40:20:40:29 | call to user_input | struct_init.c:15:12:15:12 | a | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.ql
@@ -1,0 +1,31 @@
+/**
+ * @kind problem
+ */
+
+import cpp
+import Nodes
+import IRConfiguration as IRConf
+import ASTConfiguration as ASTConf
+private import semmle.code.cpp.ir.dataflow.DataFlow as IR
+private import semmle.code.cpp.dataflow.DataFlow as AST
+
+from Node source, Node sink, IRConf::Conf irConf, ASTConf::Conf astConf, string msg
+where
+  irConf.hasFlow(source.asIR(), sink.asIR()) and
+  not exists(AST::DataFlow::Node astSource, AST::DataFlow::Node astSink |
+    astSource.asExpr() = source.asIR().asExpr() and
+    astSink.asExpr() = sink.asIR().asExpr()
+  |
+    astConf.hasFlow(astSource, astSink)
+  ) and
+  msg = "IR only"
+  or
+  astConf.hasFlow(source.asAST(), sink.asAST()) and
+  not exists(IR::DataFlow::Node irSource, IR::DataFlow::Node irSink |
+    irSource.asExpr() = source.asAST().asExpr() and
+    irSink.asExpr() = sink.asAST().asExpr()
+  |
+    irConf.hasFlow(irSource, irSink)
+  ) and
+  msg = "AST only"
+select source, sink, msg

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.ql
@@ -5,43 +5,14 @@
 import cpp
 import semmle.code.cpp.ir.dataflow.DataFlow::DataFlow as IR
 import semmle.code.cpp.dataflow.DataFlow::DataFlow as AST
+import Nodes
 
-newtype TNode =
-  TASTNode(AST::Node n) or
-  TIRNode(IR::Node n)
-
-class Node extends TNode {
-  string toString() { none() }
-
-  IR::Node asIR() { none() }
-
-  AST::Node asAST() { none() }
-
-  Location getLocation() { none() }
+class ASTPartialDefNode extends ASTNode {
+  override string toString() { result = n.asPartialDefinition().toString() }
 }
 
-class ASTNode extends Node, TASTNode {
-  AST::Node n;
-
-  ASTNode() { this = TASTNode(n) }
-
+class IRPartialDefNode extends IRNode {
   override string toString() { result = n.asPartialDefinition().toString() }
-
-  override AST::Node asAST() { result = n }
-
-  override Location getLocation() { result = n.getLocation() }
-}
-
-class IRNode extends Node, TIRNode {
-  IR::Node n;
-
-  IRNode() { this = TIRNode(n) }
-
-  override string toString() { result = n.asPartialDefinition().toString() }
-
-  override IR::Node asIR() { result = n }
-
-  override Location getLocation() { result = n.getLocation() }
 }
 
 from Node node, AST::Node astNode, IR::Node irNode, string msg

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.ql
@@ -8,10 +8,14 @@ import semmle.code.cpp.dataflow.DataFlow::DataFlow as AST
 import Nodes
 
 class ASTPartialDefNode extends ASTNode {
+  ASTPartialDefNode() { exists(n.asPartialDefinition()) }
+
   override string toString() { result = n.asPartialDefinition().toString() }
 }
 
 class IRPartialDefNode extends IRNode {
+  IRPartialDefNode() { exists(n.asPartialDefinition()) }
+
   override string toString() { result = n.asPartialDefinition().toString() }
 }
 


### PR DESCRIPTION
I also refactored the `partial-definitions` test as it used the same pattern as the new test.