### PR TITLE
JS: Add more metric queries

### DIFF
--- a/javascript/ql/src/meta/MetaMetrics.qll
+++ b/javascript/ql/src/meta/MetaMetrics.qll
@@ -2,6 +2,9 @@
  * Helpers to generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
  */
 private import javascript
+private import semmle.javascript.dependencies.Dependencies
+private import semmle.javascript.dependencies.FrameworkLibraries
+private import semmle.javascript.frameworks.Testing
 
 /**
  * Gets the root folder of the snapshot.
@@ -9,3 +12,20 @@ private import javascript
  * This is selected as the location for project-wide metrics.
  */
 Folder projectRoot() { result.getRelativePath() = "" }
+
+/** A file we ignore because it is a test file or compiled/generated/bundled code. */
+class IgnoredFile extends File {
+  IgnoredFile() {
+    any(Test t).getFile() = this
+    or
+    getRelativePath().regexpMatch("(?i).*/test(case)?s?/.*")
+    or
+    getBaseName().regexpMatch("(?i)(.*[._\\-]|^)(min|bundle|concat|spec|tests?)\\.[a-zA-Z]+")
+    or
+    exists(TopLevel tl | tl.getFile() = this |
+      tl.isExterns()
+      or
+      tl instanceof FrameworkLibraryInstance
+    )
+  }
+}

--- a/javascript/ql/src/meta/MetaMetrics.qll
+++ b/javascript/ql/src/meta/MetaMetrics.qll
@@ -1,6 +1,7 @@
 /**
  * Helpers to generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
  */
+
 private import javascript
 private import semmle.javascript.dependencies.Dependencies
 private import semmle.javascript.dependencies.FrameworkLibraries

--- a/javascript/ql/src/meta/MetaMetrics.qll
+++ b/javascript/ql/src/meta/MetaMetrics.qll
@@ -1,0 +1,11 @@
+/**
+ * Helpers to generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
+ */
+private import javascript
+
+/**
+ * Gets the root folder of the snapshot.
+ *
+ * This is selected as the location for project-wide metrics.
+ */
+Folder projectRoot() { result.getRelativePath() = "" }

--- a/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -9,7 +9,6 @@ private import semmle.javascript.dependencies.Dependencies
 private import semmle.javascript.dependencies.FrameworkLibraries
 private import semmle.javascript.frameworks.Testing
 private import DataFlow
-
 import meta.MetaMetrics
 
 /** An call site that is relevant for analysis quality. */

--- a/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -12,23 +12,6 @@ private import DataFlow
 
 import meta.MetaMetrics
 
