### PR TITLE
JS: Private file exposure polish

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -36,6 +36,7 @@
 | Incomplete HTML attribute sanitization (`js/incomplete-html-attribute-sanitization`) | security, external/cwe/cwe-20, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities due to incomplete sanitization of HTML meta-characters. Results are shown on LGTM by default. |
 | Unsafe expansion of self-closing HTML tag (`js/unsafe-html-expansion`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities caused by unsafe expansion of self-closing HTML tags. |
 | Unsafe shell command constructed from library input (`js/shell-command-constructed-from-input`) | correctness, security, external/cwe/cwe-078, external/cwe/cwe-088 | Highlights potential command injections due to a shell command being constructed from library inputs. Results are shown on LGTM by default. |
+| Exposure of private files (`js/exposure-of-private-files`) | security, external/cwe/cwe-200 | Highlights servers that serve private files. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
@@ -26,12 +26,12 @@
     This allows clients easy access to all files inside that folder, but also allows
     access to potentially private information inside <code>package.json</code> files. 
   </p>
-  <sample src="examples/FileAccessToHttp.js"/>
+  <sample src="examples/PrivateFileExposure.js"/>
   <p>
     The issue has been fixed in the below by only serving specific folders within the
     <code>node_modules</code> folder.
   </p>
-  <sample src="examples/FileAccessToHttpFixed.js"/>
+  <sample src="examples/PrivateFileExposureFixed.js"/>
 </example>
 
 <references>

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
@@ -5,20 +5,33 @@
 
 <overview>
   <p>
-    Placeholder
+    Libraries like <code>express</code> provide easy methods for serving entire 
+    directories of static files from a web server.
+    However, using these can sometimes lead to accidential information exposure. 
+    If for example the <code>node_modules</code> folder is served, then an attacker
+    can access the <code>_where</code> field from a <code>package.json</code> file, 
+    which gives the attacker access to the absolute path of the file. 
   </p>
 </overview>
 
 <recommendation>
   <p>
-    Placeholder
+    Limit which folders of static files are served from a web server.
   </p>
 </recommendation>
 
 <example>
   <p>
-    Placeholder
+    In the example below all the files from the <code>node_modules</code> are served. 
+    This allows clients easy access to all files inside that folder, but also allows
+    access to potentially private information inside <code>package.json</code> files. 
   </p>
+  <sample src="examples/FileAccessToHttp.js"/>
+  <p>
+    The issue has been fixed in the below by only serving specific folders within the
+    <code>node_modules</code> folder.
+  </p>
+  <sample src="examples/FileAccessToHttpFixed.js"/>
 </example>
 
 <references>

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
@@ -7,10 +7,10 @@
   <p>
     Libraries like <code>express</code> provide easy methods for serving entire 
     directories of static files from a web server.
-    However, using these can sometimes lead to accidential information exposure. 
+    However, using these can sometimes lead to accidental information exposure. 
     If for example the <code>node_modules</code> folder is served, then an attacker
     can access the <code>_where</code> field from a <code>package.json</code> file, 
-    which gives the attacker access to the absolute path of the file. 
+    which gives access to the absolute path of the file. 
   </p>
 </overview>
 
@@ -22,13 +22,13 @@
 
 <example>
   <p>
-    In the example below all the files from the <code>node_modules</code> are served. 
+    In the example below, all the files from the <code>node_modules</code> are served. 
     This allows clients easy access to all files inside that folder, but also allows
     access to potentially private information inside <code>package.json</code> files. 
   </p>
   <sample src="examples/PrivateFileExposure.js"/>
   <p>
-    The issue has been fixed in the below by only serving specific folders within the
+    The issue has been fixed below by only serving specific folders within the
     <code>node_modules</code> folder.
   </p>
   <sample src="examples/PrivateFileExposureFixed.js"/>

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.qhelp
@@ -23,8 +23,8 @@
 <example>
   <p>
     In the example below, all the files from the <code>node_modules</code> are served. 
-    This allows clients easy access to all files inside that folder, but also allows
-    access to potentially private information inside <code>package.json</code> files. 
+    This allows clients to easily access all the files inside that folder,
+    which includes potentially private information inside <code>package.json</code> files.
   </p>
   <sample src="examples/PrivateFileExposure.js"/>
   <p>

--- a/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
+++ b/javascript/ql/src/Security/CWE-200/PrivateFileExposure.ql
@@ -105,7 +105,10 @@ DataFlow::Node getAPrivateFolderPath(string description) {
  * Gest a call that serves the folder `path` to the public.
  */
 DataFlow::CallNode servesAPrivateFolder(string description) {
-  result = DataFlow::moduleMember("express", "static").getACall() and
+  result = DataFlow::moduleMember(["express", "connect"], "static").getACall() and
+  result.getArgument(0) = getAPrivateFolderPath(description)
+  or
+  result = DataFlow::moduleImport("serve-static").getACall() and
   result.getArgument(0) = getAPrivateFolderPath(description)
 }
 

--- a/javascript/ql/src/Security/CWE-200/examples/PrivateFileExposure.js
+++ b/javascript/ql/src/Security/CWE-200/examples/PrivateFileExposure.js
@@ -1,0 +1,6 @@
+
+var express = require('express');
+
+var app = express();
+
+app.use('/node_modules', express.static(path.resolve(__dirname, '../node_modules')));

--- a/javascript/ql/src/Security/CWE-200/examples/PrivateFileExposureFixed.js
+++ b/javascript/ql/src/Security/CWE-200/examples/PrivateFileExposureFixed.js
@@ -1,0 +1,7 @@
+
+var express = require('express');
+
+var app = express();
+
+app.use("jquery", express.static('./node_modules/jquery/dist'));
+app.use("bootstrap", express.static('./node_modules/bootstrap/dist'));

--- a/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
@@ -16,3 +16,5 @@
 | private-file-exposure.js:22:1:22:58 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
 | private-file-exposure.js:40:1:40:88 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
 | private-file-exposure.js:41:1:41:97 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
+| private-file-exposure.js:42:1:42:66 | app.use ... dir())) | Serves the home folder , which can contain private information. |
+| private-file-exposure.js:43:1:43:46 | app.use ... )("/")) | Serves the root folder, which can contain private information. |

