### PR TITLE
JS: Monorepo support: bugfixes and separate from dependency installation

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -590,7 +590,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
 
     console.log(JSON.stringify({
         type: "project-opened",
-        files: program.getSourceFiles().map(sf => pathlib.resolve(sf.fileName)),
+        files: config.fileNames.map(file => pathlib.resolve(file)),
     }));
 }
 

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -48,6 +48,7 @@ interface ParseCommand {
 interface OpenProjectCommand {
     command: "open-project";
     tsConfig: string;
+    sourceRoot: string | null;
     virtualSourceRoot: string | null;
     packageEntryPoints: [string, string][];
     packageJsonFiles: [string, string][];
@@ -370,7 +371,7 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
 
     let packageEntryPoints = new Map(command.packageEntryPoints);
     let packageJsonFiles = new Map(command.packageJsonFiles);
-    let virtualSourceRoot = new VirtualSourceRoot(process.cwd(), command.virtualSourceRoot);
+    let virtualSourceRoot = new VirtualSourceRoot(command.sourceRoot, command.virtualSourceRoot);
 
     /**
      * Rewrites path segments of form `node_modules/PACK/suffix` to be relative to
@@ -720,6 +721,7 @@ if (process.argv.length > 2) {
             tsConfig: argument,
             packageEntryPoints: [],
             packageJsonFiles: [],
+            sourceRoot: null,
             virtualSourceRoot: null,
         });
         for (let sf of state.project.program.getSourceFiles()) {

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -41,6 +41,9 @@ import { Project } from "./common";
 import { TypeTable } from "./type_table";
 import { VirtualSourceRoot } from "./virtual_source_root";
 
+// Remove limit on stack trace depth.
+Error.stackTraceLimit = Infinity;
+
 interface ParseCommand {
     command: "parse";
     filename: string;
@@ -364,7 +367,6 @@ function parseSingleFile(filename: string): {ast: ts.SourceFile, code: string} {
 const nodeModulesRex = /[/\\]node_modules[/\\]((?:@[\w.-]+[/\\])?\w[\w.-]*)[/\\](.*)/;
 
 function handleOpenProjectCommand(command: OpenProjectCommand) {
-    Error.stackTraceLimit = Infinity;
     let tsConfigFilename = String(command.tsConfig);
     let tsConfig = ts.readConfigFile(tsConfigFilename, ts.sys.readFile);
     let basePath = pathlib.dirname(tsConfigFilename);

--- a/javascript/extractor/lib/typescript/src/virtual_source_root.ts
+++ b/javascript/extractor/lib/typescript/src/virtual_source_root.ts
@@ -7,20 +7,20 @@ import * as ts from "./typescript";
  */
 export class VirtualSourceRoot {
   constructor(
-    private sourceRoot: string,
+    private sourceRoot: string | null,
 
     /**
      * Directory whose folder structure mirrors the real source root, but with `node_modules` installed,
      * or undefined if no virtual source root exists.
      */
-    private virtualSourceRoot: string,
+    private virtualSourceRoot: string | null,
   ) {}
 
   /**
    * Maps a path under the real source root to the corresponding path in the virtual source root.
    */
   public toVirtualPath(path: string) {
-    if (!this.virtualSourceRoot) return null;
+    if (!this.virtualSourceRoot || !this.sourceRoot) return null;
     let relative = pathlib.relative(this.sourceRoot, path);
     if (relative.startsWith('..') || pathlib.isAbsolute(relative)) return null;
     return pathlib.join(this.virtualSourceRoot, relative);

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -837,7 +837,7 @@ public class AutoBuild {
       }
     }
 
-    return new DependencyInstallationResult(virtualSourceRoot, packageMainFile, packagesInRepo);
+    return new DependencyInstallationResult(sourceRoot, virtualSourceRoot, packageMainFile, packagesInRepo);
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -559,6 +559,15 @@ public class AutoBuild {
     }
   };
 
+  /**
+   * Like {@link #PATH_ORDERING} but for {@link File} objects.
+   */
+  public static final Comparator<File> FILE_ORDERING = new Comparator<File>() {
+    public int compare(File f1, File f2) {
+      return PATH_ORDERING.compare(f1.toPath(), f2.toPath());
+    }
+  };
+
   /** Extract all supported candidate files that pass the filters. */
   private void extractSource() throws IOException {
     // default extractor
@@ -577,11 +586,11 @@ public class AutoBuild {
     Set<Path> filesToExtract = new LinkedHashSet<>();
     List<Path> tsconfigFiles = new ArrayList<>();
     findFilesToExtract(defaultExtractor, filesToExtract, tsconfigFiles);
-    
+
     tsconfigFiles = tsconfigFiles.stream()
          .sorted(PATH_ORDERING)
          .collect(Collectors.toList());
-    
+
     filesToExtract = filesToExtract.stream()
         .sorted(PATH_ORDERING)
         .collect(Collectors.toCollection(() -> new LinkedHashSet<>()));
@@ -695,7 +704,7 @@ public class AutoBuild {
    * @return a path or null
    */
   public static Path tryRelativize(Path from, Path to) {
-    Path relative = from.relativize(to);      
+    Path relative = from.relativize(to);
     if (relative.startsWith("..") || relative.isAbsolute()) {
       return null;
     }

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -690,6 +690,19 @@ public class AutoBuild {
   }
 
   /**
+   * Gets a relative path from <code>from</code> to <code>to</code> provided
+   * the latter is contained in the former. Otherwise returns <code>null</code>.
+   * @return a path or null
+   */
+  public static Path tryRelativize(Path from, Path to) {
+    Path relative = from.relativize(to);      
+    if (relative.startsWith("..") || relative.isAbsolute()) {
+      return null;
+    }
+    return relative;
+  }
+
+  /**
    * Installs dependencies for use by the TypeScript type checker.
    * <p>
    * Some packages must be downloaded while others exist within the same repo ("monorepos")
@@ -727,6 +740,9 @@ public class AutoBuild {
           if (!(json instanceof JsonObject)) continue;
           JsonObject jsonObject = (JsonObject) json;
           file = file.toAbsolutePath();
+          if (tryRelativize(sourceRoot, file) == null) {
+            continue; // Ignore package.json files outside the source root.
+          }
           packageJsonFiles.put(file, jsonObject);
 
           String name = getChildAsString(jsonObject, "name");

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -712,9 +712,8 @@ public class AutoBuild {
     if (!verifyYarnInstallation()) {
       return DependencyInstallationResult.empty;
     }
-
-    final Path sourceRoot = Paths.get(".").toAbsolutePath();
-    final Path virtualSourceRoot = Paths.get(EnvironmentVariables.getScratchDir()).toAbsolutePath();
+    final Path sourceRoot = LGTM_SRC;
+    final Path virtualSourceRoot = toRealPath(Paths.get(EnvironmentVariables.getScratchDir()));
 
     // Read all package.json files and index them by name.
     Map<Path, JsonObject> packageJsonFiles = new LinkedHashMap<>();

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -28,7 +28,7 @@ public class DependencyInstallationResult {
   /**
    * Returns the source root mirrored by {@link #getVirtualSourceRoot()} or <code>null</code>
    * if no virtual source root exists.
-   * <p/>
+   * <p>
    * When invoked from the AutoBuilder, this corresponds to the source root. When invoked
    * from ODASA, there is no notion of source root, so this is always <code>null</code> in that context.
    */
@@ -38,7 +38,7 @@ public class DependencyInstallationResult {
 
   /**
    * Returns the virtual source root or <code>null</code> if no virtual source root exists.
-   *
+   * <p>
    * The virtual source root is a directory hierarchy that mirrors the real source
    * root, where dependencies are installed.
    */

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -6,19 +6,32 @@ import java.util.Map;
 
 /** Contains the results of installing dependencies. */
 public class DependencyInstallationResult {
+  private Path sourceRoot;
   private Path virtualSourceRoot;
   private Map<String, Path> packageEntryPoints;
   private Map<String, Path> packageJsonFiles;
 
   public static final DependencyInstallationResult empty =
-      new DependencyInstallationResult(null, Collections.emptyMap(), Collections.emptyMap());
+      new DependencyInstallationResult(null, null, Collections.emptyMap(), Collections.emptyMap());
 
   public DependencyInstallationResult(
+      Path sourceRoot,
       Path virtualSourceRoot,
       Map<String, Path> packageEntryPoints,
       Map<String, Path> packageJsonFiles) {
     this.packageEntryPoints = packageEntryPoints;
     this.packageJsonFiles = packageJsonFiles;
+  }
+
+  /**
+   * Returns the source root mirrored by {@link #getVirtualSourceRoot()} or <code>null</code>
+   * if no virtual source root exists.
+   * <p/>
+   * When invoked from the AutoBuilder, this corresponds to the source root. When invoked
+   * from ODASA, there is no notion of source root, so this is always <code>null</code> in that context.
+   */
+  public Path getSourceRoot() {
+    return sourceRoot;
   }
 
   /**

--- a/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/DependencyInstallationResult.java
@@ -19,6 +19,8 @@ public class DependencyInstallationResult {
       Path virtualSourceRoot,
       Map<String, Path> packageEntryPoints,
       Map<String, Path> packageJsonFiles) {
+    this.sourceRoot = sourceRoot;
+    this.virtualSourceRoot = virtualSourceRoot;
     this.packageEntryPoints = packageEntryPoints;
     this.packageJsonFiles = packageJsonFiles;
   }

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.semmle.js.extractor.ExtractorConfig.HTMLHandling;
 import com.semmle.js.extractor.ExtractorConfig.Platform;
@@ -77,8 +78,8 @@ public class Main {
   private PathMatcher includeMatcher, excludeMatcher;
   private FileExtractor fileExtractor;
   private ExtractorState extractorState;
-  private final Set<File> projectFiles = new LinkedHashSet<>();
-  private final Set<File> files = new LinkedHashSet<>();
+  private Set<File> projectFiles = new LinkedHashSet<>();
+  private Set<File> files = new LinkedHashSet<>();
   private final Set<File> extractedFiles = new LinkedHashSet<>();
 
   /* used to detect cyclic directory hierarchies */
@@ -138,6 +139,16 @@ public class Main {
     if (containsTypeScriptFiles()) {
       tsParser.verifyInstallation(!ap.has(P_QUIET));
     }
+
+    // Sort files for determinism
+    projectFiles = projectFiles.stream()
+          .sorted(AutoBuild.FILE_ORDERING)
+          .collect(Collectors.toCollection(() -> new LinkedHashSet<>()));
+
+    files = files.stream()
+        .sorted(AutoBuild.FILE_ORDERING)
+        .collect(Collectors.toCollection(() -> new LinkedHashSet<>()));
+
     for (File projectFile : projectFiles) {
 
       long start = verboseLogStartTimer(ap, "Opening project " + projectFile);

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -157,7 +157,7 @@ public class Main {
       // Extract all files belonging to this project which are also matched
       // by our include/exclude filters.
       List<File> filesToExtract = new ArrayList<>();
-      for (File sourceFile : project.getSourceFiles()) {
+      for (File sourceFile : project.getOwnFiles()) {
         if (files.contains(normalizeFile(sourceFile))
             && !extractedFiles.contains(sourceFile.getAbsoluteFile())
             && FileType.TYPESCRIPT.getExtensions().contains(FileUtil.extension(sourceFile))) {

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -131,8 +131,8 @@ public class AutoBuildTests {
         }
 
         @Override
-        protected DependencyInstallationResult installDependencies(Set<Path> filesToExtract) {
-          // never install dependencies during testing
+        protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> filesToExtract) {
+          // currently disabled in tests
           return DependencyInstallationResult.empty;
         }
 

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -1,6 +1,5 @@
 package com.semmle.js.extractor.test;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
@@ -122,11 +121,11 @@ public class AutoBuildTests {
 
         @Override
         public void extractTypeScriptFiles(
-            java.util.List<File> files,
+            java.util.List<Path> files,
             java.util.Set<Path> extractedFiles,
             FileExtractor extractor,
             ExtractorState extractorState) {
-          for (File f : files) {
+          for (Path f : files) {
             actual.add(f.toString());
           }
         }

--- a/javascript/extractor/src/com/semmle/js/parser/ParsedProject.java
+++ b/javascript/extractor/src/com/semmle/js/parser/ParsedProject.java
@@ -1,15 +1,17 @@
 package com.semmle.js.parser;
 
 import java.io.File;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class ParsedProject {
   private final File tsConfigFile;
-  private final Set<File> sourceFiles = new LinkedHashSet<>();
+  private final Set<File> ownFiles;
+  private final Set<File> allFiles;
 
-  public ParsedProject(File tsConfigFile) {
+  public ParsedProject(File tsConfigFile, Set<File> ownFiles, Set<File> allFiles) {
     this.tsConfigFile = tsConfigFile;
+    this.ownFiles = ownFiles;
+    this.allFiles = allFiles;
   }
 
   /** Returns the <tt>tsconfig.json</tt> file that defines this project. */
@@ -18,11 +20,12 @@ public class ParsedProject {
   }
 
   /** Absolute paths to the files included in this project. */
-  public Set<File> getSourceFiles() {
-    return sourceFiles;
+  public Set<File> getOwnFiles() {
+    return allFiles;
   }
 
-  public void addSourceFile(File file) {
-    sourceFiles.add(file);
+  /** Absolute paths to the files included in or referenced by this project. */
+  public Set<File> getAllFiles() {
+    return allFiles;
   }
 }

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -502,6 +502,9 @@ public class TypeScriptParser {
     request.add("tsConfig", new JsonPrimitive(tsConfigFile.getPath()));
     request.add("packageEntryPoints", mapToArray(deps.getPackageEntryPoints()));
     request.add("packageJsonFiles", mapToArray(deps.getPackageJsonFiles()));
+    request.add("sourceRoot", deps.getSourceRoot() == null
+        ? JsonNull.INSTANCE
+        : new JsonPrimitive(deps.getSourceRoot().toString()));
     request.add("virtualSourceRoot", deps.getVirtualSourceRoot() == null
         ? JsonNull.INSTANCE
         : new JsonPrimitive(deps.getVirtualSourceRoot().toString()));


### PR DESCRIPTION
This PR largely does four things:
- Make extraction more deterministic by sorting files and choosing more carefully to extract TypeScript files with the right tsconfig.json file.
- Bugfixes:
  - Use `LGTM_SRC` as source root instead of CWD. The latter only worked in `codeql`.
  - Inititialize fields correctly 🤦 
- Separate monorepo support from dependency installation. This means monorepo support is on by default but dependency installation is still feature flagged.
- To avoid an OOM when extracting kibana, restrict properties extracted for type alias types.
  - Some projects do a lot of type meta-programming, where a type alias is essentially a function call at the type-level. From that point of view, the restriction on aliases makes sense IMO, and isn't as arbitrary as it might seem at first.
  - I'm getting less and less sure about the value we're getting out of the incomplete type property graph we're extracting. It's something we might consider removing if it gets in the way of more important things.

## Evaluations

- Metrics on [typescript-full](https://git.semmle.com/asger/dist-compare-reports/tree/js/monorepo-bugfixes_1592157799600) shows overall more call edges and more typed expressions. The few regressions are due to sorting files in a way that happens to be worse for those snapshots.
- [security/smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/monorepo-bugfixes_1592349543319) was completely uneventful.
- [security/nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/monorepo-bugfixes_1592325006302) shows a new result from the new call edges. Based on the above evaluation I'd say the timings are just noise.
- A simple offline test shows the extraction time for kibana going from 2148s to 1808s, a speedup likely resulting from the restricted handling of aliasing.
- [This JS-Differences job](https://jenkins.internal.semmle.com/job/Changes/job/JS-Differences/148//artifact/data/data.html) shows the extraction time for vscode increase by 2%.

## Dist upgrade
- [x] After review, I'd like to do a distribution upgrade to verify that we don't break the world.

Commit-by-commit review recommended.