-/** A file we ignore because it is a test file or compiled/generated/bundled code. */
-class IgnoredFile extends File {
-  IgnoredFile() {
-    any(Test t).getFile() = this
-    or
-    getRelativePath().regexpMatch("(?i).*/test(case)?s?/.*")
-    or
-    getBaseName().regexpMatch("(?i)(.*[._\\-]|^)(min|bundle|concat|spec|tests?)\\.[a-zA-Z]+")
-    or
-    exists(TopLevel tl | tl.getFile() = this |
-      tl.isExterns()
-      or
-      tl instanceof FrameworkLibraryInstance
-    )
-  }
-}
-
 /** An call site that is relevant for analysis quality. */
 class RelevantInvoke extends InvokeNode {
   RelevantInvoke() { not getFile() instanceof IgnoredFile }

--- a/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/javascript/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -10,12 +10,7 @@ private import semmle.javascript.dependencies.FrameworkLibraries
 private import semmle.javascript.frameworks.Testing
 private import DataFlow
 
-/**
- * Gets the root folder of the snapshot.
- *
- * This is selected as the location for project-wide metrics.
- */
-Folder projectRoot() { result.getRelativePath() = "" }
+import meta.MetaMetrics
 
 /** A file we ignore because it is a test file or compiled/generated/bundled code. */
 class IgnoredFile extends File {

--- a/javascript/ql/src/meta/analysis-quality/ResolvableImports.ql
+++ b/javascript/ql/src/meta/analysis-quality/ResolvableImports.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Resolvable imports
+ * @description The number of imports that could be resolved to its target.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/resolvable-imports
+ */
+
+import javascript
+import CallGraphQuality
+
+Import relevantImport() { not result.getFile() instanceof IgnoredFile }
+
+select projectRoot(),
+  count(Import imprt | imprt = relevantImport() and exists(imprt.getImportedModule()))

--- a/javascript/ql/src/meta/analysis-quality/RouteHandlers.ql
+++ b/javascript/ql/src/meta/analysis-quality/RouteHandlers.ql
@@ -1,0 +1,16 @@
+/**
+ * @name Route handlers
+ * @description The number of HTTP route handler functions found.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/route-handlers
+ */
+
+import javascript
+import CallGraphQuality
+
+HTTP::RouteHandler relevantRouteHandler() { not result.getFile() instanceof IgnoredFile }
+
+select projectRoot(), count(relevantRouteHandler())

--- a/javascript/ql/src/meta/analysis-quality/SanitizersReachableFromSource.ql
+++ b/javascript/ql/src/meta/analysis-quality/SanitizersReachableFromSource.ql
@@ -1,0 +1,22 @@
+/**
+ * @name Sanitizers reachable from source
+ * @description The number of sanitizers reachable from a recognized taint source.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/sanitizers-reachable-from-source
+ */
+
+import javascript
+import TaintMetrics
+
+class BasicTaintConfiguration extends TaintTracking::Configuration {
+  BasicTaintConfiguration() { this = "BasicTaintConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) { node = relevantTaintSource() }
+
+  override predicate isSink(DataFlow::Node node) { node = relevantSanitizerInput() }
+}
+
+select projectRoot(), count(DataFlow::Node node | any(BasicTaintConfiguration cfg).hasFlow(_, node))

--- a/javascript/ql/src/meta/analysis-quality/SinksReachableFromSanitizer.ql
+++ b/javascript/ql/src/meta/analysis-quality/SinksReachableFromSanitizer.ql
@@ -1,0 +1,22 @@
+/**
+ * @name Sinks reachable from sanitizer
+ * @description The number of sinks reachable from a recognized sanitizer call.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/sinks-reachable-from-sanitizer
+ */
+
+import javascript
+import TaintMetrics
+
+class BasicTaintConfiguration extends TaintTracking::Configuration {
+  BasicTaintConfiguration() { this = "BasicTaintConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) { node = relevantSanitizerOutput() }
+
+  override predicate isSink(DataFlow::Node node) { node = relevantTaintSink() }
+}
+
+select projectRoot(), count(DataFlow::Node node | any(BasicTaintConfiguration cfg).hasFlow(_, node))

--- a/javascript/ql/src/meta/analysis-quality/TaintMetrics.qll
+++ b/javascript/ql/src/meta/analysis-quality/TaintMetrics.qll
@@ -1,0 +1,89 @@
+/**
+ * Provides predicates for measuring taint-tracking coverage.
+ */
+
+private import javascript
+import meta.MetaMetrics
+private import semmle.javascript.security.dataflow.ClientSideUrlRedirectCustomizations
+private import semmle.javascript.security.dataflow.CodeInjectionCustomizations
+private import semmle.javascript.security.dataflow.CommandInjectionCustomizations
+private import semmle.javascript.security.dataflow.Xss as Xss
+private import semmle.javascript.security.dataflow.NosqlInjectionCustomizations
+private import semmle.javascript.security.dataflow.PrototypePollutionCustomizations
+private import semmle.javascript.security.dataflow.RegExpInjectionCustomizations
+private import semmle.javascript.security.dataflow.RequestForgeryCustomizations
+private import semmle.javascript.security.dataflow.ServerSideUrlRedirectCustomizations
+private import semmle.javascript.security.dataflow.SqlInjectionCustomizations
+private import semmle.javascript.security.dataflow.TaintedPathCustomizations
+private import semmle.javascript.security.dataflow.UnsafeDeserializationCustomizations
+private import semmle.javascript.security.dataflow.XmlBombCustomizations
+private import semmle.javascript.security.dataflow.XpathInjectionCustomizations
+private import semmle.javascript.security.dataflow.XxeCustomizations
+private import semmle.javascript.security.dataflow.ZipSlipCustomizations
+
+/**
+ * Gets a relevant taint sink.
+ *
+ * To ensure this metric isn't dominated by a few queries with a huge number of sinks,
+ * we only include sinks for queries that have fairly specific sinks and/or have high severity
+ * relative to the number of sinks.
+ *
+ * Examples of excluded queries:
+ * - UnsafeDynamicMethodAccess: high severity (RCE) but has way too many sinks (every callee).
+ * - ClearTextLogging: not severe enough relative to number of sinks.
+ */
+DataFlow::Node relevantTaintSink() {
+  not result.getFile() instanceof IgnoredFile and
+  (
+    result instanceof ClientSideUrlRedirect::Sink or
+    result instanceof CodeInjection::Sink or
+    result instanceof CommandInjection::Sink or
+    result instanceof Xss::Shared::Sink or
+    result instanceof NosqlInjection::Sink or
+    result instanceof PrototypePollution::Sink or
+    result instanceof RegExpInjection::Sink or
+    result instanceof RequestForgery::Sink or
+    result instanceof ServerSideUrlRedirect::Sink or
+    result instanceof SqlInjection::Sink or
+    result instanceof TaintedPath::Sink or
+    result instanceof UnsafeDeserialization::Sink or
+    result instanceof XmlBomb::Sink or
+    result instanceof XpathInjection::Sink or
+    result instanceof Xxe::Sink or
+    result instanceof ZipSlip::Sink
+  )
+}
+
+/**
+ * Gets a remote flow source or `document.location` source.
+ */
+DataFlow::Node relevantTaintSource() {
+  not result.getFile() instanceof IgnoredFile and
+  (
+    result instanceof RemoteFlowSource
+    or
+    result = DOM::locationSource()
+  )
+}
+
+/**
+ * Gets the output of a call that shows intent to sanitize a value
+ * (indicating a likely vulnerability if the sanitizer was removed).
+ *
+ * Currently we only recognize HTML sanitizers.
+ */
+DataFlow::Node relevantSanitizerOutput() {
+  result = any(HtmlSanitizerCall call) and
+  not result.getFile() instanceof IgnoredFile
+}
+
+/**
+ * Gets the input to a call that shows intent to sanitize a value
+ * (indicating a likely vulnerability if the sanitizer was removed).
+ *
+ * Currently we only recognize HTML sanitizers.
+ */
+DataFlow::Node relevantSanitizerInput() {
+  result = any(HtmlSanitizerCall call).getInput() and
+  not result.getFile() instanceof IgnoredFile
+}

--- a/javascript/ql/src/meta/analysis-quality/TaintSinks.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintSinks.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Taint sinks
+ * @description The number of high-severity taint sinks.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/taint-sinks
+ */
+
+import javascript
+import TaintMetrics
+
+select projectRoot(), count(relevantTaintSink())

--- a/javascript/ql/src/meta/analysis-quality/TaintSources.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintSources.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Taint sources
+ * @description The number of remote flow sources and document.location sources
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/taint-sources
+ */
+
+import javascript
+import TaintMetrics
+
+select projectRoot(), count(relevantTaintSource())

--- a/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintSteps.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Taint steps
+ * @description The number of default taint steps.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/taint-steps
+ */
+
+import javascript
+import CallGraphQuality
+
+class BasicTaintConfiguration extends TaintTracking::Configuration {
+  BasicTaintConfiguration() { this = "BasicTaintConfiguration" }
+}
+
+predicate relevantStep(DataFlow::Node pred, DataFlow::Node succ) {
+  any(BasicTaintConfiguration cfg).isAdditionalFlowStep(pred, succ) and
+  not pred.getFile() instanceof IgnoredFile and
+  not succ.getFile() instanceof IgnoredFile
+}
+
+select projectRoot(), count(DataFlow::Node pred, DataFlow::Node succ | relevantStep(pred, succ))

--- a/javascript/ql/src/meta/analysis-quality/TaintedNodes.ql
+++ b/javascript/ql/src/meta/analysis-quality/TaintedNodes.ql
@@ -1,0 +1,27 @@
+/**
+ * @name Tainted expressions
+ * @description The number of expressions reachable from a remote flow source
+ *              via default taint-tracking steps.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/tainted-nodes
+ */
+
+import javascript
+import TaintMetrics
+
+class BasicTaintConfiguration extends TaintTracking::Configuration {
+  BasicTaintConfiguration() { this = "BasicTaintConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) { node = relevantTaintSource() }
+
+  override predicate isSink(DataFlow::Node node) {
+    // To reduce noise from synthetic nodes, only count value nodes
+    node instanceof DataFlow::ValueNode and
+    not node.getFile() instanceof IgnoredFile
+  }
+}
+
+select projectRoot(), count(DataFlow::Node node | any(BasicTaintConfiguration cfg).hasFlow(_, node))

--- a/javascript/ql/src/meta/types/TypedExprs.ql
+++ b/javascript/ql/src/meta/types/TypedExprs.ql
@@ -12,8 +12,6 @@
 import javascript
 import meta.MetaMetrics
 
-predicate isProperType(Type t) {
-  not t instanceof AnyType
-}
+predicate isProperType(Type t) { not t instanceof AnyType }
 
 select projectRoot(), count(Expr e | isProperType(e.getType()))

--- a/javascript/ql/src/meta/types/TypedExprs.ql
+++ b/javascript/ql/src/meta/types/TypedExprs.ql
@@ -1,0 +1,19 @@
+/**
+ * @name Typed expressions
+ * @description The number of expressions for which the TypeScript extractor could
+ *              extract a type other than 'any'.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/typed-expressions
+ */
+
+import javascript
+import meta.MetaMetrics
+
+predicate isProperType(Type t) {
+  not t instanceof AnyType
+}
+
+select projectRoot(), count(Expr e | isProperType(e.getType()))


### PR DESCRIPTION
Adds some of the metrics described in https://github.com/github/codeql-javascript-team/issues/191 and cherry-picks the TypedExprs metric from https://github.com/github/codeql/pull/3731.

[Example run](https://git.semmle.com/asger/dist-compare-reports/tree/js/metric-queries_1592969074957), unfortunately with a buggy version of TaintedSink, and [a shorter run](https://git.semmle.com/asger/dist-compare-reports/tree/js/metric-queries_1592990060315) with that bug fixed.