### PR TITLE
JS: Bad code polish

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -35,7 +35,7 @@
 | Incomplete HTML attribute sanitization (`js/incomplete-html-attribute-sanitization`) | security, external/cwe/cwe-20, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities due to incomplete sanitization of HTML meta-characters. Results are shown on LGTM by default. |
 | Unsafe expansion of self-closing HTML tag (`js/unsafe-html-expansion`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities caused by unsafe expansion of self-closing HTML tags. |
 | Unsafe shell command constructed from library input (`js/shell-command-constructed-from-input`) | correctness, security, external/cwe/cwe-078, external/cwe/cwe-088 | Highlights potential command injections due to a shell command being constructed from library inputs. Results are shown on LGTM by default. |
-| Improper code sanitization (`js/bad-code-sanitization`) | security, external/cwe/cwe-094, external/cwe/cwe-079 | Highlights string concatenation where code is constructed without proper sanitization. Results are shown on LGTM by default. |
+| Improper code sanitization (`js/bad-code-sanitization`) | security, external/cwe/cwe-094, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights string concatenation where code is constructed without proper sanitization. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -35,6 +35,7 @@
 | Incomplete HTML attribute sanitization (`js/incomplete-html-attribute-sanitization`) | security, external/cwe/cwe-20, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities due to incomplete sanitization of HTML meta-characters. Results are shown on LGTM by default. |
 | Unsafe expansion of self-closing HTML tag (`js/unsafe-html-expansion`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities caused by unsafe expansion of self-closing HTML tags. |
 | Unsafe shell command constructed from library input (`js/shell-command-constructed-from-input`) | correctness, security, external/cwe/cwe-078, external/cwe/cwe-088 | Highlights potential command injections due to a shell command being constructed from library inputs. Results are shown on LGTM by default. |
+| Improper code sanitization (`js/bad-code-sanitization`) | security, external/cwe/cwe-094, external/cwe/cwe-079 | Highlights string concatenation where code is constructed without proper sanitization. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
@@ -22,8 +22,8 @@
     <p>
       The example below constructs a function that assigns the number 42 to the property <code>key</code>
       on an object <code>obj</code>. However, if <code>key</code> contains <code>&lt;/script&gt;</code>, then 
-      the generated code will break out of a <code>&lt;script&gt;</code> if the generated code is inserted 
-      into a <code>&lt;script&gt;</code> tag.
+      the generated code will break out of a <code>&lt;/script&gt;</code> if inserted into a 
+      <code>&lt;/script&gt;</code> tag.
     </p>
     <sample src="examples/ImproperCodeSanitization.js" />
     <p>

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
@@ -3,35 +3,36 @@
   "qhelp.dtd">
 <qhelp>
 
-<overview>
-<p>
-Placeholder
-</p>
-</overview>
+  <overview>
+    <p>
+        Using string concatenation to construct JavaScript code can be error-prone, or in the worst
+        case enable code-injection if an input is constructed by an attacker.  
+    </p>
+  </overview>
 
-<recommendation>
-<p>
-Placeholder
-</p>
-</recommendation>
+  <recommendation>
+    <p>
+      If using <code>JSON.stringify</code> or a HTML sanitizer to sanitize a string inserted into 
+      JavaScript code, then make sure to perform additional sanitization or remove potentially
+      dangerous characters. 
+    </p>
+  </recommendation>
 
-<example>
-<p>
-Placeholder
-</p>
+  <example>
+    <p>
+      The below example constructs a function that assigns the number 42 to the property <code>key</code>
+      on an object <code>obj</code>. However, if <code>key</code> contains <code>&lt;/script&gt;</code>, then 
+      the generated code will break out of a <code>&lt;script&gt;</code> if the generated code is inserted 
+      into a <code>&lt;script&gt;</code> tag.
+    </p>
+    <sample src="examples/ImproperCodeSanitization.js" />
+    <p>
+      The issue has been fixed in the below by escaping potentially dangerous characters.
+    </p>
+    <sample src="examples/ImproperCodeSanitizationFixed.js" />
+  </example>
 
-</example>
-
-<references>
-<li>
-OWASP:
-<a href="https://www.owasp.org/index.php/Code_Injection">Code Injection</a>.
-</li>
-<li>
-MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects#Function_properties">Global functions</a>.
-</li>
-<li>
-MDN: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function">Function constructor</a>.
-</li>
-</references>
+  <references>
+    <li>OWASP: <a href="https://www.owasp.org/index.php/Code_Injection">Code Injection</a>.</li>
+  </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.qhelp
@@ -6,7 +6,7 @@
   <overview>
     <p>
         Using string concatenation to construct JavaScript code can be error-prone, or in the worst
-        case enable code-injection if an input is constructed by an attacker.  
+        case, enable code injection if an input is constructed by an attacker.  
     </p>
   </overview>
 
@@ -20,14 +20,14 @@
 
   <example>
     <p>
-      The below example constructs a function that assigns the number 42 to the property <code>key</code>
+      The example below constructs a function that assigns the number 42 to the property <code>key</code>
       on an object <code>obj</code>. However, if <code>key</code> contains <code>&lt;/script&gt;</code>, then 
       the generated code will break out of a <code>&lt;script&gt;</code> if the generated code is inserted 
       into a <code>&lt;script&gt;</code> tag.
     </p>
     <sample src="examples/ImproperCodeSanitization.js" />
     <p>
-      The issue has been fixed in the below by escaping potentially dangerous characters.
+      The issue has been fixed by escaping potentially dangerous characters, as shown below.
     </p>
     <sample src="examples/ImproperCodeSanitizationFixed.js" />
   </example>

--- a/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-094/ImproperCodeSanitization.ql
@@ -1,6 +1,6 @@
 /**
  * @name Improper code sanitization
- * @description Escaping code as HTML does not provide protection against code-injection.
+ * @description Escaping code as HTML does not provide protection against code injection.
  * @kind path-problem
  * @problem.severity error
  * @precision high
@@ -38,7 +38,7 @@ private DataFlow::Node remoteFlow(DataFlow::TypeTracker t) {
 private DataFlow::Node remoteFlow() { result = remoteFlow(DataFlow::TypeTracker::end()) }
 
 /**
- * Gets a type-back-tracked instance of a code-injection sink using type-tracker `t`.
+ * Gets a type-back-tracked instance of a code injection sink using type-tracker `t`.
  */
 private DataFlow::Node endsInCodeInjectionSink(DataFlow::TypeBackTracker t) {
   t.start() and
@@ -53,7 +53,7 @@ private DataFlow::Node endsInCodeInjectionSink(DataFlow::TypeBackTracker t) {
 }
 
 /**
- * Gets a reference to to a data-flow node that ends in a code-injection sink.
+ * Gets a reference to to a data-flow node that ends in a code injection sink.
  */
 private DataFlow::Node endsInCodeInjectionSink() {
   result = endsInCodeInjectionSink(DataFlow::TypeBackTracker::end())

--- a/javascript/ql/src/Security/CWE-094/examples/ImproperCodeSanitization.js
+++ b/javascript/ql/src/Security/CWE-094/examples/ImproperCodeSanitization.js
@@ -1,0 +1,4 @@
+function createObjectWrite() {
+    const assignment = `obj[${JSON.stringify(key)}]=42`;
+    return `(function(){${assignment}})` // NOT OK
+}

--- a/javascript/ql/src/Security/CWE-094/examples/ImproperCodeSanitizationFixed.js
+++ b/javascript/ql/src/Security/CWE-094/examples/ImproperCodeSanitizationFixed.js
@@ -1,0 +1,23 @@
+const charMap = {
+    '<': '\\u003C',
+    '>' : '\\u003E',
+    '/': '\\u002F',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\0': '\\0',
+    '\u2028': '\\u2028',
+    '\u2029': '\\u2029'
+};
+
+function escapeUnsafeChars(str) {
+    return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x])
+}
+
+function createObjectWrite() {
+    const assignment = `obj[${escapeUnsafeChars(JSON.stringify(key))}]=42`;
+    return `(function(){${assignment}})` // OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -69,6 +69,16 @@ nodes
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") |
+| bad-code-sanitization.js:56:7:56:47 | taint |
+| bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] |
+| bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") |
+| bad-code-sanitization.js:56:16:56:23 | req.body |
+| bad-code-sanitization.js:56:16:56:23 | req.body |
+| bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:58:44:58:48 | taint |
 | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:44:7:62 | req.param("wobble") |
@@ -202,6 +212,15 @@ edges
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
+| bad-code-sanitization.js:56:7:56:47 | taint | bad-code-sanitization.js:58:44:58:48 | taint |
+| bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] | bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") |
+| bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") | bad-code-sanitization.js:56:7:56:47 | taint |
+| bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:56:16:56:28 | req.body.name | bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:44:58:48 | taint | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" |
 | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" |
@@ -271,6 +290,7 @@ edges
 | angularjs.js:50:22:50:36 | location.search | angularjs.js:50:22:50:29 | location | angularjs.js:50:22:50:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:50:22:50:29 | location | User-provided value |
 | angularjs.js:53:32:53:46 | location.search | angularjs.js:53:32:53:39 | location | angularjs.js:53:32:53:46 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:53:32:53:39 | location | User-provided value |
 | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` | $@ flows to here and is interpreted as code. | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | User-provided value |
+| bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` | bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` | $@ flows to here and is interpreted as code. | bad-code-sanitization.js:56:16:56:23 | req.body | User-provided value |
 | express.js:7:24:7:69 | "return ...  + "];" | express.js:7:44:7:62 | req.param("wobble") | express.js:7:24:7:69 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:7:44:7:62 | req.param("wobble") | User-provided value |
 | express.js:9:34:9:79 | "return ...  + "];" | express.js:9:54:9:72 | req.param("wobble") | express.js:9:34:9:79 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:9:54:9:72 | req.param("wobble") | User-provided value |
 | express.js:12:8:12:53 | "return ...  + "];" | express.js:12:28:12:46 | req.param("wobble") | express.js:12:8:12:53 | "return ...  + "];" | $@ flows to here and is interpreted as code. | express.js:12:28:12:46 | req.param("wobble") | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -69,6 +69,16 @@ nodes
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") |
+| bad-code-sanitization.js:56:7:56:47 | taint |
+| bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] |
+| bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") |
+| bad-code-sanitization.js:56:16:56:23 | req.body |
+| bad-code-sanitization.js:56:16:56:23 | req.body |
+| bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:58:44:58:48 | taint |
 | eslint-escope-build.js:20:22:20:22 | c |
 | eslint-escope-build.js:20:22:20:22 | c |
 | eslint-escope-build.js:21:16:21:16 | c |
@@ -206,6 +216,15 @@ edges
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:14:54:67 | `(funct ... "))}))` |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:44:54:62 | req.param("wobble") | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
+| bad-code-sanitization.js:56:7:56:47 | taint | bad-code-sanitization.js:58:44:58:48 | taint |
+| bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] | bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") |
+| bad-code-sanitization.js:56:15:56:47 | [req.bo ... n("\\n") | bad-code-sanitization.js:56:7:56:47 | taint |
+| bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:56:16:56:23 | req.body | bad-code-sanitization.js:56:16:56:28 | req.body.name |
+| bad-code-sanitization.js:56:16:56:28 | req.body.name | bad-code-sanitization.js:56:15:56:36 | [req.bo ...  "foo"] |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:14:58:53 | `(funct ... nt)}))` |
+| bad-code-sanitization.js:58:44:58:48 | taint | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 | eslint-escope-build.js:20:22:20:22 | c | eslint-escope-build.js:21:16:21:16 | c |
 | eslint-escope-build.js:20:22:20:22 | c | eslint-escope-build.js:21:16:21:16 | c |
 | eslint-escope-build.js:20:22:20:22 | c | eslint-escope-build.js:21:16:21:16 | c |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
@@ -31,6 +31,9 @@ nodes
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 edges
 | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` | bad-code-sanitization.js:7:31:7:43 | safeProp(key) |
 | bad-code-sanitization.js:2:65:2:90 | `[${JSO ... key)}]` | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` |
@@ -49,6 +52,7 @@ edges
 | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) |
 | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
+| bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 #select
 | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | $@ flows to here and is used to construct code. | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | Improperly sanitized value |
 | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | $@ flows to here and is used to construct code. | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | Improperly sanitized value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
@@ -34,6 +34,12 @@ nodes
 | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
 | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:63:11:63:55 | assignment |
+| bad-code-sanitization.js:63:24:63:55 | `obj[${ ... )}]=42` |
+| bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) |
+| bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) |
+| bad-code-sanitization.js:64:27:64:36 | assignment |
+| bad-code-sanitization.js:64:27:64:36 | assignment |
 edges
 | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` | bad-code-sanitization.js:7:31:7:43 | safeProp(key) |
 | bad-code-sanitization.js:2:65:2:90 | `[${JSO ... key)}]` | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` |
@@ -53,6 +59,11 @@ edges
 | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) |
 | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) | bad-code-sanitization.js:54:29:54:63 | JSON.st ... bble")) |
 | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) | bad-code-sanitization.js:58:29:58:49 | JSON.st ... (taint) |
+| bad-code-sanitization.js:63:11:63:55 | assignment | bad-code-sanitization.js:64:27:64:36 | assignment |
+| bad-code-sanitization.js:63:11:63:55 | assignment | bad-code-sanitization.js:64:27:64:36 | assignment |
+| bad-code-sanitization.js:63:24:63:55 | `obj[${ ... )}]=42` | bad-code-sanitization.js:63:11:63:55 | assignment |
+| bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) | bad-code-sanitization.js:63:24:63:55 | `obj[${ ... )}]=42` |
+| bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) | bad-code-sanitization.js:63:24:63:55 | `obj[${ ... )}]=42` |
 #select
 | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | $@ flows to here and is used to construct code. | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | Improperly sanitized value |
 | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | $@ flows to here and is used to construct code. | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | Improperly sanitized value |
