### PR TITLE
C++: Improve join order for AliasAnalysis::isArgumentForParameter

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -196,16 +196,17 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
-private predicate isArgumentForParameter(CallInstruction ci, Operand operand, Instruction init) {
+private predicate isArgumentForParameter(
+  CallInstruction ci, Operand operand, InitializeParameterInstruction init
+) {
   exists(Language::Function f |
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getParameter() =
-        f.getParameter(operand.(PositionalArgumentOperand).getIndex())
+      init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable and
-      init.getEnclosingFunction() = f and
+      init.getIRVariable() instanceof IRThisVariable and
+      unique( | | init.getEnclosingFunction()) = f and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -196,16 +196,17 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
-private predicate isArgumentForParameter(CallInstruction ci, Operand operand, Instruction init) {
+private predicate isArgumentForParameter(
+  CallInstruction ci, Operand operand, InitializeParameterInstruction init
+) {
   exists(Language::Function f |
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getParameter() =
-        f.getParameter(operand.(PositionalArgumentOperand).getIndex())
+      init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable and
-      init.getEnclosingFunction() = f and
+      init.getIRVariable() instanceof IRThisVariable and
+      unique( | | init.getEnclosingFunction()) = f and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and

--- a/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/experimental/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -196,16 +196,17 @@ private predicate operandReturned(Operand operand, IntValue bitOffset) {
   bitOffset = Ints::unknown()
 }
 
-private predicate isArgumentForParameter(CallInstruction ci, Operand operand, Instruction init) {
+private predicate isArgumentForParameter(
+  CallInstruction ci, Operand operand, InitializeParameterInstruction init
+) {
   exists(Language::Function f |
     ci = operand.getUse() and
     f = ci.getStaticCallTarget() and
     (
-      init.(InitializeParameterInstruction).getParameter() =
-        f.getParameter(operand.(PositionalArgumentOperand).getIndex())
+      init.getParameter() = f.getParameter(operand.(PositionalArgumentOperand).getIndex())
       or
-      init.(InitializeParameterInstruction).getIRVariable() instanceof IRThisVariable and
-      init.getEnclosingFunction() = f and
+      init.getIRVariable() instanceof IRThisVariable and
+      unique( | | init.getEnclosingFunction()) = f and
       operand instanceof ThisArgumentOperand
     ) and
     not Language::isFunctionVirtual(f) and


### PR DESCRIPTION
On openjdk we had the following tuple explosion due to the join orderer preferring an early join on `getEnclosingFunction`:

```
Tuple counts for AliasAnalysis::isArgumentForParameter#fff:
    1181391  ~0%     {3} r1 = JOIN Instruction::CallInstruction::getStaticCallTarget_dispred#ff AS L WITH Operand::NonPhiOperand#fff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, R.<0>, L.<1>
    1124923  ~0%     {3} r2 = r1 AND NOT IRCppLanguage::isFunctionVirtual#f AS R(r1.<2>)
    1114567  ~0%     {3} r3 = r2 AND NOT Alias::AliasFunction#class#f AS R(r2.<2>)
    1114567  ~0%     {3} r4 = r3 AND NOT IRCppLanguage::isFunctionVirtual#f AS R(r3.<2>)
    1114567  ~0%     {3} r5 = r4 AND NOT Alias::AliasFunction#class#f AS R(r4.<2>)
    475419   ~3%     {4} r6 = JOIN r5 WITH Operand::PositionalArgumentOperand::getIndex_dispred#ff AS R ON FIRST 1 OUTPUT r5.<2>, R.<1>, r5.<0>, r5.<1>
    452941   ~1%     {3} r7 = JOIN r6 WITH Function::Function::getParameter_dispred#fff AS R ON FIRST 2 OUTPUT R.<2>, r6.<2>, r6.<3>
    426513   ~0%     {3} r8 = JOIN r7 WITH Instruction::InitializeParameterInstruction::getParameter_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r7.<2>, r7.<1>, R.<1>
    242962   ~0%     {3} r9 = JOIN r3 WITH Operand::ThisArgumentOperand#class#ffff AS R ON FIRST 1 OUTPUT r3.<0>, r3.<1>, r3.<2>
    242962   ~0%     {3} r10 = r9 AND NOT IRCppLanguage::isFunctionVirtual#f AS R(r9.<2>)
    242962   ~0%     {3} r11 = r10 AND NOT Alias::AliasFunction#class#f AS R(r10.<2>)
    242962   ~1%     {3} r12 = SCAN r11 OUTPUT r11.<2>, r11.<0>, r11.<1>
    15012696 ~0%     {3} r13 = JOIN r12 WITH Instruction::Instruction::getEnclosingFunction_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r12.<1>, r12.<2>
    462811   ~0%     {3} r14 = JOIN r13 WITH project#Instruction::InitializeParameterInstruction#class#ff AS R ON FIRST 1 OUTPUT r13.<0>, r13.<1>, r13.<2>
    468906   ~1%     {4} r15 = JOIN r14 WITH IRConstruction::Raw::getInstructionVariable#ff AS R ON FIRST 1 OUTPUT R.<1>, r14.<1>, r14.<2>, r14.<0>
    242319   ~0%     {3} r16 = JOIN r15 WITH IRVariable::IRThisVariable#class#fffff AS R ON FIRST 1 OUTPUT r15.<2>, r15.<1>, r15.<3>
    668832   ~0%     {3} r17 = r8 \/ r16
                    return r17
```

Interestingly, it was not enough to just wrap a `unique` around `init.getEnclosingFunction()`. Instead, what fixed the join ordering was to specialize the `Instruction init` parameter to `InitializeParameterInstruction init` (which every occurence of `init` was being cast to in the body of the function anyway). This improves the tuple counts to:

```
Tuple counts for AliasAnalysis::isArgumentForParameter#fff:
    1181391 ~0%     {3} r1 = JOIN Instruction::CallInstruction::getStaticCallTarget_dispred#ff AS L WITH Operand::NonPhiOperand#fff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, R.<0>, L.<1>
    1124923 ~0%     {3} r2 = r1 AND NOT IRCppLanguage::isFunctionVirtual#f AS R(r1.<2>)
    1114567 ~0%     {3} r3 = r2 AND NOT Alias::AliasFunction#class#f AS R(r2.<2>)
    1114567 ~0%     {3} r4 = r3 AND NOT IRCppLanguage::isFunctionVirtual#f AS R(r3.<2>)
    1114567 ~0%     {3} r5 = r4 AND NOT Alias::AliasFunction#class#f AS R(r4.<2>)
    475419  ~3%     {4} r6 = JOIN r5 WITH Operand::PositionalArgumentOperand::getIndex_dispred#ff AS R ON FIRST 1 OUTPUT r5.<2>, R.<1>, r5.<0>, r5.<1>
    452941  ~1%     {3} r7 = JOIN r6 WITH Function::Function::getParameter_dispred#fff AS R ON FIRST 2 OUTPUT R.<2>, r6.<2>, r6.<3>
    426513  ~0%     {3} r8 = JOIN r7 WITH Instruction::InitializeParameterInstruction::getParameter_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r7.<2>, r7.<1>, R.<1>
    1114567 ~0%     {4} r9 = JOIN r5 WITH Operand::RegisterOperand#ffff AS R ON FIRST 1 OUTPUT R.<2>, r5.<0>, r5.<1>, r5.<2>
    242962  ~1%     {3} r10 = JOIN r9 WITH OperandTag::ThisArgumentOperandTag#class#f AS R ON FIRST 1 OUTPUT r9.<3>, r9.<1>, r9.<2>
    462811  ~0%     {3} r11 = JOIN r10 WITH AliasAnalysis::isArgumentForParameter#fff#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r10.<1>, r10.<2>
    468906  ~1%     {4} r12 = JOIN r11 WITH IRConstruction::Raw::getInstructionVariable#ff AS R ON FIRST 1 OUTPUT R.<1>, r11.<1>, r11.<2>, r11.<0>
    242319  ~0%     {3} r13 = JOIN r12 WITH IRVariable::IRThisVariable#class#fffff AS R ON FIRST 1 OUTPUT r12.<2>, r12.<1>, r12.<3>
    668832  ~0%     {3} r14 = r8 \/ r13
                    return r14
```

Notice the number of tuples returned is the same in both cases (`668832`).