### PR TITLE
Dataflow: Refactor dispatch with call context.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -53,26 +53,13 @@ private predicate functionSignature(Function f, string qualifiedName, int nparam
 }
 
 /**
- * Holds if the call context `ctx` reduces the set of viable dispatch
- * targets of `ma` in `c`.
+ * Holds if the set of viable implementations that can be called by `call`
+ * might be improved by knowing the call context.
  */
-predicate reducedViableImplInCallContext(Call call, Function f, Call ctx) { none() }
+predicate mayBenefitFromCallContext(Call call, Function f) { none() }
 
 /**
- * Gets a viable dispatch target of `ma` in the context `ctx`. This is
- * restricted to those `ma`s for which the context makes a difference.
+ * Gets a viable dispatch target of `call` in the context `ctx`. This is
+ * restricted to those `call`s for which a context might make a difference.
  */
-Function prunedViableImplInCallContext(Call call, Call ctx) { none() }
-
-/**
- * Holds if flow returning from `m` to `ma` might return further and if
- * this path restricts the set of call sites that can be returned to.
- */
-predicate reducedViableImplInReturn(Function f, Call call) { none() }
-
-/**
- * Gets a viable dispatch target of `ma` in the context `ctx`. This is
- * restricted to those `ma`s and results for which the return flow from the
- * result to `ma` restricts the possible context `ctx`.
- */
-Function prunedViableImplInCallContextReverse(Call call, Call ctx) { none() }
+Function viableImplInCallContext(Call call, Call ctx) { none() }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -344,7 +344,7 @@ private module Cached {
         mayBenefitFromCallContext(call, c) and
         c = viableCallable(ctx) and
         ctxtgts = count(viableImplInCallContext(call, ctx)) and
-        tgts = strictcount(viableImpl(call)) and
+        tgts = strictcount(viableCallable(call)) and
         ctxtgts < tgts
       )
     }
@@ -369,7 +369,7 @@ private module Cached {
     predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
       exists(int tgts, int ctxtgts |
         mayBenefitFromCallContext(call, _) and
-        c = viableImpl(call) and
+        c = viableCallable(call) and
         ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
         tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
         ctxtgts < tgts

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -330,6 +330,67 @@ private module Cached {
     import Final
   }
 
+  import FlowThrough
+
+  cached
+  private module DispatchWithCallContext {
+    /**
+     * Holds if the call context `ctx` reduces the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    cached
+    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, c) and
+        c = viableCallable(ctx) and
+        ctxtgts = count(viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(viableImpl(call)) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls for which a context
+     * makes a difference.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInCallContext(call, _, ctx)
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path restricts the set of call sites that can be
+     * returned to.
+     */
+    cached
+    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, _) and
+        c = viableImpl(call) and
+        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls and results for which
+     * the return flow from the result to `call` restricts the possible context
+     * `ctx`.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContextReverse(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInReturn(result, call)
+    }
+  }
+
+  import DispatchWithCallContext
+
   /**
    * Holds if `p` can flow to the pre-update node associated with post-update
    * node `n`, in the same callable, using only value-preserving steps.
@@ -370,8 +431,6 @@ private module Cached {
   predicate store(Node node1, TypedContent tc, Node node2, DataFlowType contentType) {
     store(node1, tc.getContent(), node2, contentType, tc.getContainerType())
   }
-
-  import FlowThrough
 
   /**
    * Holds if the call context `call` either improves virtual dispatch in

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -226,28 +226,13 @@ private predicate functionSignature(Function f, string qualifiedName, int nparam
 }
 
 /**
- * Holds if the call context `ctx` reduces the set of viable dispatch
- * targets of `ma` in `c`.
+ * Holds if the set of viable implementations that can be called by `call`
+ * might be improved by knowing the call context.
  */
-predicate reducedViableImplInCallContext(CallInstruction call, Function f, CallInstruction ctx) {
-  none()
-}
+predicate mayBenefitFromCallContext(CallInstruction call, Function f) { none() }
 
 /**
- * Gets a viable dispatch target of `ma` in the context `ctx`. This is
- * restricted to those `ma`s for which the context makes a difference.
+ * Gets a viable dispatch target of `call` in the context `ctx`. This is
+ * restricted to those `call`s for which a context might make a difference.
  */
-Function prunedViableImplInCallContext(CallInstruction call, CallInstruction ctx) { none() }
-
-/**
- * Holds if flow returning from `m` to `ma` might return further and if
- * this path restricts the set of call sites that can be returned to.
- */
-predicate reducedViableImplInReturn(Function f, CallInstruction call) { none() }
-
-/**
- * Gets a viable dispatch target of `ma` in the context `ctx`. This is
- * restricted to those `ma`s and results for which the return flow from the
- * result to `ma` restricts the possible context `ctx`.
- */
-Function prunedViableImplInCallContextReverse(CallInstruction call, CallInstruction ctx) { none() }
+Function viableImplInCallContext(CallInstruction call, CallInstruction ctx) { none() }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -344,7 +344,7 @@ private module Cached {
         mayBenefitFromCallContext(call, c) and
         c = viableCallable(ctx) and
         ctxtgts = count(viableImplInCallContext(call, ctx)) and
-        tgts = strictcount(viableImpl(call)) and
+        tgts = strictcount(viableCallable(call)) and
         ctxtgts < tgts
       )
     }