--- a/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
@@ -18,3 +18,4 @@
 | private-file-exposure.js:41:1:41:97 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
 | private-file-exposure.js:42:1:42:66 | app.use ... dir())) | Serves the home folder , which can contain private information. |
 | private-file-exposure.js:43:1:43:46 | app.use ... )("/")) | Serves the root folder, which can contain private information. |
+| private-file-exposure.js:51:5:51:88 | app.use ... les'))) | Serves the folder "../node_modules", which can contain private information. |

--- a/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-200/PrivateFileExposure.expected
@@ -14,3 +14,5 @@
 | private-file-exposure.js:18:1:18:74 | app.use ... les"))) | Serves the folder "/node_modules", which can contain private information. |
 | private-file-exposure.js:19:1:19:88 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
 | private-file-exposure.js:22:1:22:58 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
+| private-file-exposure.js:40:1:40:88 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |
+| private-file-exposure.js:41:1:41:97 | app.use ... lar/')) | Serves the folder "/node_modules/angular/", which can contain private information. |

--- a/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
+++ b/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
@@ -35,3 +35,7 @@ app.use('/js/', express.static('node_modules/bootstrap/dist/js'))
 app.use('/css/', express.static('node_modules/font-awesome/css'));
 app.use('basedir', express.static(__dirname)); // GOOD, because there is no package.json in the same folder.
 app.use('/monthly', express.static(__dirname + '/')); // GOOD, because there is no package.json in the same folder.
+
+const connect = require("connect");
+app.use('/angular', connect.static(path.join(__dirname, "/node_modules") + '/angular/')); // NOT OK
+app.use('/angular', require('serve-static')(path.join(__dirname, "/node_modules") + '/angular/')); // NOT OK

--- a/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
+++ b/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
@@ -41,3 +41,22 @@ app.use('/angular', connect.static(path.join(__dirname, "/node_modules") + '/ang
 app.use('/angular', require('serve-static')(path.join(__dirname, "/node_modules") + '/angular/')); // NOT OK
 app.use('/home', require('serve-static')(require("os").homedir())); // NOT OK
 app.use('/root', require('serve-static')("/")); // NOT OK
+
+// Bad documentation example
+function bad() {
+    var express = require('express');
+
+    var app = express();
+
+    app.use('/node_modules', express.static(path.resolve(__dirname, '../node_modules'))); // NOT OK
+}
+
+// Good documentation example
+function good() {
+    var express = require('express');
+
+    var app = express();
+
+    app.use("jquery", express.static('./node_modules/jquery/dist')); // OK
+    app.use("bootstrap", express.static('./node_modules/bootstrap/dist')); // OK
+}

--- a/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
+++ b/javascript/ql/test/query-tests/Security/CWE-200/private-file-exposure.js
@@ -39,3 +39,5 @@ app.use('/monthly', express.static(__dirname + '/')); // GOOD, because there is 
 const connect = require("connect");
 app.use('/angular', connect.static(path.join(__dirname, "/node_modules") + '/angular/')); // NOT OK
 app.use('/angular', require('serve-static')(path.join(__dirname, "/node_modules") + '/angular/')); // NOT OK
+app.use('/home', require('serve-static')(require("os").homedir())); // NOT OK
+app.use('/root', require('serve-static')("/")); // NOT OK


### PR DESCRIPTION
- detects more libraries that serve static folders.
- detects more folders as private (`/`, `require("os").homedir()`). 
- adds qhelp and change-note. 