### PR TITLE
Data flow: Model field clearing

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -754,6 +754,13 @@ abstract class AccessPathFront extends TAccessPathFront {
   abstract boolean toBoolNonEmpty();
 
   predicate headUsesContent(TypedContent tc) { this = TFrontHead(tc) }
+
+  predicate isClearedAt(Node n) {
+    exists(TypedContent tc |
+      this.headUsesContent(tc) and
+      clearsContent(n, tc.getContent())
+    )
+  }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -217,6 +217,13 @@ predicate readStep(Node node1, Content f, Node node2) {
 }
 
 /**
+ * Holds if values stored inside content `c` are cleared at node `n`.
+ */
+predicate clearsContent(Node n, Content c) {
+  none() // stub implementation
+}
+
+/**
  * Gets a representative (boxed) type for `t` for the purpose of pruning
  * possible flow. A single type is used for all numeric types to account for
  * numeric conversions, and otherwise the erasure is used.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -754,6 +754,13 @@ abstract class AccessPathFront extends TAccessPathFront {
   abstract boolean toBoolNonEmpty();
 
   predicate headUsesContent(TypedContent tc) { this = TFrontHead(tc) }
+
+  predicate isClearedAt(Node n) {
+    exists(TypedContent tc |
+      this.headUsesContent(tc) and
+      clearsContent(n, tc.getContent())
+    )
+  }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -227,6 +227,13 @@ predicate readStep(Node node1, Content f, Node node2) {
 }
 
 /**
+ * Holds if values stored inside content `c` are cleared at node `n`.
+ */
+predicate clearsContent(Node n, Content c) {
+  none() // stub implementation
+}
+
+/**
  * Gets a representative (boxed) type for `t` for the purpose of pruning
  * possible flow. A single type is used for all numeric types to account for
  * numeric conversions, and otherwise the erasure is used.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1201,6 +1201,7 @@ private predicate flowCandFwd(
   Configuration config
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
+  not apf.isClearedAt(node) and
   if node instanceof CastingNode
   then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
   else any()
@@ -1219,8 +1220,7 @@ private predicate flowCandFwd0(
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
-    localFlowBigStep(mid, node, true, _, config, _) and
-    not apf.isClearedAt(node)
+    localFlowBigStep(mid, node, true, _, config, _)
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
@@ -1233,8 +1233,7 @@ private predicate flowCandFwd0(
     nodeCand2(node, unbind(config)) and
     jumpStep(mid, node, config) and
     fromArg = false and
-    argApf = TAccessPathFrontNone() and
-    not apf.isClearedAt(node)
+    argApf = TAccessPathFrontNone()
   )
   or
   exists(Node mid, AccessPathFrontNil nil |
@@ -1259,8 +1258,7 @@ private predicate flowCandFwd0(
   exists(TypedContent tc |
     flowCandFwdRead(tc, node, fromArg, argApf, config) and
     flowCandFwdConsCand(tc, apf, config) and
-    nodeCand2(node, _, _, unbindBool(apf.toBoolNonEmpty()), unbind(config)) and
-    not apf.isClearedAt(node)
+    nodeCand2(node, _, _, unbindBool(apf.toBoolNonEmpty()), unbind(config))
   )
   or
   // flow into a callable
@@ -1316,8 +1314,7 @@ private predicate flowCandFwdIn(
 ) {
   exists(ArgumentNode arg, boolean allowsFieldFlow |
     flowCandFwd(arg, fromArg, argApf, apf, config) and
-    flowIntoCallNodeCand2(call, arg, p, allowsFieldFlow, config) and
-    not apf.isClearedAt(p)
+    flowIntoCallNodeCand2(call, arg, p, allowsFieldFlow, config)
   |
     apf instanceof AccessPathFrontNil or allowsFieldFlow = true
   )
@@ -1330,8 +1327,7 @@ private predicate flowCandFwdOut(
 ) {
   exists(ReturnNodeExt ret, boolean allowsFieldFlow |
     flowCandFwd(ret, fromArg, argApf, apf, config) and
-    flowOutOfCallNodeCand2(call, ret, node, allowsFieldFlow, config) and
-    not apf.isClearedAt(node)
+    flowOutOfCallNodeCand2(call, ret, node, allowsFieldFlow, config)
   |
     apf instanceof AccessPathFrontNil or allowsFieldFlow = true
   )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1051,8 +1051,12 @@ private predicate flowIntoCallNodeCand2(
 }
 
 private module LocalFlowBigStep {
-  private class BigStepBarrierNode extends Node {
-    BigStepBarrierNode() {
+  /**
+   * A node where some checking is required, and hence the big-step relation
+   * is not allowed to step over.
+   */
+  private class FlowCheckNode extends Node {
+    FlowCheckNode() {
       this instanceof CastNode or
       clearsContent(this, _)
     }
@@ -1072,7 +1076,7 @@ private module LocalFlowBigStep {
       node instanceof OutNodeExt or
       store(_, _, node, _) or
       read(_, _, node) or
-      node instanceof BigStepBarrierNode
+      node instanceof FlowCheckNode
     )
   }
 
@@ -1090,7 +1094,7 @@ private module LocalFlowBigStep {
       read(node, _, next)
     )
     or
-    node instanceof BigStepBarrierNode
+    node instanceof FlowCheckNode
     or
     config.isSink(node)
   }