@@ -369,7 +369,7 @@ private module Cached {
     predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
       exists(int tgts, int ctxtgts |
         mayBenefitFromCallContext(call, _) and
-        c = viableImpl(call) and
+        c = viableCallable(call) and
         ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
         tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
         ctxtgts < tgts

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -330,6 +330,67 @@ private module Cached {
     import Final
   }
 
+  import FlowThrough
+
+  cached
+  private module DispatchWithCallContext {
+    /**
+     * Holds if the call context `ctx` reduces the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    cached
+    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, c) and
+        c = viableCallable(ctx) and
+        ctxtgts = count(viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(viableImpl(call)) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls for which a context
+     * makes a difference.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInCallContext(call, _, ctx)
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path restricts the set of call sites that can be
+     * returned to.
+     */
+    cached
+    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, _) and
+        c = viableImpl(call) and
+        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls and results for which
+     * the return flow from the result to `call` restricts the possible context
+     * `ctx`.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContextReverse(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInReturn(result, call)
+    }
+  }
+
+  import DispatchWithCallContext
+
   /**
    * Holds if `p` can flow to the pre-update node associated with post-update
    * node `n`, in the same callable, using only value-preserving steps.
@@ -370,8 +431,6 @@ private module Cached {
   predicate store(Node node1, TypedContent tc, Node node2, DataFlowType contentType) {
     store(node1, tc.getContent(), node2, contentType, tc.getContainerType())
   }
-
-  import FlowThrough
 
   /**
    * Holds if the call context `call` either improves virtual dispatch in

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -344,7 +344,7 @@ private module Cached {
         mayBenefitFromCallContext(call, c) and
         c = viableCallable(ctx) and
         ctxtgts = count(viableImplInCallContext(call, ctx)) and
-        tgts = strictcount(viableImpl(call)) and
+        tgts = strictcount(viableCallable(call)) and
         ctxtgts < tgts
       )
     }
@@ -369,7 +369,7 @@ private module Cached {
     predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
       exists(int tgts, int ctxtgts |
         mayBenefitFromCallContext(call, _) and
-        c = viableImpl(call) and
+        c = viableCallable(call) and
         ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
         tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
         ctxtgts < tgts

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -330,6 +330,67 @@ private module Cached {
     import Final
   }
 
+  import FlowThrough
+
+  cached
+  private module DispatchWithCallContext {
+    /**
+     * Holds if the call context `ctx` reduces the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    cached
+    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, c) and
+        c = viableCallable(ctx) and
+        ctxtgts = count(viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(viableImpl(call)) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls for which a context
+     * makes a difference.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInCallContext(call, _, ctx)
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path restricts the set of call sites that can be
+     * returned to.
+     */
+    cached
+    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, _) and
+        c = viableImpl(call) and
+        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls and results for which
+     * the return flow from the result to `call` restricts the possible context
+     * `ctx`.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContextReverse(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInReturn(result, call)
+    }
+  }
+
+  import DispatchWithCallContext
+
   /**
    * Holds if `p` can flow to the pre-update node associated with post-update
    * node `n`, in the same callable, using only value-preserving steps.
@@ -370,8 +431,6 @@ private module Cached {
   predicate store(Node node1, TypedContent tc, Node node2, DataFlowType contentType) {
     store(node1, tc.getContent(), node2, contentType, tc.getContainerType())
   }
-
-  import FlowThrough
 
   /**
    * Holds if the call context `call` either improves virtual dispatch in

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowDispatch.qll
@@ -2,14 +2,13 @@ private import java
 private import DataFlowPrivate
 import semmle.code.java.dispatch.VirtualDispatch
 
-cached
 private module DispatchImpl {
   /**
    * Holds if the set of viable implementations that can be called by `ma`
    * might be improved by knowing the call context. This is the case if the
    * qualifier is the `i`th parameter of the enclosing callable `c`.
    */
