### PR TITLE
C++: Raise cpp/tainted-format-string* precisions to high

### DIFF
--- a/change-notes/1.25/analysis-cpp.md
+++ b/change-notes/1.25/analysis-cpp.md
@@ -13,6 +13,8 @@ The following changes in version 1.25 affect C/C++ analysis in all applications.
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Uncontrolled format string (`cpp/tainted-format-string`) |  | This query is now displayed by default on LGTM. |
+| Uncontrolled format string (through global variable) (`cpp/tainted-format-string-through-global`) |  | This query is now displayed by default on LGTM. |
 
 ## Changes to libraries
 

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatString.ql
@@ -5,7 +5,7 @@
  *              or data representation problems.
  * @kind path-problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id cpp/tainted-format-string
  * @tags reliability
  *       security

--- a/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatStringThroughGlobalVar.ql
+++ b/cpp/ql/src/Security/CWE/CWE-134/UncontrolledFormatStringThroughGlobalVar.ql
@@ -5,7 +5,7 @@
  *              or data representation problems.
  * @kind path-problem
  * @problem.severity warning
- * @precision medium
+ * @precision high
  * @id cpp/tainted-format-string-through-global
  * @tags reliability
  *       security


### PR DESCRIPTION
From the commit:
> I think these queries have excellent results on lgtm.com. Many of the results come from projects that use `sprintf` like it's a templating engine, trusting that values from `argv` or `getenv` contain the correct number of `%s`. I think we want to flag that.
>
> The structure of the change note is modeled after 91af51cf46.

You can see the alerts on LGTM [for the global-taint query](https://lgtm.com/rules/2155960669/alerts/) and [for the local-taint query](https://lgtm.com/rules/2159571090/alerts/).

I don't know why there are two queries, but at least it allows us to lower the precision for only one of them if it doesn't work out.