### PR TITLE
JS: limit size of `getStringValue`

### DIFF
--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -1519,7 +1519,8 @@ class AddExpr extends @addexpr, BinaryExpr {
   override string getOperator() { result = "+" }
 
   override string getStringValue() {
-    result = getLeftOperand().getStringValue() + getRightOperand().getStringValue()
+    result = getLeftOperand().getStringValue() + getRightOperand().getStringValue() and
+    result.length() < 1000 * 1000
   }
 }
 


### PR DESCRIPTION
A few projects failed with an error like `com.semmle.util.exception.CatastrophicError: String too long (6249960 characters)`. 
([This is one of the problematic files](https://github.com/cihadturhan/tr-geojson/blob/master/js/env-data.js)). 

This PR fixes that issue by simply limiting the size of the string we construct in `Expr::getStringValue`.  
The size limit of 1 million chars should be enough for any reasonable use. 