-  private predicate benefitsFromCallContext(MethodAccess ma, Callable c, int i) {
+  private predicate mayBenefitFromCallContext(MethodAccess ma, Callable c, int i) {
     exists(Parameter p |
       2 <= strictcount(viableImpl(ma)) and
       ma.getQualifier().(VarAccess).getVariable() = p and
@@ -28,7 +27,7 @@ private module DispatchImpl {
   pragma[nomagic]
   private predicate relevantContext(Call ctx, int i) {
     exists(Callable c |
-      benefitsFromCallContext(_, c, i) and
+      mayBenefitFromCallContext(_, c, i) and
       c = viableCallable(ctx)
     )
   }
@@ -54,13 +53,22 @@ private module DispatchImpl {
   }
 
   /**
+   * Holds if the set of viable implementations that can be called by `ma`
+   * might be improved by knowing the call context. This is the case if the
+   * qualifier is a parameter of the enclosing callable `c`.
+   */
+  predicate mayBenefitFromCallContext(MethodAccess ma, Callable c) {
+    mayBenefitFromCallContext(ma, c, _)
+  }
+
+  /**
    * Gets a viable dispatch target of `ma` in the context `ctx`. This is
    * restricted to those `ma`s for which a context might make a difference.
    */
-  private Method viableImplInCallContext(MethodAccess ma, Call ctx) {
+  Method viableImplInCallContext(MethodAccess ma, Call ctx) {
     result = viableImpl(ma) and
     exists(int i, Callable c, Method def, RefType t, boolean exact |
-      benefitsFromCallContext(ma, c, i) and
+      mayBenefitFromCallContext(ma, c, i) and
       c = viableCallable(ctx) and
       contextArgHasType(ctx, i, t, exact) and
       ma.getMethod() = def
@@ -135,57 +143,6 @@ private module DispatchImpl {
         t1 instanceof RefType and t2 instanceof BoundedType
       )
     )
-  }
-
-  /**
-   * Holds if the call context `ctx` reduces the set of viable dispatch
-   * targets of `ma` in `c`.
-   */
-  cached
-  predicate reducedViableImplInCallContext(MethodAccess ma, Callable c, Call ctx) {
-    exists(int tgts, int ctxtgts |
-      benefitsFromCallContext(ma, c, _) and
-      c = viableCallable(ctx) and
-      ctxtgts = count(viableImplInCallContext(ma, ctx)) and
-      tgts = strictcount(viableImpl(ma)) and
-      ctxtgts < tgts
-    )
-  }
-
-  /**
-   * Gets a viable dispatch target of `ma` in the context `ctx`. This is
-   * restricted to those `ma`s for which the context makes a difference.
-   */
-  cached
-  Method prunedViableImplInCallContext(MethodAccess ma, Call ctx) {
-    result = viableImplInCallContext(ma, ctx) and
-    reducedViableImplInCallContext(ma, _, ctx)
-  }
-
-  /**
-   * Holds if flow returning from `m` to `ma` might return further and if
-   * this path restricts the set of call sites that can be returned to.
-   */
-  cached
-  predicate reducedViableImplInReturn(Method m, MethodAccess ma) {
-    exists(int tgts, int ctxtgts |
-      benefitsFromCallContext(ma, _, _) and
-      m = viableImpl(ma) and
-      ctxtgts = count(Call ctx | m = viableImplInCallContext(ma, ctx)) and
-      tgts = strictcount(Call ctx | viableCallable(ctx) = ma.getEnclosingCallable()) and
-      ctxtgts < tgts
-    )
-  }
-
-  /**
-   * Gets a viable dispatch target of `ma` in the context `ctx`. This is
-   * restricted to those `ma`s and results for which the return flow from the
-   * result to `ma` restricts the possible context `ctx`.
-   */
-  cached
-  Method prunedViableImplInCallContextReverse(MethodAccess ma, Call ctx) {
-    result = viableImplInCallContext(ma, ctx) and
-    reducedViableImplInReturn(result, ma)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -344,7 +344,7 @@ private module Cached {
         mayBenefitFromCallContext(call, c) and
         c = viableCallable(ctx) and
         ctxtgts = count(viableImplInCallContext(call, ctx)) and
-        tgts = strictcount(viableImpl(call)) and
+        tgts = strictcount(viableCallable(call)) and
         ctxtgts < tgts
       )
     }
@@ -369,7 +369,7 @@ private module Cached {
     predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
       exists(int tgts, int ctxtgts |
         mayBenefitFromCallContext(call, _) and
-        c = viableImpl(call) and
+        c = viableCallable(call) and
         ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
         tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
         ctxtgts < tgts

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -330,6 +330,67 @@ private module Cached {
     import Final
   }
 
+  import FlowThrough
+
+  cached
+  private module DispatchWithCallContext {
+    /**
+     * Holds if the call context `ctx` reduces the set of viable run-time
+     * dispatch targets of call `call` in `c`.
+     */
+    cached
+    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, c) and
+        c = viableCallable(ctx) and
+        ctxtgts = count(viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(viableImpl(call)) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls for which a context
+     * makes a difference.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContext(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInCallContext(call, _, ctx)
+    }
+
+    /**
+     * Holds if flow returning from callable `c` to call `call` might return
+     * further and if this path restricts the set of call sites that can be
+     * returned to.
+     */
+    cached
+    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      exists(int tgts, int ctxtgts |
+        mayBenefitFromCallContext(call, _) and
+        c = viableImpl(call) and
+        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContext(call, ctx)) and
+        tgts = strictcount(DataFlowCall ctx | viableCallable(ctx) = call.getEnclosingCallable()) and
+        ctxtgts < tgts
+      )
+    }
+
+    /**
+     * Gets a viable run-time dispatch target for the call `call` in the
+     * context `ctx`. This is restricted to those calls and results for which
+     * the return flow from the result to `call` restricts the possible context
+     * `ctx`.
+     */
+    cached
+    DataFlowCallable prunedViableImplInCallContextReverse(DataFlowCall call, DataFlowCall ctx) {
+      result = viableImplInCallContext(call, ctx) and
+      reducedViableImplInReturn(result, call)
+    }
+  }
+
+  import DispatchWithCallContext
+
   /**
    * Holds if `p` can flow to the pre-update node associated with post-update
    * node `n`, in the same callable, using only value-preserving steps.
@@ -370,8 +431,6 @@ private module Cached {
   predicate store(Node node1, TypedContent tc, Node node2, DataFlowType contentType) {
     store(node1, tc.getContent(), node2, contentType, tc.getContainerType())
   }
-
-  import FlowThrough
 
   /**
    * Holds if the call context `call` either improves virtual dispatch in


### PR DESCRIPTION
This should be a clean refactor that doesn't change any behaviour or performance as it is simply moving some predicates around.

The upside of this refactor is that it reduces and simplifies the language-specific interface that's required for using call-context dependent virtual dispatch.