### PR TITLE
Data flow: Further pruning based on `read` column of `nodeCand2()` predicate

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -201,8 +201,7 @@ edges
 | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
 | H.cs:147:17:147:32 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
 | H.cs:147:25:147:31 | object creation of type A : A | H.cs:147:17:147:32 | call to method Through : A |
-| H.cs:155:17:155:23 | object creation of type B : B | H.cs:156:9:156:9 | access to local variable b : B |
-| H.cs:156:9:156:9 | access to local variable b : B | H.cs:157:20:157:20 | access to local variable b : B |
+| H.cs:155:17:155:23 | object creation of type B : B | H.cs:157:20:157:20 | access to local variable b : B |
 | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B | H.cs:164:19:164:19 | [post] access to local variable a [FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B |
 | H.cs:163:17:163:28 | object creation of type Object : Object | H.cs:164:22:164:22 | access to local variable o : Object |
@@ -472,7 +471,6 @@ nodes
 | H.cs:147:25:147:31 | object creation of type A : A | semmle.label | object creation of type A : A |
 | H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
 | H.cs:155:17:155:23 | object creation of type B : B | semmle.label | object creation of type B : B |
-| H.cs:156:9:156:9 | access to local variable b : B | semmle.label | access to local variable b : B |
 | H.cs:157:9:157:9 | [post] access to parameter a [FieldA] : B | semmle.label | [post] access to parameter a [FieldA] : B |
 | H.cs:157:20:157:20 | access to local variable b : B | semmle.label | access to local variable b : B |
 | H.cs:163:17:163:28 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |


### PR DESCRIPTION
We were missing out on additional pruning in `flowCandFwd()`, because we ignored the `read` column of `nodeCand2()`. 

### C# tuple counts

Ran [this](https://gist.github.com/hvitved/ac1e68269d9d0dd4dc1c7a0a43a61b04#file-csharpdataflowtuplecounts-qll) on `mono`:

  | fwd1 | nc1 | fwd2 | nc2 | ff1 | fb1 | ff2 | fb2 | f | fwd3 | lbs | nc3 | fwd3t | nc3t | ccfwd | cc | fwd4 | nc4 | fwd4t | nc4t | pn
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before | 3163944 | 1830102 | 928649 | 110442 | 32513 | 24077 | 11395 | 1448 | 1159 | 39147 | 79804 | 23209 | 67287 | 23658 | 1004 | 77 | 22041 | 21967 | 23001 | 22032 | 28565
After | 3163944 | 1830102 | 928649 | 110442 | 32513 | 24077 | 11395 | 1448 | 1159 | 38547 | 93237 | 23139 | 64595 | 23556 | 975 | 77 | 22020 | 21946 | 22972 | 22009 | 28536
Increase | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% | -2% | 17% | 0% | -4% | 0% | -3% | 0% | 0% | 0% | 0% | 0% | 0%

### Java tuple counts

Ran [this](https://gist.github.com/hvitved/ac1e68269d9d0dd4dc1c7a0a43a61b04#file-javadataflowtuplecounts-qll) on JDK:

  | fwd1 | nc1 | fwd2 | nc2 | ff1 | fb1 | ff2 | fb2 | f | fwd3 | lbs | nc3 | fwd3t | nc3t | ccfwd | cc | fwd4 | nc4 | fwd4t | nc4t | pn
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Before | 2604206 | 1555243 | 920416 | 565520 | 30417 | 22434 | 14298 | 8872 | 7884 | 208534 | 813190 | 127783 | 976581 | 346054 | 11750 | 3955 | 113281 | 108944 | 403062 | 322831 | 313277
After | 2604206 | 1555243 | 920416 | 565520 | 30417 | 22434 | 14298 | 8872 | 7884 | 195284 | 846259 | 125882 | 851799 | 341831 | 10322 | 3946 | 111649 | 107336 | 395717 | 317363 | 307376
Increase | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% | -6% | 4% | -1% | -13% | -1% | -12% | 0% | -1% | -1% | -2% | -2% | -2%

### Differences jobs:
- C#: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/538/
- C++: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1499/
- Java: https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/960/