@@ -61,3 +72,4 @@ edges
 | bad-code-sanitization.js:40:23:40:43 | JSON.st ... (input) | bad-code-sanitization.js:40:23:40:43 | JSON.st ... (input) | bad-code-sanitization.js:40:23:40:43 | JSON.st ... (input) | $@ flows to here and is used to construct code. | bad-code-sanitization.js:40:23:40:43 | JSON.st ... (input) | Improperly sanitized value |
 | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) | $@ flows to here and is used to construct code. | bad-code-sanitization.js:44:22:44:42 | JSON.st ... (input) | Improperly sanitized value |
 | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | $@ flows to here and is used to construct code. | bad-code-sanitization.js:52:28:52:62 | JSON.st ... bble")) | Improperly sanitized value |
+| bad-code-sanitization.js:64:27:64:36 | assignment | bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) | bad-code-sanitization.js:64:27:64:36 | assignment | $@ flows to here and is used to construct code. | bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) | Improperly sanitized value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/bad-code-sanitization.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/bad-code-sanitization.js
@@ -57,3 +57,36 @@ app.get('/some/path', function(req, res) {
    
   setTimeout(`(function(){${JSON.stringify(taint)}))`); // OK - the source is remote-flow, and the sink is code-injection.
 });
+
+// Bad documentation example: 
+function createObjectWrite() {
+    const assignment = `obj[${JSON.stringify(key)}]=42`;
+    return `(function(){${assignment}})` // NOT OK
+}
+
+// Good documentation example: 
+function good() {
+    const charMap = {
+        '<': '\\u003C',
+        '>' : '\\u003E',
+        '/': '\\u002F',
+        '\\': '\\\\',
+        '\b': '\\b',
+        '\f': '\\f',
+        '\n': '\\n',
+        '\r': '\\r',
+        '\t': '\\t',
+        '\0': '\\0',
+        '\u2028': '\\u2028',
+        '\u2029': '\\u2029'
+    };
+    
+    function escapeUnsafeChars(str) {
+        return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x])
+    }
+    
+    function createObjectWrite() {
+        const assignment = `obj[${escapeUnsafeChars(JSON.stringify(key))}]=42`;
+        return `(function(){${assignment}})` // OK
+    }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/bad-code-sanitization.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/bad-code-sanitization.js
@@ -52,4 +52,8 @@ app.get('/some/path', function(req, res) {
   var foo = `(function(){${JSON.stringify(req.param("wobble"))}))` // NOT - the source is remote-flow, but we know of no sink.
 
   setTimeout(`(function(){${JSON.stringify(req.param("wobble"))}))`); // OK - the source is remote-flow, and the sink is code-injection.
+
+  var taint = [req.body.name, "foo"].join("\n");
+   
+  setTimeout(`(function(){${JSON.stringify(taint)}))`); // OK - the source is remote-flow, and the sink is code-injection.
 });

--- a/javascript/ql/test/query-tests/Security/CWE-094/tmp.html
+++ b/javascript/ql/test/query-tests/Security/CWE-094/tmp.html
@@ -1,0 +1,9 @@
+<html>
+
+<body>
+    <script>
+        var foo ="bla</script onload=\"\">";
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Mainly adds qhelp for the new query. 
And adds more type-tracking steps when tracking remote-flow (for duplicate alert detection with `js/code-injection`). 

The `String.replace` sanitizer is still very basic, but I think it is OK to keep it like that. 