### PR TITLE
Exclude dependency-based query from C# Code Scanning

### DIFF
--- a/cpp/ql/src/codeql-suites/cpp-security-extended.qls
+++ b/cpp/ql/src/codeql-suites/cpp-security-extended.qls
@@ -2,5 +2,5 @@
 - qlpack: codeql-cpp
 - apply: security-extended-selectors.yml
   from: codeql-suite-helpers
-- apply: codeql-suites/excluded-slow-queries.yml
+- apply: codeql-suites/exclude-slow-queries.yml
   from: codeql-cpp

--- a/csharp/ql/src/codeql-suites/csharp-code-scanning.qls
+++ b/csharp/ql/src/codeql-suites/csharp-code-scanning.qls
@@ -2,3 +2,5 @@
 - qlpack: codeql-csharp
 - apply: code-scanning-selectors.yml
   from: codeql-suite-helpers
+- apply: codeql-suites/exclude-dependency-queries.yml
+  from: codeql-csharp

--- a/csharp/ql/src/codeql-suites/csharp-security-and-quality.qls
+++ b/csharp/ql/src/codeql-suites/csharp-security-and-quality.qls
@@ -2,3 +2,5 @@
 - qlpack: codeql-csharp
 - apply: security-and-quality-selectors.yml
   from: codeql-suite-helpers
+- apply: codeql-suites/exclude-dependency-queries.yml
+  from: codeql-csharp

--- a/csharp/ql/src/codeql-suites/csharp-security-extended.qls
+++ b/csharp/ql/src/codeql-suites/csharp-security-extended.qls
@@ -2,3 +2,5 @@
 - qlpack: codeql-csharp
 - apply: security-extended-selectors.yml
   from: codeql-suite-helpers
+- apply: codeql-suites/exclude-dependency-queries.yml
+  from: codeql-csharp

--- a/csharp/ql/src/codeql-suites/exclude-dependency-queries.yml
+++ b/csharp/ql/src/codeql-suites/exclude-dependency-queries.yml
@@ -1,0 +1,4 @@
+- description: C# queries which overlap with dependency analysis
+- exclude:
+    query path:
+      - Security Features/CWE-937/VulnerablePackage.ql


### PR DESCRIPTION
This query overlaps with tools such as dependabot.