### PR TITLE
JS: support member calls of `console`

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -54,7 +54,7 @@ private module Console {
         name = getAStandardLoggerMethodName() or
         name = "assert"
       ) and
-      this = console().getAMethodCall(name)
+      this = console().getAMemberCall(name)
     }
 
     override DataFlow::Node getAMessageComponent() {

--- a/javascript/ql/test/library-tests/frameworks/Logging/LoggerCall.expected
+++ b/javascript/ql/test/library-tests/frameworks/Logging/LoggerCall.expected
@@ -15,3 +15,5 @@
 | tst.js:14:1:14:48 | require ... ", arg) | tst.js:14:45:14:47 | arg |
 | tst.js:16:1:16:35 | console ... ", arg) | tst.js:16:22:16:29 | "msg %s" |
 | tst.js:16:1:16:35 | console ... ", arg) | tst.js:16:32:16:34 | arg |
+| tst.js:19:1:19:18 | log("msg %s", arg) | tst.js:19:5:19:12 | "msg %s" |
+| tst.js:19:1:19:18 | log("msg %s", arg) | tst.js:19:15:19:17 | arg |

--- a/javascript/ql/test/library-tests/frameworks/Logging/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Logging/tst.js
@@ -14,3 +14,6 @@ require("winston").createLogger().info("msg %s", arg);
 require("log4js").getLogger().log("msg %s", arg);
 
 console.assert(true, "msg %s", arg);
+
+let log = console.log;
+log("msg %s", arg);


### PR DESCRIPTION
It appears that the members of `console` are bound by default now, so it seems reasonable to use `getAMemberCall` instead of `getAMethodCall`. Thanks #3734.