### PR TITLE
C#/C++: Use CODEQL_EXTRACTOR_<LANG>_* in autobuilder

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
@@ -344,7 +344,7 @@ namespace Semmle.Extraction.Tests
             Actions.GetEnvironmentVariable[$"CODEQL_AUTOBUILDER_{codeqlUpperLanguage}_NO_INDEXING"] = "false";
             Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_SOURCE_ARCHIVE_DIR"] = "";
-            Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_ROOT"] = @"C:\codeql\csharp";
+            Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_ROOT"] = $@"C:\codeql\{lgtmLanguage}";
             Actions.GetEnvironmentVariable["CODEQL_JAVA_HOME"] = @"C:\codeql\tools\java";
             Actions.GetEnvironmentVariable["SEMMLE_DIST"] = @"C:\odasa";
             Actions.GetEnvironmentVariable["SEMMLE_JAVA_HOME"] = @"C:\odasa\tools\java";

--- a/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Tests/BuildScripts.cs
@@ -340,9 +340,10 @@ namespace Semmle.Extraction.Tests
             string? nugetRestore = null, string? allSolutions = null,
             string cwd = @"C:\Project")
         {
-            Actions.GetEnvironmentVariable["CODEQL_AUTOBUILDER_CSHARP_NO_INDEXING"] = "false";
-            Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
-            Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
+            string codeqlUpperLanguage = lgtmLanguage.ToUpper();
+            Actions.GetEnvironmentVariable[$"CODEQL_AUTOBUILDER_{codeqlUpperLanguage}_NO_INDEXING"] = "false";
+            Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_TRAP_DIR"] = "";
+            Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_SOURCE_ARCHIVE_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_ROOT"] = @"C:\codeql\csharp";
             Actions.GetEnvironmentVariable["CODEQL_JAVA_HOME"] = @"C:\codeql\tools\java";
             Actions.GetEnvironmentVariable["SEMMLE_DIST"] = @"C:\odasa";

--- a/csharp/autobuilder/Semmle.Autobuild/AutobuildOptions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/AutobuildOptions.cs
@@ -54,7 +54,8 @@ namespace Semmle.Autobuild
             NugetRestore = actions.GetEnvironmentVariable(prefix + "NUGET_RESTORE").AsBool("nuget_restore", true);
 
             Language = actions.GetEnvironmentVariable("LGTM_PROJECT_LANGUAGE").AsLanguage();
-            Indexing = !actions.GetEnvironmentVariable("CODEQL_AUTOBUILDER_CSHARP_NO_INDEXING").AsBool("no_indexing", false);
+
+            Indexing = !actions.GetEnvironmentVariable($"CODEQL_AUTOBUILDER_{Language.UpperCaseName}_NO_INDEXING").AsBool("no_indexing", false);
         }
     }
 

--- a/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
@@ -199,14 +199,14 @@ namespace Semmle.Autobuild
                 throw new InvalidEnvironmentException("The environment variable CODEQL_EXTRACTOR_CSHARP_ROOT or SEMMLE_DIST has not been set.");
 
             TrapDir =
-                Actions.GetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_TRAP_DIR") ??
+                Actions.GetEnvironmentVariable($"CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_TRAP_DIR") ??
                 Actions.GetEnvironmentVariable("TRAP_FOLDER") ??
-                throw new InvalidEnvironmentException("The environment variable CODEQL_EXTRACTOR_CSHARP_TRAP_DIR or TRAP_FOLDER has not been set.");
+                throw new InvalidEnvironmentException($"The environment variable CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_TRAP_DIR or TRAP_FOLDER has not been set.");
 
             SourceArchiveDir =
-                Actions.GetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR") ??
+                Actions.GetEnvironmentVariable($"CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_SOURCE_ARCHIVE_DIR") ??
                 Actions.GetEnvironmentVariable("SOURCE_ARCHIVE") ??
-                throw new InvalidEnvironmentException("The environment variable CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR or SOURCE_ARCHIVE has not been set.");
+                throw new InvalidEnvironmentException($"The environment variable CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_SOURCE_ARCHIVE_DIR or SOURCE_ARCHIVE has not been set.");
         }
 
         private string TrapDir { get; }

--- a/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/Autobuilder.cs
@@ -184,7 +184,7 @@ namespace Semmle.Autobuild
                 return ret ?? new List<IProjectOrSolution>();
             });
 
-            CodeQLExtractorCSharpRoot = Actions.GetEnvironmentVariable("CODEQL_EXTRACTOR_CSHARP_ROOT");
+            CodeQLExtractorLangRoot = Actions.GetEnvironmentVariable($"CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_ROOT");
             SemmleDist = Actions.GetEnvironmentVariable("SEMMLE_DIST");
             SemmlePlatformTools = Actions.GetEnvironmentVariable("SEMMLE_PLATFORM_TOOLS");
 
@@ -194,9 +194,9 @@ namespace Semmle.Autobuild
                 throw new InvalidEnvironmentException("The environment variable CODEQL_JAVA_HOME or SEMMLE_JAVA_HOME has not been set.");
 
             Distribution =
-                CodeQLExtractorCSharpRoot ??
+                CodeQLExtractorLangRoot ??
                 SemmleDist ??
-                throw new InvalidEnvironmentException("The environment variable CODEQL_EXTRACTOR_CSHARP_ROOT or SEMMLE_DIST has not been set.");
+                throw new InvalidEnvironmentException($"The environment variable CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_ROOT or SEMMLE_DIST has not been set.");
 
             TrapDir =
                 Actions.GetEnvironmentVariable($"CODEQL_EXTRACTOR_{this.Options.Language.UpperCaseName}_TRAP_DIR") ??
@@ -397,9 +397,9 @@ namespace Semmle.Autobuild
                 });
 
         /// <summary>
-        /// Value of CODEQL_EXTRACTOR_CSHARP_ROOT environment variable.
+        /// Value of CODEQL_EXTRACTOR_<LANG>_ROOT environment variable.
         /// </summary>
-        private string? CodeQLExtractorCSharpRoot { get; }
+        private string? CodeQLExtractorLangRoot { get; }
 
         /// <summary>
         /// Value of SEMMLE_DIST environment variable.

--- a/csharp/autobuilder/Semmle.Autobuild/Language.cs
+++ b/csharp/autobuilder/Semmle.Autobuild/Language.cs
@@ -2,17 +2,19 @@
 {
     public sealed class Language
     {
-        public static readonly Language Cpp = new Language(".vcxproj");
-        public static readonly Language CSharp = new Language(".csproj");
+        public static readonly Language Cpp = new Language(".vcxproj", "CPP");
+        public static readonly Language CSharp = new Language(".csproj", "CSHARP");
 
         public bool ProjectFileHasThisLanguage(string path) =>
             System.IO.Path.GetExtension(path) == ProjectExtension;
 
         public readonly string ProjectExtension;
+        public readonly string UpperCaseName;
 
-        private Language(string extension)
+        private Language(string extension, string name)
         {
             ProjectExtension = extension;
+            UpperCaseName = name;
         }
 
         public override string ToString() =>


### PR DESCRIPTION
In preparation for a C++ autobuilder on Windows, this makes the C# autobuilder use `LGTM_PROJECT_LANGUAGE` to decide which CodeQL environment variables to read. In particular, it will now use CODEQL_EXTRACTOR_CPP_* when in C++ mode.