### PR TITLE
C#: Enable syntax highlighting in QLDoc snippets

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Initializer.cs
@@ -74,7 +74,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                     var typeInfoRight = cx.GetTypeInfo(assignment.Right);
                     if (typeInfoRight.Type is null)
                         // The type may be null for nested initializers such as
-                        // ```
+                        // ```csharp
                         // new ClassWithArrayField() { As = { [0] = a } }
                         // ```
                         // In this case we take the type from the assignment

--- a/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.ql
+++ b/csharp/ql/src/Security Features/CWE-451/MissingXFrameOptions.ql
@@ -20,7 +20,7 @@ import semmle.code.csharp.frameworks.system.Web
  */
 predicate hasWebConfigXFrameOptions(WebConfigXML webConfig) {
   // Looking for an entry in `webConfig` that looks like this:
-  // ```
+  // ```xml
   // <system.webServer>
   //   <httpProtocol>
   //    <customHeaders>

--- a/csharp/ql/src/Stubs/Stubs.qll
+++ b/csharp/ql/src/Stubs/Stubs.qll
@@ -5,7 +5,7 @@
  * This will generate stubs for all the required dependencies as well.
  *
  * Use
- * ```
+ * ```ql
  * select generatedCode()
  * ```
  * to retrieve the generated C# code.

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Foreach.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Foreach.qll
@@ -5,13 +5,13 @@
  * Also we only deal with foreach stmts where there is only
  * one declaration (see below).
  * For example the code:
- *    ```
+ *    ```csharp
  *      foreach(var item in some_enumerable) {
  *        // body
  *      }
  *    ```
  * gets desugared to:
- *    ```
+ *    ```csharp
  *      Enumerator e = some_enumerable.GetEnumerator();
  *      try
  *      {

--- a/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Lock.qll
+++ b/csharp/ql/src/experimental/ir/implementation/raw/internal/desugar/Lock.qll
@@ -1,11 +1,11 @@
 /**
  * File that provides the desugaring of a `lock` stmt.
  * The statement:
- *    ```
+ *    ```csharp
  *      lock (anExpr) ...
  *    ```
  * gets desugared to:
- *    ```
+ *    ```csharp
  *      SomeRefType lockedVar = anExpr;
  *      bool __lockWasTaken = false;
  *      try {

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
@@ -12,7 +12,7 @@ module AliasModels {
      * the function returns.
      *
      * Example:
-     * ```
+     * ```csharp
      * int* g;
      * int* func(int* p, int* q, int* r, int* s, int n) {
      *   *s = 1;  // `s` does not escape.

--- a/csharp/ql/src/experimental/ir/internal/IRGuards.qll
+++ b/csharp/ql/src/experimental/ir/internal/IRGuards.qll
@@ -93,7 +93,7 @@ class GuardCondition extends Expr {
  * implies that the truth of the child expression `part` has truth value `partIsTrue`.
  *
  * For example if the binary operation:
- * ```
+ * ```csharp
  *   x && y
  * ```
  * is true, `x` and `y` must also be true, so `impliesValue(x, true, true)` and
@@ -341,7 +341,7 @@ class IRGuardCondition extends Instruction {
    * predecessors. For example, in the following situation, an inference can be made about the
    * value of `x` at the end of the `if` statement, but there is no block which is controlled by
    * the `if` statement when `x >= y`.
-   * ```
+   * ```csharp
    * if (x < y) {
    *   x = y;
    * }

--- a/csharp/ql/src/experimental/ir/rangeanalysis/RangeAnalysis.qll
+++ b/csharp/ql/src/experimental/ir/rangeanalysis/RangeAnalysis.qll
@@ -10,7 +10,7 @@
 
 /*
  * This library tackles range analysis as a flow problem. Consider e.g.:
- * ```
+ * ```csharp
  *   len = arr.length;
  *   if (x < len) { ... y = x-1; ... y ... }
  * ```

--- a/csharp/ql/src/semmle/code/asp/AspNet.qll
+++ b/csharp/ql/src/semmle/code/asp/AspNet.qll
@@ -32,7 +32,7 @@ class AspAttribute extends AspElement, @asp_attribute { }
 /**
  * An open tag, for example the tag on line 1 in
  *
- * ```
+ * ```html
  * <script runat="server">
  *   Label.Text = "Hello, World!";
  * </script>
@@ -67,7 +67,7 @@ class AspOpenTag extends AspElement, @asp_open_tag {
 /**
  * A close tag, for example the tag on line 3 in
  *
- * ```
+ * ```html
  * <script runat="server">
  *   Label.Text = "Hello, World!";
  * </script>
@@ -123,7 +123,7 @@ class AspServerComment extends AspComment {
 /**
  * A data-binding expression, for example `<%# myArray %>` in
  *
- * ```
+ * ```html
  * <asp:ListBox id="List1" datasource='<%# myArray %>' runat="server">
  * ```
  */

--- a/csharp/ql/src/semmle/code/cil/BasicBlock.qll
+++ b/csharp/ql/src/semmle/code/cil/BasicBlock.qll
@@ -23,7 +23,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (x < 0)
    *   x = -x;
    * ```
@@ -41,7 +41,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (!(x >= 0))
    *   x = -x;
    * ```
@@ -75,7 +75,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -97,7 +97,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -124,7 +124,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (x < 0) {
    *   x = -x;
    *   if (x > 10)
@@ -158,7 +158,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -182,7 +182,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   try {
    *     return s.Length;
@@ -207,7 +207,7 @@ class BasicBlock extends Cached::TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   try {
    *     return s.Length;
@@ -353,7 +353,7 @@ class ConditionBlock extends BasicBlock {
      * all predecessors of `this.getATrueSuccessor()` are either `this` or dominated by `this.getATrueSuccessor()`.
      *
      * For example, in the following C# snippet:
-     * ```
+     * ```csharp
      * if (x)
      *   controlled;
      * false_successor;
@@ -361,7 +361,7 @@ class ConditionBlock extends BasicBlock {
      * ```
      * `false_successor` dominates `uncontrolled`, but not all of its predecessors are `this` (`if (x)`)
      *  or dominated by itself. Whereas in the following code:
-     * ```
+     * ```csharp
      * if (x)
      *   while (controlled)
      *     also_controlled;

--- a/csharp/ql/src/semmle/code/csharp/Assignable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Assignable.qll
@@ -55,7 +55,7 @@ private predicate nameOfChild(NameOfExpr noe, Expr child) {
  *
  * For example, the last occurrence of `Length` in
  *
- * ```
+ * ```csharp
  * class C {
  *   int Length;
  *
@@ -89,7 +89,7 @@ class AssignableRead extends AssignableAccess {
    * that can be reached from this read without passing through any other reads,
    * and which is guaranteed to read the same value. Example:
    *
-   * ```
+   * ```csharp
    * int Field;
    *
    * void SetField(int i) {
@@ -131,7 +131,7 @@ class AssignableRead extends AssignableAccess {
  *
  * For example, the last occurrence of `Length` in
  *
- * ```
+ * ```csharp
  * class C {
  *   int Length;
  *
@@ -454,7 +454,7 @@ class AssignableDefinition extends TAssignableDefinition {
    * reads, and which is guaranteed to read the value assigned in this
    * definition. Example:
    *
-   * ```
+   * ```csharp
    * int Field;
    *
    * void SetField(int i) {
@@ -720,7 +720,7 @@ module AssignableDefinitions {
    * An initializer definition for a field or a property, for example
    * line 2 in
    *
-   * ```
+   * ```csharp
    * class C {
    *   int Field = 0;
    * }

--- a/csharp/ql/src/semmle/code/csharp/Attribute.qll
+++ b/csharp/ql/src/semmle/code/csharp/Attribute.qll
@@ -38,7 +38,7 @@ class Attributable extends @attributable {
 /**
  * An attribute, for example `[...]` on line 1 in
  *
- * ```
+ * ```csharp
  * [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
  * public static extern int GetFinalPathNameByHandle(
  *   SafeHandle handle,
@@ -64,7 +64,7 @@ class Attribute extends TopLevelExprParent, @attribute {
    * Gets the `i`th constructor argument of this attribute. For example, only
    * `true` is a constructor argument in
    *
-   * ```
+   * ```csharp
    * MyAttribute[true, Foo = 0]
    * ```
    */
@@ -76,7 +76,7 @@ class Attribute extends TopLevelExprParent, @attribute {
    * Gets the named argument `name` of this attribute. For example, only
    * `0` is a named argument in
    *
-   * ```
+   * ```csharp
    * MyAttribute[true, Foo = 0]
    * ```
    */

--- a/csharp/ql/src/semmle/code/csharp/Callable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Callable.qll
@@ -44,7 +44,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    * where the same callable is compiled multiple times. For example, if we
    * compile both `A.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() => 0;
@@ -54,7 +54,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    *
    * and later `B.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() { return 1; }
@@ -92,7 +92,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    * the case where the same callable is compiled multiple times. For example,
    * if we compile both `A.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() { return 0; }
@@ -102,7 +102,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    *
    * and later `B.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() { return 1; }
@@ -128,7 +128,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    * the case where the same callable is compiled multiple times. For example,
    * if we compile both `A.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() => 0;
@@ -138,7 +138,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
    *
    * and later `B.cs`
    *
-   * ```
+   * ```csharp
    * namespaces N {
    *   public class C {
    *     public int M() => 1;
@@ -223,7 +223,7 @@ class Callable extends DotNet::Callable, Parameterizable, ExprOrStmtParent, @cal
 /**
  * A method, for example
  *
- * ```
+ * ```csharp
  * public override bool Equals(object other) {
  *   ...
  * }
@@ -289,7 +289,7 @@ class Method extends Callable, Virtualizable, Attributable, @method {
 /**
  * An extension method, for example
  *
- * ```
+ * ```csharp
  * static bool IsDefined(this Widget w) {
  *   ...
  * }
@@ -307,7 +307,7 @@ class ExtensionMethod extends Method {
 /**
  * A constructor, for example `public C() { }` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public C() { }
  * }
@@ -326,7 +326,7 @@ class Constructor extends DotNet::Constructor, Callable, Member, Attributable, @
    * the initializer of the constructor on line 2 is `this(null)`
    * on line 3 in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public C()
    *     : this(null) { ... }
@@ -361,7 +361,7 @@ class Constructor extends DotNet::Constructor, Callable, Member, Attributable, @
  * A static constructor (as opposed to an instance constructor),
  * for example `static public C() { }` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   static public C() { }
  * }
@@ -377,7 +377,7 @@ class StaticConstructor extends Constructor {
  * An instance constructor (as opposed to a static constructor),
  * for example `public C() { }` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public C() { }
  * }
@@ -390,7 +390,7 @@ class InstanceConstructor extends Constructor {
 /**
  * A destructor, for example `~C() { }` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   ~C() { }
  * }
@@ -461,7 +461,7 @@ class UnaryOperator extends Operator {
 /**
  * A user-defined plus operator (`+`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator +(Widget w) {
  *   ...
  * }
@@ -476,7 +476,7 @@ class PlusOperator extends UnaryOperator {
 /**
  * A user-defined minus operator (`-`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator -(Widget w) {
  *   ...
  * }
@@ -491,7 +491,7 @@ class MinusOperator extends UnaryOperator {
 /**
  * A user-defined not operator (`!`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator !(Widget w) {
  *   ...
  * }
@@ -506,7 +506,7 @@ class NotOperator extends UnaryOperator {
 /**
  * A user-defined complement operator (`~`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator ~(Widget w) {
  *   ...
  * }
@@ -521,7 +521,7 @@ class ComplementOperator extends UnaryOperator {
 /**
  * A user-defined increment operator (`++`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator ++(Widget w) {
  *   ...
  * }
@@ -536,7 +536,7 @@ class IncrementOperator extends UnaryOperator {
 /**
  * A user-defined decrement operator (`--`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator --(Widget w) {
  *   ...
  * }
@@ -551,7 +551,7 @@ class DecrementOperator extends UnaryOperator {
 /**
  * A user-defined false operator (`false`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator false(Widget w) {
  *   ...
  * }
@@ -566,7 +566,7 @@ class FalseOperator extends UnaryOperator {
 /**
  * A user-defined true operator (`true`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator true(Widget w) {
  *   ...
  * }
@@ -598,7 +598,7 @@ class BinaryOperator extends Operator {
 /**
  * A user-defined addition operator (`+`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator +(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -613,7 +613,7 @@ class AddOperator extends BinaryOperator {
 /**
  * A user-defined subtraction operator (`-`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator -(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -628,7 +628,7 @@ class SubOperator extends BinaryOperator {
 /**
  * A user-defined multiplication operator (`*`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator *(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -643,7 +643,7 @@ class MulOperator extends BinaryOperator {
 /**
  * A user-defined division operator (`/`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator /(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -658,7 +658,7 @@ class DivOperator extends BinaryOperator {
 /**
  * A user-defined remainder operator (`%`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator %(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -673,7 +673,7 @@ class RemOperator extends BinaryOperator {
 /**
  * A user-defined and operator (`&`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator &(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -688,7 +688,7 @@ class AndOperator extends BinaryOperator {
 /**
  * A user-defined or operator (`|`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator |(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -703,7 +703,7 @@ class OrOperator extends BinaryOperator {
 /**
  * A user-defined xor operator (`^`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator ^(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -718,7 +718,7 @@ class XorOperator extends BinaryOperator {
 /**
  * A user-defined left shift operator (`<<`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator <<(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -733,7 +733,7 @@ class LShiftOperator extends BinaryOperator {
 /**
  * A user-defined right shift operator (`>>`), for example
  *
- * ```
+ * ```csharp
  * public static Widget operator >>(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -748,7 +748,7 @@ class RShiftOperator extends BinaryOperator {
 /**
  * A user-defined equals operator (`==`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator ==(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -763,7 +763,7 @@ class EQOperator extends BinaryOperator {
 /**
  * A user-defined not equals operator (`!=`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator !=(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -778,7 +778,7 @@ class NEOperator extends BinaryOperator {
 /**
  * A user-defined lesser than operator (`<`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator <(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -793,7 +793,7 @@ class LTOperator extends BinaryOperator {
 /**
  * A user-defined greater than operator (`>`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator >(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -808,7 +808,7 @@ class GTOperator extends BinaryOperator {
 /**
  * A user-defined less than or equals operator (`<=`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator <=(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -823,7 +823,7 @@ class LEOperator extends BinaryOperator {
 /**
  * A user-defined greater than or equals operator (`>=`), for example
  *
- * ```
+ * ```csharp
  * public static bool operator >=(Widget lhs, Widget rhs) {
  *   ...
  * }
@@ -838,7 +838,7 @@ class GEOperator extends BinaryOperator {
 /**
  * A user-defined conversion operator, for example
  *
- * ```
+ * ```csharp
  * public static implicit operator int(BigInteger i) {
  *   ...
  * }
@@ -860,7 +860,7 @@ class ConversionOperator extends Operator {
 /**
  * A user-defined implicit conversion operator, for example
  *
- * ```
+ * ```csharp
  * public static implicit operator int(BigInteger i) {
  *   ...
  * }
@@ -875,7 +875,7 @@ class ImplicitConversionOperator extends ConversionOperator {
 /**
  * A user-defined explicit conversion operator, for example
  *
- * ```
+ * ```csharp
  * public static explicit operator int(BigInteger i) {
  *   ...
  * }
@@ -891,7 +891,7 @@ class ExplicitConversionOperator extends ConversionOperator {
  * A local function, defined within the scope of another callable.
  * For example, `Fac` on lines 2--4 in
  *
- * ```
+ * ```csharp
  * int Choose(int n, int m) {
  *   int Fac(int x) {
  *     return x > 1 ? x * Fac(x - 1) : 1;

--- a/csharp/ql/src/semmle/code/csharp/Comments.qll
+++ b/csharp/ql/src/semmle/code/csharp/Comments.qll
@@ -34,7 +34,7 @@ class CommentLine extends @commentline {
 /**
  * A single-line comment, for example line 1 in
  *
- * ```
+ * ```csharp
  * // This method returns the successor of its argument
  * public int Succ(int x) => x + 1;
  * ```
@@ -47,7 +47,7 @@ class SinglelineComment extends CommentLine, @singlelinecomment {
  * A line of comment in a multiline style, for example each of the
  * lines in
  *
- * ```
+ * ```csharp
  * /* This is
  *    a comment * /
  * ```
@@ -60,7 +60,7 @@ class MultilineComment extends CommentLine, @multilinecomment {
  * A line of XML documentation comment, for example each of the
  * lines in
  *
- * ```
+ * ```csharp
  * /// <summary>
  * ///   This method ...
  * /// </summary>
@@ -148,7 +148,7 @@ class XmlComment extends CommentLine, @xmldoccomment {
 /**
  * A collection of adjacent comment lines, for example
  *
- * ```
+ * ```csharp
  * /// <summary>
  * /// Represents a named tuple.
  * /// </summary>

--- a/csharp/ql/src/semmle/code/csharp/Conversion.qll
+++ b/csharp/ql/src/semmle/code/csharp/Conversion.qll
@@ -362,7 +362,7 @@ private module Identity {
     IdentityConvertibleGenericType fromType, IdentityConvertibleGenericType toType
   ) {
     // Semantically equivalent with
-    // ```
+    // ```ql
     // ugt = fromType.getUnboundGeneric()
     // and
     // forex(int i |
@@ -773,7 +773,7 @@ predicate convConversionOperator(Type fromType, Type toType) {
 /** 13.1.3.2: Variance conversion. */
 private predicate convVariance(GenericType fromType, GenericType toType) {
   // Semantically equivalent with
-  // ```
+  // ```ql
   // ugt = fromType.getUnboundGeneric()
   // and
   // forex(int i |

--- a/csharp/ql/src/semmle/code/csharp/Event.qll
+++ b/csharp/ql/src/semmle/code/csharp/Event.qll
@@ -8,7 +8,7 @@ import Type
 /**
  * An event, for example `E` on line 3 in
  *
- * ```
+ * ```csharp
  * class C {
  *   delegate void D();
  *   public event D E;
@@ -67,7 +67,7 @@ class Event extends DeclarationWithAccessors, @event {
  * An event accessor, for example `add` on line 4 or `remove`
  * on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   delegate void D();
  *   public event D E {
@@ -95,7 +95,7 @@ class EventAccessor extends Accessor, @event_accessor {
 /**
  * An add event accessor, for example `add` on line 4 in
  *
- * ```
+ * ```csharp
  * class C {
  *   delegate void D();
  *   public event D E {
@@ -112,7 +112,7 @@ class AddEventAccessor extends EventAccessor, @add_event_accessor {
 /**
  * A remove event accessor, for example `remove` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   delegate void D();
  *   public event D E {

--- a/csharp/ql/src/semmle/code/csharp/ExprOrStmtParent.qll
+++ b/csharp/ql/src/semmle/code/csharp/ExprOrStmtParent.qll
@@ -126,7 +126,7 @@ class TopLevelExprParent extends Element, @top_level_expr_parent {
  * encountered multiple potential implementations at compile-time. For example,
  * if we compile both `A.cs`
  *
- * ```
+ * ```csharp
  * namespaces N {
  *   public class C {
  *     public int M() => 0;
@@ -136,7 +136,7 @@ class TopLevelExprParent extends Element, @top_level_expr_parent {
  *
  * and later `B.cs`
  *
- * ```
+ * ```csharp
  * namespaces N {
  *   public class C {
  *     public int M() => 1;

--- a/csharp/ql/src/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/src/semmle/code/csharp/Generics.qll
@@ -190,7 +190,7 @@ class TypeParameter extends DotNet::TypeParameter, Type, @type_parameter {
  *
  * For example, `where` on line 2 in
  *
- * ```
+ * ```csharp
  * class Factory<T>
  *   where T : ICloneable {
  * }
@@ -233,7 +233,7 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
  *
  * For example,
  *
- * ```
+ * ```csharp
  * struct KeyValuePair<Key, Value> {
  *   ...
  * }
@@ -256,7 +256,7 @@ class UnboundGenericStruct extends Struct, UnboundGenericType {
 /**
  * An unbound generic class, for example
  *
- * ```
+ * ```csharp
  * class List<T> {
  *   ...
  * }
@@ -279,7 +279,7 @@ class UnboundGenericClass extends Class, UnboundGenericType {
 /**
  * An unbound generic interface, for example
  *
- * ```
+ * ```csharp
  * interface IEnumerable<T> {
  *   ...
  * }
@@ -305,7 +305,7 @@ class UnboundGenericInterface extends Interface, UnboundGenericType {
  *
  * For example
  *
- * ```
+ * ```csharp
  * delegate void F<T>(T t);
  * ```
  */
@@ -375,7 +375,7 @@ class ConstructedType extends ValueOrRefType, ConstructedGeneric {
  *
  * For example, `KeyValuePair<int, string>` on line 4 in
  *
- * ```
+ * ```csharp
  * struct KeyValuePair<Key, Value> { ... }
  *
  * class C {
@@ -398,7 +398,7 @@ class ConstructedStruct extends Struct, ConstructedType {
  *
  * For example, `List<int>` on line 4 in
  *
- * ```
+ * ```csharp
  * class List<T> { ... }
  *
  * class C {
@@ -421,7 +421,7 @@ class ConstructedClass extends Class, ConstructedType {
  *
  * For example, `IEnumerable<string>` on line 4 in
  *
- * ```
+ * ```csharp
  * interface IEnumerable<T> { ... }
  *
  * class C {
@@ -444,7 +444,7 @@ class ConstructedInterface extends Interface, ConstructedType {
  *
  * For example, `F<int>` on line 4 in
  *
- * ```
+ * ```csharp
  * delegate void F<T>(T t);
  *
  * class C {
@@ -466,7 +466,7 @@ class ConstructedDelegateType extends DelegateType, ConstructedType {
  * An unbound generic method. This is a generic method whose signature involves formal type parameters,
  * For example `M<T>` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   void M<T>() { ... }
  * }
@@ -492,7 +492,7 @@ class UnboundGenericMethod extends Method, UnboundGeneric {
  * A constructed (bound) method, for example the target `M<int>` of the call on
  * line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   void M<T>() { ... }
  *
@@ -526,8 +526,8 @@ class ConstructedMethod extends Method, ConstructedGeneric {
 /**
  * An unbound generic local function, for example `f` on line 3 in
  *
- * ```
- * class {
+ * ```csharp
+ * class C {
  *   void M() {
  *     void f<T>(T t) { ... }
  *   }
@@ -544,8 +544,8 @@ class UnboundLocalFunction extends LocalFunction, UnboundGeneric {
  * A constructed generic local function, for example the target `f<int>`
  * of the function call `f(5)` on line 4 in
  *
- * ```
- * class {
+ * ```csharp
+ * class C {
  *   void M() {
  *     void f<T>(T t) { ... }
  *     f(5);
@@ -580,7 +580,7 @@ class NonConstructedMethod extends Method {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * class A<T1> {
    *   void M1(T1 x1) { }
    *   void M2<T2>(T1 x1, T2 x) { }

--- a/csharp/ql/src/semmle/code/csharp/Implements.qll
+++ b/csharp/ql/src/semmle/code/csharp/Implements.qll
@@ -21,7 +21,7 @@ private import Conversion
  *
  * Example:
  *
- * ```
+ * ```csharp
  * interface I { void M(); }
  *
  * class A { public void M() { } }
@@ -52,7 +52,7 @@ predicate implements(Virtualizable m1, Virtualizable m2, ValueOrRefType t) {
  *
  * Example:
  *
- * ```
+ * ```csharp
  * interface I { void M(); }
  *
  * class A { public void M() { } }
@@ -143,10 +143,10 @@ private predicate getACompatibleInterfaceAccessorAux(
  * of the interface `i`. Note that the class or struct need not be a
  * sub type of the interface in the inheritance hierarchy:
  *
- * ```
- * interface I { void M() }
+ * ```csharp
+ * interface I { void M(); }
  *
- * class A { public void M() }
+ * class A { public void M() { } }
  *
  * class B { }
  *

--- a/csharp/ql/src/semmle/code/csharp/Member.qll
+++ b/csharp/ql/src/semmle/code/csharp/Member.qll
@@ -24,7 +24,7 @@ class Declaration extends DotNet::Declaration, Element, @declaration {
    * Gets the fully qualified name of this declaration, including types, for example
    * the fully qualified name with types of `M` on line 3 is `N.C.M(int, string)` in
    *
-   * ```
+   * ```csharp
    * namespace N {
    *   class C {
    *     void M(int i, string s) { }
@@ -195,7 +195,7 @@ class Virtualizable extends Member, @virtualizable {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * interface I { void M(); }
    *
    * class A { public void M() { } }
@@ -223,7 +223,7 @@ class Virtualizable extends Member, @virtualizable {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * interface I { void M(); }
    *
    * class A { public void M() { } }
@@ -251,7 +251,7 @@ class Virtualizable extends Member, @virtualizable {
    * Note that this is generally *not* equivalent with
    * `getOverridee*().getImplementee()`, as the example below illustrates:
    *
-   * ```
+   * ```csharp
    * interface I { void M(); }
    *
    * class A { public virtual void M() { } }

--- a/csharp/ql/src/semmle/code/csharp/Namespace.qll
+++ b/csharp/ql/src/semmle/code/csharp/Namespace.qll
@@ -12,7 +12,7 @@ class TypeContainer extends DotNet::NamedElement, Element, @type_container { }
 /**
  * A namespace, for example
  *
- * ```
+ * ```csharp
  * namespace System.IO {
  *   ...
  * }
@@ -37,7 +37,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets a type directly declared in this namespace, if any.
    * For example, the class `File` in
    *
-   * ```
+   * ```csharp
    * namespace System.IO {
    *   public class File { ... }
    * }
@@ -49,7 +49,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets a class directly declared in this namespace, if any.
    * For example, the class `File` in
    *
-   * ```
+   * ```csharp
    * namespace System.IO {
    *   public class File { ... }
    * }
@@ -61,7 +61,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets an interface directly declared in this namespace, if any.
    * For example, the interface `IEnumerable` in
    *
-   * ```
+   * ```csharp
    * namespace System.Collections {
    *   public interface IEnumerable { ... }
    * }
@@ -73,7 +73,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets a struct directly declared in this namespace, if any.
    * For example, the struct `Timespan` in
    *
-   * ```
+   * ```csharp
    * namespace System {
    *   public struct Timespan { ... }
    * }
@@ -85,7 +85,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets an enum directly declared in this namespace, if any.
    * For example, the enum `DayOfWeek` in
    *
-   * ```
+   * ```csharp
    * namespace System {
    *   public enum DayOfWeek { ... }
    * }
@@ -97,7 +97,7 @@ class Namespace extends DotNet::Namespace, TypeContainer, Declaration, @namespac
    * Gets a delegate directly declared in this namespace, if any.
    * For example, the delegate `AsyncCallback` in
    *
-   * ```
+   * ```csharp
    * namespace System {
    *   public delegate void AsyncCallback(IAsyncResult ar);
    * }
@@ -135,7 +135,7 @@ class GlobalNamespace extends Namespace {
 /**
  * An explicit namespace declaration in a source file. For example:
  *
- * ```
+ * ```csharp
  * namespace N1.N2 {
  *   ...
  * }
@@ -145,7 +145,7 @@ class NamespaceDeclaration extends Element, @namespace_declaration {
   /**
    * Gets the declared namespace, for example `N1.N2` in
    *
-   * ```
+   * ```csharp
    * namespace N1.N2 {
    *   ...
    * }
@@ -159,7 +159,7 @@ class NamespaceDeclaration extends Element, @namespace_declaration {
    * declaration `namespace N1` on line 1, but `namespace N1` on line 1 and
    * `namespace N1.N2` on line 7 do not have parent namespace declarations.
    *
-   * ```
+   * ```csharp
    * namespace N1 {
    *   namespace N2 {
    *     ...
@@ -180,7 +180,7 @@ class NamespaceDeclaration extends Element, @namespace_declaration {
    * `namespace N2` on line 2 is a child namespace declaration of
    * `namespace N1` on line 1.
    *
-   * ```
+   * ```csharp
    * namespace N1 {
    *   namespace N2 {
    *     ...
@@ -196,7 +196,7 @@ class NamespaceDeclaration extends Element, @namespace_declaration {
    * Gets a type directly declared within this namespace declaration.
    * For example, class `C` in
    *
-   * ```
+   * ```csharp
    * namespace N {
    *   class C { ... }
    * }

--- a/csharp/ql/src/semmle/code/csharp/Property.qll
+++ b/csharp/ql/src/semmle/code/csharp/Property.qll
@@ -106,7 +106,7 @@ class DeclarationWithGetSetAccessors extends DeclarationWithAccessors, TopLevelE
 /**
  * A property, for example `P` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public int P { get; set; }
  * }
@@ -123,7 +123,7 @@ class Property extends DotNet::Property, DeclarationWithGetSetAccessors, @proper
    * Holds if this property is automatically implemented. For example, `P1`
    * on line 2 is automatically implemented, while `P2` on line 5 is not in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P1 { get; set; }
    *
@@ -195,7 +195,7 @@ class Property extends DotNet::Property, DeclarationWithGetSetAccessors, @proper
    * Gets the initial value of this property, if any. For example, the initial
    * value of `P` on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P { get; set; } = 20;
    * }
@@ -207,7 +207,7 @@ class Property extends DotNet::Property, DeclarationWithGetSetAccessors, @proper
    * Holds if this property has an initial value. For example, the initial
    * value of `P` on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P { get; set; } = 20;
    * }
@@ -219,7 +219,7 @@ class Property extends DotNet::Property, DeclarationWithGetSetAccessors, @proper
    * Gets the expression body of this property, if any. For example, the expression
    * body of `P` on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P => 20;
    * }
@@ -237,7 +237,7 @@ class Property extends DotNet::Property, DeclarationWithGetSetAccessors, @proper
 /**
  * An indexer, for example `string this[int i]` on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public string this[int i] {
  *     get { return i.ToString(); }
@@ -261,7 +261,7 @@ class Indexer extends DeclarationWithGetSetAccessors, Parameterizable, @indexer 
    * Gets the expression body of this indexer, if any. For example, the
    * expression body of the indexer on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int this[int i] => 20;
    * }
@@ -314,7 +314,7 @@ class Accessor extends Callable, Modifiable, Attributable, @callable_accessor {
    * Gets the declaration that this accessor belongs to. For example, both
    * accessors on lines 3 and 4 belong to the property `P` on line 2 in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P {
    *     get;
@@ -330,7 +330,7 @@ class Accessor extends Callable, Modifiable, Attributable, @callable_accessor {
    * the `get` accessor on line 3 has no access modifier and the `set` accessor
    * on line 4 has a `private` access modifier in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int P {
    *     get;
@@ -349,7 +349,7 @@ class Accessor extends Callable, Modifiable, Attributable, @callable_accessor {
    * has the modifiers `public` and `virtual`, and the `set` accessor on line 4
    * has the modifiers `private` and `virtual` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public virtual int P {
    *     get;
@@ -375,7 +375,7 @@ class Accessor extends Callable, Modifiable, Attributable, @callable_accessor {
 /**
  * A `get` accessor, for example `get { return p; }` in
  *
- * ```
+ * ```csharp
  * public class C {
  *   int p;
  *   public int P {
@@ -394,7 +394,7 @@ class Getter extends Accessor, @getter {
    * Gets the field used in the trival implementation of this getter, if any.
    * For example, the field `p` in
    *
-   * ```
+   * ```csharp
    * public class C {
    *   int p;
    *   public int P {
@@ -420,7 +420,7 @@ class Getter extends Accessor, @getter {
 /**
  * A `set` accessor, for example `set { p = value; }` in
  *
- * ```
+ * ```csharp
  * public class C {
  *   int p;
  *   public int P {
@@ -442,7 +442,7 @@ class Setter extends Accessor, @setter {
    * Gets the field used in the trival implementation of this setter, if any.
    * For example, the field `p` in
    *
-   * ```
+   * ```csharp
    * public class C {
    *   int p;
    *   public int P {
@@ -478,7 +478,7 @@ private ParameterAccess accessToValue() {
  * A property with a trivial getter and setter. For example, properties `P1`
  * and `P2` are trivial, while `P3` is not, in
  *
- * ```
+ * ```csharp
  * public class C {
  *   int p1;
  *   public int P1 {
@@ -536,7 +536,7 @@ class IndexerProperty extends Property {
     // too many indexer calls, for example the call to the indexer
     // setter at `dict[0]` in
     //
-    // ```
+    // ```csharp
     // class A
     // {
     //     Dictionary<int, string> dict;

--- a/csharp/ql/src/semmle/code/csharp/Stmt.qll
+++ b/csharp/ql/src/semmle/code/csharp/Stmt.qll
@@ -44,7 +44,7 @@ class Stmt extends ControlFlowElement, @stmt {
 /**
  * A block statement, for example
  *
- * ```
+ * ```csharp
  * {
  *   ...
  * }
@@ -81,7 +81,7 @@ class BlockStmt extends Stmt, @block_stmt {
 /**
  * An expression statement, for example `M1()` on line 5
  *
- * ```
+ * ```csharp
  * class C {
  *   int M1() { ... }
  *
@@ -111,7 +111,7 @@ class SelectionStmt extends Stmt, @cond_stmt {
 /**
  * An `if` statement, for example
  *
- * ```
+ * ```csharp
  * if (x==0) {
  *   ...
  * } else {
@@ -136,7 +136,7 @@ class IfStmt extends SelectionStmt, @if_stmt {
 /**
  * A `switch` statement, for example
  *
- * ```
+ * ```csharp
  * switch (instruction) {
  *   ...
  * }
@@ -152,7 +152,7 @@ class SwitchStmt extends SelectionStmt, Switch, @switch_stmt {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * switch (x) {
    *   case "abc":              // i = 0
    *     return 0;
@@ -185,7 +185,7 @@ class SwitchStmt extends SelectionStmt, Switch, @switch_stmt {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * switch (x) {
    *   case "abc":              // i = 0
    *     return 0;
@@ -268,7 +268,7 @@ class CaseStmt extends Case, @case_stmt {
    * Gets the condition on this case, if any. For example, the type case on line 3
    * has no condition, and the type case on line 4 has condition `s.Length > 0`, in
    *
-   * ```
+   * ```csharp
    * switch(p)
    * {
    *     case int i:
@@ -290,7 +290,7 @@ class CaseStmt extends Case, @case_stmt {
  * A constant case of a `switch` statement, for example `case OpCode.Nop:`
  * on line 2 in
  *
- * ```
+ * ```csharp
  * switch (instruction) {
  *   case OpCode.Nop: ...
  *   default: ...
@@ -311,7 +311,7 @@ class ConstCase extends CaseStmt, LabeledStmt {
  * A default case of a `switch` statement, for example `default:` on
  * line 3 in
  *
- * ```
+ * ```csharp
  * switch (instruction) {
  *   case OpCode.Nop: ...
  *   default: ...
@@ -344,7 +344,7 @@ class LoopStmt extends Stmt, @loop_stmt {
 /**
  * A `while` statement, for example
  *
- * ```
+ * ```csharp
  * while (remaining > 0) {
  *   ...
  * }
@@ -359,7 +359,7 @@ class WhileStmt extends LoopStmt, @while_stmt {
 /**
  * A `do`-`while` statement, for example
  *
- * ```
+ * ```csharp
  * do {
  *   ...
  * }
@@ -375,7 +375,7 @@ class DoStmt extends LoopStmt, @do_stmt {
 /**
  * A `for` loop, for example
  *
- * ```
+ * ```csharp
  * for (int i = 0; i < 10; i++) {
  *   ...
  * }
@@ -387,7 +387,7 @@ class ForStmt extends LoopStmt, @for_stmt {
    *
    * For example, `i = 0` in
    *
-   * ```
+   * ```csharp
    * for (int i = 0; i < 10; i++) {
    *   ...
    * }
@@ -401,7 +401,7 @@ class ForStmt extends LoopStmt, @for_stmt {
    *
    * For example, the second (`n = 1`) initializer is `j = 10` in
    *
-   * ```
+   * ```csharp
    * for (int i = 0, j = 10; i < j; i++) {
    *   ...
    * }
@@ -418,7 +418,7 @@ class ForStmt extends LoopStmt, @for_stmt {
    *
    * For example, `i++` in
    *
-   * ```
+   * ```csharp
    * for (int i = 0; i < 10; i++) {
    *   ...
    * }
@@ -431,7 +431,7 @@ class ForStmt extends LoopStmt, @for_stmt {
    *
    * For example, the second (`n = 1`) update expression is `j--` in
    *
-   * ```
+   * ```csharp
    * for (int i = 0, j = 10; i < j; i++, j--) {
    *   ...
    * }
@@ -445,7 +445,7 @@ class ForStmt extends LoopStmt, @for_stmt {
 /**
  * A `foreach` loop, for example
  *
- * ```
+ * ```csharp
  * foreach (var item in items) {
  *   ...
  * }
@@ -457,7 +457,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `item` in
    *
-   * ```
+   * ```csharp
    * foreach (var item in items) {
    *   ...
    * }
@@ -470,7 +470,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `var item` in
    *
-   * ```
+   * ```csharp
    * foreach (var item in items) {
    *   ...
    * }
@@ -483,7 +483,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `int a` is the 0th local variable declaration in
    *
-   * ```
+   * ```csharp
    * foreach ((int a, int b) in items) {
    *   ...
    * }
@@ -499,7 +499,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    * Gets the local variable declaration tuple of this `foreach` loop, if any.
    * For example, `(int a, int b)` in
    *
-   * ```
+   * ```csharp
    * foreach ((int a, int b) in items) {
    *   ...
    * }
@@ -512,7 +512,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `a` is the 0th local variable in
    *
-   * ```
+   * ```csharp
    * foreach ((int a, int b) in items) {
    *   ...
    * }
@@ -525,7 +525,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `a` and `b` in
    *
-   * ```
+   * ```csharp
    * foreach ((int a, int b) in items) {
    *   ...
    * }
@@ -538,7 +538,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `int a` and `int b` in
    *
-   * ```
+   * ```csharp
    * foreach ((int a, int b) in items) {
    *   ...
    * }
@@ -553,7 +553,7 @@ class ForeachStmt extends LoopStmt, @foreach_stmt {
    *
    * For example, `items` in
    *
-   * ```
+   * ```csharp
    * foreach (var item in items) {
    *   ...
    * }
@@ -576,7 +576,7 @@ class JumpStmt extends Stmt, @jump_stmt { }
 /**
  * A `break` statement, for example line 4 in
  *
- * ```
+ * ```csharp
  * while (true) {
  *   ...
  *   if (done)
@@ -591,7 +591,7 @@ class BreakStmt extends JumpStmt, @break_stmt {
 /**
  * A `continue` statement, for example line 4 in
  *
- * ```
+ * ```csharp
  * while (true) {
  *   ...
  *   if (!done)
@@ -618,7 +618,7 @@ class GotoStmt extends JumpStmt, @goto_any_stmt {
 /**
  * A `goto` statement that jumps to a labeled statement, for example line 4 in
  *
- * ```
+ * ```csharp
  * while (true) {
  *   ...
  *   if (done)
@@ -644,7 +644,7 @@ class GotoLabelStmt extends GotoStmt, @goto_stmt {
  *
  * For example, line 5 in
  *
- * ```
+ * ```csharp
  * switch (x) {
  *   case 0 :
  *     return 1;
@@ -669,7 +669,7 @@ class GotoCaseStmt extends GotoStmt, @goto_case_stmt {
  *
  * For example, line 5 in
  *
- * ```
+ * ```csharp
  * switch (x) {
  *   case 0 :
  *     return 1;
@@ -689,7 +689,7 @@ class GotoDefaultStmt extends GotoStmt, @goto_default_stmt {
 /**
  * A `throw` statement, for example line 3 in
  *
- * ```
+ * ```csharp
  * void M(string s) {
  *   if (s == null)
  *     throw new ArgumentNullException(nameof(s));
@@ -727,7 +727,7 @@ class ExceptionClass extends Class {
 /**
  * A `return` statement, for example line 2 in
  *
- * ```
+ * ```csharp
  * int M() {
  *   return 0;
  * }
@@ -754,7 +754,7 @@ class YieldStmt extends JumpStmt, @yield_stmt {
 /**
  * A `yield break` statement, for example line 6 in
  *
- * ```
+ * ```csharp
  * IEnumerable<int> DownFrom(int i) {
  *   while (true) {
  *     if (i > 0)
@@ -774,7 +774,7 @@ class YieldBreakStmt extends YieldStmt {
 /**
  * A `yield return` statement, for example line 4 in
  *
- * ```
+ * ```csharp
  * IEnumerable<int> DownFrom(int i) {
  *   while (true) {
  *     if (i > 0)
@@ -794,7 +794,7 @@ class YieldReturnStmt extends YieldStmt {
 /**
  * A `try` statement, for example
  *
- * ```
+ * ```csharp
  * try {
  *   ...
  * }
@@ -900,7 +900,7 @@ class CatchClause extends Stmt, @catch {
    * Gets the type of the exception caught. For example, the type of the exception
    * caught on line 4 is `System.IO.IOException` in
    *
-   * ```
+   * ```csharp
    * try {
    *   ...
    * }
@@ -915,7 +915,7 @@ class CatchClause extends Stmt, @catch {
    * Gets the `catch` filter clause, if any. For example, the filter expression
    * of the catch clause on line 4 is `ex.HResult == 1` in
    *
-   * ```
+   * ```csharp
    * try {
    *   ...
    * }
@@ -944,7 +944,7 @@ class CatchClause extends Stmt, @catch {
  *
  * For example, the `catch` clause on line 4 in
  *
- * ```
+ * ```csharp
  * try {
  *   ...
  * }
@@ -972,7 +972,7 @@ class SpecificCatchClause extends CatchClause {
  *
  * For example, the `catch` clause on line 4 in
  *
- * ```
+ * ```csharp
  * try {
  *   ...
  * }
@@ -990,7 +990,7 @@ class GeneralCatchClause extends CatchClause {
 /**
  * A `checked` statement, for example
  *
- * ```
+ * ```csharp
  * checked {
  *   int i = 2147483647;
  *   i++;
@@ -1007,7 +1007,7 @@ class CheckedStmt extends Stmt, @checked_stmt {
 /**
  * An `unchecked` statement, for example
  *
- * ```
+ * ```csharp
  * unchecked {
  *   int i = 2147483647;
  *   i++;
@@ -1024,7 +1024,7 @@ class UncheckedStmt extends Stmt, @unchecked_stmt {
 /**
  * A `lock` statement, for example
  *
- * ```
+ * ```csharp
  * lock (mutex) {
  *   ...
  * }
@@ -1074,7 +1074,7 @@ class UsingStmt extends Stmt, @using_stmt {
    * expression assigned to a variable, for example `File.Open("settings.xml")`
    * in
    *
-   * ```
+   * ```csharp
    * using (FileStream f = File.Open("settings.xml")) {
    *   ...
    * }
@@ -1083,7 +1083,7 @@ class UsingStmt extends Stmt, @using_stmt {
    * or an expression directly used, for example `File.Open("settings.xml")`
    * in
    *
-   * ```
+   * ```csharp
    * using (File.Open("settings.xml")) {
    *   ...
    * }
@@ -1095,7 +1095,7 @@ class UsingStmt extends Stmt, @using_stmt {
 /**
  * A `using` block statement, for example
  *
- * ```
+ * ```csharp
  * using (FileStream f = File.Open("settings.xml")) {
  *   ...
  * }
@@ -1115,7 +1115,7 @@ class UsingBlockStmt extends UsingStmt, @using_block_stmt {
    * Gets the expression directly used by this `using` statement, if any. For
    * example, `f` on line 2 in
    *
-   * ```
+   * ```csharp
    * var f = File.Open("settings.xml");
    * using (f) {
    *   ...
@@ -1139,7 +1139,7 @@ class UsingBlockStmt extends UsingStmt, @using_block_stmt {
 /**
  * A local declaration statement, for example line 2 in
  *
- * ```
+ * ```csharp
  * void M() {
  *   string x = null, y = "";
  * }
@@ -1150,7 +1150,7 @@ class LocalVariableDeclStmt extends Stmt, @decl_stmt {
    * Gets a local variable declaration, for example `x = null` and
    * `y = ""` in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   string x = null, y = "";
    * }
@@ -1162,7 +1162,7 @@ class LocalVariableDeclStmt extends Stmt, @decl_stmt {
    * Gets the `n`th local variable declaration. For example, the second
    * (`n = 1`) declaration is `y = ""` in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   string x = null, y = "";
    * }
@@ -1176,7 +1176,7 @@ class LocalVariableDeclStmt extends Stmt, @decl_stmt {
 /**
  * A local constant declaration statement, for example line 2 in
  *
- * ```
+ * ```csharp
  * void M() {
  *   const int x = 1, y = 2;
  * }
@@ -1186,7 +1186,7 @@ class LocalConstantDeclStmt extends LocalVariableDeclStmt, @const_decl_stmt {
   /**
    * Gets a local constant declaration, for example `x = 1` and `y = 2` in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   const int x = 1, y = 2;
    * }
@@ -1198,7 +1198,7 @@ class LocalConstantDeclStmt extends LocalVariableDeclStmt, @const_decl_stmt {
    * Gets the `n`th local constant declaration. For example, the second
    * (`n = 1`) declaration is `y = 2` in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   const int x = 1, y = 2;
    * }
@@ -1212,7 +1212,7 @@ class LocalConstantDeclStmt extends LocalVariableDeclStmt, @const_decl_stmt {
 /**
  * A `using` declaration statement, for example
  *
- * ```
+ * ```csharp
  * using FileStream f = File.Open("settings.xml");
  * ```
  */
@@ -1233,7 +1233,7 @@ class UsingDeclStmt extends LocalVariableDeclStmt, UsingStmt, @using_decl_stmt {
 /**
  * An empty statement, for example line 2 in
  *
- * ```
+ * ```csharp
  * while (true) do {
  *   ;
  * }
@@ -1246,7 +1246,7 @@ class EmptyStmt extends Stmt, @empty_stmt {
 /**
  * An `unsafe` statement, for example
  *
- * ```
+ * ```csharp
  * unsafe {
  *   var data = new int[10];
  *   fixed (int* p = data) {
@@ -1265,7 +1265,7 @@ class UnsafeStmt extends Stmt, @unsafe_stmt {
 /**
  * A `fixed` statement, for example lines 3--5 in
  *
- * ```
+ * ```csharp
  * unsafe {
  *   var data = new int[10];
  *   fixed (int* p = data) {
@@ -1296,7 +1296,7 @@ class FixedStmt extends Stmt, @fixed_stmt {
 /**
  * A label statement, for example line 7 in
  *
- * ```
+ * ```csharp
  * while (true) {
  *   if (done)
  *     goto exit;
@@ -1319,7 +1319,7 @@ class LabeledStmt extends Stmt, @labeled_stmt {
    *
    * For example, the `return` statement in
    *
-   * ```
+   * ```csharp
    * exit:
    *   return MetadataToken.Zero;
    * ```
@@ -1341,7 +1341,7 @@ class LabeledStmt extends Stmt, @labeled_stmt {
  * A statement defining a local function. For example,
  * the statement on lines 2--4 in
  *
- * ```
+ * ```csharp
  * int Choose(int n, int m) {
  *   int Fac(int x) {
  *     return x > 1 ? x * Fac(x - 1) : 1;

--- a/csharp/ql/src/semmle/code/csharp/Type.qll
+++ b/csharp/ql/src/semmle/code/csharp/Type.qll
@@ -96,7 +96,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
    * In the following example, only the class `C2` has a parent namespace declaration
    * returned by `getParentNamespaceDeclaration`.
    *
-   * ```
+   * ```csharp
    * class C1 { ... }
    *
    * namespace N {
@@ -140,7 +140,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
    *
    * For example, `C` has the methods `A.M1()`, `B.M3()`, and `C.M4()` in
    *
-   * ```
+   * ```csharp
    * class A {
    *   public void M1() { }
    *   private void M2() { }
@@ -165,7 +165,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
    * For example, `C` has the callables `A.get_P1`, `A.set_P1`, `A.M2()`, `B.get_P2`,
    * `B.set_P2`, and `C.M3()` in
    *
-   * ```
+   * ```csharp
    * class A {
    *   public int P1 { get; set; }
    *   public virtual int P2 { get; set; }
@@ -194,7 +194,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
    *
    * For example, `C` has the members `A.P1`, `A.M2()`, `B.P2`, and `C.M3()` in
    *
-   * ```
+   * ```csharp
    * class A {
    *   public int P1 { get; set; }
    *   public virtual int P2 { get; set; }
@@ -368,7 +368,7 @@ class ValueOrRefType extends DotNet::ValueOrRefType, Type, Attributable, @value_
 /**
  * A nested type, for example `class B` in
  *
- * ```
+ * ```csharp
  * class A {
  *   class B {
  *     ...
@@ -608,7 +608,7 @@ class DecimalType extends SimpleType, @decimal_type {
 /**
  * An `enum`. For example
  *
- * ```
+ * ```csharp
  * enum Parity {
  *   Even,
  *   Odd
@@ -622,7 +622,7 @@ class Enum extends ValueType, @enum_type {
    *
    * For example, the underlying type of `Parity` is `int` in
    *
-   * ```
+   * ```csharp
    * enum Parity : int {
    *   Even,
    *   Odd
@@ -635,11 +635,12 @@ class Enum extends ValueType, @enum_type {
    * Gets an `enum` constant declared in this `enum`, for example `Even`
    * and `Odd` in
    *
-   * ```
+   * ```csharp
    * enum Parity : int {
    *   Even,
    *   Odd
    * }
+   * ```
    */
   EnumConstant getAnEnumConstant() { result.getDeclaringEnum() = this }
 
@@ -652,7 +653,7 @@ class Enum extends ValueType, @enum_type {
 /**
  * A `struct`, for example
  *
- * ```
+ * ```csharp
  * struct S {
  *   ...
  * }
@@ -706,7 +707,7 @@ private predicate isNonOverridden(Member m) { not m.(Virtualizable).isOverridden
 /**
  * A `class`, for example
  *
- * ```
+ * ```csharp
  * class C {
  *   ...
  * }
@@ -719,7 +720,7 @@ class Class extends RefType, @class_type { }
  *
  * For example, the class with fields `X` and `Y` in
  *
- * ```
+ * ```csharp
  * new { X = 0, Y = 0 };
  * ```
  */
@@ -748,7 +749,7 @@ class StringType extends Class {
 /**
  * An `interface`, for example
  *
- * ```
+ * ```csharp
  * interface I {
  *   ...
  * }
@@ -759,7 +760,7 @@ class Interface extends RefType, @interface_type { }
 /**
  * A `delegate` type, for example
  *
- * ```
+ * ```csharp
  * delegate int D(int p);
  * ```
  */
@@ -959,7 +960,7 @@ class TypeMention extends @type_mention {
    * Gets the element to which this type mention belongs, if any.
    * For example, `IEnumerable<int>` belongs to parameter `p` in
    *
-   * ```
+   * ```csharp
    * void M(IEnumerable<int> p) { }
    * ```
    */
@@ -969,7 +970,7 @@ class TypeMention extends @type_mention {
    * Gets the parent of this type mention, if any.
    * For example, the parent of `int` is `IEnumerable<int>` in
    *
-   * ```
+   * ```csharp
    * void M(IEnumerable<int> p) {
    *   ...
    * }

--- a/csharp/ql/src/semmle/code/csharp/Using.qll
+++ b/csharp/ql/src/semmle/code/csharp/Using.qll
@@ -17,7 +17,7 @@ class UsingDirective extends Element, @using_directive {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * using System;
    *
    * namespace N {

--- a/csharp/ql/src/semmle/code/csharp/Variable.qll
+++ b/csharp/ql/src/semmle/code/csharp/Variable.qll
@@ -36,7 +36,7 @@ class LocalScopeVariable extends Variable, @local_scope_variable {
    * Holds if this variable is captured by a nested callable. For example,
    * `v` is captured by the nested lambda expression in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   var v = "captured";
    *   Action a = () => {
@@ -51,7 +51,7 @@ class LocalScopeVariable extends Variable, @local_scope_variable {
    * Gets a callable that captures this variable, if any. For example,
    * `v` is captured by the nested lambda expression in
    *
-   * ```
+   * ```csharp
    * void M() {
    *   var v = "captured";
    *   Action a = () => {
@@ -77,7 +77,7 @@ class LocalScopeVariable extends Variable, @local_scope_variable {
  * A parameter of a parameterizable declaration (callable, delegate, or indexer).
  * For example, `p` in
  *
- * ```
+ * ```csharp
  * void M(int p) {
  *   ...
  * }
@@ -89,7 +89,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Gets the position of this parameter. For example, the position of `x` is
    * 0 and the position of `y` is 1 in
    *
-   * ```
+   * ```csharp
    * void M(int x, int y) {
    *   ...
    * }
@@ -103,7 +103,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Holds if this parameter is a normal value parameter. For example, `p`
    * is a value parameter in
    *
-   * ```
+   * ```csharp
    * void M(int p) {
    *   ...
    * }
@@ -115,7 +115,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Holds if this parameter is a reference parameter. For example, `p`
    * is a reference parameter in
    *
-   * ```
+   * ```csharp
    * void M(ref int p) {
    *   ...
    * }
@@ -127,7 +127,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Holds if this parameter is an output parameter. For example, `p`
    * is an output parameter in
    *
-   * ```
+   * ```csharp
    * void M(out int p) {
    *   ...
    * }
@@ -139,7 +139,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Holds if this parameter is a value type that is passed in by reference.
    * For example, `p` is an input parameter in
    *
-   * ```
+   * ```csharp
    * void M(in int p) {
    *   ...
    * }
@@ -154,7 +154,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Holds if this parameter is a parameter array. For example, `args`
    * is a parameter array in
    *
-   * ```
+   * ```csharp
    * void M(params string[] args) {
    *   ...
    * }
@@ -167,7 +167,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * For example, `list` is the first parameter of the extension method
    * `Count` in
    *
-   * ```
+   * ```csharp
    * static int Count(this IEnumerable list) {
    *   ...
    * }
@@ -198,7 +198,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    * Gets the default value of this parameter, if any. For example, the
    * default value of `numberOfTries` is `3` in
    *
-   * ```
+   * ```csharp
    * void Connect(int numberOfTries = 3) {
    *   ...
    * }
@@ -220,7 +220,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * class C {
    *   void M(int x, int y = 2, int z = 3) { }
    *
@@ -249,7 +249,7 @@ class Parameter extends DotNet::Parameter, LocalScopeVariable, Attributable, Top
  * special `value` parameter. For example, the `value` parameter of
  * `set_ReadOnly` in
  *
- * ```
+ * ```csharp
  * public bool ReadOnly {
  *   get {
  *     return flags.HasValue(Attribute.ReadOnly);
@@ -272,7 +272,7 @@ class ImplicitAccessorParameter extends Parameter {
  * A local variable, declared within the scope of a callable. For example,
  * the variables `total` and `s` in
  *
- * ```
+ * ```csharp
  * void M(string[] ss) {
  *   int total = 0;
  *   ...
@@ -290,7 +290,7 @@ class LocalVariable extends LocalScopeVariable, @local_variable {
    * For example, the initializer of `total` is `0`, and `s` has no
    * initializer, in
    *
-   * ```
+   * ```csharp
    * void M(string[] ss) {
    *   int total = 0;
    *   ...
@@ -305,7 +305,7 @@ class LocalVariable extends LocalScopeVariable, @local_variable {
    * Holds if this variable is implicitly typed. For example, the variable
    * `s` is implicitly type, and the variable `total` is not, in
    *
-   * ```
+   * ```csharp
    * void M(string[] ss) {
    *   int total = 0;
    *   ...
@@ -338,7 +338,7 @@ class LocalVariable extends LocalScopeVariable, @local_variable {
  * A local constant, modeled as a special kind of local variable. For example,
  * the local constant `maxTries` in
  *
- * ```
+ * ```csharp
  * void M() {
  *   const int maxTries = 10;
  *   ...
@@ -356,7 +356,7 @@ class LocalConstant extends LocalVariable, @local_constant {
 /**
  * A field. For example, the fields `x` and `y` in
  *
- * ```
+ * ```csharp
  * struct Coord {
  *   public int x, y;
  * }
@@ -368,7 +368,7 @@ class Field extends Variable, AssignableMember, Attributable, TopLevelExprParent
    * Gets the initial value of this field, if any. For example, the initial
    * value of `F` on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int F = 20;
    * }
@@ -380,7 +380,7 @@ class Field extends Variable, AssignableMember, Attributable, TopLevelExprParent
    * Holds if this field has an initial value. For example, the initial
    * value of `F` on line 2 is `20` in
    *
-   * ```
+   * ```csharp
    * class C {
    *   public int F = 20;
    * }
@@ -413,7 +413,7 @@ class Field extends Variable, AssignableMember, Attributable, TopLevelExprParent
  * A member constant, modeled a special kind of field. For example,
  * the constant `Separator` in
  *
- * ```
+ * ```csharp
  * class Path {
  *   const char Separator = `\\`;
  *   ...
@@ -428,7 +428,7 @@ class MemberConstant extends Field, @constant {
 /**
  * An `enum` member constant. For example, `ReadOnly` and `Shared` in
  *
- * ```
+ * ```csharp
  * enum Attribute {
  *   ReadOnly = 1,
  *   Shared = 2
@@ -445,7 +445,7 @@ class EnumConstant extends MemberConstant {
    * Gets the underlying integral type of this `enum` constant. For example,
    * the underlying type of `Attribute` is `byte` in
    *
-   * ```
+   * ```csharp
    * enum Attribute : byte {
    *   ReadOnly = 1,
    *   Shared = 2
@@ -460,7 +460,7 @@ class EnumConstant extends MemberConstant {
    * In this example, `ReadOnly` has an explicit value but
    * `Shared` does not have an explicit value.
    *
-   * ```
+   * ```csharp
    * enum Attribute {
    *   ReadOnly = 1,
    *   Shared

--- a/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
@@ -52,7 +52,7 @@ class Assertion extends MethodCall {
    * Moreover, this assertion corresponds to multiple control flow nodes,
    * which is why
    *
-   * ```
+   * ```ql
    * exists(BasicBlock bb |
    *   bb.getANode() = this.getAControlFlowNode() |
    *   bb.immediatelyDominates(succ)
@@ -100,7 +100,7 @@ class Assertion extends MethodCall {
     or
     // Equivalent with
     //
-    // ```
+    // ```ql
     // exists(JoinBlockPredecessor pred | pred = bb.getAPredecessor() |
     //   this.strictlyDominatesSplit(pred)
     // ) and

--- a/csharp/ql/src/semmle/code/csharp/commons/ComparisonTest.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/ComparisonTest.qll
@@ -348,11 +348,12 @@ class CompareMethodCallComparisonTest extends ComparisonTest, TCompareCall { }
  * A comparison test using a user-defined comparison operator, for example
  * `this == other` on line 3 in
  *
- * ```
+ * ```csharp
  * public class C {
  *   public static bool operator ==(C lhs, C rhs) => true;
  *   public bool Is(C other) => this == other;
  * }
+ * ```
  */
 class OperatorCallComparisonTest extends ComparisonTest, TComparisonOperatorCall { }
 

--- a/csharp/ql/src/semmle/code/csharp/commons/Constants.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Constants.qll
@@ -23,7 +23,7 @@ predicate isConstantCondition(Expr e, boolean b) {
  * Holds if comparison operation `co` is constant with the Boolean value `b`.
  * For example, the comparison `x > x` is constantly `false` in
  *
- * ```
+ * ```csharp
  * int MaxWrong(int x, int y) => x > x ? x : y;
  * ```
  */

--- a/csharp/ql/src/semmle/code/csharp/commons/Strings.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Strings.qll
@@ -12,7 +12,7 @@ private import semmle.code.csharp.frameworks.system.Text
  * invocation will take place, unless the expression is already a string.
  * For example, `o` and `o.ToString()` on lines 2 and 3, respectively, in
  *
- * ```
+ * ```csharp
  * void Hello(object o) {
  *   Console.WriteLine("Hello, " + o);
  *   Console.WriteLine("Hello, " + o.ToString());

--- a/csharp/ql/src/semmle/code/csharp/commons/TargetFramework.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/TargetFramework.qll
@@ -6,7 +6,7 @@ import csharp
  * An attribute of type `System.Runtime.Versioning.TargetFrameworkAttribute`,
  * specifying the target framework of an assembly. For example
  *
- * ```
+ * ```csharp
  * [assembly: TargetFramework(".NETFramework,Version=v4.6.1")]
  * ```
  */
@@ -20,7 +20,7 @@ class TargetFrameworkAttribute extends Attribute {
 
   /**
    * Gets the framework name of this attribute. For example, the framework name of
-   * ```
+   * ```csharp
    * [assembly: TargetFramework(".NETFramework,Version=v4.6.1")]
    * ```
    * is `".NETFramework,Version=v4.6.1"`.
@@ -33,7 +33,7 @@ class TargetFrameworkAttribute extends Attribute {
 
   /**
    * Gets the framework type of this attribute. For example, the framework type of
-   * ```
+   * ```csharp
    * [assembly: TargetFramework(".NETFramework,Version=v4.6.1")]
    * ```
    * is `".NETFramework"`. Other framework types include `".NETStandard"` and `".NETCoreApp"`.
@@ -42,7 +42,7 @@ class TargetFrameworkAttribute extends Attribute {
 
   /**
    * Gets the framework version of this attribute. For example, the framework version of
-   * ```
+   * ```csharp
    * [assembly: TargetFramework(".NETFramework,Version=v4.6.1")]
    * ```
    * is `"4.6.1"`. Note that you can use the `Version` class to compare versions, for example

--- a/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/BasicBlocks.qll
@@ -34,7 +34,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (x < 0)
    *   x = -x;
    * ```
@@ -52,7 +52,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (!(x >= 0))
    *   x = -x;
    * ```
@@ -89,7 +89,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -112,7 +112,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -134,7 +134,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -161,7 +161,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * if (x < 0) {
    *   x = -x;
    *   if (x > 10)
@@ -195,7 +195,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   if (s == null)
    *     throw new ArgumentNullException(nameof(s));
@@ -219,7 +219,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   try {
    *     return s.Length;
@@ -244,7 +244,7 @@ class BasicBlock extends TBasicBlockStart {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s) {
    *   try {
    *     return s.Length;
@@ -447,7 +447,7 @@ class ConditionBlock extends BasicBlock {
      * all predecessors of `this.getATrueSuccessor()` are either `this` or dominated by `this.getATrueSuccessor()`.
      *
      * For example, in the following C# snippet:
-     * ```
+     * ```csharp
      * if (x)
      *   controlled;
      * false_successor;
@@ -455,7 +455,7 @@ class ConditionBlock extends BasicBlock {
      * ```
      * `false_successor` dominates `uncontrolled`, but not all of its predecessors are `this` (`if (x)`)
      *  or dominated by itself. Whereas in the following code:
-     * ```
+     * ```csharp
      * if (x)
      *   while (controlled)
      *     also_controlled;

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -118,7 +118,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * Moreover, this control flow element corresponds to multiple control flow nodes,
    * which is why
    *
-   * ```
+   * ```ql
    * exists(ConditionBlock cb |
    *   cb.getLastNode() = this.getAControlFlowNode() |
    *   cb.immediatelyControls(succ, s)
@@ -162,7 +162,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
     or
     // Equivalent with
     //
-    // ```
+    // ```ql
     // exists(JoinBlockPredecessor pred | pred = controlled.getAPredecessor() |
     //   this.controlsBlockSplit(pred, s)
     // ) and
@@ -192,7 +192,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    *
    * This predicate is different from
    *
-   * ```
+   * ```ql
    * exists(ConditionBlock cb |
    *   cb.getLastNode() = this.getAControlFlowNode() |
    *   cb.controls(controlled, s)
@@ -216,7 +216,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    *
    * This predicate is different from
    *
-   * ```
+   * ```ql
    * exists(ConditionBlock cb |
    *   cb.getLastNode() = this.getAControlFlowNode() |
    *   cb.controls(controlled.getAControlFlowNode().getBasicBlock(), s)

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -48,7 +48,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * int M(string s)
      * {
      *     if (s == null)
@@ -80,7 +80,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * int M(string s)
      * {
      *     if (s == null)
@@ -113,7 +113,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * int M(string s)
      * {
      *     try
@@ -151,7 +151,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * int M(string s)
      * {
      *     try
@@ -201,7 +201,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * if (x < 0)
      *     x = -x;
      * ```
@@ -221,7 +221,7 @@ module ControlFlow {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * if (!(x >= 0))
      *     x = -x;
      * ```
@@ -557,7 +557,7 @@ module ControlFlow {
           this.hasQualifier()
           or
           // Member initializers like
-          // ```
+          // ```csharp
           // new Dictionary<int, string>() { [0] = "Zero", [1] = "One", [2] = "Two" }
           // ```
           // need special treatment, because the the accesses `[0]`, `[1]`, and `[2]`
@@ -582,7 +582,7 @@ module ControlFlow {
        * that the accessor is called *after* the assigned value has been evaluated.
        * In the example above, this means we want a CFG that looks like
        *
-       * ```
+       * ```csharp
        * x -> 0 -> set_Prop -> x.Prop = 0
        * ```
        */

--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -62,7 +62,7 @@ abstract class AbstractValue extends TAbstractValue {
    *
    * Such values only propagate through adjacent reads, for example, in
    *
-   * ```
+   * ```csharp
    * int M()
    * {
    *     var x = new string[]{ "a", "b", "c" }.ToList();
@@ -350,7 +350,7 @@ class DereferenceableExpr extends Expr {
    *
    * For example, if the case statement `case string s` matches in
    *
-   * ```
+   * ```csharp
    * switch (o)
    * {
    *     case string s:
@@ -562,7 +562,7 @@ class AccessOrCallExpr extends Expr {
    *
    * Examples:
    *
-   * ```
+   * ```csharp
    * x.Foo.Bar();   // SSA qualifier: SSA definition for `x.Foo`
    * x.Bar();       // SSA qualifier: SSA definition for `x`
    * x.Foo().Bar(); // SSA qualifier: SSA definition for `x`
@@ -607,7 +607,7 @@ private AssignableAccess getATrackedAccess(Ssa::Definition def, ControlFlow::Nod
  *
  * For example, the property call `x.Field.Property` on line 3 is guarded in
  *
- * ```
+ * ```csharp
  * string M(C x) {
  *   if (x.Field.Property != null)
  *     return x.Field.Property.ToString();
@@ -621,7 +621,7 @@ private AssignableAccess getATrackedAccess(Ssa::Definition def, ControlFlow::Nod
  * guard, whereas the null-guard on `stack.Pop()` on line 4 is not (invoking
  * `Pop()` twice on a stack does not yield the same result):
  *
- * ```
+ * ```csharp
  * string M(Stack<object> stack) {
  *   if (stack == null)
  *     return "";
@@ -686,7 +686,7 @@ class GuardedExpr extends AccessOrCallExpr {
  * into account. That is, one control flow node belonging to an expression may
  * be guarded, while another split need not be guarded:
  *
- * ```
+ * ```csharp
  * if (b)
  *     if (x == null)
  *         return;
@@ -736,7 +736,7 @@ class GuardedControlFlowNode extends ControlFlow::Nodes::ElementNode {
  * is, one data flow node belonging to an expression may be guarded, while another
  * split need not be guarded:
  *
- * ```
+ * ```csharp
  * if (b)
  *     if (x == null)
  *         return;
@@ -1262,7 +1262,7 @@ module Internal {
      *
      * For example, if the case statement `case ""` matches in
      *
-     * ```
+     * ```csharp
      * switch (o)
      * {
      *     case "":

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Completion.qll
@@ -635,7 +635,7 @@ class EmptinessCompletion extends ConditionalCompletion, TEmptinessCompletion {
  *
  * Example:
  *
- * ```
+ * ```csharp
  * while (...) {
  *    ...
  *    break;
@@ -656,7 +656,7 @@ class BreakNormalCompletion extends NormalCompletion, TBreakNormalCompletion {
 /**
  * A nested completion. For example, in
  *
- * ```
+ * ```csharp
  * void M(bool b)
  * {
  *     try

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -278,7 +278,7 @@ module InitializerSplitting {
    * A split for non-static member initializers belonging to a given non-static
    * constructor. For example, in
    *
-   * ```
+   * ```csharp
    * class C
    * {
    *     int Field1 = 0;
@@ -301,7 +301,7 @@ module InitializerSplitting {
    * on the two constructors. This is in order to generate CFGs for the two
    * constructors that mimic
    *
-   * ```
+   * ```csharp
    * public C()
    * {
    *     Field1 = 0;
@@ -312,7 +312,7 @@ module InitializerSplitting {
    *
    * and
    *
-   * ```
+   * ```csharp
    * public C()
    * {
    *     Field1 = 0;
@@ -467,7 +467,7 @@ module FinallySplitting {
    * A split for elements belonging to a `finally` block, which determines how to
    * continue execution after leaving the `finally` block. For example, in
    *
-   * ```
+   * ```csharp
    * try
    * {
    *     if (!M())
@@ -599,7 +599,7 @@ module FinallySplitting {
       // If this split is normal, and an outer split can exit based on a inherited
       // completion, we need to exit this split as well. For example, in
       //
-      // ```
+      // ```csharp
       // bool done;
       // try
       // {
@@ -677,7 +677,7 @@ module ExceptionHandlerSplitting {
    * A split for elements belonging to a `catch` clause, which determines the type of
    * exception to handle. For example, in
    *
-   * ```
+   * ```csharp
    * try
    * {
    *     if (M() > 0)
@@ -698,11 +698,11 @@ module ExceptionHandlerSplitting {
    * ```
    *
    * all control flow nodes in
-   * ```
+   * ```csharp
    * catch (ArgumentException e)
    * ```
    * and
-   * ```
+   * ```csharp
    * catch (ArithmeticException e) when (e.Message != null)
    * ```
    * have two splits: one representing the `try` block throwing an `ArgumentException`,
@@ -853,7 +853,7 @@ module BooleanSplitting {
      *
      * For example, in
      *
-     * ```
+     * ```csharp
      * var b = GetB();
      * if (b)
      *     Console.WriteLine("b is true");
@@ -892,7 +892,7 @@ module BooleanSplitting {
    *
    * For example, in
    *
-   * ```
+   * ```csharp
    * var b = GetB();
    * if (b)
    *     Console.WriteLine("b is true");
@@ -969,7 +969,7 @@ module BooleanSplitting {
    * A split for elements that can reach a condition where this split determines
    * the Boolean value that the condition evaluates to. For example, in
    *
-   * ```
+   * ```csharp
    * if (b)
    *     Console.WriteLine("b is true");
    * if (!b)
@@ -1171,7 +1171,7 @@ module LoopUnrollingSplitting {
    * A split for loops where the body is guaranteed to be executed at least once, and
    * can therefore be unrolled in the control flow graph. For example, in
    *
-   * ```
+   * ```csharp
    * void M(string[] args)
    * {
    *     if (args.Length == 0)
@@ -1338,7 +1338,7 @@ predicate succExitSplits(ControlFlowElement pred, Splits predSplits, Callable su
  *
  * For the successor relation
  *
- * ```
+ * ```ql
  * succSplits(ControlFlowElement pred, Splits predSplits, ControlFlowElement succ, Splits succSplits, Completion c)
  * ```
  *

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/SuccessorType.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/SuccessorType.qll
@@ -59,7 +59,7 @@ module SuccessorTypes {
    *
    * For example, this program fragment:
    *
-   * ```
+   * ```csharp
    * if (x < 0)
    *     return 0;
    * else
@@ -95,7 +95,7 @@ module SuccessorTypes {
    *
    * For example, this program fragment:
    *
-   * ```
+   * ```csharp
    * int? M(string s) => s?.Length;
    * ```
    *
@@ -134,7 +134,7 @@ module SuccessorTypes {
    *
    * For example, this program fragment:
    *
-   * ```
+   * ```csharp
    * switch (x) {
    *     case 0 :
    *         return 0;
@@ -181,7 +181,7 @@ module SuccessorTypes {
    *
    * For example, this program fragment:
    *
-   * ```
+   * ```csharp
    * foreach (var arg in args)
    * {
    *     yield return arg;
@@ -228,7 +228,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * void M()
    * {
    *     return;
@@ -249,7 +249,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(int x)
    * {
    *     while (true)
@@ -277,7 +277,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(int x)
    * {
    *     while (true) {
@@ -302,7 +302,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(int x)
    * {
    *     while (true)
@@ -333,7 +333,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s)
    * {
    *     if (s == null)
@@ -361,7 +361,7 @@ module SuccessorTypes {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * int M(string s)
    * {
    *     if (s == null)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -5,7 +5,7 @@
  * a `null` pointer exception (`NullReferenceException`) may be thrown.
  * Example:
  *
- * ```
+ * ```csharp
  * void M(string s) {
  *   if (s != null) {
  *     ...

--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -171,7 +171,7 @@ module Ssa {
        * callable. A pseudo read is inserted to make assignments to `out`/`ref` variables
        * live, for example line 1 in
        *
-       * ```
+       * ```csharp
        * void M(out int i) {
        *   i = 0;
        * }
@@ -189,7 +189,7 @@ module Ssa {
        * A pseudo read is inserted to make assignments to the `ref` variable live, for example
        * line 2 in
        *
-       * ```
+       * ```csharp
        * void M() {
        *   ref int i = ref GetRef();
        *   i = 0;
@@ -612,7 +612,7 @@ module Ssa {
      * For example, if `bb` is a basic block with a phi node for `v` (considered
      * to be at index -1), reads `v` at node 2, and defines it at node 5, we have:
      *
-     * ```
+     * ```ql
      * ssaRefRank(bb, -1, v, SsaDef()) = 1    // phi node
      * ssaRefRank(bb,  2, v, Read())   = 2    // read at node 2
      * ssaRefRank(bb,  5, v, SsaDef()) = 3    // definition at node 5
@@ -893,7 +893,7 @@ module Ssa {
    * of the field or property. For example, there is an implicit update of
    * `this.Field` on line 7 in
    *
-   * ```
+   * ```csharp
    * int Field;
    *
    * void SetField(int i) { Field = i; }
@@ -1359,7 +1359,7 @@ module Ssa {
    * site that conceivably could reach an update of the captured variable.
    * For example, there is an implicit update of `v` on line 4 in
    *
-   * ```
+   * ```csharp
    * int M() {
    *   int i = 0;
    *   Action a = () => { i = 1; };
@@ -1559,7 +1559,7 @@ module Ssa {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * void M() {
    *   int i = 0;
    *   void M2() {
@@ -1736,7 +1736,7 @@ module Ssa {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * class C {
      *   void M1() {
      *     int i = 0;
@@ -1775,7 +1775,7 @@ module Ssa {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * class C {
      *   void M1() {
      *     int i = 0;
@@ -1845,7 +1845,7 @@ module Ssa {
         (
           exists(ReadKind rk | liveAfterWrite(bb, i, v, rk) |
             // A `ref` assignment such as
-            // ```
+            // ```csharp
             // ref int i = ref GetRef();
             // ```
             // is dead when there are no reads of or writes to `i`.
@@ -2005,7 +2005,7 @@ module Ssa {
      * can be reached from this SSA definition without passing through any
      * other SSA definitions. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2034,7 +2034,7 @@ module Ssa {
      * control flow node `cfn` that can be reached from this SSA definition
      * without passing through any other SSA definitions. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2066,7 +2066,7 @@ module Ssa {
      * can be reached from this SSA definition without passing through any
      * other SSA definition or read. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2102,7 +2102,7 @@ module Ssa {
      * control flow node `cfn` that can be reached from this SSA definition
      * without passing through any other SSA definition or read. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2142,7 +2142,7 @@ module Ssa {
      * another SSA definition for the source variable, without passing through
      * any other read. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2172,7 +2172,7 @@ module Ssa {
      * enclosing callable, or another SSA definition for the source variable,
      * without passing through any other read. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2203,7 +2203,7 @@ module Ssa {
      * Gets a definition that ultimately defines this SSA definition and is
      * not itself a pseudo node. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {
@@ -2322,7 +2322,7 @@ module Ssa {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * class C {
      *   void M1() {
      *     int i = 0;
@@ -2349,7 +2349,7 @@ module Ssa {
      *
      * Example:
      *
-     * ```
+     * ```csharp
      * class C {
      *   void M1() {
      *     int i = 0;
@@ -2510,7 +2510,7 @@ module Ssa {
     /**
      * Gets an input of this phi node. Example:
      *
-     * ```
+     * ```csharp
      * int Field;
      *
      * void SetField(int i) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/PublicCallableParameter.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/flowsources/PublicCallableParameter.qll
@@ -7,7 +7,7 @@ import csharp
 /**
  * A parameter of a public callable, for example `p` in
  *
- * ```
+ * ```csharp
  * public void M(int p) {
  *   ...
  * }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/ControlFlowReachability.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/ControlFlowReachability.qll
@@ -44,7 +44,7 @@ private ControlFlow::BasicBlock getABasicBlockInScope(ControlFlowScope scope, bo
  *
  * For example, in
  *
- * ```
+ * ```csharp
  * if (b)
  *     ....
  * var x = "foo";

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DelegateDataFlow.qll
@@ -36,7 +36,7 @@ abstract private class DelegateFlowSink extends DataFlow::ExprNode {
    * context, if any. The call context records the *last* call required to
    * resolve the target, if any. Example:
    *
-   * ```
+   * ```csharp
    * public int M(Func<string, int> f, string x) {
    *   return f(x);
    * }
@@ -60,7 +60,7 @@ abstract private class DelegateFlowSink extends DataFlow::ExprNode {
    * Note that only the *last* call required is taken into account, hence if
    * `M` above is redefined as follows:
    *
-   * ```
+   * ```csharp
    * public int M(Func<string, int> f, string x) {
    *   return M2(f, x);
    * }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/Steps.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/Steps.qll
@@ -78,7 +78,7 @@ module Steps {
    * assumption. For example, there is flow from `0` on line 3 to `i` on line
    * 8 and from `1` on line 4 to `i` on line 12 in
    *
-   * ```
+   * ```csharp
    * public class C {
    *   public void A() {
    *     B(0);
@@ -106,7 +106,7 @@ module Steps {
    * 8 (but not from `1` on line 4 to `i` on line 12 because `C` is virtual)
    * in
    *
-   * ```
+   * ```csharp
    * public class C {
    *   public void A() {
    *     B(0);

--- a/csharp/ql/src/semmle/code/csharp/dispatch/OverridableCallable.qll
+++ b/csharp/ql/src/semmle/code/csharp/dispatch/OverridableCallable.qll
@@ -38,7 +38,7 @@ class OverridableCallable extends Callable {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * interface I { void M(); }
    *
    * class A { public void M() { } }
@@ -76,7 +76,7 @@ class OverridableCallable extends Callable {
    *
    * Note that this is generally *not* equivalent with
    *
-   * ```
+   * ```ql
    * result = getAnImplementor()
    * or
    * result = getAnImplementor().(OverridableCallable).getAnOverrider+()`
@@ -84,7 +84,7 @@ class OverridableCallable extends Callable {
    *
    * as the example below illustrates:
    *
-   * ```
+   * ```csharp
    * interface I { void M(); }
    *
    * class A { public virtual void M() { } }
@@ -118,7 +118,7 @@ class OverridableCallable extends Callable {
    *
    * Example:
    *
-   * ```
+   * ```csharp
    * class C1 { public virtual void M() { } }
    *
    * class C2 : C1 { public override void M() { } }

--- a/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Access.qll
@@ -51,7 +51,7 @@ private module AccessImpl {
 /**
  * A `this` access, for example `this` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int Count;
  *
@@ -64,7 +64,7 @@ private module AccessImpl {
  * Note that a `this` access may be implicit, for example the implicit `this`
  * qualifier on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int Count;
  *
@@ -83,7 +83,7 @@ class ThisAccess extends Access, @this_access_expr {
 /**
  * A `base` access, for example `base` on line 2 in
  *
- * ```
+ * ```csharp
  * public override void Dispose() {
  *   base.Dispose();
  *   ...
@@ -211,7 +211,7 @@ class LocalScopeVariableWrite extends LocalScopeVariableAccess, VariableWrite { 
 /**
  * An access to a parameter, for example the access to `p` on line 2 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   return -p;
  * }
@@ -227,7 +227,7 @@ class ParameterAccess extends LocalScopeVariableAccess, @parameter_access_expr {
  * An access to a parameter that reads the underlying value, for example
  * the access to `p` on line 2 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   return -p;
  * }
@@ -245,7 +245,7 @@ class ParameterRead extends ParameterAccess, LocalScopeVariableRead {
  * An access to a parameter that updates the underlying value, for example
  * the access to `p` on line 2 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   p = 1;
  *   return p;
@@ -257,7 +257,7 @@ class ParameterWrite extends ParameterAccess, VariableWrite { }
 /**
  * An access to a local variable, for example the access to `x` on line 3 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   var x = -p;
  *   return x;
@@ -279,7 +279,7 @@ class LocalVariableAccess extends LocalScopeVariableAccess, @local_variable_acce
  * An access to a local variable that reads the underlying value, for example
  * the access to `x` on line 3 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   var x = -p;
  *   return x;
@@ -298,7 +298,7 @@ class LocalVariableRead extends LocalVariableAccess, LocalScopeVariableRead {
  * An access to a local variable that updates the underlying value, for example
  * the access to `x` on line 3 in
  *
- * ```
+ * ```csharp
  * int M(int p) {
  *   int x;
  *   x = -p;
@@ -311,7 +311,7 @@ class LocalVariableWrite extends LocalVariableAccess, VariableWrite { }
 /**
  * An access to a field, for example the access to `F` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int F = 0;
  *
@@ -331,7 +331,7 @@ class FieldAccess extends AssignableMemberAccess, VariableAccess, @field_access_
  * An access to a field that reads the underlying value, for example the
  * access to `F` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int F = 0;
  *
@@ -347,7 +347,7 @@ class FieldRead extends FieldAccess, VariableRead { }
  * An access to a field that updates the underlying value, for example the
  * access to `F` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int F = 0;
  *
@@ -362,7 +362,7 @@ class FieldWrite extends FieldAccess, VariableWrite { }
 /**
  * An access to a member (field), for example the access to `F` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   const int F = 0;
  *
@@ -399,7 +399,7 @@ library class PropertyAccessExpr extends Expr, @property_access_expr {
 /**
  * An access to a property, for example the access to `P` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int P { get; private set; }
  *
@@ -417,7 +417,7 @@ class PropertyAccess extends AssignableMemberAccess, PropertyAccessExpr {
  * An access to a property that reads the underlying value, for example
  * the access to `P` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int P { get; private set; }
  *
@@ -437,7 +437,7 @@ class PropertyRead extends PropertyAccess, AssignableRead {
  * An access to a property that updates the underlying value, for example the
  * access to `P` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int P { get; private set; }
  *
@@ -453,7 +453,7 @@ class PropertyWrite extends PropertyAccess, AssignableWrite { }
  * An access to a trivial property - a property with a default getter and
  * setter. For example, the access to `P` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   int P { get; private set; }
  *
@@ -471,7 +471,7 @@ class TrivialPropertyAccess extends PropertyAccess {
  * An access to a virtual property - a property that is virtual or defined in
  * an interface. For example, the access to `P` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   virtual int P { get; private set; }
  *
@@ -534,7 +534,7 @@ library class IndexerAccessExpr extends Expr, @indexer_access_expr {
 /**
  * An access to an indexer, for example the access to `c` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public string this[int i] { ... }
  *
@@ -556,7 +556,7 @@ class IndexerAccess extends AssignableMemberAccess, ElementAccess, IndexerAccess
  * An access to an indexer that reads the underlying value, for example the
  * access to `c` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public string this[int i] { ... }
  *
@@ -576,7 +576,7 @@ class IndexerRead extends IndexerAccess, ElementRead {
  * An access to an indexer that updates the underlying value, for example the
  * access to `c` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public string this[int i] { ... }
  *
@@ -592,7 +592,7 @@ class IndexerWrite extends IndexerAccess, ElementWrite { }
  * An access to a virtual indexer - an indexer that is virtual or defined in
  * an interface. For example, the access to `c` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public virtual string this[int i] { ... }
  *
@@ -600,6 +600,7 @@ class IndexerWrite extends IndexerAccess, ElementWrite { }
  *     return c[0];
  *   }
  * }
+ * ```
  */
 class VirtualIndexerAccess extends IndexerAccess {
   VirtualIndexerAccess() { targetIsOverridableOrImplementable() }
@@ -620,7 +621,7 @@ library class EventAccessExpr extends Expr, @event_access_expr {
  * An access to an event, for example the accesses to `Click` on lines
  * 7 and 8 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -641,7 +642,7 @@ class EventAccess extends AssignableMemberAccess, EventAccessExpr {
  * An access to an event that reads the underlying value, for example the
  * accesses to `Click` on lines 7 and 8 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -660,7 +661,7 @@ class EventRead extends EventAccess, AssignableRead { }
  * An access to an event that updates the underlying value, for example the
  * access to `Click` on line 7 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -678,7 +679,7 @@ class EventWrite extends EventAccess, AssignableWrite { }
  * An access to a virtual event - an event that is virtual or defined in
  * an interface. For example, the accesses to `Click` on lines 7 and 8 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -708,7 +709,7 @@ class CallableAccess extends Access, @method_access_expr {
 /**
  * An access to a method, for example the access to `Filter` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   bool Filter(string s) { ... }
  *
@@ -731,7 +732,7 @@ class MethodAccess extends MemberAccess, CallableAccess {
 /**
  * An access to a local function, for example the access to `Filter` on line 4 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public IEnumerable<string> DoFilter(IEnumerable<string> list) {
  *     bool Filter(string s) { ... };
@@ -755,7 +756,7 @@ class LocalFunctionAccess extends CallableAccess {
  * An access to a virtual method - a method that is virtual or defined in
  * an interface. For example, the access to `Filter` on line 5 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public virtual bool Filter(string s) { ... }
  *
@@ -774,7 +775,7 @@ class VirtualMethodAccess extends MethodAccess {
 /**
  * An access to a type, for example the access to `C` on line 3 in
  *
- * ```
+ * ```csharp
  * class C {
  *   public Type GetCType() {
  *     return typeof(C);
@@ -791,7 +792,7 @@ class TypeAccess extends MemberAccess, @type_access_expr {
 /**
  * An access to an array, for example the access to `args` on line 3 in
  *
- * ```
+ * ```csharp
  * public int FirstOrNegative(params int[] args) {
  *   return args.Length > 0
  *     ? args[0]
@@ -812,7 +813,7 @@ class ArrayAccess extends ElementAccess, @array_access_expr {
  * An access to an array that reads the underlying value, for example
  * the access to `a` on line 2 in
  *
- * ```
+ * ```csharp
  * public string Get(string[] a, int i) {
  *   return a[i];
  * }
@@ -824,7 +825,7 @@ class ArrayRead extends ArrayAccess, ElementRead { }
  * An access to an array that updates the underlying value, for example
  * the access to `a` on line 2 in
  *
- * ```
+ * ```csharp
  * public void Set(string[] a, int i, string s) {
  *   a[i] = s;
  * }

--- a/csharp/ql/src/semmle/code/csharp/exprs/Assignment.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Assignment.qll
@@ -192,7 +192,7 @@ class AddOrRemoveEventExpr extends AssignOperation, @assign_event_expr {
 /**
  * An event addition, for example line 9 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -213,7 +213,7 @@ class AddEventExpr extends AddOrRemoveEventExpr, @add_event_expr {
 /**
  * An event removal, for example line 9 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public delegate void EventHandler(object sender, object e);
  *

--- a/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Call.qll
@@ -22,7 +22,7 @@ class Call extends DotNet::Call, Expr, @call {
    * Gets the static (compile-time) target of this call. For example, the
    * static target of `x.M()` on line 9 is `A.M` in
    *
-   * ```
+   * ```csharp
    * class A {
    *   virtual void M() { }
    * }
@@ -65,7 +65,7 @@ class Call extends DotNet::Call, Expr, @call {
    * on line 5, `o` is not an argument for `M1`'s `args` parameter, while
    * `new object[] { o }` on line 6 is, in
    *
-   * ```
+   * ```csharp
    * class C {
    *   void M1(params object[] args) { }
    *
@@ -143,7 +143,7 @@ class Call extends DotNet::Call, Expr, @call {
    * Unlike `getTarget()`, this predicate takes reflection/dynamic based calls,
    * virtual dispatch, and delegate calls into account. Example:
    *
-   * ```
+   * ```csharp
    * class A {
    *   virtual void M() { }
    * }
@@ -188,7 +188,7 @@ class Call extends DotNet::Call, Expr, @call {
    * Unlike `getArgument()`, this predicate takes reflection based calls and named
    * arguments into account. Example:
    *
-   * ```
+   * ```csharp
    * class A {
    *   virtual void M(int first, int second) { }
    *
@@ -261,7 +261,7 @@ class Call extends DotNet::Call, Expr, @call {
  * of the arguments on lines 4 and 5, respectively, are valid for the parameter
  * `args` on line 1 in
  *
- * ```
+ * ```csharp
  * void M(params object[] args) { ... }
  *
  * void CallM(object[] os, string[] ss, string s) {
@@ -280,7 +280,7 @@ private predicate isValidExplicitParamsType(Parameter p, Type t) {
 /**
  * A method call, for example `a.M()` on line 5 in
  *
- * ```
+ * ```csharp
  * class A {
  *   void M() { }
  *
@@ -310,7 +310,7 @@ class MethodCall extends Call, QualifiableExpr, LateBindableExpr, @method_invoca
 /**
  * A call to an extension method, for example lines 5 and 6 in
  *
- * ```
+ * ```csharp
  * static class A {
  *   static void M(this int i) { }
  *
@@ -341,7 +341,7 @@ class ExtensionMethodCall extends MethodCall {
    * happens to be an extension method, for example the calls on lines 6 and
    * 7 (but not line 5) in
    *
-   * ```
+   * ```csharp
    * static class Extensions {
    *   public static void Ext(int i) { }
    *
@@ -363,7 +363,7 @@ class ExtensionMethodCall extends MethodCall {
 /**
  * A virtual method call, for example `a.M()` on line 5 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public virtual void M() { }
  *
@@ -384,7 +384,7 @@ class VirtualMethodCall extends MethodCall {
  * A constructor initializer call, for example `base()` (line 6) and
  * `this(0)` (line 8) in
  *
- * ```
+ * ```csharp
  * class A
  * {
  *     public A() { }
@@ -417,7 +417,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
    * Holds if this initialier is a `this` initializer, for example `this(0)`
    * in
    *
-   * ```
+   * ```csharp
    * class A
    * {
    *     A(int i) { }
@@ -431,7 +431,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
    * Holds if this initialier is a `base` initializer, for example `base(0)`
    * in
    *
-   * ```
+   * ```csharp
    * class A
    * {
    *     A(int i) { }
@@ -450,7 +450,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
    * the initializer call `base()` on line 7 belongs to the constructor `B`
    * on line 6 in
    *
-   * ```
+   * ```csharp
    * class A
    * {
    *     public A() { }
@@ -475,7 +475,7 @@ class ConstructorInitializer extends Call, @constructor_init_expr {
  * A call to a user-defined operator, for example `this + other`
  * on line 7 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public static A operator+(A left, A right) {
  *     return left;
@@ -499,7 +499,7 @@ class OperatorCall extends Call, LateBindableExpr, @operator_invocation_expr {
  * A call to a user-defined mutator operator, for example `a++` on
  * line 7 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public static A operator++(A a) {
  *     return a;
@@ -524,7 +524,7 @@ class MutatorOperatorCall extends OperatorCall {
 /**
  * A delegate call, for example `x()` on line 5 in
  *
- * ```
+ * ```csharp
  * class A {
  *   Action X = () => { };
  *
@@ -581,7 +581,7 @@ class DelegateCall extends Call, @delegate_invocation_expr {
    * Gets the delegate expression of this delegate call. For example, the
    * delegate expression of `X()` on line 5 is the access to the field `X` in
    *
-   * ```
+   * ```csharp
    * class A {
    *   Action X = () => { };
    *
@@ -613,7 +613,7 @@ class AccessorCall extends Call, QualifiableExpr, @call_access_expr {
  * A call to a property accessor, for example the call to `get_P` on
  * line 5 in
  *
- * ```
+ * ```csharp
  * class A {
  *   int P { get { return 0; } }
  *
@@ -644,7 +644,7 @@ class PropertyCall extends AccessorCall, PropertyAccessExpr {
  * A call to an indexer accessor, for example the call to `get_Item`
  * (defined on line 3) on line 7 in
  *
- * ```
+ * ```csharp
  * class A {
  *   string this[int i] {
  *     get { return i.ToString(); }
@@ -679,7 +679,7 @@ class IndexerCall extends AccessorCall, IndexerAccessExpr {
  * A call to an event accessor, for example the call to `add_Click`
  * (defined on line 5) on line 12 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public delegate void EventHandler(object sender, object e);
  *
@@ -722,7 +722,7 @@ class EventCall extends AccessorCall, EventAccessExpr {
 /**
  * A call to a local function, for example the call `Fac(n)` on line 6 in
  *
- * ```
+ * ```csharp
  * int Choose(int n, int m) {
  *   int Fac(int x) {
  *     return x > 1 ? x * Fac(x - 1) : 1;

--- a/csharp/ql/src/semmle/code/csharp/exprs/Creation.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Creation.qll
@@ -17,7 +17,7 @@ class ObjectOrCollectionInitializer extends Expr, @objectorcollection_init_expr 
 /**
  * An object initializer, for example `{ X = 0, Y = 1 }` on line 6 in
  *
- * ```
+ * ```csharp
  * class A {
  *   int X;
  *   int Y;
@@ -34,7 +34,7 @@ class ObjectInitializer extends ObjectOrCollectionInitializer, @object_init_expr
    * is a member initializer of the object initializer `{ X = 0, Y = 1 }` on
    * line 6 in
    *
-   * ```
+   * ```csharp
    * class A {
    *   int X;
    *   int Y;
@@ -52,7 +52,7 @@ class ObjectInitializer extends ObjectOrCollectionInitializer, @object_init_expr
    * `Y = 1` is the second (`i = 1`) member initializer of the object initializer
    * `{ X = 0, Y = 1 }` on line 6 in
    *
-   * ```
+   * ```csharp
    * class A {
    *   int X;
    *   int Y;
@@ -78,7 +78,7 @@ class ObjectInitializer extends ObjectOrCollectionInitializer, @object_init_expr
 /**
  * A member initializer, for example `X = 0` on line 6 in
  *
- * ```
+ * ```csharp
  * class A {
  *   int X;
  *   int Y;
@@ -99,7 +99,7 @@ class MemberInitializer extends AssignExpr {
 /**
  * A collection initializer, for example `{ {0, "a"}, {1, "b"} }` in
  *
- * ```
+ * ```csharp
  * var dict = new Dictionary<int, string>{
  *   {0, "a"},
  *   {1, "b"}
@@ -111,7 +111,7 @@ class CollectionInitializer extends ObjectOrCollectionInitializer, @collection_i
    * Gets an element initializer of this collection initializer, for example the
    * implicit call to `Add(0, "a")` on line 2 in
    *
-   * ```
+   * ```csharp
    * var dict = new Dictionary<int, string>{
    *   {0, "a"},
    *   {1, "b"}
@@ -125,7 +125,7 @@ class CollectionInitializer extends ObjectOrCollectionInitializer, @collection_i
    * example the second (`i = 1`) element initializer is the implicit call to
    * `Add(1, "b")` in
    *
-   * ```
+   * ```csharp
    * var dict = new Dictionary<int, string>{
    *   {0, "a"},
    *   {1, "b"}
@@ -148,7 +148,7 @@ class CollectionInitializer extends ObjectOrCollectionInitializer, @collection_i
  * An element initializer, for example the implicit call to `Add(0, "a")`
  * on line 2 in
  *
- * ```
+ * ```csharp
  * var dict = new Dictionary<int, string>{
  *   {0, "a"},
  *   {1, "b"}
@@ -162,7 +162,7 @@ class ElementInitializer extends MethodCall {
 /**
  * A constructor call, for example `new A()` on line 3 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public static A Create() {
  *     return new A();
@@ -188,7 +188,7 @@ class ObjectCreation extends Call, LateBindableExpr, @object_creation_expr {
    * Gets the object initializer or collection initializer of this constructor
    * call, if any. For example `{ {0, "a"}, {1, "b"} }` in
    *
-   * ```
+   * ```csharp
    * var dict = new Dictionary<int, string>{
    *   {0, "a"},
    *   {1, "b"}
@@ -210,7 +210,7 @@ class ObjectCreation extends Call, LateBindableExpr, @object_creation_expr {
  * An anonymous constructor call, for example
  * `new { First = x[0], Last = x[x.Length - 1] }` on line 2 in
  *
- * ```
+ * ```csharp
  * public IEnumerable<string> FirstLast(IEnumerable<string> list) {
  *   return list.Select(x => new { First = x[0], Last = x[x.Length - 1] }).
  *               Select(y => y.First + y.Last);
@@ -245,7 +245,7 @@ class DelegateCreation extends Expr, @delegate_creation_expr {
 /**
  * An explicit delegate creation, for example `new D(M)` on line 6 in
  *
- * ```
+ * ```csharp
  * class A {
  *   delegate void D(int x);
  *
@@ -260,7 +260,7 @@ class ExplicitDelegateCreation extends DelegateCreation, @explicit_delegate_crea
 /**
  * An implicit delegate creation, for example the access to `M` on line 6 in
  *
- * ```
+ * ```csharp
  * class A {
  *   delegate void D(int x);
  *
@@ -275,7 +275,7 @@ class ImplicitDelegateCreation extends DelegateCreation, @implicit_delegate_crea
 /**
  * An array initializer, for example `{ {0, 1}, {2, 3}, {4, 5} }` in
  *
- * ```
+ * ```csharp
  * var ints = new int[,] {
  *   {0, 1},
  *   {2, 3},
@@ -288,7 +288,7 @@ class ArrayInitializer extends Expr, @array_init_expr {
    * Gets an element of this array initializer, for example `{0, 1}` on line
    * 2 (itself an array initializer) in
    *
-   * ```
+   * ```csharp
    * var ints = new int[,] {
    *   {0, 1},
    *   {2, 3},
@@ -302,7 +302,7 @@ class ArrayInitializer extends Expr, @array_init_expr {
    * Gets the `i`th element of this array initializer, for example the second
    * (`i = 1`) element is `{2, 3}` on line 3 (itself an array initializer) in
    *
-   * ```
+   * ```csharp
    * var ints = new int[,] {
    *   {0, 1},
    *   {2, 3},
@@ -335,7 +335,7 @@ class ArrayCreation extends Expr, @array_creation_expr {
    * Gets a dimension's length argument of this array creation, for
    * example `5` in
    *
-   * ```
+   * ```csharp
    * new int[5, 10]
    * ```
    */
@@ -345,7 +345,7 @@ class ArrayCreation extends Expr, @array_creation_expr {
    * Gets the `i`th dimension's length argument of this array creation, for
    * example the second (`i = 1`) dimension's length is `10` in
    *
-   * ```
+   * ```csharp
    * new int[5, 10]
    * ```
    */

--- a/csharp/ql/src/semmle/code/csharp/exprs/Dynamic.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Dynamic.qll
@@ -22,7 +22,7 @@ class DynamicExpr extends LateBindableExpr {
  * A constructor call where one of the arguments is a `dynamic` expression, for
  * example `new A(d)` on line 8 in
  *
- * ```
+ * ```csharp
  * class A {
  *   A(int i) { }
  *
@@ -48,7 +48,7 @@ class DynamicObjectCreation extends DynamicExpr, ObjectCreation {
  * A method call where the qualifier or one of the arguments is a `dynamic`
  * expression, for example `M(d)` on line 8 in
  *
- * ```
+ * ```csharp
  * class A {
  *   void M(int i) { }
  *
@@ -72,7 +72,7 @@ class DynamicMethodCall extends DynamicExpr, MethodCall {
  * A call to a user-defined operator where one of the operands is a `dynamic`
  * expression, for example `this + d` on line 12 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public static A operator+(A left, int right) {
  *     return left;
@@ -100,7 +100,7 @@ class DynamicOperatorCall extends DynamicExpr, OperatorCall {
  * A call to a user-defined mutator operator where the operand is a `dynamic`
  * expression, for example `d++` on line 20 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -147,7 +147,7 @@ class DynamicAccess extends DynamicExpr {
  * A member access where the qualifier is a `dynamic` expression, for example
  * `d.X` on line 24 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -193,7 +193,7 @@ class DynamicMemberAccess extends DynamicAccess, MemberAccess, AssignableAccess,
  * An access to a dynamic member that reads the underlying value, for example
  * `d.X` on line 16 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -220,7 +220,7 @@ class DynamicMemberRead extends DynamicMemberAccess, AssignableRead { }
  * An access to a dynamic member that updates the underlying value, for
  * example `d.X` on line 16 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -259,7 +259,7 @@ class DynamicMember extends AssignableMember {
  * A call to an accessor where the qualifier is a `dynamic` expression, for
  * example `d.X` on line 20 and `d[0]` on line 25 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -315,7 +315,7 @@ class DynamicAccessorCall extends DynamicAccess {
  * An element access where the qualifier is a `dynamic` expression, for example
  * `d[0]` on line 12 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -344,7 +344,7 @@ class DynamicElementAccess extends DynamicAccess, ElementAccess, @dynamic_elemen
  * An access to a dynamic element that reads the underlying value, for example
  * `d[0]` on line 12 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *
@@ -367,7 +367,7 @@ class DynamicElementRead extends DynamicElementAccess, ElementRead { }
  * An access to a dynamic element that updates the underlying value, for example
  * `d[0]` on line 12 in
  *
- * ```
+ * ```csharp
  * class A {
  *   public A() { }
  *

--- a/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/Expr.qll
@@ -125,7 +125,7 @@ class LocalVariableDeclExpr extends Expr, @local_var_decl_expr {
   /**
    * Gets the local variable being declared, if any. The only case where
    * no variable is declared is when a discard symbol is used, for example
-   * ```
+   * ```csharp
    * if (int.TryParse(s, out var _))
    *     ...
    * ```
@@ -237,7 +237,7 @@ class TernaryOperation extends Operation, @ternary_op { }
 /**
  * A parenthesized expression, for example `(2 + 3)` in
  *
- * ```
+ * ```csharp
  * 4 * (2 + 3)
  * ```
  */
@@ -291,7 +291,7 @@ private predicate hasChildPattern(ControlFlowElement pm, Expr child) {
 /**
  * A pattern expression, for example `(_, false)` in
  *
- * ```
+ * ```csharp
  * (a,b) switch {
  *     (_, false) => true,
  *     _ => false
@@ -308,7 +308,7 @@ class PatternExpr extends Expr {
    * (transitively). For example, `_`, `false`, and `(_, false)` belong to the
    * pattern match `(_, false) => true` in
    *
-   * ```
+   * ```csharp
    * (a,b) switch {
    *     (_, false) => true,
    *     _ => false
@@ -458,7 +458,7 @@ class Switch extends ControlFlowElement, @switch {
 
 /**
  * A `switch` expression, for example
- * ```
+ * ```csharp
  * (a,b) switch {
  *     (false, false) => true,
  *     _ => false
@@ -544,7 +544,7 @@ class Cast extends Expr {
  * An implicit cast. For example, the implicit cast from `string` to `object`
  * on line 3 in
  *
- * ```
+ * ```csharp
  * class C {
  *   void M1(object o) { }
  *   void M2(string s) => M1(s);
@@ -559,7 +559,7 @@ class ImplicitCast extends Cast {
  * An explicit cast. For example, the explicit cast from `object` to `string`
  * on line 2 in
  *
- * ```
+ * ```csharp
  * class C {
  *   string M1(object o) => (string) o;
  * }
@@ -630,7 +630,7 @@ class SizeofExpr extends UnaryOperation, @sizeof_expr {
  * A pointer indirection operation, for example `*pn` on line 7,
  * `pa->M()` on line 13, and `cp[1]` on line 18 in
  *
- * ```
+ * ```csharp
  * struct A {
  *   public void M() { }
  *
@@ -667,7 +667,7 @@ class PointerIndirectionExpr extends UnaryOperation, @pointer_indirection_expr {
 /**
  * An address-of expression, for example `&n` on line 4 in
  *
- * ```
+ * ```csharp
  * class A {
  *   unsafe int DirectDerefence() {
  *     int n = 10;
@@ -694,7 +694,7 @@ class AwaitExpr extends Expr, @await_expr {
 /**
  * A `nameof` expression, for example `nameof(s)` on line 3 in
  *
- * ```
+ * ```csharp
  * void M(string s) {
  *   if (s == null)
  *     throw new ArgumentNullException(nameof(s));
@@ -715,7 +715,7 @@ class NameOfExpr extends Expr, @nameof_expr {
 /**
  * An interpolated string, for example `$"Hello, {name}!"` on line 2 in
  *
- * ```
+ * ```csharp
  * void Hello(string name) {
  *   Console.WriteLine($"Hello, {name}!");
  * }
@@ -863,8 +863,8 @@ private Expr getAnAssignOrForeachChild() {
  * An expression representing a tuple, for example
  * `(1, 2)` on line 2 or `(var x, var y)` on line 5 in
  *
- * ```
- * class {
+ * ```csharp
+ * class C {
  *   (int, int) F() => (1, 2);
  *
  *   void M() {
@@ -889,7 +889,7 @@ class TupleExpr extends Expr, @tuple_expr {
 /**
  * A reference expression, for example `ref a[i]` on line 2 in
  *
- * ```
+ * ```csharp
  * ref int GetElement(int[] a, int i) {
  *   return ref a[i];
  * }
@@ -907,7 +907,7 @@ class RefExpr extends Expr, @ref_expr {
 /**
  * A discard expression, for example `_` in
  *
- * ```
+ * ```csharp
  * (var name, _, _) = GetDetails();
  * ```
  */
@@ -921,7 +921,7 @@ private class UnknownExpr extends Expr, @unknown_expr {
 
 /**
  * A range expression, used to create a `System.Range`. For example
- * ```
+ * ```csharp
  * 1..3
  * 1..^1
  * 3..
@@ -955,7 +955,7 @@ class IndexExpr extends Expr, @index_expr {
 
 /**
  * A nullable warning suppression expression, for example `x!` in
- * ```
+ * ```csharp
  * string GetName()
  * {
  *     string? x = ...;

--- a/csharp/ql/src/semmle/code/csharp/exprs/LogicalOperation.qll
+++ b/csharp/ql/src/semmle/code/csharp/exprs/LogicalOperation.qll
@@ -53,7 +53,7 @@ class LogicalOrExpr extends BinaryLogicalOperation, @log_or_expr {
 /**
  * A null-coalescing operation, for example `s ?? ""` on line 2 in
  *
- * ```
+ * ```csharp
  * string NonNullOrEmpty(string s) {
  *   return s ?? "";
  * }
@@ -73,7 +73,7 @@ class TernaryLogicalOperation extends LogicalOperation, TernaryOperation, @terna
  * A conditional expression, for example `s != null ? s.Length : -1`
  * on line 2 in
  *
- * ```
+ * ```csharp
  * int LengthOrNegative(string s) {
  *   return s != null ? s.Length : -1;
  * }

--- a/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/System.qll
@@ -564,7 +564,7 @@ private EqualsMethod getInheritedEqualsMethod(ValueOrRefType t) { t.hasMethod(re
  *
  * Example:
  *
- * ```
+ * ```csharp
  * abstract class A<T> : IEquatable<T> {
  *   public abstract bool Equals(T other);
  *   public override bool Equals(object other) { return other != null && GetType() == other.GetType() && Equals((T)other); }
@@ -653,7 +653,7 @@ private DisposeMethod getInheritedDisposeMethod(ValueOrRefType t) { t.hasMethod(
  *
  * Example:
  *
- * ```
+ * ```csharp
  * class A : IDisposable {
  *   public void Dispose() { Dispose(true); }
  *   public virtual void Dispose(bool disposing) { ... }

--- a/csharp/ql/src/semmle/code/dotnet/Element.qll
+++ b/csharp/ql/src/semmle/code/dotnet/Element.qll
@@ -50,7 +50,7 @@ class NamedElement extends Element, @dotnet_named_element {
    * Gets the fully qualified name of this element, for example the
    * fully qualified name of `M` on line 3 is `N.C.M` in
    *
-   * ```
+   * ```csharp
    * namespace N {
    *   class C {
    *     void M(int i, string s) { }


### PR DESCRIPTION
Replaced `` ``` `` with `` ```csharp `` or  `` ```ql `` where relevant, which means we now get nice syntax highlighting for the QLDoc code snippets in VSCode:

![image](https://user-images.githubusercontent.com/3667920/85437419-d4e34580-b58a-11ea-864d-a72e2cd4c81c.png)