@@ -1134,14 +1138,14 @@ private module LocalFlowBigStep {
       exists(Node mid |
         localFlowStepPlus(node1, mid, preservesValue, t, config, cc) and
         localFlowStepNodeCand1(mid, node2, config) and
-        not mid instanceof BigStepBarrierNode and
+        not mid instanceof FlowCheckNode and
         nodeCand2(node2, unbind(config))
       )
       or
       exists(Node mid |
         localFlowStepPlus(node1, mid, _, _, config, cc) and
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
-        not mid instanceof BigStepBarrierNode and
+        not mid instanceof FlowCheckNode and
         preservesValue = false and
         t = getErasedNodeTypeBound(node2) and
         nodeCand2(node2, unbind(config))

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -754,6 +754,13 @@ abstract class AccessPathFront extends TAccessPathFront {
   abstract boolean toBoolNonEmpty();
 
   predicate headUsesContent(TypedContent tc) { this = TFrontHead(tc) }
+
+  predicate isClearedAt(Node n) {
+    exists(TypedContent tc |
+      this.headUsesContent(tc) and
+      clearsContent(n, tc.getContent())
+    )
+  }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -548,6 +548,20 @@ private module Cached {
   }
 
   /**
+   * Holds if values stored inside content `c` are cleared at node `n`. For example,
+   * any value stored inside `f` is cleared at the pre-update node associated with `x`
+   * in `x.f = newValue`.
+   */
+  cached
+  predicate clearsContent(Node n, Content c) {
+    fieldOrPropertyAssign(_, c, _, n.asExpr())
+    or
+    fieldOrPropertyInit(n.asExpr(), c, _)
+    or
+    exists(n.(LibraryCodeNode).getSuccessor(any(AccessPath ap | ap.getHead() = c)))
+  }
+
+  /**
    * Holds if the node `n` is unreachable when the call context is `call`.
    */
   cached

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -431,6 +431,9 @@ private module Cached {
       )
     } or
     TMallocNode(ControlFlow::Nodes::ElementNode cfn) { cfn.getElement() instanceof ObjectCreation } or
+    TObjectInitializerNode(ControlFlow::Nodes::ElementNode cfn) {
+      cfn.getElement().(ObjectCreation).hasInitializer()
+    } or
     TExprPostUpdateNode(ControlFlow::Nodes::ElementNode cfn) {
       exists(Argument a, Type t |
         a = cfn.getElement() and
@@ -486,6 +489,8 @@ private module Cached {
       n = nodeFrom and
       nodeTo = n.getSuccessor(AccessPath::empty())
     )
+    or
+    nodeTo.(ObjectCreationNode).getPreUpdateNode() = nodeFrom.(ObjectInitializerNode)
   }
 
   /**
@@ -556,7 +561,7 @@ private module Cached {
   predicate clearsContent(Node n, Content c) {
     fieldOrPropertyAssign(_, c, _, n.asExpr())
     or
-    fieldOrPropertyInit(n.asExpr(), c, _)
+    fieldOrPropertyInit(n.(ObjectInitializerNode).getObjectCreation(), c, _)
     or
     exists(n.(LibraryCodeNode).getSuccessor(any(AccessPath ap | ap.getHead() = c)))
   }
@@ -1664,9 +1669,50 @@ abstract class PostUpdateNode extends Node {
 
 private module PostUpdateNodes {
   class ObjectCreationNode extends PostUpdateNode, ExprNode, TExprNode {
-    ObjectCreationNode() { exists(ObjectCreation oc | this = TExprNode(oc.getAControlFlowNode())) }
+    private ObjectCreation oc;
 
-    override MallocNode getPreUpdateNode() { this = TExprNode(result.getControlFlowNode()) }
+    ObjectCreationNode() { this = TExprNode(oc.getAControlFlowNode()) }
+
+    override Node getPreUpdateNode() {
+      exists(ControlFlow::Nodes::ElementNode cfn | this = TExprNode(cfn) |
+        result.(ObjectInitializerNode).getControlFlowNode() = cfn
+        or
+        not oc.hasInitializer() and
+        result.(MallocNode).getControlFlowNode() = cfn
+      )
+    }
+  }
+
+  /**
+   * A node that represents the value of a newly created object after the object
+   * has been created, but before the object initializer has been executed.
+   *
+   * Such a node acts as both a post-update node for the `MallocNode`, as well as
+   * a pre-update node for the `ObjectCreationNode`.
+   */
+  class ObjectInitializerNode extends PostUpdateNode, NodeImpl, TObjectInitializerNode {
+    private ObjectCreation oc;
+    private ControlFlow::Nodes::ElementNode cfn;
+
+    ObjectInitializerNode() {
+      this = TObjectInitializerNode(cfn) and
+      cfn = oc.getAControlFlowNode()
+    }
+
+    /** Gets the object creation to which this initializer node belongs. */
+    ObjectCreation getObjectCreation() { result = oc }
+
+    override MallocNode getPreUpdateNode() { result.getControlFlowNode() = cfn }
+
+    override DataFlowCallable getEnclosingCallableImpl() { result = cfn.getEnclosingCallable() }
+
+    override DotNet::Type getTypeImpl() { result = oc.getType() }
+
+    override ControlFlow::Nodes::ElementNode getControlFlowNodeImpl() { result = cfn }
+
+    override Location getLocationImpl() { result = cfn.getLocation() }
+
+    override string toStringImpl() { result = "[pre-initializer] " + cfn }
   }
 
   class ExprPostUpdateNode extends PostUpdateNode, NodeImpl, TExprPostUpdateNode {

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -201,7 +201,8 @@ edges
 | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:147:17:147:32 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
 | H.cs:147:25:147:31 | object creation of type A : A | H.cs:147:17:147:32 | call to method Through : A |
-| H.cs:155:17:155:23 | object creation of type B : B | H.cs:157:20:157:20 | access to local variable b : B |
+| H.cs:155:17:155:23 | object creation of type B : B | H.cs:156:9:156:9 | access to local variable b : B |
+| H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
 | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a [FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B |
 | H.cs:163:17:163:28 | object creation of type Object : Object | H.cs:164:22:164:22 | access to local variable o : Object |
@@ -215,48 +216,28 @@ edges
 | H.cs:165:21:165:28 | access to field FieldA : B | H.cs:165:17:165:28 | (...) ... : B |
 | H.cs:165:21:165:28 | access to field FieldA [FieldB] : Object | H.cs:165:17:165:28 | (...) ... [FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b [FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
-| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:14:17:14:23 | object creation of type I [Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:21:13:21:19 | object creation of type I [Field1] : Object |
 | I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:26:13:26:37 | object creation of type I [Field1] : Object |
-| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:30:13:30:19 | object creation of type I [Field1] : Object |
 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:7:9:7:14 | [post] this access [Field1] : Object |
-| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:14:17:14:23 | object creation of type I [Field2] : Object |
-| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:21:13:21:19 | object creation of type I [Field2] : Object |
-| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:26:13:26:37 | object creation of type I [Field2] : Object |
-| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:30:13:30:19 | object creation of type I [Field2] : Object |
-| I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:8:9:8:14 | [post] this access [Field2] : Object |
 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:15:20:15:20 | access to local variable o : Object |
-| I.cs:14:17:14:23 | object creation of type I [Field1] : Object | I.cs:18:14:18:14 | access to local variable i [Field1] : Object |
-| I.cs:14:17:14:23 | object creation of type I [Field2] : Object | I.cs:19:14:19:14 | access to local variable i [Field2] : Object |
-| I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | I.cs:18:14:18:14 | access to local variable i [Field1] : Object |
+| I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | I.cs:16:9:16:9 | access to local variable i [Field1] : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object |
-| I.cs:15:20:15:20 | access to local variable o : Object | I.cs:16:20:16:20 | access to local variable o : Object |
-| I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object | I.cs:19:14:19:14 | access to local variable i [Field2] : Object |
-| I.cs:16:20:16:20 | access to local variable o : Object | I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object |
+| I.cs:16:9:16:9 | access to local variable i [Field1] : Object | I.cs:17:9:17:9 | access to local variable i [Field1] : Object |
+| I.cs:17:9:17:9 | access to local variable i [Field1] : Object | I.cs:18:14:18:14 | access to local variable i [Field1] : Object |
 | I.cs:18:14:18:14 | access to local variable i [Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
-| I.cs:19:14:19:14 | access to local variable i [Field2] : Object | I.cs:19:14:19:21 | access to field Field2 |
-| I.cs:21:13:21:19 | object creation of type I [Field1] : Object | I.cs:23:14:23:14 | access to local variable i [Field1] : Object |
-| I.cs:21:13:21:19 | object creation of type I [Field2] : Object | I.cs:24:14:24:14 | access to local variable i [Field2] : Object |
+| I.cs:21:13:21:19 | object creation of type I [Field1] : Object | I.cs:22:9:22:9 | access to local variable i [Field1] : Object |
+| I.cs:22:9:22:9 | access to local variable i [Field1] : Object | I.cs:23:14:23:14 | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
-| I.cs:24:14:24:14 | access to local variable i [Field2] : Object | I.cs:24:14:24:21 | access to field Field2 |
 | I.cs:26:13:26:37 | object creation of type I [Field1] : Object | I.cs:27:14:27:14 | access to local variable i [Field1] : Object |
-| I.cs:26:13:26:37 | object creation of type I [Field2] : Object | I.cs:28:14:28:14 | access to local variable i [Field2] : Object |
 | I.cs:27:14:27:14 | access to local variable i [Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
-| I.cs:28:14:28:14 | access to local variable i [Field2] : Object | I.cs:28:14:28:21 | access to field Field2 |
-| I.cs:30:13:30:19 | object creation of type I [Field1] : Object | I.cs:34:12:34:12 | access to local variable i [Field1] : Object |
-| I.cs:30:13:30:19 | object creation of type I [Field2] : Object | I.cs:34:12:34:12 | access to local variable i [Field2] : Object |
 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:32:20:32:20 | access to local variable o : Object |
-| I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | I.cs:34:12:34:12 | access to local variable i [Field1] : Object |
+| I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | I.cs:33:9:33:9 | access to local variable i [Field1] : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object |
-| I.cs:32:20:32:20 | access to local variable o : Object | I.cs:33:20:33:20 | access to local variable o : Object |
-| I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object | I.cs:34:12:34:12 | access to local variable i [Field2] : Object |
-| I.cs:33:20:33:20 | access to local variable o : Object | I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object |
+| I.cs:33:9:33:9 | access to local variable i [Field1] : Object | I.cs:34:12:34:12 | access to local variable i [Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i [Field1] : Object | I.cs:37:23:37:23 | i [Field1] : Object |
-| I.cs:34:12:34:12 | access to local variable i [Field2] : Object | I.cs:37:23:37:23 | i [Field2] : Object |
-| I.cs:37:23:37:23 | i [Field1] : Object | I.cs:40:14:40:14 | access to parameter i [Field1] : Object |
-| I.cs:37:23:37:23 | i [Field2] : Object | I.cs:41:14:41:14 | access to parameter i [Field2] : Object |
+| I.cs:37:23:37:23 | i [Field1] : Object | I.cs:39:9:39:9 | access to parameter i [Field1] : Object |
+| I.cs:39:9:39:9 | access to parameter i [Field1] : Object | I.cs:40:14:40:14 | access to parameter i [Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i [Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
-| I.cs:41:14:41:14 | access to parameter i [Field2] : Object | I.cs:41:14:41:21 | access to field Field2 |
 nodes
 | A.cs:5:17:5:23 | object creation of type C : C | semmle.label | object creation of type C : C |
 | A.cs:6:17:6:25 | call to method Make [c] : C | semmle.label | call to method Make [c] : C |
@@ -491,6 +472,7 @@ nodes
 | H.cs:147:25:147:31 | object creation of type A : A | semmle.label | object creation of type A : A |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
 | H.cs:155:17:155:23 | object creation of type B : B | semmle.label | object creation of type B : B |
+| H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
 | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B | semmle.label | [post] access to parameter a [FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
 | H.cs:163:17:163:28 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
@@ -508,46 +490,29 @@ nodes
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
 | I.cs:7:9:7:14 | [post] this access [Field1] : Object | semmle.label | [post] this access [Field1] : Object |
 | I.cs:7:18:7:29 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
-| I.cs:8:9:8:14 | [post] this access [Field2] : Object | semmle.label | [post] this access [Field2] : Object |
-| I.cs:8:18:8:29 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | I.cs:13:17:13:28 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
-| I.cs:14:17:14:23 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
-| I.cs:14:17:14:23 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | semmle.label | [post] access to local variable i [Field1] : Object |
 | I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object | semmle.label | [post] access to local variable i [Field2] : Object |
-| I.cs:16:20:16:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:16:9:16:9 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
+| I.cs:17:9:17:9 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:18:14:18:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:19:14:19:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
-| I.cs:19:14:19:21 | access to field Field2 | semmle.label | access to field Field2 |
 | I.cs:21:13:21:19 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
-| I.cs:21:13:21:19 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
+| I.cs:22:9:22:9 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:24:14:24:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
-| I.cs:24:14:24:21 | access to field Field2 | semmle.label | access to field Field2 |
 | I.cs:26:13:26:37 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
-| I.cs:26:13:26:37 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
 | I.cs:27:14:27:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:28:14:28:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
-| I.cs:28:14:28:21 | access to field Field2 | semmle.label | access to field Field2 |
-| I.cs:30:13:30:19 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
-| I.cs:30:13:30:19 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
 | I.cs:31:13:31:24 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | semmle.label | [post] access to local variable i [Field1] : Object |
 | I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
-| I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object | semmle.label | [post] access to local variable i [Field2] : Object |
-| I.cs:33:20:33:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:33:9:33:9 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:34:12:34:12 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
-| I.cs:34:12:34:12 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
 | I.cs:37:23:37:23 | i [Field1] : Object | semmle.label | i [Field1] : Object |
-| I.cs:37:23:37:23 | i [Field2] : Object | semmle.label | i [Field2] : Object |
+| I.cs:39:9:39:9 | access to parameter i [Field1] : Object | semmle.label | access to parameter i [Field1] : Object |
 | I.cs:40:14:40:14 | access to parameter i [Field1] : Object | semmle.label | access to parameter i [Field1] : Object |
 | I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:41:14:41:14 | access to parameter i [Field2] : Object | semmle.label | access to parameter i [Field2] : Object |
-| I.cs:41:14:41:21 | access to field Field2 | semmle.label | access to field Field2 |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C : C | object creation of type C : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 : C1 | object creation of type C1 : C1 |
@@ -597,15 +562,7 @@ nodes
 | H.cs:148:14:148:14 | access to local variable a | H.cs:147:25:147:31 | object creation of type A : A | H.cs:148:14:148:14 | access to local variable a | $@ | H.cs:147:25:147:31 | object creation of type A : A | object creation of type A : A |
 | H.cs:166:14:166:14 | access to local variable b | H.cs:155:17:155:23 | object creation of type B : B | H.cs:166:14:166:14 | access to local variable b | $@ | H.cs:155:17:155:23 | object creation of type B : B | object creation of type B : B |
 | H.cs:167:14:167:21 | access to field FieldB | H.cs:163:17:163:28 | object creation of type Object : Object | H.cs:167:14:167:21 | access to field FieldB | $@ | H.cs:163:17:163:28 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:18:14:18:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
 | I.cs:18:14:18:21 | access to field Field1 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:13:17:13:28 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:19:14:19:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:19:14:19:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:19:14:19:21 | access to field Field2 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:19:14:19:21 | access to field Field2 | $@ | I.cs:13:17:13:28 | object creation of type Object : Object | object creation of type Object : Object |
 | I.cs:23:14:23:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:23:14:23:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:24:14:24:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:24:14:24:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
 | I.cs:27:14:27:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:27:14:27:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:28:14:28:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:28:14:28:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:40:14:40:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
 | I.cs:40:14:40:21 | access to field Field1 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:31:13:31:24 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:41:14:41:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:41:14:41:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
-| I.cs:41:14:41:21 | access to field Field2 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:41:14:41:21 | access to field Field2 | $@ | I.cs:31:13:31:24 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -215,6 +215,48 @@ edges
 | H.cs:165:21:165:28 | access to field FieldA : B | H.cs:165:17:165:28 | (...) ... : B |
 | H.cs:165:21:165:28 | access to field FieldA [FieldB] : Object | H.cs:165:17:165:28 | (...) ... [FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b [FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:14:17:14:23 | object creation of type I [Field1] : Object |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:21:13:21:19 | object creation of type I [Field1] : Object |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:26:13:26:37 | object creation of type I [Field1] : Object |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:30:13:30:19 | object creation of type I [Field1] : Object |
+| I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:7:9:7:14 | [post] this access [Field1] : Object |
+| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:14:17:14:23 | object creation of type I [Field2] : Object |
+| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:21:13:21:19 | object creation of type I [Field2] : Object |
+| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:26:13:26:37 | object creation of type I [Field2] : Object |
+| I.cs:8:9:8:14 | [post] this access [Field2] : Object | I.cs:30:13:30:19 | object creation of type I [Field2] : Object |
+| I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:8:9:8:14 | [post] this access [Field2] : Object |
+| I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:15:20:15:20 | access to local variable o : Object |
+| I.cs:14:17:14:23 | object creation of type I [Field1] : Object | I.cs:18:14:18:14 | access to local variable i [Field1] : Object |
+| I.cs:14:17:14:23 | object creation of type I [Field2] : Object | I.cs:19:14:19:14 | access to local variable i [Field2] : Object |
+| I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | I.cs:18:14:18:14 | access to local variable i [Field1] : Object |
+| I.cs:15:20:15:20 | access to local variable o : Object | I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object |
+| I.cs:15:20:15:20 | access to local variable o : Object | I.cs:16:20:16:20 | access to local variable o : Object |
+| I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object | I.cs:19:14:19:14 | access to local variable i [Field2] : Object |
+| I.cs:16:20:16:20 | access to local variable o : Object | I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object |
+| I.cs:18:14:18:14 | access to local variable i [Field1] : Object | I.cs:18:14:18:21 | access to field Field1 |
+| I.cs:19:14:19:14 | access to local variable i [Field2] : Object | I.cs:19:14:19:21 | access to field Field2 |
+| I.cs:21:13:21:19 | object creation of type I [Field1] : Object | I.cs:23:14:23:14 | access to local variable i [Field1] : Object |
+| I.cs:21:13:21:19 | object creation of type I [Field2] : Object | I.cs:24:14:24:14 | access to local variable i [Field2] : Object |
+| I.cs:23:14:23:14 | access to local variable i [Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
+| I.cs:24:14:24:14 | access to local variable i [Field2] : Object | I.cs:24:14:24:21 | access to field Field2 |
+| I.cs:26:13:26:37 | object creation of type I [Field1] : Object | I.cs:27:14:27:14 | access to local variable i [Field1] : Object |
+| I.cs:26:13:26:37 | object creation of type I [Field2] : Object | I.cs:28:14:28:14 | access to local variable i [Field2] : Object |
+| I.cs:27:14:27:14 | access to local variable i [Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
+| I.cs:28:14:28:14 | access to local variable i [Field2] : Object | I.cs:28:14:28:21 | access to field Field2 |
+| I.cs:30:13:30:19 | object creation of type I [Field1] : Object | I.cs:34:12:34:12 | access to local variable i [Field1] : Object |
+| I.cs:30:13:30:19 | object creation of type I [Field2] : Object | I.cs:34:12:34:12 | access to local variable i [Field2] : Object |
+| I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:32:20:32:20 | access to local variable o : Object |
+| I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | I.cs:34:12:34:12 | access to local variable i [Field1] : Object |
+| I.cs:32:20:32:20 | access to local variable o : Object | I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object |
+| I.cs:32:20:32:20 | access to local variable o : Object | I.cs:33:20:33:20 | access to local variable o : Object |
+| I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object | I.cs:34:12:34:12 | access to local variable i [Field2] : Object |
+| I.cs:33:20:33:20 | access to local variable o : Object | I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object |
+| I.cs:34:12:34:12 | access to local variable i [Field1] : Object | I.cs:37:23:37:23 | i [Field1] : Object |
+| I.cs:34:12:34:12 | access to local variable i [Field2] : Object | I.cs:37:23:37:23 | i [Field2] : Object |
+| I.cs:37:23:37:23 | i [Field1] : Object | I.cs:40:14:40:14 | access to parameter i [Field1] : Object |
+| I.cs:37:23:37:23 | i [Field2] : Object | I.cs:41:14:41:14 | access to parameter i [Field2] : Object |
+| I.cs:40:14:40:14 | access to parameter i [Field1] : Object | I.cs:40:14:40:21 | access to field Field1 |
+| I.cs:41:14:41:14 | access to parameter i [Field2] : Object | I.cs:41:14:41:21 | access to field Field2 |
 nodes
 | A.cs:5:17:5:23 | object creation of type C : C | semmle.label | object creation of type C : C |
 | A.cs:6:17:6:25 | call to method Make [c] : C | semmle.label | call to method Make [c] : C |
@@ -464,6 +506,48 @@ nodes
 | H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
 | H.cs:167:14:167:14 | access to local variable b [FieldB] : Object | semmle.label | access to local variable b [FieldB] : Object |
 | H.cs:167:14:167:21 | access to field FieldB | semmle.label | access to field FieldB |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | semmle.label | [post] this access [Field1] : Object |
+| I.cs:7:18:7:29 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| I.cs:8:9:8:14 | [post] this access [Field2] : Object | semmle.label | [post] this access [Field2] : Object |
+| I.cs:8:18:8:29 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| I.cs:13:17:13:28 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| I.cs:14:17:14:23 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
+| I.cs:14:17:14:23 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
+| I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | semmle.label | [post] access to local variable i [Field1] : Object |
+| I.cs:15:20:15:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:16:9:16:9 | [post] access to local variable i [Field2] : Object | semmle.label | [post] access to local variable i [Field2] : Object |
+| I.cs:16:20:16:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:18:14:18:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
+| I.cs:18:14:18:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:19:14:19:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
+| I.cs:19:14:19:21 | access to field Field2 | semmle.label | access to field Field2 |
+| I.cs:21:13:21:19 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
+| I.cs:21:13:21:19 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
+| I.cs:23:14:23:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
+| I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:24:14:24:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
+| I.cs:24:14:24:21 | access to field Field2 | semmle.label | access to field Field2 |
+| I.cs:26:13:26:37 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
+| I.cs:26:13:26:37 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
+| I.cs:27:14:27:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
+| I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:28:14:28:14 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
+| I.cs:28:14:28:21 | access to field Field2 | semmle.label | access to field Field2 |
+| I.cs:30:13:30:19 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
+| I.cs:30:13:30:19 | object creation of type I [Field2] : Object | semmle.label | object creation of type I [Field2] : Object |
+| I.cs:31:13:31:24 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | semmle.label | [post] access to local variable i [Field1] : Object |
+| I.cs:32:20:32:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:33:9:33:9 | [post] access to local variable i [Field2] : Object | semmle.label | [post] access to local variable i [Field2] : Object |
+| I.cs:33:20:33:20 | access to local variable o : Object | semmle.label | access to local variable o : Object |
+| I.cs:34:12:34:12 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
+| I.cs:34:12:34:12 | access to local variable i [Field2] : Object | semmle.label | access to local variable i [Field2] : Object |
+| I.cs:37:23:37:23 | i [Field1] : Object | semmle.label | i [Field1] : Object |
+| I.cs:37:23:37:23 | i [Field2] : Object | semmle.label | i [Field2] : Object |
+| I.cs:40:14:40:14 | access to parameter i [Field1] : Object | semmle.label | access to parameter i [Field1] : Object |
+| I.cs:40:14:40:21 | access to field Field1 | semmle.label | access to field Field1 |
+| I.cs:41:14:41:14 | access to parameter i [Field2] : Object | semmle.label | access to parameter i [Field2] : Object |
+| I.cs:41:14:41:21 | access to field Field2 | semmle.label | access to field Field2 |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C : C | object creation of type C : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 : C1 | object creation of type C1 : C1 |
@@ -513,3 +597,15 @@ nodes
 | H.cs:148:14:148:14 | access to local variable a | H.cs:147:25:147:31 | object creation of type A : A | H.cs:148:14:148:14 | access to local variable a | $@ | H.cs:147:25:147:31 | object creation of type A : A | object creation of type A : A |
 | H.cs:166:14:166:14 | access to local variable b | H.cs:155:17:155:23 | object creation of type B : B | H.cs:166:14:166:14 | access to local variable b | $@ | H.cs:155:17:155:23 | object creation of type B : B | object creation of type B : B |
 | H.cs:167:14:167:21 | access to field FieldB | H.cs:163:17:163:28 | object creation of type Object : Object | H.cs:167:14:167:21 | access to field FieldB | $@ | H.cs:163:17:163:28 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:18:14:18:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:18:14:18:21 | access to field Field1 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:18:14:18:21 | access to field Field1 | $@ | I.cs:13:17:13:28 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:19:14:19:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:19:14:19:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:19:14:19:21 | access to field Field2 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:19:14:19:21 | access to field Field2 | $@ | I.cs:13:17:13:28 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:23:14:23:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:23:14:23:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:24:14:24:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:24:14:24:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:27:14:27:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:27:14:27:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:28:14:28:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:28:14:28:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:40:14:40:21 | access to field Field1 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:7:18:7:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:40:14:40:21 | access to field Field1 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:40:14:40:21 | access to field Field1 | $@ | I.cs:31:13:31:24 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:41:14:41:21 | access to field Field2 | I.cs:8:18:8:29 | object creation of type Object : Object | I.cs:41:14:41:21 | access to field Field2 | $@ | I.cs:8:18:8:29 | object creation of type Object : Object | object creation of type Object : Object |
+| I.cs:41:14:41:21 | access to field Field2 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:41:14:41:21 | access to field Field2 | $@ | I.cs:31:13:31:24 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -217,7 +217,7 @@ edges
 | H.cs:165:21:165:28 | access to field FieldA [FieldB] : Object | H.cs:165:17:165:28 | (...) ... [FieldB] : Object |
 | H.cs:167:14:167:14 | access to local variable b [FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB |
 | I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:21:13:21:19 | object creation of type I [Field1] : Object |
-| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:26:13:26:37 | object creation of type I [Field1] : Object |
+| I.cs:7:9:7:14 | [post] this access [Field1] : Object | I.cs:26:13:26:37 | [pre-initializer] object creation of type I [Field1] : Object |
 | I.cs:7:18:7:29 | object creation of type Object : Object | I.cs:7:9:7:14 | [post] this access [Field1] : Object |
 | I.cs:13:17:13:28 | object creation of type Object : Object | I.cs:15:20:15:20 | access to local variable o : Object |
 | I.cs:15:9:15:9 | [post] access to local variable i [Field1] : Object | I.cs:16:9:16:9 | access to local variable i [Field1] : Object |
@@ -228,7 +228,7 @@ edges
 | I.cs:21:13:21:19 | object creation of type I [Field1] : Object | I.cs:22:9:22:9 | access to local variable i [Field1] : Object |
 | I.cs:22:9:22:9 | access to local variable i [Field1] : Object | I.cs:23:14:23:14 | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [Field1] : Object | I.cs:23:14:23:21 | access to field Field1 |
-| I.cs:26:13:26:37 | object creation of type I [Field1] : Object | I.cs:27:14:27:14 | access to local variable i [Field1] : Object |
+| I.cs:26:13:26:37 | [pre-initializer] object creation of type I [Field1] : Object | I.cs:27:14:27:14 | access to local variable i [Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i [Field1] : Object | I.cs:27:14:27:21 | access to field Field1 |
 | I.cs:31:13:31:24 | object creation of type Object : Object | I.cs:32:20:32:20 | access to local variable o : Object |
 | I.cs:32:9:32:9 | [post] access to local variable i [Field1] : Object | I.cs:33:9:33:9 | access to local variable i [Field1] : Object |
@@ -501,7 +501,7 @@ nodes
 | I.cs:22:9:22:9 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:23:14:23:21 | access to field Field1 | semmle.label | access to field Field1 |
-| I.cs:26:13:26:37 | object creation of type I [Field1] : Object | semmle.label | object creation of type I [Field1] : Object |
+| I.cs:26:13:26:37 | [pre-initializer] object creation of type I [Field1] : Object | semmle.label | [pre-initializer] object creation of type I [Field1] : Object |
 | I.cs:27:14:27:14 | access to local variable i [Field1] : Object | semmle.label | access to local variable i [Field1] : Object |
 | I.cs:27:14:27:21 | access to field Field1 | semmle.label | access to field Field1 |
 | I.cs:31:13:31:24 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/I.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/I.cs
@@ -1,0 +1,46 @@
+public class I
+{
+    object Field1;
+    object Field2;
+    public I()
+    {
+        Field1 = new object();
+        Field2 = new object();
+    }
+
+    private void M()
+    {
+        var o = new object();
+        var i = new I();
+        i.Field1 = o;
+        i.Field2 = o;
+        i.Field2 = null;
+        Sink(i.Field1); // flow
+        Sink(i.Field2); // no flow [FALSE POSITIVE]
+
+        i = new I();
+        i.Field2 = null;
+        Sink(i.Field1); // flow
+        Sink(i.Field2); // no flow [FALSE POSITIVE]
+
+        i = new I() { Field2 = null };
+        Sink(i.Field1); // flow
+        Sink(i.Field2); // no flow [FALSE POSITIVE]
+
+        i = new I();
+        o = new object();
+        i.Field1 = o;
+        i.Field2 = o;
+        M2(i);
+    }
+
+    private void M2(I i)
+    {
+        i.Field2 = null;
+        Sink(i.Field1); // flow
+        Sink(i.Field2); // no flow [FALSE POSITIVE]
+
+    }
+
+    public static void Sink(object o) { }
+}

--- a/csharp/ql/test/library-tests/dataflow/fields/I.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/I.cs
@@ -16,16 +16,16 @@ public class I
         i.Field2 = o;
         i.Field2 = null;
         Sink(i.Field1); // flow
-        Sink(i.Field2); // no flow [FALSE POSITIVE]
+        Sink(i.Field2); // no flow
 
         i = new I();
         i.Field2 = null;
         Sink(i.Field1); // flow
-        Sink(i.Field2); // no flow [FALSE POSITIVE]
+        Sink(i.Field2); // no flow
 
         i = new I() { Field2 = null };
         Sink(i.Field1); // flow
-        Sink(i.Field2); // no flow [FALSE POSITIVE]
+        Sink(i.Field2); // no flow
 
         i = new I();
         o = new object();
@@ -38,7 +38,7 @@ public class I
     {
         i.Field2 = null;
         Sink(i.Field1); // flow
-        Sink(i.Field2); // no flow [FALSE POSITIVE]
+        Sink(i.Field2); // no flow
 
     }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -754,6 +754,13 @@ abstract class AccessPathFront extends TAccessPathFront {
   abstract boolean toBoolNonEmpty();
 
   predicate headUsesContent(TypedContent tc) { this = TFrontHead(tc) }
+
+  predicate isClearedAt(Node n) {
+    exists(TypedContent tc |
+      this.headUsesContent(tc) and
+      clearsContent(n, tc.getContent())
+    )
+  }
 }
 
 class AccessPathFrontNil extends AccessPathFront, TFrontNil {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -196,6 +196,15 @@ predicate readStep(Node node1, Content f, Node node2) {
 }
 
 /**
+ * Holds if values stored inside content `c` are cleared at node `n`. For example,
+ * any value stored inside `f` is cleared at the pre-update node associated with `x`
+ * in `x.f = newValue`.
+ */
+predicate clearsContent(Node n, Content c) {
+  n = any(PostUpdateNode pun | storeStep(_, c, pun)).getPreUpdateNode()
+}
+
+/**
  * Gets a representative (boxed) type for `t` for the purpose of pruning
  * possible flow. A single type is used for all numeric types to account for
  * numeric conversions, and otherwise the erasure is used.

--- a/java/ql/test/library-tests/dataflow/fields/F.java
+++ b/java/ql/test/library-tests/dataflow/fields/F.java
@@ -1,0 +1,38 @@
+public class F {
+  Object Field1;
+  Object Field2;
+  public F() {
+    Field1 = new Object();
+    Field2 = new Object();
+  }
+
+  private void m() {
+    Object o = new Object();
+    F f = new F();
+    f.Field1 = o;
+    f.Field2 = o;
+    f.Field2 = null;
+    sink(f.Field1); // flow
+    sink(f.Field2); // no flow [FALSE POSITIVE]
+
+    f = new F();
+    f.Field2 = null;
+    sink(f.Field1); // flow
+    sink(f.Field2); // no flow [FALSE POSITIVE]
+
+    f = new F();
+    o = new Object();
+    f.Field1 = o;
+    f.Field2 = o;
+    m2(f);
+  }
+
+  private void m2(F f)
+  {
+    f.Field2 = null;
+    sink(f.Field1); // flow
+    sink(f.Field2); // no flow [FALSE POSITIVE]
+  }
+
+  public static void sink(Object o) { }
+}

--- a/java/ql/test/library-tests/dataflow/fields/F.java
+++ b/java/ql/test/library-tests/dataflow/fields/F.java
@@ -13,12 +13,12 @@ public class F {
     f.Field2 = o;
     f.Field2 = null;
     sink(f.Field1); // flow
-    sink(f.Field2); // no flow [FALSE POSITIVE]
+    sink(f.Field2); // no flow
 
     f = new F();
     f.Field2 = null;
     sink(f.Field1); // flow
-    sink(f.Field2); // no flow [FALSE POSITIVE]
+    sink(f.Field2); // no flow
 
     f = new F();
     o = new Object();
@@ -31,7 +31,7 @@ public class F {
   {
     f.Field2 = null;
     sink(f.Field1); // flow
-    sink(f.Field2); // no flow [FALSE POSITIVE]
+    sink(f.Field2); // no flow
   }
 
   public static void sink(Object o) { }

--- a/java/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/java/ql/test/library-tests/dataflow/fields/flow.expected
@@ -26,3 +26,13 @@
 | E.java:2:32:2:43 | new Object(...) | E.java:21:10:21:24 | bh2.buf.content |
 | E.java:2:32:2:43 | new Object(...) | E.java:24:10:24:28 | p2.data.buf.content |
 | E.java:2:32:2:43 | new Object(...) | E.java:30:10:30:27 | p.data.buf.content |
+| F.java:5:14:5:25 | new Object(...) | F.java:15:10:15:17 | f.Field1 |
+| F.java:5:14:5:25 | new Object(...) | F.java:20:10:20:17 | f.Field1 |
+| F.java:5:14:5:25 | new Object(...) | F.java:33:10:33:17 | f.Field1 |
+| F.java:6:14:6:25 | new Object(...) | F.java:16:10:16:17 | f.Field2 |
+| F.java:6:14:6:25 | new Object(...) | F.java:21:10:21:17 | f.Field2 |
+| F.java:6:14:6:25 | new Object(...) | F.java:34:10:34:17 | f.Field2 |
+| F.java:10:16:10:27 | new Object(...) | F.java:15:10:15:17 | f.Field1 |
+| F.java:10:16:10:27 | new Object(...) | F.java:16:10:16:17 | f.Field2 |
+| F.java:24:9:24:20 | new Object(...) | F.java:33:10:33:17 | f.Field1 |
+| F.java:24:9:24:20 | new Object(...) | F.java:34:10:34:17 | f.Field2 |

--- a/java/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/java/ql/test/library-tests/dataflow/fields/flow.expected
@@ -26,13 +26,6 @@
 | E.java:2:32:2:43 | new Object(...) | E.java:21:10:21:24 | bh2.buf.content |
 | E.java:2:32:2:43 | new Object(...) | E.java:24:10:24:28 | p2.data.buf.content |
 | E.java:2:32:2:43 | new Object(...) | E.java:30:10:30:27 | p.data.buf.content |
-| F.java:5:14:5:25 | new Object(...) | F.java:15:10:15:17 | f.Field1 |
 | F.java:5:14:5:25 | new Object(...) | F.java:20:10:20:17 | f.Field1 |
-| F.java:5:14:5:25 | new Object(...) | F.java:33:10:33:17 | f.Field1 |
-| F.java:6:14:6:25 | new Object(...) | F.java:16:10:16:17 | f.Field2 |
-| F.java:6:14:6:25 | new Object(...) | F.java:21:10:21:17 | f.Field2 |
-| F.java:6:14:6:25 | new Object(...) | F.java:34:10:34:17 | f.Field2 |
 | F.java:10:16:10:27 | new Object(...) | F.java:15:10:15:17 | f.Field1 |
-| F.java:10:16:10:27 | new Object(...) | F.java:16:10:16:17 | f.Field2 |
 | F.java:24:9:24:20 | new Object(...) | F.java:33:10:33:17 | f.Field1 |
-| F.java:24:9:24:20 | new Object(...) | F.java:34:10:34:17 | f.Field2 |


### PR DESCRIPTION
Add support to the shared data-flow library for modelling clearing/unsetting of fields. For example, in
```csharp
x.Field = taint;
x.Field = null;
Sink(x.Field);
```
the field `Field` is cleared in both assignments, meaning that previous values stored inside `Field` cannot flow any further (so, in particular, `taint` cannot flow to `Sink()`).

I have implemented clearing via assignments for C# and Java, which relies on the fact that both languages have use-use flow. Note also that, in general, clearing is not simply the same as stores, for example when modelling collection-flow using "field"-flow:
```csharp
a.Add(taint);
a.Add(null); // Does not clear `a`
Sink(a[i]);
```

I have not implemented the logic for C++, as I seem to recall that use-use flow is not used there (cc @jbj / @MathiasVP ).

This PR is best reviewed commmit-by-commit.

Differences jobs:
- C#: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/235/
- C++: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1217/
- Java: https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/795/