### PR TITLE
JS: don't report insecure randomness when the insecure random is just a fallback

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -56,6 +56,7 @@
 | Expression has no effect (`js/useless-expression`) | Fewer results | This query no longer flags an expression when that expression is the only content of the containing file. |
 | Hard-coded credentials (`js/hardcoded-credentials`) | More results | This query now recognizes hard-coded credentials sent via HTTP authorization headers. |
 | Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes additional url scheme checks. |
+| Insecure randomness (`js/insecure-randomness`) | Less results | This query now recognizes when an insecure random value is used as a fallback when secure random values are unsupported. |
 | Misspelled variable name (`js/misspelled-variable-name`) | Message changed | The message for this query now correctly identifies the misspelled variable in additional cases. |
 | Non-linear pattern (`js/non-linear-pattern`) | Fewer duplicates and message changed | This query now generates fewer duplicate alerts and has a clearer explanation in case of type annotations used in a pattern. |
 | Prototype pollution in utility function (`js/prototype-pollution-utility`) | More results | This query now recognizes additional utility functions as vulnerable to prototype polution. |

--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -56,7 +56,7 @@
 | Expression has no effect (`js/useless-expression`) | Fewer results | This query no longer flags an expression when that expression is the only content of the containing file. |
 | Hard-coded credentials (`js/hardcoded-credentials`) | More results | This query now recognizes hard-coded credentials sent via HTTP authorization headers. |
 | Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes additional url scheme checks. |
-| Insecure randomness (`js/insecure-randomness`) | Less results | This query now recognizes when an insecure random value is used as a fallback when secure random values are unsupported. |
+| Insecure randomness (`js/insecure-randomness`) | Fewer results | This query now recognizes when an insecure random value is used as a fallback when secure random values are unsupported. |
 | Misspelled variable name (`js/misspelled-variable-name`) | Message changed | The message for this query now correctly identifies the misspelled variable in additional cases. |
 | Non-linear pattern (`js/non-linear-pattern`) | Fewer duplicates and message changed | This query now generates fewer duplicate alerts and has a clearer explanation in case of type annotations used in a pattern. |
 | Prototype pollution in utility function (`js/prototype-pollution-utility`) | More results | This query now recognizes additional utility functions as vulnerable to prototype polution. |

--- a/javascript/ql/src/Security/CWE-327/BadRandomness.ql
+++ b/javascript/ql/src/Security/CWE-327/BadRandomness.ql
@@ -56,26 +56,6 @@ private DataFlow::Node isPowerOfTwoMinusOne() {
 }
 
 /**
- * Gets a Buffer/TypedArray containing cryptographically secure random numbers.
- */
-private DataFlow::SourceNode randomBufferSource() {
-  result = DataFlow::moduleMember("crypto", ["randomBytes", "randomFillSync"]).getACall()
-  or
-  exists(DataFlow::CallNode call |
-    call = DataFlow::moduleMember("crypto", ["randomFill", "randomFillSync"]) and
-    result = call.getArgument(0).getALocalSource()
-  )
-  or
-  result = DataFlow::globalVarRef("crypto").getAMethodCall("getRandomValues")
-  or
-  result = DataFlow::moduleImport("secure-random").getACall()
-  or
-  result =
-    DataFlow::moduleImport("secure-random")
-        .getAMethodCall(["randomArray", "randomUint8Array", "randomBuffer"])
-}
-
-/**
  * Gets the pseudo-property used to track elements inside a Buffer.
  * The API for `Set` is close enough to the API for `Buffer` that we can reuse the type-tracking steps.
  */
@@ -86,7 +66,7 @@ private string prop() { result = DataFlow::PseudoProperties::setElement() }
  */
 private DataFlow::Node goodRandom(DataFlow::TypeTracker t, DataFlow::SourceNode source) {
   t.startInProp(prop()) and
-  result = randomBufferSource() and
+  result = InsecureRandomness::randomBufferSource() and
   result = source
   or
   // Loading a number from a `Buffer`.

--- a/javascript/ql/test/query-tests/Security/CWE-338/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-338/tst.js
@@ -93,4 +93,20 @@ function f18() {
 (function(){
     var crypto = require('crypto');
     crypto.createHmac('sha256', Math.random());
-})()
+})();
+
+(function () {
+    function genRandom() {
+        if (window.crypto && crypto.getRandomValues && !isSafari()) {
+            var a = window.crypto.getRandomValues(new Uint32Array(3)),
+                token = '';
+            for (var i = 0, l = a.length; i < l; i++) {
+                token += a[i].toString(36);
+            }
+            return token;
+        } else {
+            return (Math.random() * new Date().getTime()).toString(36).replace(/\./g, '');
+        }
+    };
+    var secret = genRandom(); // OK - Math.random() is only a fallback.
+})();


### PR DESCRIPTION
To avoid a lot of the FPs that appear here: https://lgtm.com/projects/g/muaz-khan/WebRTC-Experiment/alerts?id=js%2Finsecure-randomness&mode=list

Here are some of the sources we now skip: https://lgtm.com/query/864565454247826420/