### PR TITLE
Java: SSRF query

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.java
@@ -1,0 +1,57 @@
+class SSRF {
+    /** Test url.openStream() */
+    public void openUrlStream(HttpServletRequest servletRequest) {
+        {
+            String urlStr = servletRequest.getParameter("url");
+            URL uri = new URL(urlStr);
+            InputStream input = uri.openStream(); // BAD: open url stream from remote source without validation
+        }
+
+        {
+            String urlStr = servletRequest.getParameter("url");
+            if (urlStr.startsWith("https://www.mycorp.com")) {
+                URL uri = new URL(urlStr);
+                InputStream input = uri.openStream(); // GOOD: open url stream from remote source with validation
+            }
+        }
+    }
+
+    /** Test url.openConnection() */
+    public void openUrlConnection(HttpServletRequest servletRequest) {
+        {
+            String urlStr = servletRequest.getParameter("url");
+            URL uri = new URL(urlStr);
+            URLConnection input = uri.openConnection(); // BAD: open url connection from remote source without
+                                                        // validation
+        }
+
+        {
+            String urlStr = servletRequest.getParameter("url");
+            if (urlStr.startsWith("https://www.mycorp.com")) {
+                URL uri = new URL(urlStr);
+                URLConnection input = uri.openConnection(); // GOOD: open url connection from remote source with
+                                                            // validation
+            }
+        }
+    }
+
+    /** Test Apache HttpRequest */
+    public void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
+            throws ServletException, IOException {
+        String method = servletRequest.getMethod();
+        String proxyRequestUri = servletRequest.getParameter("url");
+
+        {
+            URI targetUriObj = new URI(proxyRequestUri);
+            HttpRequest proxyRequest = new BasicHttpRequest(method, proxyRequestUri);  //BAD: open HTTPRequest from remote source without validation    
+        }
+
+        {
+            if (proxyRequestUri.startsWith("https://www.mycorp.com")) {
+                URI targetUriObj = new URI(proxyRequestUri);
+                HttpRequest proxyRequest = new BasicHttpRequest(method, proxyRequestUri);  //GOOD: open HTTPRequest from remote source with validation        
+            }
+        }
+    }
+
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.qhelp
@@ -7,8 +7,8 @@
     <p>By providing unexpected URLs, attackers can trick the application to send malicious requests, possibly bypassing access controls such as firewalls that prevent the attackers from accessing those URLs directly. The server can be used as a proxy to conduct port scanning of hosts in internal networks, use other URLs such as that can access documents on the system (using file:// or jar://), or use other content protocols such as gopher:// or tftp://, or invoke internal REST APIs.</p>
     <p>This query detects the following two scenarios:</p>
     <ol>
-      <li>Java networking uri.openConnection() and its derived uri.openStream(), which is a shorthand for openConnection().getInputStream(), from remote source.</li>
-      <li>Apache HTTPRequest constructed from remote source.</li>
+      <li>Java networking URL.openConnection() and its derived URL.openStream(), which is a shorthand for openConnection().getInputStream(), from remote source</li>
+      <li>Apache HTTPRequest constructed from remote source</li>
     </ol>
   </overview>
 
@@ -26,7 +26,7 @@
       <a href="https://cwe.mitre.org/data/definitions/918.html">CWE-918: Server-Side Request Forgery (SSRF)</a>
       <a href="https://owasp.org/www-community/attacks/Server_Side_Request_Forgery">OWASP - Server Side Request Forgery</a>
       <a href="https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html">Server Side Request Forgery Prevention</a>
-      <a href="https://www.ciphertechs.com/blog/hawtio-advisory/">CVE-2019-9827:  Unauthenticated Server-Side Request Forgery (SSRF) with Hawtio up to and including version 2.5.0</a>
+      <a href="https://www.ciphertechs.com/blog/hawtio-advisory/">CVE-2019-9827: Unauthenticated Server-Side Request Forgery (SSRF) with Hawtio up to and including version 2.5.0</a>
     </li>
   </references>
 </qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.qhelp
@@ -1,0 +1,32 @@
+<!DOCTYPE qhelp PUBLIC "-//Semmle//qhelp//EN" "qhelp.dtd">
+<qhelp>
+
+  <overview>
+    <p>Server Side Request Forgery (SSRF) is an attack vector that abuses an application to interact with the internal/external network or the machine itself, frequently through the attack vector of URL mishandling.</p>
+    <p>In an SSRF attack, the attacker can abuse functionality on the server to read or update internal resources, e.g. cloud server meta-data, internal REST interface, and files.</p>
+    <p>By providing unexpected URLs, attackers can trick the application to send malicious requests, possibly bypassing access controls such as firewalls that prevent the attackers from accessing those URLs directly. The server can be used as a proxy to conduct port scanning of hosts in internal networks, use other URLs such as that can access documents on the system (using file:// or jar://), or use other content protocols such as gopher:// or tftp://, or invoke internal REST APIs.</p>
+    <p>This query detects the following two scenarios:</p>
+    <ol>
+      <li>Java networking uri.openConnection() and its derived uri.openStream(), which is a shorthand for openConnection().getInputStream(), from remote source.</li>
+      <li>Apache HTTPRequest constructed from remote source.</li>
+    </ol>
+  </overview>
+
+  <recommendation>
+    <p>Properly validate URLs and only send requests to identified and trusted applications and services.</p>
+  </recommendation>
+
+  <example>
+    <p>The following example shows both 'BAD' and 'GOOD' configurations. In the 'BAD' configuration, remote source is not validated before sending requests. In the 'GOOD' configuration, remote source is validated before sending requests.</p>
+    <sample src="SSRF.java" />
+  </example>
+
+  <references>
+    <li>
+      <a href="https://cwe.mitre.org/data/definitions/918.html">CWE-918: Server-Side Request Forgery (SSRF)</a>
+      <a href="https://owasp.org/www-community/attacks/Server_Side_Request_Forgery">OWASP - Server Side Request Forgery</a>
+      <a href="https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html">Server Side Request Forgery Prevention</a>
+      <a href="https://www.ciphertechs.com/blog/hawtio-advisory/">CVE-2019-9827:  Unauthenticated Server-Side Request Forgery (SSRF) with Hawtio up to and including version 2.5.0</a>
+    </li>
+  </references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.ql
@@ -1,0 +1,76 @@
+/**
+ * @name Open URLs created from remote source
+ * @description Mishandling of malicious URLs makes an application to interact with the internal/external network or the machine itself, which discloses sensitive information or enables further attacks.
+ * @kind path-problem
+ * @tags security
+ *       external/cwe/cwe-918
+ */
+
+import java
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+class URLConstructor extends ClassInstanceExpr {
+  URLConstructor() { this.getConstructor().getDeclaringType() instanceof TypeUrl }
+
+  Expr stringArg() {
+    // Query only in URL's that were constructed by calling the single parameter string constructor.
+    this.getConstructor().getNumberOfParameters() = 1 and
+    this.getConstructor().getParameter(0).getType() instanceof TypeString and
+    result = this.getArgument(0)
+  }
+}
+
+/** The type `org.apache.http.message.BasicHttpEntityEnclosingRequest` and "org.apache.http.message.BasicHttpRequest". */
+class TypeApacheHttpRequest extends RefType {
+  TypeApacheHttpRequest() {
+    hasQualifiedName("org.apache.http.message", "BasicHttpEntityEnclosingRequest") or
+    hasQualifiedName("org.apache.http.message", "BasicHttpRequest")
+  }
+}
+
+/** Constructor call of Apache HttpRequest */
+class ApacheHttpRequestConstructor extends ClassInstanceExpr {
+  ApacheHttpRequestConstructor() {
+    this.getConstructor().getDeclaringType() instanceof TypeApacheHttpRequest
+  }
+}
+
+/** Open URL methods of `java.net.URL` */
+class URLOpenMethod extends Method {
+  URLOpenMethod() {
+    this.getDeclaringType() instanceof TypeUrl and
+    (
+      this.getName() = "openConnection" or
+      this.getName() = "openStream"
+    )
+  }
+}
+
+class RemoteInputToURLOpenMethodFlowConfig extends TaintTracking::Configuration {
+  RemoteInputToURLOpenMethodFlowConfig() { this = "SSRF::RemoteInputToURLOpenMethodFlowConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      sink.asExpr() = ma.getQualifier() and
+      ma.getMethod() instanceof URLOpenMethod
+    )
+    or
+    exists(ApacheHttpRequestConstructor cc | sink.asExpr() = cc.getAnArgument())
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+    exists(URLConstructor u |
+      node1.asExpr() = u.stringArg() and
+      node2.asExpr() = u
+    )
+  }
+}
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, RemoteInputToURLOpenMethodFlowConfig c
+where c.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "URL constructed from remote source $@ ", source.getNode(),
+  "could be vulnerable to SSRF attack"

--- a/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-918/SSRF.ql
@@ -62,6 +62,14 @@ class RemoteInputToURLOpenMethodFlowConfig extends TaintTracking::Configuration 
     exists(ApacheHttpRequestConstructor cc | sink.asExpr() = cc.getAnArgument())
   }
 
+  override predicate isSanitizer(DataFlow::Node node) {
+    exists(IfStmt is, Variable v |
+      node.asExpr().getEnclosingStmt().getEnclosingStmt*() = is and
+      is.getCondition().getAChildExpr() = v.getAnAccess() and
+      node.asExpr().(VarAccess).getVariable() = v
+    )
+  }
+
   override predicate isAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
     exists(URLConstructor u |
       node1.asExpr() = u.stringArg() and

--- a/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.expected
@@ -1,0 +1,18 @@
+edges
+| SSRF.java:21:19:21:52 | getParameter(...) : String | SSRF.java:23:23:23:25 | uri |
+| SSRF.java:28:19:28:52 | getParameter(...) : String | SSRF.java:30:25:30:27 | uri |
+| SSRF.java:37:28:37:61 | getParameter(...) : String | SSRF.java:46:97:46:111 | proxyRequestUri |
+| SSRF.java:37:28:37:61 | getParameter(...) : String | SSRF.java:48:48:48:62 | proxyRequestUri |
+nodes
+| SSRF.java:21:19:21:52 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| SSRF.java:23:23:23:25 | uri | semmle.label | uri |
+| SSRF.java:28:19:28:52 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| SSRF.java:30:25:30:27 | uri | semmle.label | uri |
+| SSRF.java:37:28:37:61 | getParameter(...) : String | semmle.label | getParameter(...) : String |
+| SSRF.java:46:97:46:111 | proxyRequestUri | semmle.label | proxyRequestUri |
+| SSRF.java:48:48:48:62 | proxyRequestUri | semmle.label | proxyRequestUri |
+#select
+| SSRF.java:23:23:23:25 | uri | SSRF.java:21:19:21:52 | getParameter(...) : String | SSRF.java:23:23:23:25 | uri | URL constructed from remote source $@  | SSRF.java:21:19:21:52 | getParameter(...) | could be vulnerable to SSRF attack |
+| SSRF.java:30:25:30:27 | uri | SSRF.java:28:19:28:52 | getParameter(...) : String | SSRF.java:30:25:30:27 | uri | URL constructed from remote source $@  | SSRF.java:28:19:28:52 | getParameter(...) | could be vulnerable to SSRF attack |
+| SSRF.java:46:97:46:111 | proxyRequestUri | SSRF.java:37:28:37:61 | getParameter(...) : String | SSRF.java:46:97:46:111 | proxyRequestUri | URL constructed from remote source $@  | SSRF.java:37:28:37:61 | getParameter(...) | could be vulnerable to SSRF attack |
+| SSRF.java:48:48:48:62 | proxyRequestUri | SSRF.java:37:28:37:61 | getParameter(...) : String | SSRF.java:48:48:48:62 | proxyRequestUri | URL constructed from remote source $@  | SSRF.java:37:28:37:61 | getParameter(...) | could be vulnerable to SSRF attack |

--- a/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.java
@@ -1,0 +1,52 @@
+import java.io.InputStream;
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URLConnection;
+import java.net.URI;
+import java.net.URL;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+
+class SSRF {
+	/** Test url.openStream() */
+	public void openUrlStream(HttpServletRequest servletRequest) {
+		String urlStr = servletRequest.getParameter("url");
+		URL uri = new URL(urlStr);
+		InputStream input = uri.openStream();
+	}
+
+	/** Test url.openConnection() */
+	public void openUrlConnection(HttpServletRequest servletRequest) {
+		String urlStr = servletRequest.getParameter("url");
+		URL uri = new URL(urlStr);
+		URLConnection input = uri.openConnection();
+	}
+
+	/** Test Apache HttpRequest */
+	public void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
+			throws ServletException, IOException {
+		String method = servletRequest.getMethod();
+		String proxyRequestUri = servletRequest.getParameter("url");
+
+		URI targetUriObj = new URI(proxyRequestUri);
+
+		HttpRequest proxyRequest;
+		// spec: RFC 2616, sec 4.3: either of these two headers signal that there is a
+		// message body.
+		if (servletRequest.getHeader("CONTENT_LENGTH") != null
+				|| servletRequest.getHeader("TRANSFER_ENCODING") != null) {
+				BasicHttpEntityEnclosingRequest eProxyRequest = new BasicHttpEntityEnclosingRequest(method, proxyRequestUri);
+		} else {
+			proxyRequest = new BasicHttpRequest(method, proxyRequestUri);
+		}
+	}
+
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.java
@@ -49,4 +49,35 @@ class SSRF {
 		}
 	}
 
+	/** Test GOOD case of url.openConnection() */
+	public void openUrlConnection2(HttpServletRequest servletRequest) {
+		String urlStr = servletRequest.getParameter("url");
+		if (urlStr.startsWith("https://www.mycorp.com")) {
+			URL uri = new URL(urlStr);
+			URLConnection input = uri.openConnection();
+		}
+	}
+
+	/** Test GOOD case of Apache HttpRequest */
+	public void service2(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
+			throws ServletException, IOException {
+		String method = servletRequest.getMethod();
+		String proxyRequestUri = servletRequest.getParameter("url");
+
+		URI targetUriObj = new URI(proxyRequestUri);
+
+		HttpRequest proxyRequest;
+		// spec: RFC 2616, sec 4.3: either of these two headers signal that there is a
+		// message body.
+		if (proxyRequestUri.startsWith("https://www.mycorp.com")) {
+			if (servletRequest.getHeader("CONTENT_LENGTH") != null
+					|| servletRequest.getHeader("TRANSFER_ENCODING") != null) {
+				BasicHttpEntityEnclosingRequest eProxyRequest = new BasicHttpEntityEnclosingRequest(method,
+						proxyRequestUri);
+			} else {
+				proxyRequest = new BasicHttpRequest(method, proxyRequestUri);
+			}
+		}
+	}
+
 }

--- a/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-918/SSRF.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-918/SSRF.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-918/options
+++ b/java/ql/test/experimental/query-tests/security/CWE-918/options
@@ -1,0 +1,1 @@
+// semmle-extractor-options: --javac-args -cp ${testdir}/../../../../stubs/apache-http-4.4.13:${testdir}/../../../../stubs/servlet-api-2.4

--- a/java/ql/test/stubs/apache-http-4.4.13/NOTICE
+++ b/java/ql/test/stubs/apache-http-4.4.13/NOTICE
@@ -1,0 +1,193 @@
+
+   Copyright 2001-2004 The Apache Software Foundation.
+   Copyright 2001-2006 The Apache Software Foundation.
+   Copyright 2003-2004 The Apache Software Foundation.
+   Copyright 2004 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/Header.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/Header.java
@@ -1,0 +1,70 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/Header.java $
+ * $Revision: 569636 $
+ * $Date: 2007-08-25 00:34:47 -0700 (Sat, 25 Aug 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * Represents an HTTP header field.
+ * 
+ * <p>
+ * The HTTP header fields follow the same generic format as that given in
+ * Section 3.1 of RFC 822. Each header field consists of a name followed by a
+ * colon (":") and the field value. Field names are case-insensitive. The field
+ * value MAY be preceded by any amount of LWS, though a single SP is preferred.
+ *
+ * <pre>
+ *     message-header = field-name ":" [ field-value ]
+ *     field-name     = token
+ *     field-value    = *( field-content | LWS )
+ *     field-content  = &lt;the OCTETs making up the field-value
+ *                      and consisting of either *TEXT or combinations
+ *                      of token, separators, and quoted-string&gt;
+ * </pre>
+ * 
+ * @author <a href="mailto:remm@apache.org">Remy Maucherat</a>
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ * @version $Revision: 569636 $
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface Header {
+
+    String getName();
+
+    String getValue();
+
+    HeaderElement[] getElements() throws ParseException;
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElement.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElement.java
@@ -1,0 +1,65 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HeaderElement.java $
+ * $Revision: 569828 $
+ * $Date: 2007-08-26 08:49:38 -0700 (Sun, 26 Aug 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * One element of an HTTP {@link Header header} value.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ *
+ *         <!-- empty lines above to avoid 'svn diff' context problems -->
+ * @version $Revision: 569828 $ $Date: 2007-08-26 08:49:38 -0700 (Sun, 26 Aug
+ *          2007) $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface HeaderElement {
+
+    String getName();
+
+    String getValue();
+
+    NameValuePair[] getParameters();
+
+    NameValuePair getParameterByName(String name);
+
+    int getParameterCount();
+
+    NameValuePair getParameter(int index);
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElementIterator.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderElementIterator.java
@@ -1,0 +1,66 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HeaderElementIterator.java $
+ * $Revision: 584542 $
+ * $Date: 2007-10-14 06:29:34 -0700 (Sun, 14 Oct 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+import java.util.Iterator;
+
+/**
+ * A type-safe iterator for {@link HeaderElement HeaderElement} objects.
+ * 
+ * @version $Revision: 584542 $
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead.
+ *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     for further details.
+ */
+@Deprecated
+public interface HeaderElementIterator extends Iterator {
+    
+    /**
+     * Indicates whether there is another header element in this 
+     * iteration.
+     *
+     * @return  <code>true</code> if there is another header element,
+     *          <code>false</code> otherwise
+     */
+    boolean hasNext();
+    
+    /**
+     * Obtains the next header element from this iteration.
+     * This method should only be called while {@link #hasNext hasNext}
+     * is true.
+     *
+     * @return  the next header element in this iteration
+     */
+    HeaderElement nextElement();
+    
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderIterator.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HeaderIterator.java
@@ -1,0 +1,64 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HeaderIterator.java $
+ * $Revision: 581981 $
+ * $Date: 2007-10-04 11:26:26 -0700 (Thu, 04 Oct 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+import java.util.Iterator;
+
+/**
+ * A type-safe iterator for {@link Header Header} objects.
+ * 
+ * @version $Revision: 581981 $
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface HeaderIterator extends Iterator {
+
+    /**
+     * Indicates whether there is another header in this iteration.
+     *
+     * @return <code>true</code> if there is another header, <code>false</code>
+     *         otherwise
+     */
+    boolean hasNext();
+
+    /**
+     * Obtains the next header from this iteration. This method should only be
+     * called while {@link #hasNext hasNext} is true.
+     *
+     * @return the next header in this iteration
+     */
+    Header nextHeader();
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpEntity.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpEntity.java
@@ -1,0 +1,186 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HttpEntity.java $
+ * $Revision: 645824 $
+ * $Date: 2008-04-08 03:12:41 -0700 (Tue, 08 Apr 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * An entity that can be sent or received with an HTTP message. Entities can be
+ * found in some {@link HttpEntityEnclosingRequest requests} and in
+ * {@link HttpResponse responses}, where they are optional.
+ * <p>
+ * In some places, the JavaDoc distinguishes three kinds of entities, depending
+ * on where their {@link #getContent content} originates:
+ * <ul>
+ * <li><b>streamed</b>: The content is received from a stream, or generated on
+ * the fly. In particular, this category includes entities being received from a
+ * {@link HttpConnection connection}. {@link #isStreaming Streamed} entities are
+ * generally not {@link #isRepeatable repeatable}.</li>
+ * <li><b>self-contained</b>: The content is in memory or obtained by means that
+ * are independent from a connection or other entity. Self-contained entities
+ * are generally {@link #isRepeatable repeatable}.</li>
+ * <li><b>wrapping</b>: The content is obtained from another entity.</li>
+ * </ul>
+ * This distinction is important for connection management with incoming
+ * entities. For entities that are created by an application and only sent using
+ * the HTTP components framework, the difference between streamed and
+ * self-contained is of little importance. In that case, it is suggested to
+ * consider non-repeatable entities as streamed, and those that are repeatable
+ * (without a huge effort) as self-contained.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 645824 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface HttpEntity {
+
+    /**
+     * Tells if the entity is capable to produce its data more than once. A
+     * repeatable entity's getContent() and writeTo(OutputStream) methods can be
+     * called more than once whereas a non-repeatable entity's can not.
+     * 
+     * @return true if the entity is repeatable, false otherwise.
+     */
+    boolean isRepeatable();
+
+    /**
+     * Tells about chunked encoding for this entity. The primary purpose of this
+     * method is to indicate whether chunked encoding should be used when the entity
+     * is sent. For entities that are received, it can also indicate whether the
+     * entity was received with chunked encoding. <br/>
+     * The behavior of wrapping entities is implementation dependent, but should
+     * respect the primary purpose.
+     *
+     * @return <code>true</code> if chunked encoding is preferred for this entity,
+     *         or <code>false</code> if it is not
+     */
+    boolean isChunked();
+
+    /**
+     * Tells the length of the content, if known.
+     *
+     * @return the number of bytes of the content, or a negative number if unknown.
+     *         If the content length is known but exceeds
+     *         {@link java.lang.Long#MAX_VALUE Long.MAX_VALUE}, a negative number is
+     *         returned.
+     */
+    long getContentLength();
+
+    /**
+     * Obtains the Content-Type header, if known. This is the header that should be
+     * used when sending the entity, or the one that was received with the entity.
+     * It can include a charset attribute.
+     *
+     * @return the Content-Type header for this entity, or <code>null</code> if the
+     *         content type is unknown
+     */
+    Header getContentType();
+
+    /**
+     * Obtains the Content-Encoding header, if known. This is the header that should
+     * be used when sending the entity, or the one that was received with the
+     * entity. Wrapping entities that modify the content encoding should adjust this
+     * header accordingly.
+     *
+     * @return the Content-Encoding header for this entity, or <code>null</code> if
+     *         the content encoding is unknown
+     */
+    Header getContentEncoding();
+
+    /**
+     * Creates a new InputStream object of the entity. It is a programming error to
+     * return the same InputStream object more than once. Entities that are not
+     * {@link #isRepeatable repeatable} will throw an exception if this method is
+     * called multiple times.
+     *
+     * @return a new input stream that returns the entity data.
+     *
+     * @throws IOException           if the stream could not be created
+     * @throws IllegalStateException if this entity is not repeatable and the stream
+     *                               has already been obtained previously
+     */
+    InputStream getContent() throws IOException, IllegalStateException;
+
+    /**
+     * Writes the entity content to the output stream.
+     * 
+     * @param outstream the output stream to write entity content to
+     * 
+     * @throws IOException if an I/O error occurs
+     */
+    void writeTo(OutputStream outstream) throws IOException;
+
+    /**
+     * Tells whether this entity depends on an underlying stream. Streamed entities
+     * should return <code>true</code> until the content has been consumed,
+     * <code>false</code> afterwards. Self-contained entities should return
+     * <code>false</code>. Wrapping entities should delegate this call to the
+     * wrapped entity. <br/>
+     * The content of a streamed entity is consumed when the stream returned by
+     * {@link #getContent getContent} has been read to EOF, or after
+     * {@link #consumeContent consumeContent} has been called. If a streamed entity
+     * can not detect whether the stream has been read to EOF, it should return
+     * <code>true</code> until {@link #consumeContent consumeContent} is called.
+     *
+     * @return <code>true</code> if the entity content is streamed and not yet
+     *         consumed, <code>false</code> otherwise
+     */
+    boolean isStreaming(); // don't expect an exception here
+
+    /**
+     * TODO: The name of this method is misnomer. It will be renamed to #finish() in
+     * the next major release. <br/>
+     * This method is called to indicate that the content of this entity is no
+     * longer required. All entity implementations are expected to release all
+     * allocated resources as a result of this method invocation. Content streaming
+     * entities are also expected to dispose of the remaining content, if any.
+     * Wrapping entities should delegate this call to the wrapped entity. <br/>
+     * This method is of particular importance for entities being received from a
+     * {@link HttpConnection connection}. The entity needs to be consumed completely
+     * in order to re-use the connection with keep-alive.
+     *
+     * @throws IOException if an I/O error occurs. This indicates that connection
+     *                     keep-alive is not possible.
+     */
+    void consumeContent() throws IOException;
+
+} // interface HttpEntity

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpEntityEnclosingRequest.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpEntityEnclosingRequest.java
@@ -1,0 +1,70 @@
+/*
+ * $Header: $
+ * $Revision: 618017 $
+ * $Date: 2008-02-03 08:42:22 -0800 (Sun, 03 Feb 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * A request with an entity.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 618017 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface HttpEntityEnclosingRequest extends HttpRequest {
+
+    /**
+     * Tells if this request should use the expect-continue handshake. The expect
+     * continue handshake gives the server a chance to decide whether to accept the
+     * entity enclosing request before the possibly lengthy entity is sent across
+     * the wire.
+     * 
+     * @return true if the expect continue handshake should be used, false if not.
+     */
+    boolean expectContinue();
+
+    /**
+     * Hands the entity to the request.
+     * 
+     * @param entity the entity to send.
+     */
+    void setEntity(HttpEntity entity);
+
+    HttpEntity getEntity();
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpMessage.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpMessage.java
@@ -1,0 +1,196 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HttpMessage.java $
+ * $Revision: 610823 $
+ * $Date: 2008-01-10 07:53:53 -0800 (Thu, 10 Jan 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+import org.apache.http.params.HttpParams;
+
+/**
+ * A generic HTTP message.
+ * Holds what is common between requests and responses.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 610823 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead.
+ *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     for further details.
+ */
+@Deprecated
+public interface HttpMessage {
+    
+    /**
+     * Returns the protocol version this message is compatible with.
+     */
+    ProtocolVersion getProtocolVersion();
+
+    /**
+     * Checks if a certain header is present in this message. Header values are
+     * ignored.
+     * 
+     * @param name the header name to check for.
+     * @return true if at least one header with this name is present.
+     */
+    boolean containsHeader(String name);
+    
+    /**
+     * Returns all the headers with a specified name of this message. Header values
+     * are ignored. Headers are orderd in the sequence they will be sent over a
+     * connection.
+     * 
+     * @param name the name of the headers to return.
+     * @return the headers whose name property equals <code>name</code>.
+     */
+    Header[] getHeaders(String name);
+
+    /**
+     * Returns the first header with a specified name of this message. Header
+     * values are ignored. If there is more than one matching header in the
+     * message the first element of {@link #getHeaders(String)} is returned.
+     * If there is no matching header in the message <code>null</code> is 
+     * returned.
+     * 
+     * @param name the name of the header to return.
+     * @return the first header whose name property equals <code>name</code>
+     *   or <code>null</code> if no such header could be found.
+     */
+    Header getFirstHeader(String name);
+
+    /**
+     * Returns the last header with a specified name of this message. Header values
+     * are ignored. If there is more than one matching header in the message the
+     * last element of {@link #getHeaders(String)} is returned. If there is no 
+     * matching header in the message <code>null</code> is returned.
+     * 
+     * @param name the name of the header to return.
+     * @return the last header whose name property equals <code>name</code>.
+     *   or <code>null</code> if no such header could be found.
+     */
+    Header getLastHeader(String name);
+
+    /**
+     * Returns all the headers of this message. Headers are orderd in the sequence
+     * they will be sent over a connection.
+     * 
+     * @return all the headers of this message
+     */
+    Header[] getAllHeaders();
+
+    /**
+     * Adds a header to this message. The header will be appended to the end of
+     * the list.
+     * 
+     * @param header the header to append.
+     */
+    void addHeader(Header header);
+
+    /**
+     * Adds a header to this message. The header will be appended to the end of
+     * the list.
+     * 
+     * @param name the name of the header.
+     * @param value the value of the header.
+     */
+    void addHeader(String name, String value);
+
+    /**
+     * Overwrites the first header with the same name. The new header will be appended to 
+     * the end of the list, if no header with the given name can be found.
+     * 
+     * @param header the header to set.
+     */
+    void setHeader(Header header);
+
+    /**
+     * Overwrites the first header with the same name. The new header will be appended to 
+     * the end of the list, if no header with the given name can be found.
+     * 
+     * @param name the name of the header.
+     * @param value the value of the header.
+     */
+    void setHeader(String name, String value);
+
+    /**
+     * Overwrites all the headers in the message.
+     * 
+     * @param headers the array of headers to set.
+     */
+    void setHeaders(Header[] headers);
+
+    /**
+     * Removes a header from this message.
+     * 
+     * @param header the header to remove.
+     */
+    void removeHeader(Header header);
+    
+    /**
+     * Removes all headers with a certain name from this message.
+     * 
+     * @param name The name of the headers to remove.
+     */
+    void removeHeaders(String name);
+    
+    /**
+     * Returns an iterator of all the headers.
+     * 
+     * @return Iterator that returns Header objects in the sequence they are
+     *         sent over a connection.
+     */
+    HeaderIterator headerIterator();
+
+    /**
+     * Returns an iterator of the headers with a given name.
+     *
+     * @param name      the name of the headers over which to iterate, or
+     *                  <code>null</code> for all headers
+     *
+     * @return Iterator that returns Header objects with the argument name
+     *         in the sequence they are sent over a connection.
+     */
+    HeaderIterator headerIterator(String name);
+
+    /**
+     * Returns the parameters effective for this message as set by
+     * {@link #setParams(HttpParams)}.
+     */
+    HttpParams getParams();
+
+    /**
+     * Provides parameters to be used for the processing of this message.
+     * @param params the parameters
+     */
+    void setParams(HttpParams params);
+        
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpRequest.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/HttpRequest.java
@@ -1,0 +1,58 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/HttpRequest.java $
+ * $Revision: 528428 $
+ * $Date: 2007-04-13 03:26:04 -0700 (Fri, 13 Apr 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * An HTTP request.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 528428 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface HttpRequest extends HttpMessage {
+
+    /**
+     * Returns the request line of this request.
+     * 
+     * @return the request line.
+     */
+    RequestLine getRequestLine();
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/NameValuePair.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/NameValuePair.java
@@ -1,0 +1,124 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/NameValuePair.java $
+ * $Revision: 496070 $
+ * $Date: 2007-01-14 04:18:34 -0800 (Sun, 14 Jan 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * A simple class encapsulating an attribute/value pair.
+ * <p>
+ * This class comforms to the generic grammar and formatting rules outlined in
+ * the <a href=
+ * "http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2">Section
+ * 2.2</a> and <a href=
+ * "http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.6">Section
+ * 3.6</a> of <a href="http://www.w3.org/Protocols/rfc2616/rfc2616.txt">RFC
+ * 2616</a>
+ * </p>
+ * <h>2.2 Basic Rules</h>
+ * <p>
+ * The following rules are used throughout this specification to describe basic
+ * parsing constructs. The US-ASCII coded character set is defined by ANSI
+ * X3.4-1986.
+ * </p>
+ * 
+ * <pre>
+ *     OCTET          = <any 8-bit sequence of data>
+ *     CHAR           = <any US-ASCII character (octets 0 - 127)>
+ *     UPALPHA        = <any US-ASCII uppercase letter "A".."Z">
+ *     LOALPHA        = <any US-ASCII lowercase letter "a".."z">
+ *     ALPHA          = UPALPHA | LOALPHA
+ *     DIGIT          = <any US-ASCII digit "0".."9">
+ *     CTL            = <any US-ASCII control character
+ *                      (octets 0 - 31) and DEL (127)>
+ *     CR             = <US-ASCII CR, carriage return (13)>
+ *     LF             = <US-ASCII LF, linefeed (10)>
+ *     SP             = <US-ASCII SP, space (32)>
+ *     HT             = <US-ASCII HT, horizontal-tab (9)>
+ *     <">            = <US-ASCII double-quote mark (34)>
+ * </pre>
+ * <p>
+ * Many HTTP/1.1 header field values consist of words separated by LWS or
+ * special characters. These special characters MUST be in a quoted string to be
+ * used within a parameter value (as defined in section 3.6).
+ * <p>
+ * 
+ * <pre>
+ * token          = 1*<any CHAR except CTLs or separators>
+ * separators     = "(" | ")" | "<" | ">" | "@"
+ *                | "," | ";" | ":" | "\" | <">
+ *                | "/" | "[" | "]" | "?" | "="
+ *                | "{" | "}" | SP | HT
+ * </pre>
+ * <p>
+ * A string of text is parsed as a single word if it is quoted using
+ * double-quote marks.
+ * </p>
+ * 
+ * <pre>
+ * quoted-string  = ( <"> *(qdtext | quoted-pair ) <"> )
+ * qdtext         = <any TEXT except <">>
+ * </pre>
+ * <p>
+ * The backslash character ("\") MAY be used as a single-character quoting
+ * mechanism only within quoted-string and comment constructs.
+ * </p>
+ * 
+ * <pre>
+ * quoted-pair    = "\" CHAR
+ * </pre>
+ * 
+ * <h>3.6 Transfer Codings</h>
+ * <p>
+ * Parameters are in the form of attribute/value pairs.
+ * </p>
+ * 
+ * <pre>
+ * parameter               = attribute "=" value
+ * attribute               = token
+ * value                   = token | quoted-string
+ * </pre>
+ * 
+ * @author <a href="mailto:oleg at ural.com">Oleg Kalnichevski</a>
+ * 
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface NameValuePair {
+
+    String getName();
+
+    String getValue();
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/ParseException.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/ParseException.java
@@ -1,0 +1,64 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/ParseException.java $
+ * $Revision: 609106 $
+ * $Date: 2008-01-05 01:15:42 -0800 (Sat, 05 Jan 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * Indicates a parse error. Parse errors when receiving a message will typically
+ * trigger {@link ProtocolException}. Parse errors that do not occur during
+ * protocol execution may be handled differently. This is an unchecked
+ * exceptions, since there are cases where the data to be parsed has been
+ * generated and is therefore known to be parseable.
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public class ParseException extends RuntimeException {
+    /**
+     * Creates a {@link ParseException} without details.
+     */
+    public ParseException() {
+    }
+
+    /**
+     * Creates a {@link ParseException} with a detail message.
+     * 
+     * @param message the exception detail message, or <code>null</code>
+     */
+    public ParseException(String message) {
+    }
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/ProtocolVersion.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/ProtocolVersion.java
@@ -1,0 +1,211 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/ProtocolVersion.java $
+ * $Revision: 609106 $
+ * $Date: 2008-01-05 01:15:42 -0800 (Sat, 05 Jan 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+import java.io.Serializable;
+
+/**
+ * Represents a protocol version, as specified in RFC 2616. RFC 2616 specifies
+ * only HTTP versions, like "HTTP/1.1" and "HTTP/1.0". RFC 3261 specifies a
+ * message format that is identical to HTTP except for the protocol name. It
+ * defines a protocol version "SIP/2.0". There are some nitty-gritty differences
+ * between the interpretation of versions in HTTP and SIP. In those cases, HTTP
+ * takes precedence.
+ * <p>
+ * This class defines a protocol version as a combination of protocol name,
+ * major version number, and minor version number. Note that {@link #equals} and
+ * {@link #hashCode} are defined as final here, they cannot be overridden in
+ * derived classes.
+ * 
+ * @author <a href="mailto:oleg@ural.ru">Oleg Kalnichevski</a>
+ * @author <a href="mailto:rolandw at apache.org">Roland Weber</a>
+ * 
+ * @version $Revision: 609106 $
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public class ProtocolVersion implements Serializable, Cloneable {
+    /**
+     * Create a protocol version designator.
+     *
+     * @param protocol the name of the protocol, for example "HTTP"
+     * @param major    the major version number of the protocol
+     * @param minor    the minor version number of the protocol
+     */
+    public ProtocolVersion(String protocol, int major, int minor) {
+    }
+
+    /**
+     * Returns the name of the protocol.
+     * 
+     * @return the protocol name
+     */
+    public final String getProtocol() {
+        return null;
+    }
+
+    /**
+     * Returns the major version number of the protocol.
+     * 
+     * @return the major version number.
+     */
+    public final int getMajor() {
+        return -1;
+    }
+
+    /**
+     * Returns the minor version number of the HTTP protocol.
+     * 
+     * @return the minor version number.
+     */
+    public final int getMinor() {
+        return -1;
+    }
+
+    /**
+     * Obtains a specific version of this protocol. This can be used by derived
+     * classes to instantiate themselves instead of the base class, and to define
+     * constants for commonly used versions. <br/>
+     * The default implementation in this class returns <code>this</code> if the
+     * version matches, and creates a new {@link ProtocolVersion} otherwise.
+     *
+     * @param major the major version
+     * @param minor the minor version
+     *
+     * @return a protocol version with the same protocol name and the argument
+     *         version
+     */
+    public ProtocolVersion forVersion(int major, int minor) {
+        return null;
+    }
+
+    /**
+     * Obtains a hash code consistent with {@link #equals}.
+     *
+     * @return the hashcode of this protocol version
+     */
+    public final int hashCode() {
+        return -1;
+    }
+
+    /**
+     * Checks equality of this protocol version with an object. The object is equal
+     * if it is a protocl version with the same protocol name, major version number,
+     * and minor version number. The specific class of the object is <i>not</i>
+     * relevant, instances of derived classes with identical attributes are equal to
+     * instances of the base class and vice versa.
+     *
+     * @param obj the object to compare with
+     *
+     * @return <code>true</code> if the argument is the same protocol version,
+     *         <code>false</code> otherwise
+     */
+    public final boolean equals(Object obj) {
+        return false;
+    }
+
+    /**
+     * Checks whether this protocol can be compared to another one. Only protocol
+     * versions with the same protocol name can be {@link #compareToVersion
+     * compared}.
+     *
+     * @param that the protocol version to consider
+     *
+     * @return <code>true</code> if {@link #compareToVersion compareToVersion} can
+     *         be called with the argument, <code>false</code> otherwise
+     */
+    public boolean isComparable(ProtocolVersion that) {
+        return false;
+    }
+
+    /**
+     * Compares this protocol version with another one. Only protocol versions with
+     * the same protocol name can be compared. This method does <i>not</i> define a
+     * total ordering, as it would be required for {@link java.lang.Comparable}.
+     *
+     * @param that the protocl version to compare with
+     * 
+     * @return a negative integer, zero, or a positive integer as this version is
+     *         less than, equal to, or greater than the argument version.
+     *
+     * @throws IllegalArgumentException if the argument has a different protocol
+     *                                  name than this object, or if the argument is
+     *                                  <code>null</code>
+     */
+    public int compareToVersion(ProtocolVersion that) {
+        return -1;
+    }
+
+    /**
+     * Tests if this protocol version is greater or equal to the given one.
+     *
+     * @param version the version against which to check this version
+     *
+     * @return <code>true</code> if this protocol version is {@link #isComparable
+     *         comparable} to the argument and {@link #compareToVersion compares} as
+     *         greater or equal, <code>false</code> otherwise
+     */
+    public final boolean greaterEquals(ProtocolVersion version) {
+        return false;
+    }
+
+    /**
+     * Tests if this protocol version is less or equal to the given one.
+     *
+     * @param version the version against which to check this version
+     *
+     * @return <code>true</code> if this protocol version is {@link #isComparable
+     *         comparable} to the argument and {@link #compareToVersion compares} as
+     *         less or equal, <code>false</code> otherwise
+     */
+    public final boolean lessEquals(ProtocolVersion version) {
+        return false;
+    }
+
+    /**
+     * Converts this protocol version to a string.
+     *
+     * @return a protocol version string, like "HTTP/1.1"
+     */
+    public String toString() {
+        return null;
+    }
+
+    public Object clone() throws CloneNotSupportedException {
+        return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/RequestLine.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/RequestLine.java
@@ -1,0 +1,58 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/RequestLine.java $
+ * $Revision: 573864 $
+ * $Date: 2007-09-08 08:53:25 -0700 (Sat, 08 Sep 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+/**
+ * The first line of an {@link HttpRequest HttpRequest}. It contains the method,
+ * URI, and HTTP version of the request. For details, see RFC 2616.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 573864 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public interface RequestLine {
+
+    String getMethod();
+
+    ProtocolVersion getProtocolVersion();
+
+    String getUri();
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/AbstractHttpMessage.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/AbstractHttpMessage.java
@@ -1,0 +1,128 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/message/AbstractHttpMessage.java $
+ * $Revision: 620287 $
+ * $Date: 2008-02-10 07:15:53 -0800 (Sun, 10 Feb 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.message;
+
+import java.util.Iterator;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpMessage;
+import org.apache.http.params.HttpParams;
+
+/**
+ * Basic implementation of an HTTP message that can be modified.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 620287 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public abstract class AbstractHttpMessage implements HttpMessage {
+    // non-javadoc, see interface HttpMessage
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public Header[] getHeaders(final String name) {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public Header getFirstHeader(final String name) {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public Header getLastHeader(final String name) {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public Header[] getAllHeaders() {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void addHeader(final Header header) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void addHeader(final String name, final String value) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void setHeader(final Header header) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void setHeader(final String name, final String value) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void setHeaders(final Header[] headers) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void removeHeader(final Header header) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void removeHeaders(final String name) {
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public HeaderIterator headerIterator() {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public HeaderIterator headerIterator(String name) {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public HttpParams getParams() {
+        return null;
+    }
+
+    // non-javadoc, see interface HttpMessage
+    public void setParams(final HttpParams params) {
+    }
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicHttpEntityEnclosingRequest.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicHttpEntityEnclosingRequest.java
@@ -1,0 +1,79 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/message/BasicHttpEntityEnclosingRequest.java $
+ * $Revision: 618017 $
+ * $Date: 2008-02-03 08:42:22 -0800 (Sun, 03 Feb 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.message;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+
+/**
+ * Basic implementation of a request with an entity that can be modified.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 618017 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public class BasicHttpEntityEnclosingRequest extends BasicHttpRequest implements HttpEntityEnclosingRequest {
+    public BasicHttpEntityEnclosingRequest(final String method, final String uri) {
+        super(method, uri);
+    }
+
+    public BasicHttpEntityEnclosingRequest(final String method, final String uri, final ProtocolVersion ver) {
+        super(method, uri, ver);
+    }
+
+    public BasicHttpEntityEnclosingRequest(final RequestLine requestline) {
+        super(requestline);
+    }
+
+    public HttpEntity getEntity() {
+        return null;
+    }
+
+    public void setEntity(final HttpEntity entity) {
+    }
+
+    public boolean expectContinue() {
+        return false;
+    }
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicHttpRequest.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/message/BasicHttpRequest.java
@@ -1,0 +1,71 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/message/BasicHttpRequest.java $
+ * $Revision: 573864 $
+ * $Date: 2007-09-08 08:53:25 -0700 (Sat, 08 Sep 2007) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.message;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.RequestLine;
+
+/**
+ * Basic implementation of an HTTP request that can be modified.
+ *
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ *
+ * @version $Revision: 573864 $
+ * 
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead. Please
+ *             visit <a href=
+ *             "http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this
+ *             webpage</a> for further details.
+ */
+@Deprecated
+public class BasicHttpRequest extends AbstractHttpMessage implements HttpRequest {
+    public BasicHttpRequest(final String method, final String uri) {
+    }
+
+    public BasicHttpRequest(final String method, final String uri, final ProtocolVersion ver) {
+    }
+
+    public BasicHttpRequest(final RequestLine requestline) {
+    }
+
+    public ProtocolVersion getProtocolVersion() {
+        return null;
+    }
+
+    public RequestLine getRequestLine() {
+        return null;
+    }
+
+}

--- a/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/params/HttpParams.java
+++ b/java/ql/test/stubs/apache-http-4.4.13/org/apache/http/params/HttpParams.java
@@ -1,0 +1,176 @@
+/*
+ * $HeadURL: http://svn.apache.org/repos/asf/httpcomponents/httpcore/trunk/module-main/src/main/java/org/apache/http/params/HttpParams.java $
+ * $Revision: 610763 $
+ * $Date: 2008-01-10 04:01:13 -0800 (Thu, 10 Jan 2008) $
+ *
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.params;
+/**
+ * Represents a collection of HTTP protocol and framework parameters.
+ *   
+ * @author <a href="mailto:oleg at ural.ru">Oleg Kalnichevski</a>
+ * 
+ * @version $Revision: 610763 $
+ *
+ * @since 4.0
+ *
+ * @deprecated Please use {@link java.net.URL#openConnection} instead.
+ *     Please visit <a href="http://android-developers.blogspot.com/2011/09/androids-http-clients.html">this webpage</a>
+ *     for further details.
+ */
+@Deprecated
+public interface HttpParams {
+    /** 
+     * Obtains the value of the given parameter.
+     * 
+     * @param name the parent name.
+     * 
+     * @return  an object that represents the value of the parameter,
+     *          <code>null</code> if the parameter is not set or if it
+     *          is explicitly set to <code>null</code>
+     * 
+     * @see #setParameter(String, Object)
+     */
+    Object getParameter(String name);
+    /**
+     * Assigns the value to the parameter with the given name.
+     *
+     * @param name parameter name
+     * @param value parameter value
+     */
+    HttpParams setParameter(String name, Object value);
+    /**
+     * Creates a copy of these parameters.
+     *
+     * @return  a new set of parameters holding the same values as this one
+     */
+    HttpParams copy();
+    
+    /**
+     * Removes the parameter with the specified name.
+     * 
+     * @param name parameter name
+     * 
+     * @return true if the parameter existed and has been removed, false else.
+     */
+    boolean removeParameter(String name);
+    /** 
+     * Returns a {@link Long} parameter value with the given name. 
+     * If the parameter is not explicitly set, the default value is returned.  
+     * 
+     * @param name the parent name.
+     * @param defaultValue the default value.
+     * 
+     * @return a {@link Long} that represents the value of the parameter.
+     * 
+     * @see #setLongParameter(String, long)
+     */
+    long getLongParameter(String name, long defaultValue);
+    /**
+     * Assigns a {@link Long} to the parameter with the given name
+     * 
+     * @param name parameter name
+     * @param value parameter value
+     */ 
+    HttpParams setLongParameter(String name, long value);
+    /** 
+     * Returns an {@link Integer} parameter value with the given name. 
+     * If the parameter is not explicitly set, the default value is returned.  
+     * 
+     * @param name the parent name.
+     * @param defaultValue the default value.
+     * 
+     * @return a {@link Integer} that represents the value of the parameter.
+     * 
+     * @see #setIntParameter(String, int)
+     */
+    int getIntParameter(String name, int defaultValue);
+    /**
+     * Assigns an {@link Integer} to the parameter with the given name
+     * 
+     * @param name parameter name
+     * @param value parameter value
+     */ 
+    HttpParams setIntParameter(String name, int value);
+    /** 
+     * Returns a {@link Double} parameter value with the given name. 
+     * If the parameter is not explicitly set, the default value is returned.  
+     *
+     * @param name the parent name.
+     * @param defaultValue the default value.
+     * 
+     * @return a {@link Double} that represents the value of the parameter.
+     * 
+     * @see #setDoubleParameter(String, double)
+     */
+    double getDoubleParameter(String name, double defaultValue);
+    /**
+     * Assigns a {@link Double} to the parameter with the given name
+     * 
+     * @param name parameter name
+     * @param value parameter value
+     */ 
+    HttpParams setDoubleParameter(String name, double value);
+    /** 
+     * Returns a {@link Boolean} parameter value with the given name. 
+     * If the parameter is not explicitly set, the default value is returned.  
+     * 
+     * @param name the parent name.
+     * @param defaultValue the default value.
+     * 
+     * @return a {@link Boolean} that represents the value of the parameter.
+     * 
+     * @see #setBooleanParameter(String, boolean)
+     */
+    boolean getBooleanParameter(String name, boolean defaultValue);
+    /**
+     * Assigns a {@link Boolean} to the parameter with the given name
+     * 
+     * @param name parameter name
+     * @param value parameter value
+     */ 
+    HttpParams setBooleanParameter(String name, boolean value);
+    /**
+     * Checks if a boolean parameter is set to <code>true</code>.
+     * 
+     * @param name parameter name
+     * 
+     * @return <tt>true</tt> if the parameter is set to value <tt>true</tt>,
+     *         <tt>false</tt> if it is not set or set to <code>false</code>
+     */
+    boolean isParameterTrue(String name);
+    /**
+     * Checks if a boolean parameter is not set or <code>false</code>.
+     * 
+     * @param name parameter name
+     * 
+     * @return <tt>true</tt> if the parameter is either not set or
+     *         set to value <tt>false</tt>,
+     *         <tt>false</tt> if it is set to <code>true</code>
+     */
+    boolean isParameterFalse(String name);
+}


### PR DESCRIPTION
Server Side Request Forgery (SSRF) is an attack vector that abuses an application to interact with the internal/external network or the machine itself, frequently through the attack vector of URL mishandling.

In an SSRF attack, the attacker can abuse functionality on the server to read or update internal resources, e.g. cloud server meta-data, internal REST interface, and protected files.

This query detects the following two scenarios:</p>
+ Java networking uri.openConnection() and its derived uri.openStream(), which is a shorthand for openConnection().getInputStream(), from remote source
+ Apache HTTPRequest constructed from remote source</li>

There are two existing queries in the CodeQL repository that handle two important/specific cases of this vulnerability category:
+ [CWE-319](https://github.com/github/codeql/blob/d9bc07cb912e8acfaec273f43e6dcfa3230c463d/java/ql/src/Security/CWE/CWE-319/UseSSL.ql) for cleartext HTTP connection
+ [CWE-036](https://github.com/github/codeql/blob/01157e43e35b4e8efb2d2c9e2fb875150bf7f637/java/ql/src/experimental/Security/CWE/CWE-036/OpenStream.ql) for the special case of openConnection().getInputStream() leading to local file disclosure

Thus this query has a broader scope and also covers the frequently used Apache HTTP library.

Please consider to merge the PR. Thanks. 