### PR TITLE
Python: Changing signature in overriden method is not an error

### DIFF
--- a/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
@@ -4,8 +4,8 @@
  *              the arguments with which it is called, and if it were called, would be likely to cause an error.
  * @kind problem
  * @tags maintainability
- * @problem.severity error
- * @sub-severity low
+ * @problem.severity recommendation
+ * @sub-severity high
  * @precision high
  * @id py/inheritance/incorrect-overridden-signature
  */


### PR DESCRIPTION
Rather, fulfiling the Liskov substitution principle is an opinionated recommendation. Looking at `py/inheritance/incorrect-overridden-signature` and `py/mixed-tuple-returns`, it seems very appropriate that this should have `@severity recommendation`, and `@sub-severity high`.