### PR TITLE
JS: Dont try to extract TypeScript from script tags

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
@@ -1,12 +1,14 @@
 package com.semmle.js.extractor;
 
+import java.util.regex.Pattern;
+
 import com.semmle.js.extractor.ExtractorConfig.Platform;
 import com.semmle.js.extractor.ExtractorConfig.SourceType;
 import com.semmle.js.parser.ParseError;
 import com.semmle.util.data.StringUtil;
 import com.semmle.util.trap.TrapWriter;
 import com.semmle.util.trap.TrapWriter.Label;
-import java.util.regex.Pattern;
+
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Attributes;
 import net.htmlparser.jericho.CharacterReference;
@@ -142,6 +144,10 @@ public class HTMLExtractor implements IExtractor {
   private SourceType getScriptSourceType(Element script) {
     String scriptType = getAttributeValueLC(script, "type");
     String scriptLanguage = getAttributeValueLC(script, "language");
+
+    if (scriptLanguage == null) { // Vue templates use 'lang' instead of 'language'.
+      scriptLanguage = getAttributeValueLC(script, "lang");
+    }
 
     // if `type` and `language` are both either missing, contain the
     // string "javascript", or if `type` is the string "text/jsx", this is a plain script

--- a/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/Test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/Test.expected
@@ -1,0 +1,2 @@
+classDeclaration
+exprType

--- a/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/Test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/Test.ql
@@ -1,0 +1,5 @@
+import javascript
+
+query ClassDefinition classDeclaration() { any() }
+
+query Type exprType(Expr e) { result = e.getType() }

--- a/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/test.vue
+++ b/javascript/ql/test/library-tests/TypeScript/EmbeddedInScript/test.vue
@@ -1,0 +1,5 @@
+<script lang='ts'>
+  export default class MyComponent {
+      x!: number;
+  }
+</script>


### PR DESCRIPTION
Stops trying to parse script tags with a `lang` property set to something that doesn't indicate it contains JavaScript content.

In particular, Vue components sometimes use `lang='ts'` instead of using the `language` attribute.

Actually extracting the contents as TypeScript is a little tricky due to HTML extraction being multi-threaded and TypeScript extaction single-threaded. It would require a lock or other measure to prevent multiple threads trying to talk to the TypeScript compiler simultaneously, so I dropped that.