### PR TITLE
JS: Reduce precision of js/unused-npm-dependency

### DIFF
--- a/javascript/config/suites/javascript/frameworks-more
+++ b/javascript/config/suites/javascript/frameworks-more
@@ -15,7 +15,6 @@
 + semmlecode-javascript-queries/NodeJS/DubiousImport.ql: /Frameworks/Node.js
 + semmlecode-javascript-queries/NodeJS/InvalidExport.ql: /Frameworks/Node.js
 + semmlecode-javascript-queries/NodeJS/MissingExports.ql: /Frameworks/Node.js
-+ semmlecode-javascript-queries/NodeJS/UnusedDependency.ql: /Frameworks/Node.js
 + semmlecode-javascript-queries/NodeJS/UnresolvableImport.ql: /Frameworks/Node.js
 + semmlecode-javascript-queries/React/DirectStateMutation.ql: /Frameworks/React
 + semmlecode-javascript-queries/React/InconsistentStateUpdate.ql: /Frameworks/React

--- a/javascript/ql/src/NodeJS/UnusedDependency.ql
+++ b/javascript/ql/src/NodeJS/UnusedDependency.ql
@@ -7,7 +7,7 @@
  * @id js/node/unused-npm-dependency
  * @tags maintainability
  *       frameworks/node.js
- * @precision medium
+ * @precision low
  */
 
 import javascript


### PR DESCRIPTION
Sometimes a dependency is needed for satisfying a peer dependency of another dependency, but we can't detect this without downloading the package manifest for those dependencies.

This can cause FPs for `js/unused-npm-dependency`, which is already hidden by default due to its high FP rate, but it seems people turn it on anyway. Reducing precision to `low`.