### PR TITLE
JS: Support calls to returned functions

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -70,7 +70,9 @@ module CallGraph {
   }
 
   cached
-  private predicate locallyReturnedFunction(DataFlow::FunctionNode outer, DataFlow::FunctionNode inner) {
+  private predicate locallyReturnedFunction(
+    DataFlow::FunctionNode outer, DataFlow::FunctionNode inner
+  ) {
     inner.flowsTo(outer.getAReturn())
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/CallGraphs.qll
@@ -61,6 +61,17 @@ module CallGraph {
       function = cls.getConstructor() and
       cls.getAClassReference(t.continue()).flowsTo(result)
     )
+    or
+    imprecision = 0 and
+    exists(DataFlow::FunctionNode outer |
+      result = getAFunctionReference(outer, 0, t.continue()).getAnInvocation() and
+      locallyReturnedFunction(outer, function)
+    )
+  }
+
+  cached
+  private predicate locallyReturnedFunction(DataFlow::FunctionNode outer, DataFlow::FunctionNode inner) {
+    inner.flowsTo(outer.getAReturn())
   }
 
   /**

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,4 +2,5 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
+| returned-function.js:23:1:23:4 | r2() | returned-function.js:8:9:10:9 | functio ...       } | -1 |
 badAnnotation

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,5 +2,4 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 |
-| returned-function.js:23:1:23:4 | r2() | returned-function.js:8:9:10:9 | functio ...       } | -1 |
 badAnnotation

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -66,7 +66,8 @@ query predicate missingCallee(AnnotatedCall call, AnnotatedFunction target, int 
 
 query predicate badAnnotation(string name) {
   name = any(AnnotatedCall cl).getCallTargetName() and
-  not name = any(AnnotatedFunction cl).getCalleeName()
+  not name = any(AnnotatedFunction cl).getCalleeName() and
+  name != "NONE"
   or
   not name = any(AnnotatedCall cl).getCallTargetName() and
   name = any(AnnotatedFunction cl).getCalleeName()

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/returned-function.js
@@ -1,0 +1,32 @@
+import 'dummy';
+
+/** name:curry1 */
+function curry1() {
+    /** name:curry2 */
+    function curry2(x) {
+        /** name:curry3 */
+        function curry3(y) {
+
+        }
+        return curry3;
+    }
+    return curry2;
+};
+
+/** calls:curry1 */
+let r1 = curry1();
+
+/** calls:curry2 */
+let r2 = r1();
+
+/** calls:curry3 */
+r2();
+
+function callback(f) {
+    // Call graph should not include callback invocations.
+    /** calls:NONE */
+    f();
+}
+
+let w1 = callback(curry1);
+callback(() => {});

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandler.expected
@@ -15,6 +15,7 @@
 | src/handler-in-property.js:12:18:12:37 | function(req, res){} |
 | src/middleware-attacher-getter.js:4:17:4:36 | function(req, res){} |
 | src/middleware-attacher-getter.js:19:19:19:38 | function(req, res){} |
+| src/middleware-attacher-getter.js:29:32:29:51 | function(req, res){} |
 | src/middleware-attacher.js:3:13:3:32 | function(req, res){} |
 | src/nodejs.js:3:19:3:38 | function(req, res){} |
 | src/nodejs.js:8:14:8:33 | function(req, res){} |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
@@ -2,7 +2,6 @@
 | src/bound-handler.js:9:12:9:31 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/hapi.js:1:1:1:30 | functio ... t, h){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/iterated-handlers.js:4:2:4:22 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
-| src/middleware-attacher-getter.js:29:32:29:51 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:7:19:7:38 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:8:12:10:5 | (req, res) {\\n\\n    } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:20:16:22:9 | (req, r ...       } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |


### PR DESCRIPTION
A safer version of https://github.com/github/codeql/pull/3639, adds call edges to functions returned by other functions:

```js
function outer() {
  return inner(x) { ... }
}

outer()(x); // call edge
```

Evaluations:
- [security/nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/returned-functions_1592061452695) shows a fair number of new call edges. I've verified a few of them manually and saw only TPs.
- [security/gecko](https://git.semmle.com/asger/dist-compare-reports/tree/js/returned-functions_1592201487270) looks fine (unlike https://github.com/github/codeql/pull/3639, which timed out on gecko)
