### PR TITLE
C++: getCanonicalQLClass -> getAPrimaryQlClass

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Class.qll
+++ b/cpp/ql/src/semmle/code/cpp/Class.qll
@@ -849,9 +849,7 @@ class ClassDerivation extends Locatable, @derivation {
 class LocalClass extends Class {
   LocalClass() { isLocal() }
 
-  override string getAPrimaryQlClass() {
-    not this instanceof LocalStruct and result = "LocalClass"
-  }
+  override string getAPrimaryQlClass() { not this instanceof LocalStruct and result = "LocalClass" }
 
   override Function getEnclosingAccessHolder() { result = this.getEnclosingFunction() }
 }

--- a/cpp/ql/src/semmle/code/cpp/Class.qll
+++ b/cpp/ql/src/semmle/code/cpp/Class.qll
@@ -33,7 +33,7 @@ private import semmle.code.cpp.internal.ResolveClass
 class Class extends UserType {
   Class() { isClass(underlyingElement(this)) }
 
-  override string getCanonicalQLClass() { result = "Class" }
+  override string getAPrimaryQlClass() { result = "Class" }
 
   /** Gets a child declaration of this class, struct or union. */
   override Declaration getADeclaration() { result = this.getAMember() }
@@ -768,7 +768,7 @@ class ClassDerivation extends Locatable, @derivation {
    */
   Class getBaseClass() { result = getBaseType().getUnderlyingType() }
 
-  override string getCanonicalQLClass() { result = "ClassDerivation" }
+  override string getAPrimaryQlClass() { result = "ClassDerivation" }
 
   /**
    * Gets the type from which we are deriving, without resolving any
@@ -849,7 +849,7 @@ class ClassDerivation extends Locatable, @derivation {
 class LocalClass extends Class {
   LocalClass() { isLocal() }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof LocalStruct and result = "LocalClass"
   }
 
@@ -872,7 +872,7 @@ class LocalClass extends Class {
 class NestedClass extends Class {
   NestedClass() { this.isMember() }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof NestedStruct and result = "NestedClass"
   }
 
@@ -893,7 +893,7 @@ class NestedClass extends Class {
 class AbstractClass extends Class {
   AbstractClass() { exists(PureVirtualFunction f | this.getAMemberFunction() = f) }
 
-  override string getCanonicalQLClass() { result = "AbstractClass" }
+  override string getAPrimaryQlClass() { result = "AbstractClass" }
 }
 
 /**
@@ -934,7 +934,7 @@ class TemplateClass extends Class {
     exists(result.getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "TemplateClass" }
+  override string getAPrimaryQlClass() { result = "TemplateClass" }
 }
 
 /**
@@ -955,7 +955,7 @@ class ClassTemplateInstantiation extends Class {
 
   ClassTemplateInstantiation() { tc.getAnInstantiation() = this }
 
-  override string getCanonicalQLClass() { result = "ClassTemplateInstantiation" }
+  override string getAPrimaryQlClass() { result = "ClassTemplateInstantiation" }
 
   /**
    * Gets the class template from which this instantiation was instantiated.
@@ -996,7 +996,7 @@ abstract class ClassTemplateSpecialization extends Class {
       count(int i | exists(result.getTemplateArgument(i)))
   }
 
-  override string getCanonicalQLClass() { result = "ClassTemplateSpecialization" }
+  override string getAPrimaryQlClass() { result = "ClassTemplateSpecialization" }
 }
 
 /**
@@ -1025,7 +1025,7 @@ class FullClassTemplateSpecialization extends ClassTemplateSpecialization {
     not this instanceof ClassTemplateInstantiation
   }
 
-  override string getCanonicalQLClass() { result = "FullClassTemplateSpecialization" }
+  override string getAPrimaryQlClass() { result = "FullClassTemplateSpecialization" }
 }
 
 /**
@@ -1064,7 +1064,7 @@ class PartialClassTemplateSpecialization extends ClassTemplateSpecialization {
       count(int i | exists(getTemplateArgument(i)))
   }
 
-  override string getCanonicalQLClass() { result = "PartialClassTemplateSpecialization" }
+  override string getAPrimaryQlClass() { result = "PartialClassTemplateSpecialization" }
 }
 
 /**
@@ -1089,7 +1089,7 @@ deprecated class Interface extends Class {
     )
   }
 
-  override string getCanonicalQLClass() { result = "Interface" }
+  override string getAPrimaryQlClass() { result = "Interface" }
 }
 
 /**
@@ -1104,7 +1104,7 @@ deprecated class Interface extends Class {
 class VirtualClassDerivation extends ClassDerivation {
   VirtualClassDerivation() { hasSpecifier("virtual") }
 
-  override string getCanonicalQLClass() { result = "VirtualClassDerivation" }
+  override string getAPrimaryQlClass() { result = "VirtualClassDerivation" }
 }
 
 /**
@@ -1124,7 +1124,7 @@ class VirtualClassDerivation extends ClassDerivation {
 class VirtualBaseClass extends Class {
   VirtualBaseClass() { exists(VirtualClassDerivation cd | cd.getBaseClass() = this) }
 
-  override string getCanonicalQLClass() { result = "VirtualBaseClass" }
+  override string getAPrimaryQlClass() { result = "VirtualBaseClass" }
 
   /** A virtual class derivation of which this class/struct is the base. */
   VirtualClassDerivation getAVirtualDerivation() { result.getBaseClass() = this }
@@ -1146,7 +1146,7 @@ class VirtualBaseClass extends Class {
 class ProxyClass extends UserType {
   ProxyClass() { usertypes(underlyingElement(this), _, 9) }
 
-  override string getCanonicalQLClass() { result = "ProxyClass" }
+  override string getAPrimaryQlClass() { result = "ProxyClass" }
 
   /** Gets the location of the proxy class. */
   override Location getLocation() { result = getTemplateParameter().getDefinitionLocation() }

--- a/cpp/ql/src/semmle/code/cpp/Element.qll
+++ b/cpp/ql/src/semmle/code/cpp/Element.qll
@@ -55,12 +55,21 @@ class ElementBase extends @element {
   cached
   string toString() { none() }
 
+  /** DEPRECATED: use `getAPrimaryQlClass` instead. */
+  deprecated string getCanonicalQLClass() { result = this.getAPrimaryQlClass() }
+
   /**
-   * Canonical QL class corresponding to this element.
+   * Gets the name of a primary CodeQL class to which this element belongs.
    *
-   * ElementBase is the root class for this predicate.
+   * For most elements, this is simply the most precise syntactic category to
+   * which they belong; for example, `AddExpr` is a primary class, but
+   * `BinaryOperation` is not.
+   *
+   * This predicate always has a result. If no primary class can be
+   * determined, the result is `"???"`. If multiple primary classes match,
+   * this predicate can have multiple results.
    */
-  string getCanonicalQLClass() { result = "???" }
+  string getAPrimaryQlClass() { result = "???" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Enum.qll
+++ b/cpp/ql/src/semmle/code/cpp/Enum.qll
@@ -38,7 +38,7 @@ class Enum extends UserType, IntegralOrEnumType {
     enumconstants(unresolveElement(result), underlyingElement(this), index, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "Enum" }
+  override string getAPrimaryQlClass() { result = "Enum" }
 
   /**
    * Gets a descriptive string for the enum. This method is only intended to
@@ -87,7 +87,7 @@ class Enum extends UserType, IntegralOrEnumType {
 class LocalEnum extends Enum {
   LocalEnum() { isLocal() }
 
-  override string getCanonicalQLClass() { result = "LocalEnum" }
+  override string getAPrimaryQlClass() { result = "LocalEnum" }
 }
 
 /**
@@ -105,7 +105,7 @@ class LocalEnum extends Enum {
 class NestedEnum extends Enum {
   NestedEnum() { this.isMember() }
 
-  override string getCanonicalQLClass() { result = "NestedEnum" }
+  override string getAPrimaryQlClass() { result = "NestedEnum" }
 
   /** Holds if this member is private. */
   predicate isPrivate() { this.hasSpecifier("private") }
@@ -130,7 +130,7 @@ class NestedEnum extends Enum {
 class ScopedEnum extends Enum {
   ScopedEnum() { usertypes(underlyingElement(this), _, 13) }
 
-  override string getCanonicalQLClass() { result = "ScopedEnum" }
+  override string getAPrimaryQlClass() { result = "ScopedEnum" }
 }
 
 /**
@@ -153,7 +153,7 @@ class EnumConstant extends Declaration, @enumconstant {
     enumconstants(underlyingElement(this), unresolveElement(result), _, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "EnumConstant" }
+  override string getAPrimaryQlClass() { result = "EnumConstant" }
 
   override Class getDeclaringType() { result = this.getDeclaringEnum().getDeclaringType() }
 

--- a/cpp/ql/src/semmle/code/cpp/Field.qll
+++ b/cpp/ql/src/semmle/code/cpp/Field.qll
@@ -23,7 +23,7 @@ import semmle.code.cpp.exprs.Access
 class Field extends MemberVariable {
   Field() { fieldoffsets(underlyingElement(this), _, _) }
 
-  override string getCanonicalQLClass() { result = "Field" }
+  override string getAPrimaryQlClass() { result = "Field" }
 
   /**
    * Gets the offset of this field in bytes from the start of its declaring
@@ -90,7 +90,7 @@ class Field extends MemberVariable {
 class BitField extends Field {
   BitField() { bitfield(underlyingElement(this), _, _) }
 
-  override string getCanonicalQLClass() { result = "BitField" }
+  override string getAPrimaryQlClass() { result = "BitField" }
 
   /**
    * Gets the size of this bitfield in bits (on the machine where facts

--- a/cpp/ql/src/semmle/code/cpp/File.qll
+++ b/cpp/ql/src/semmle/code/cpp/File.qll
@@ -178,7 +178,7 @@ class Folder extends Container, @folder {
     result.hasLocationInfo(_, 0, 0, 0, 0)
   }
 
-  override string getCanonicalQLClass() { result = "Folder" }
+  override string getAPrimaryQlClass() { result = "Folder" }
 
   /**
    * DEPRECATED: Use `getLocation` instead.
@@ -246,7 +246,7 @@ class File extends Container, @file {
 
   override string toString() { result = Container.super.toString() }
 
-  override string getCanonicalQLClass() { result = "File" }
+  override string getAPrimaryQlClass() { result = "File" }
 
   override Location getLocation() {
     result.getContainer() = this and
@@ -382,7 +382,7 @@ class HeaderFile extends File {
     exists(Include i | i.getIncludedFile() = this)
   }
 
-  override string getCanonicalQLClass() { result = "HeaderFile" }
+  override string getAPrimaryQlClass() { result = "HeaderFile" }
 
   /**
    * Holds if this header file does not contain any declaration entries or top level
@@ -408,7 +408,7 @@ class HeaderFile extends File {
 class CFile extends File {
   CFile() { exists(string ext | ext = this.getExtension().toLowerCase() | ext = "c" or ext = "i") }
 
-  override string getCanonicalQLClass() { result = "CFile" }
+  override string getAPrimaryQlClass() { result = "CFile" }
 }
 
 /**
@@ -436,7 +436,7 @@ class CppFile extends File {
     )
   }
 
-  override string getCanonicalQLClass() { result = "CppFile" }
+  override string getAPrimaryQlClass() { result = "CppFile" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/FriendDecl.qll
+++ b/cpp/ql/src/semmle/code/cpp/FriendDecl.qll
@@ -27,7 +27,7 @@ class FriendDecl extends Declaration, @frienddecl {
    */
   override Location getADeclarationLocation() { result = this.getLocation() }
 
-  override string getCanonicalQLClass() { result = "FriendDecl" }
+  override string getAPrimaryQlClass() { result = "FriendDecl" }
 
   /**
    * Implements the abstract method `Declaration.getDefinitionLocation`. A

--- a/cpp/ql/src/semmle/code/cpp/Function.qll
+++ b/cpp/ql/src/semmle/code/cpp/Function.qll
@@ -513,7 +513,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
   /** Gets the function which is being declared or defined. */
   override Function getDeclaration() { result = getFunction() }
 
-  override string getCanonicalQLClass() { result = "FunctionDeclarationEntry" }
+  override string getAPrimaryQlClass() { result = "FunctionDeclarationEntry" }
 
   /** Gets the function which is being declared or defined. */
   Function getFunction() { fun_decls(underlyingElement(this), unresolveElement(result), _, _, _) }
@@ -698,7 +698,7 @@ class FunctionDeclarationEntry extends DeclarationEntry, @fun_decl {
 class TopLevelFunction extends Function {
   TopLevelFunction() { not this.isMember() }
 
-  override string getCanonicalQLClass() { result = "TopLevelFunction" }
+  override string getAPrimaryQlClass() { result = "TopLevelFunction" }
 }
 
 /**
@@ -707,7 +707,7 @@ class TopLevelFunction extends Function {
 class Operator extends Function {
   Operator() { functions(underlyingElement(this), _, 5) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof MemberFunction and result = "Operator"
   }
 }
@@ -738,7 +738,7 @@ class TemplateFunction extends Function {
     is_function_template(underlyingElement(this)) and exists(getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "TemplateFunction" }
+  override string getAPrimaryQlClass() { result = "TemplateFunction" }
 
   /**
    * Gets a compiler-generated instantiation of this function template.
@@ -778,7 +778,7 @@ class FunctionTemplateInstantiation extends Function {
 
   FunctionTemplateInstantiation() { tf.getAnInstantiation() = this }
 
-  override string getCanonicalQLClass() { result = "FunctionTemplateInstantiation" }
+  override string getAPrimaryQlClass() { result = "FunctionTemplateInstantiation" }
 
   /**
    * Gets the function template from which this instantiation was instantiated.
@@ -823,7 +823,7 @@ class FunctionTemplateInstantiation extends Function {
 class FunctionTemplateSpecialization extends Function {
   FunctionTemplateSpecialization() { this.isSpecialization() }
 
-  override string getCanonicalQLClass() { result = "FunctionTemplateSpecialization" }
+  override string getAPrimaryQlClass() { result = "FunctionTemplateSpecialization" }
 
   /**
    * Gets the primary template for the specialization (the function template

--- a/cpp/ql/src/semmle/code/cpp/Initializer.qll
+++ b/cpp/ql/src/semmle/code/cpp/Initializer.qll
@@ -22,7 +22,7 @@ import semmle.code.cpp.controlflow.ControlFlowGraph
 class Initializer extends ControlFlowNode, @initialiser {
   override Location getLocation() { initialisers(underlyingElement(this), _, _, result) }
 
-  override string getCanonicalQLClass() { result = "Initializer" }
+  override string getAPrimaryQlClass() { result = "Initializer" }
 
   /** Holds if this initializer is explicit in the source. */
   override predicate fromSource() { not this.getLocation() instanceof UnknownLocation }

--- a/cpp/ql/src/semmle/code/cpp/Macro.qll
+++ b/cpp/ql/src/semmle/code/cpp/Macro.qll
@@ -13,7 +13,7 @@ class Macro extends PreprocessorDirective, @ppd_define {
    */
   override string getHead() { preproctext(underlyingElement(this), result, _) }
 
-  override string getCanonicalQLClass() { result = "Macro" }
+  override string getAPrimaryQlClass() { result = "Macro" }
 
   /**
    * Gets the body of this macro. For example, `(((x)>(y))?(x):(y))` in
@@ -74,7 +74,7 @@ class MacroAccess extends Locatable, @macroinvocation {
    */
   override Location getLocation() { result = this.getOutermostMacroAccess().getActualLocation() }
 
-  override string getCanonicalQLClass() { result = "MacroAccess" }
+  override string getAPrimaryQlClass() { result = "MacroAccess" }
 
   /**
    * Gets the location of this macro access. For a nested access, where
@@ -147,7 +147,7 @@ class MacroAccess extends Locatable, @macroinvocation {
 class MacroInvocation extends MacroAccess {
   MacroInvocation() { macroinvocations(underlyingElement(this), _, _, 1) }
 
-  override string getCanonicalQLClass() { result = "MacroInvocation" }
+  override string getAPrimaryQlClass() { result = "MacroInvocation" }
 
   /**
    * Gets an element that occurs in this macro invocation or a nested macro

--- a/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
@@ -25,7 +25,7 @@ import cpp
 class MemberFunction extends Function {
   MemberFunction() { this.isMember() }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof CopyAssignmentOperator and
     not this instanceof MoveAssignmentOperator and
     result = "MemberFunction"
@@ -93,7 +93,7 @@ class MemberFunction extends Function {
 class VirtualFunction extends MemberFunction {
   VirtualFunction() { this.hasSpecifier("virtual") or purefunctions(underlyingElement(this)) }
 
-  override string getCanonicalQLClass() { result = "VirtualFunction" }
+  override string getAPrimaryQlClass() { result = "VirtualFunction" }
 
   /** Holds if this virtual function is pure. */
   predicate isPure() { this instanceof PureVirtualFunction }
@@ -125,7 +125,7 @@ class VirtualFunction extends MemberFunction {
 class PureVirtualFunction extends VirtualFunction {
   PureVirtualFunction() { purefunctions(underlyingElement(this)) }
 
-  override string getCanonicalQLClass() { result = "PureVirtualFunction" }
+  override string getAPrimaryQlClass() { result = "PureVirtualFunction" }
 }
 
 /**
@@ -147,7 +147,7 @@ class PureVirtualFunction extends VirtualFunction {
 class ConstMemberFunction extends MemberFunction {
   ConstMemberFunction() { this.hasSpecifier("const") }
 
-  override string getCanonicalQLClass() { result = "ConstMemberFunction" }
+  override string getAPrimaryQlClass() { result = "ConstMemberFunction" }
 }
 
 /**
@@ -165,7 +165,7 @@ class ConstMemberFunction extends MemberFunction {
 class Constructor extends MemberFunction {
   Constructor() { functions(underlyingElement(this), _, 2) }
 
-  override string getCanonicalQLClass() { result = "Constructor" }
+  override string getAPrimaryQlClass() { result = "Constructor" }
 
   /**
    * Holds if this constructor serves as a default constructor.
@@ -224,7 +224,7 @@ class ConversionConstructor extends Constructor, ImplicitConversionFunction {
     not this instanceof CopyConstructor
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof MoveConstructor and result = "ConversionConstructor"
   }
 
@@ -282,7 +282,7 @@ class CopyConstructor extends Constructor {
     not exists(getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "CopyConstructor" }
+  override string getAPrimaryQlClass() { result = "CopyConstructor" }
 
   /**
    * Holds if we cannot determine that this constructor will become a copy
@@ -339,7 +339,7 @@ class MoveConstructor extends Constructor {
     not exists(getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "MoveConstructor" }
+  override string getAPrimaryQlClass() { result = "MoveConstructor" }
 
   /**
    * Holds if we cannot determine that this constructor will become a move
@@ -390,7 +390,7 @@ class NoArgConstructor extends Constructor {
 class Destructor extends MemberFunction {
   Destructor() { functions(underlyingElement(this), _, 3) }
 
-  override string getCanonicalQLClass() { result = "Destructor" }
+  override string getAPrimaryQlClass() { result = "Destructor" }
 
   /**
    * Gets a compiler-generated action which destructs a base class or member
@@ -421,7 +421,7 @@ class Destructor extends MemberFunction {
 class ConversionOperator extends MemberFunction, ImplicitConversionFunction {
   ConversionOperator() { functions(underlyingElement(this), _, 4) }
 
-  override string getCanonicalQLClass() { result = "ConversionOperator" }
+  override string getAPrimaryQlClass() { result = "ConversionOperator" }
 
   override Type getSourceType() { result = this.getDeclaringType() }
 
@@ -457,7 +457,7 @@ class CopyAssignmentOperator extends Operator {
     not exists(getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "CopyAssignmentOperator" }
+  override string getAPrimaryQlClass() { result = "CopyAssignmentOperator" }
 }
 
 /**
@@ -483,5 +483,5 @@ class MoveAssignmentOperator extends Operator {
     not exists(getATemplateArgument())
   }
 
-  override string getCanonicalQLClass() { result = "MoveAssignmentOperator" }
+  override string getAPrimaryQlClass() { result = "MoveAssignmentOperator" }
 }

--- a/cpp/ql/src/semmle/code/cpp/Namespace.qll
+++ b/cpp/ql/src/semmle/code/cpp/Namespace.qll
@@ -131,7 +131,7 @@ class NamespaceDeclarationEntry extends Locatable, @namespace_decl {
    */
   Location getBodyLocation() { namespace_decls(underlyingElement(this), _, _, result) }
 
-  override string getCanonicalQLClass() { result = "NamespaceDeclarationEntry" }
+  override string getAPrimaryQlClass() { result = "NamespaceDeclarationEntry" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Parameter.qll
+++ b/cpp/ql/src/semmle/code/cpp/Parameter.qll
@@ -49,7 +49,7 @@ class Parameter extends LocalScopeVariable, @parameter {
     result = "p#" + this.getIndex().toString()
   }
 
-  override string getCanonicalQLClass() { result = "Parameter" }
+  override string getAPrimaryQlClass() { result = "Parameter" }
 
   /**
    * Gets the name of this parameter, including it's type.

--- a/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
+++ b/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
@@ -152,7 +152,7 @@ class PreprocessorIf extends PreprocessorBranch, @ppd_if {
 class PreprocessorIfdef extends PreprocessorBranch, @ppd_ifdef {
   override string toString() { result = "#ifdef " + this.getHead() }
 
-  override string getCanonicalQLClass() { result = "PreprocessorIfdef" }
+  override string getAPrimaryQlClass() { result = "PreprocessorIfdef" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -155,7 +155,7 @@ class PrintASTNode extends TPrintASTNode {
  * Retrieves the canonical QL class(es) for entity `el`
  */
 private string qlClass(ElementBase el) {
-  result = "[" + concat(el.getCanonicalQLClass(), ",") + "] "
+  result = "[" + concat(el.getAPrimaryQlClass(), ",") + "] "
   // Alternative implementation -- do not delete. It is useful for QL class discovery.
   //result = "["+ concat(el.getAQlClass(), ",") + "] "
 }

--- a/cpp/ql/src/semmle/code/cpp/Specifier.qll
+++ b/cpp/ql/src/semmle/code/cpp/Specifier.qll
@@ -16,7 +16,7 @@ class Specifier extends Element, @specifier {
     result instanceof UnknownDefaultLocation
   }
 
-  override string getCanonicalQLClass() { result = "Specifier" }
+  override string getAPrimaryQlClass() { result = "Specifier" }
 
   /** Gets the name of this specifier. */
   string getName() { specifiers(underlyingElement(this), result) }
@@ -37,7 +37,7 @@ class FunctionSpecifier extends Specifier {
     this.hasName("explicit")
   }
 
-  override string getCanonicalQLClass() { result = "FunctionSpecifier)" }
+  override string getAPrimaryQlClass() { result = "FunctionSpecifier)" }
 }
 
 /**
@@ -53,7 +53,7 @@ class StorageClassSpecifier extends Specifier {
     this.hasName("mutable")
   }
 
-  override string getCanonicalQLClass() { result = "StorageClassSpecifier" }
+  override string getAPrimaryQlClass() { result = "StorageClassSpecifier" }
 }
 
 /**
@@ -108,7 +108,7 @@ class AccessSpecifier extends Specifier {
     )
   }
 
-  override string getCanonicalQLClass() { result = "AccessSpecifier" }
+  override string getAPrimaryQlClass() { result = "AccessSpecifier" }
 }
 
 /**
@@ -238,7 +238,7 @@ class FormatAttribute extends GnuAttribute {
     )
   }
 
-  override string getCanonicalQLClass() { result = "FormatAttribute" }
+  override string getAPrimaryQlClass() { result = "FormatAttribute" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Struct.qll
+++ b/cpp/ql/src/semmle/code/cpp/Struct.qll
@@ -43,9 +43,7 @@ class Struct extends Class {
 class LocalStruct extends Struct {
   LocalStruct() { isLocal() }
 
-  override string getAPrimaryQlClass() {
-    not this instanceof LocalUnion and result = "LocalStruct"
-  }
+  override string getAPrimaryQlClass() { not this instanceof LocalUnion and result = "LocalStruct" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Struct.qll
+++ b/cpp/ql/src/semmle/code/cpp/Struct.qll
@@ -22,7 +22,7 @@ import semmle.code.cpp.Class
 class Struct extends Class {
   Struct() { usertypes(underlyingElement(this), _, 1) or usertypes(underlyingElement(this), _, 3) }
 
-  override string getCanonicalQLClass() { result = "Struct" }
+  override string getAPrimaryQlClass() { result = "Struct" }
 
   override string explain() { result = "struct " + this.getName() }
 
@@ -43,7 +43,7 @@ class Struct extends Class {
 class LocalStruct extends Struct {
   LocalStruct() { isLocal() }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof LocalUnion and result = "LocalStruct"
   }
 }
@@ -62,7 +62,7 @@ class LocalStruct extends Struct {
 class NestedStruct extends Struct {
   NestedStruct() { this.isMember() }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not this instanceof NestedUnion and result = "NestedStruct"
   }
 

--- a/cpp/ql/src/semmle/code/cpp/Type.qll
+++ b/cpp/ql/src/semmle/code/cpp/Type.qll
@@ -325,7 +325,7 @@ class BuiltInType extends Type, @builtintype {
 class ErroneousType extends BuiltInType {
   ErroneousType() { builtintypes(underlyingElement(this), _, 1, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "ErroneousType" }
+  override string getAPrimaryQlClass() { result = "ErroneousType" }
 }
 
 /**
@@ -345,7 +345,7 @@ class ErroneousType extends BuiltInType {
 class UnknownType extends BuiltInType {
   UnknownType() { builtintypes(underlyingElement(this), _, 2, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "UnknownType" }
+  override string getAPrimaryQlClass() { result = "UnknownType" }
 }
 
 private predicate isArithmeticType(@builtintype type, int kind) {
@@ -364,7 +364,7 @@ private predicate isArithmeticType(@builtintype type, int kind) {
 class ArithmeticType extends BuiltInType {
   ArithmeticType() { isArithmeticType(underlyingElement(this), _) }
 
-  override string getCanonicalQLClass() { result = "ArithmeticType" }
+  override string getAPrimaryQlClass() { result = "ArithmeticType" }
 }
 
 private predicate isIntegralType(@builtintype type, int kind) {
@@ -564,7 +564,7 @@ class IntegralType extends ArithmeticType, IntegralOrEnumType {
 class BoolType extends IntegralType {
   BoolType() { builtintypes(underlyingElement(this), _, 4, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "BoolType" }
+  override string getAPrimaryQlClass() { result = "BoolType" }
 }
 
 /**
@@ -589,7 +589,7 @@ abstract class CharType extends IntegralType { }
 class PlainCharType extends CharType {
   PlainCharType() { builtintypes(underlyingElement(this), _, 5, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "PlainCharType" }
+  override string getAPrimaryQlClass() { result = "PlainCharType" }
 }
 
 /**
@@ -602,7 +602,7 @@ class PlainCharType extends CharType {
 class UnsignedCharType extends CharType {
   UnsignedCharType() { builtintypes(underlyingElement(this), _, 6, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "UnsignedCharType" }
+  override string getAPrimaryQlClass() { result = "UnsignedCharType" }
 }
 
 /**
@@ -615,7 +615,7 @@ class UnsignedCharType extends CharType {
 class SignedCharType extends CharType {
   SignedCharType() { builtintypes(underlyingElement(this), _, 7, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "SignedCharType" }
+  override string getAPrimaryQlClass() { result = "SignedCharType" }
 }
 
 /**
@@ -632,7 +632,7 @@ class ShortType extends IntegralType {
     builtintypes(underlyingElement(this), _, 10, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "ShortType" }
+  override string getAPrimaryQlClass() { result = "ShortType" }
 }
 
 /**
@@ -649,7 +649,7 @@ class IntType extends IntegralType {
     builtintypes(underlyingElement(this), _, 13, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "IntType" }
+  override string getAPrimaryQlClass() { result = "IntType" }
 }
 
 /**
@@ -666,7 +666,7 @@ class LongType extends IntegralType {
     builtintypes(underlyingElement(this), _, 16, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "LongType" }
+  override string getAPrimaryQlClass() { result = "LongType" }
 }
 
 /**
@@ -683,7 +683,7 @@ class LongLongType extends IntegralType {
     builtintypes(underlyingElement(this), _, 19, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "LongLongType" }
+  override string getAPrimaryQlClass() { result = "LongLongType" }
 }
 
 /**
@@ -701,7 +701,7 @@ class Int128Type extends IntegralType {
     builtintypes(underlyingElement(this), _, 37, _, _, _)
   }
 
-  override string getCanonicalQLClass() { result = "Int128Type" }
+  override string getAPrimaryQlClass() { result = "Int128Type" }
 }
 
 private newtype TTypeDomain =
@@ -897,7 +897,7 @@ class DecimalFloatingPointType extends FloatingPointType {
 class FloatType extends RealNumberType, BinaryFloatingPointType {
   FloatType() { builtintypes(underlyingElement(this), _, 24, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "FloatType" }
+  override string getAPrimaryQlClass() { result = "FloatType" }
 }
 
 /**
@@ -909,7 +909,7 @@ class FloatType extends RealNumberType, BinaryFloatingPointType {
 class DoubleType extends RealNumberType, BinaryFloatingPointType {
   DoubleType() { builtintypes(underlyingElement(this), _, 25, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "DoubleType" }
+  override string getAPrimaryQlClass() { result = "DoubleType" }
 }
 
 /**
@@ -921,7 +921,7 @@ class DoubleType extends RealNumberType, BinaryFloatingPointType {
 class LongDoubleType extends RealNumberType, BinaryFloatingPointType {
   LongDoubleType() { builtintypes(underlyingElement(this), _, 26, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "LongDoubleType" }
+  override string getAPrimaryQlClass() { result = "LongDoubleType" }
 }
 
 /**
@@ -933,7 +933,7 @@ class LongDoubleType extends RealNumberType, BinaryFloatingPointType {
 class Float128Type extends RealNumberType, BinaryFloatingPointType {
   Float128Type() { builtintypes(underlyingElement(this), _, 38, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Float128Type" }
+  override string getAPrimaryQlClass() { result = "Float128Type" }
 }
 
 /**
@@ -945,7 +945,7 @@ class Float128Type extends RealNumberType, BinaryFloatingPointType {
 class Decimal32Type extends RealNumberType, DecimalFloatingPointType {
   Decimal32Type() { builtintypes(underlyingElement(this), _, 40, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Decimal32Type" }
+  override string getAPrimaryQlClass() { result = "Decimal32Type" }
 }
 
 /**
@@ -957,7 +957,7 @@ class Decimal32Type extends RealNumberType, DecimalFloatingPointType {
 class Decimal64Type extends RealNumberType, DecimalFloatingPointType {
   Decimal64Type() { builtintypes(underlyingElement(this), _, 41, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Decimal64Type" }
+  override string getAPrimaryQlClass() { result = "Decimal64Type" }
 }
 
 /**
@@ -969,7 +969,7 @@ class Decimal64Type extends RealNumberType, DecimalFloatingPointType {
 class Decimal128Type extends RealNumberType, DecimalFloatingPointType {
   Decimal128Type() { builtintypes(underlyingElement(this), _, 42, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Decimal128Type" }
+  override string getAPrimaryQlClass() { result = "Decimal128Type" }
 }
 
 /**
@@ -981,7 +981,7 @@ class Decimal128Type extends RealNumberType, DecimalFloatingPointType {
 class VoidType extends BuiltInType {
   VoidType() { builtintypes(underlyingElement(this), _, 3, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "VoidType" }
+  override string getAPrimaryQlClass() { result = "VoidType" }
 }
 
 /**
@@ -997,7 +997,7 @@ class VoidType extends BuiltInType {
 class WideCharType extends IntegralType {
   WideCharType() { builtintypes(underlyingElement(this), _, 33, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "WideCharType" }
+  override string getAPrimaryQlClass() { result = "WideCharType" }
 }
 
 /**
@@ -1009,7 +1009,7 @@ class WideCharType extends IntegralType {
 class Char8Type extends IntegralType {
   Char8Type() { builtintypes(underlyingElement(this), _, 51, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Char8Type" }
+  override string getAPrimaryQlClass() { result = "Char8Type" }
 }
 
 /**
@@ -1021,7 +1021,7 @@ class Char8Type extends IntegralType {
 class Char16Type extends IntegralType {
   Char16Type() { builtintypes(underlyingElement(this), _, 43, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Char16Type" }
+  override string getAPrimaryQlClass() { result = "Char16Type" }
 }
 
 /**
@@ -1033,7 +1033,7 @@ class Char16Type extends IntegralType {
 class Char32Type extends IntegralType {
   Char32Type() { builtintypes(underlyingElement(this), _, 44, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "Char32Type" }
+  override string getAPrimaryQlClass() { result = "Char32Type" }
 }
 
 /**
@@ -1048,7 +1048,7 @@ class Char32Type extends IntegralType {
 class NullPointerType extends BuiltInType {
   NullPointerType() { builtintypes(underlyingElement(this), _, 34, _, _, _) }
 
-  override string getCanonicalQLClass() { result = "NullPointerType" }
+  override string getAPrimaryQlClass() { result = "NullPointerType" }
 }
 
 /**
@@ -1136,7 +1136,7 @@ class DerivedType extends Type, @derivedtype {
  * ```
  */
 class Decltype extends Type, @decltype {
-  override string getCanonicalQLClass() { result = "Decltype" }
+  override string getAPrimaryQlClass() { result = "Decltype" }
 
   /**
    * The expression whose type is being obtained by this decltype.
@@ -1209,7 +1209,7 @@ class Decltype extends Type, @decltype {
 class PointerType extends DerivedType {
   PointerType() { derivedtypes(underlyingElement(this), _, 1, _) }
 
-  override string getCanonicalQLClass() { result = "PointerType" }
+  override string getAPrimaryQlClass() { result = "PointerType" }
 
   override int getPointerIndirectionLevel() {
     result = 1 + this.getBaseType().getPointerIndirectionLevel()
@@ -1235,7 +1235,7 @@ class ReferenceType extends DerivedType {
     derivedtypes(underlyingElement(this), _, 2, _) or derivedtypes(underlyingElement(this), _, 8, _)
   }
 
-  override string getCanonicalQLClass() { result = "ReferenceType" }
+  override string getAPrimaryQlClass() { result = "ReferenceType" }
 
   override int getPointerIndirectionLevel() { result = getBaseType().getPointerIndirectionLevel() }
 
@@ -1262,7 +1262,7 @@ class ReferenceType extends DerivedType {
 class LValueReferenceType extends ReferenceType {
   LValueReferenceType() { derivedtypes(underlyingElement(this), _, 2, _) }
 
-  override string getCanonicalQLClass() { result = "LValueReferenceType" }
+  override string getAPrimaryQlClass() { result = "LValueReferenceType" }
 }
 
 /**
@@ -1278,7 +1278,7 @@ class LValueReferenceType extends ReferenceType {
 class RValueReferenceType extends ReferenceType {
   RValueReferenceType() { derivedtypes(underlyingElement(this), _, 8, _) }
 
-  override string getCanonicalQLClass() { result = "RValueReferenceType" }
+  override string getAPrimaryQlClass() { result = "RValueReferenceType" }
 
   override string explain() { result = "rvalue " + super.explain() }
 }
@@ -1293,7 +1293,7 @@ class RValueReferenceType extends ReferenceType {
 class SpecifiedType extends DerivedType {
   SpecifiedType() { derivedtypes(underlyingElement(this), _, 3, _) }
 
-  override string getCanonicalQLClass() { result = "SpecifiedType" }
+  override string getAPrimaryQlClass() { result = "SpecifiedType" }
 
   override int getSize() { result = this.getBaseType().getSize() }
 
@@ -1341,7 +1341,7 @@ class SpecifiedType extends DerivedType {
 class ArrayType extends DerivedType {
   ArrayType() { derivedtypes(underlyingElement(this), _, 4, _) }
 
-  override string getCanonicalQLClass() { result = "ArrayType" }
+  override string getAPrimaryQlClass() { result = "ArrayType" }
 
   /**
    * Holds if this array is declared to be of a constant size. See
@@ -1412,7 +1412,7 @@ class GNUVectorType extends DerivedType {
    */
   int getNumElements() { arraysizes(underlyingElement(this), result, _, _) }
 
-  override string getCanonicalQLClass() { result = "GNUVectorType" }
+  override string getAPrimaryQlClass() { result = "GNUVectorType" }
 
   /**
    * Gets the size, in bytes, of this vector type.
@@ -1443,7 +1443,7 @@ class GNUVectorType extends DerivedType {
 class FunctionPointerType extends FunctionPointerIshType {
   FunctionPointerType() { derivedtypes(underlyingElement(this), _, 6, _) }
 
-  override string getCanonicalQLClass() { result = "FunctionPointerType" }
+  override string getAPrimaryQlClass() { result = "FunctionPointerType" }
 
   override int getPointerIndirectionLevel() { result = 1 }
 
@@ -1461,7 +1461,7 @@ class FunctionPointerType extends FunctionPointerIshType {
 class FunctionReferenceType extends FunctionPointerIshType {
   FunctionReferenceType() { derivedtypes(underlyingElement(this), _, 7, _) }
 
-  override string getCanonicalQLClass() { result = "FunctionReferenceType" }
+  override string getAPrimaryQlClass() { result = "FunctionReferenceType" }
 
   override int getPointerIndirectionLevel() { result = getBaseType().getPointerIndirectionLevel() }
 
@@ -1550,7 +1550,7 @@ class PointerToMemberType extends Type, @ptrtomember {
   /** a printable representation of this named element */
   override string toString() { result = this.getName() }
 
-  override string getCanonicalQLClass() { result = "PointerToMemberType" }
+  override string getAPrimaryQlClass() { result = "PointerToMemberType" }
 
   /** the name of this type */
   override string getName() { result = "..:: *" }
@@ -1595,7 +1595,7 @@ class RoutineType extends Type, @routinetype {
   /** a printable representation of this named element */
   override string toString() { result = this.getName() }
 
-  override string getCanonicalQLClass() { result = "RoutineType" }
+  override string getAPrimaryQlClass() { result = "RoutineType" }
 
   override string getName() { result = "..()(..)" }
 
@@ -1672,7 +1672,7 @@ class TemplateParameter extends UserType {
     usertypes(underlyingElement(this), _, 7) or usertypes(underlyingElement(this), _, 8)
   }
 
-  override string getCanonicalQLClass() { result = "TemplateParameter" }
+  override string getAPrimaryQlClass() { result = "TemplateParameter" }
 
   override predicate involvesTemplateParameter() { any() }
 }
@@ -1690,7 +1690,7 @@ class TemplateParameter extends UserType {
 class TemplateTemplateParameter extends TemplateParameter {
   TemplateTemplateParameter() { usertypes(underlyingElement(this), _, 8) }
 
-  override string getCanonicalQLClass() { result = "TemplateTemplateParameter" }
+  override string getAPrimaryQlClass() { result = "TemplateTemplateParameter" }
 }
 
 /**
@@ -1702,7 +1702,7 @@ class TemplateTemplateParameter extends TemplateParameter {
 class AutoType extends TemplateParameter {
   AutoType() { usertypes(underlyingElement(this), "auto", 7) }
 
-  override string getCanonicalQLClass() { result = "AutoType" }
+  override string getAPrimaryQlClass() { result = "AutoType" }
 
   override Location getLocation() {
     suppressUnusedThis(this) and
@@ -1738,7 +1738,7 @@ private predicate suppressUnusedThis(Type t) { any() }
 class TypeMention extends Locatable, @type_mention {
   override string toString() { result = "type mention" }
 
-  override string getCanonicalQLClass() { result = "TypeMention" }
+  override string getAPrimaryQlClass() { result = "TypeMention" }
 
   /**
    * Gets the type being referenced by this type mention.

--- a/cpp/ql/src/semmle/code/cpp/TypedefType.qll
+++ b/cpp/ql/src/semmle/code/cpp/TypedefType.qll
@@ -59,7 +59,7 @@ class TypedefType extends UserType {
 class CTypedefType extends TypedefType {
   CTypedefType() { usertypes(underlyingElement(this), _, 5) }
 
-  override string getCanonicalQLClass() { result = "CTypedefType" }
+  override string getAPrimaryQlClass() { result = "CTypedefType" }
 
   override string explain() {
     result = "typedef {" + this.getBaseType().explain() + "} as \"" + this.getName() + "\""
@@ -75,7 +75,7 @@ class CTypedefType extends TypedefType {
 class UsingAliasTypedefType extends TypedefType {
   UsingAliasTypedefType() { usertypes(underlyingElement(this), _, 14) }
 
-  override string getCanonicalQLClass() { result = "UsingAliasTypedefType" }
+  override string getAPrimaryQlClass() { result = "UsingAliasTypedefType" }
 
   override string explain() {
     result = "using {" + this.getBaseType().explain() + "} as \"" + this.getName() + "\""
@@ -92,7 +92,7 @@ class UsingAliasTypedefType extends TypedefType {
 class LocalTypedefType extends TypedefType {
   LocalTypedefType() { isLocal() }
 
-  override string getCanonicalQLClass() { result = "LocalTypedefType" }
+  override string getAPrimaryQlClass() { result = "LocalTypedefType" }
 }
 
 /**
@@ -105,7 +105,7 @@ class LocalTypedefType extends TypedefType {
 class NestedTypedefType extends TypedefType {
   NestedTypedefType() { this.isMember() }
 
-  override string getCanonicalQLClass() { result = "NestedTypedefType" }
+  override string getAPrimaryQlClass() { result = "NestedTypedefType" }
 
   /**
    * DEPRECATED: use `.hasSpecifier("private")` instead.

--- a/cpp/ql/src/semmle/code/cpp/Union.qll
+++ b/cpp/ql/src/semmle/code/cpp/Union.qll
@@ -17,7 +17,7 @@ import semmle.code.cpp.Struct
 class Union extends Struct {
   Union() { usertypes(underlyingElement(this), _, 3) }
 
-  override string getCanonicalQLClass() { result = "Union" }
+  override string getAPrimaryQlClass() { result = "Union" }
 
   override string explain() { result = "union " + this.getName() }
 
@@ -39,7 +39,7 @@ class Union extends Struct {
 class LocalUnion extends Union {
   LocalUnion() { isLocal() }
 
-  override string getCanonicalQLClass() { result = "LocalUnion" }
+  override string getAPrimaryQlClass() { result = "LocalUnion" }
 }
 
 /**
@@ -57,7 +57,7 @@ class LocalUnion extends Union {
 class NestedUnion extends Union {
   NestedUnion() { this.isMember() }
 
-  override string getCanonicalQLClass() { result = "NestedUnion" }
+  override string getAPrimaryQlClass() { result = "NestedUnion" }
 
   /** Holds if this member is private. */
   predicate isPrivate() { this.hasSpecifier("private") }

--- a/cpp/ql/src/semmle/code/cpp/UserType.qll
+++ b/cpp/ql/src/semmle/code/cpp/UserType.qll
@@ -24,7 +24,7 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
    */
   override string getName() { usertypes(underlyingElement(this), result, _) }
 
-  override string getCanonicalQLClass() { result = "UserType" }
+  override string getAPrimaryQlClass() { result = "UserType" }
 
   /**
    * Gets the simple name of this type, without any template parameters.  For example
@@ -111,7 +111,7 @@ class TypeDeclarationEntry extends DeclarationEntry, @type_decl {
 
   override string getName() { result = getType().getName() }
 
-  override string getCanonicalQLClass() { result = "TypeDeclarationEntry" }
+  override string getAPrimaryQlClass() { result = "TypeDeclarationEntry" }
 
   /**
    * The type which is being declared or defined.

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -32,7 +32,7 @@ private import semmle.code.cpp.internal.ResolveClass
  * can have multiple declarations.
  */
 class Variable extends Declaration, @variable {
-  override string getCanonicalQLClass() { result = "Variable" }
+  override string getAPrimaryQlClass() { result = "Variable" }
 
   /** Gets the initializer of this variable, if any. */
   Initializer getInitializer() { result.getDeclaration() = this }
@@ -190,7 +190,7 @@ class Variable extends Declaration, @variable {
 class VariableDeclarationEntry extends DeclarationEntry, @var_decl {
   override Variable getDeclaration() { result = getVariable() }
 
-  override string getCanonicalQLClass() { result = "VariableDeclarationEntry" }
+  override string getAPrimaryQlClass() { result = "VariableDeclarationEntry" }
 
   /**
    * Gets the variable which is being declared or defined.
@@ -249,7 +249,7 @@ class VariableDeclarationEntry extends DeclarationEntry, @var_decl {
 class ParameterDeclarationEntry extends VariableDeclarationEntry {
   ParameterDeclarationEntry() { param_decl_bind(underlyingElement(this), _, _) }
 
-  override string getCanonicalQLClass() { result = "ParameterDeclarationEntry" }
+  override string getAPrimaryQlClass() { result = "ParameterDeclarationEntry" }
 
   /**
    * Gets the function declaration or definition which this parameter
@@ -363,7 +363,7 @@ class StackVariable extends LocalScopeVariable {
  * A local variable can be declared by a `DeclStmt` or a `ConditionDeclExpr`.
  */
 class LocalVariable extends LocalScopeVariable, @localvariable {
-  override string getCanonicalQLClass() { result = "LocalVariable" }
+  override string getAPrimaryQlClass() { result = "LocalVariable" }
 
   override string getName() { localvariables(underlyingElement(this), _, result) }
 
@@ -464,7 +464,7 @@ class NamespaceVariable extends GlobalOrNamespaceVariable {
     exists(Namespace n | namespacembrs(unresolveElement(n), underlyingElement(this)))
   }
 
-  override string getCanonicalQLClass() { result = "NamespaceVariable" }
+  override string getAPrimaryQlClass() { result = "NamespaceVariable" }
 }
 
 /**
@@ -485,7 +485,7 @@ class NamespaceVariable extends GlobalOrNamespaceVariable {
 class GlobalVariable extends GlobalOrNamespaceVariable {
   GlobalVariable() { not this instanceof NamespaceVariable }
 
-  override string getCanonicalQLClass() { result = "GlobalVariable" }
+  override string getAPrimaryQlClass() { result = "GlobalVariable" }
 }
 
 /**
@@ -505,7 +505,7 @@ class GlobalVariable extends GlobalOrNamespaceVariable {
 class MemberVariable extends Variable, @membervariable {
   MemberVariable() { this.isMember() }
 
-  override string getCanonicalQLClass() { result = "MemberVariable" }
+  override string getAPrimaryQlClass() { result = "MemberVariable" }
 
   /** Holds if this member is private. */
   predicate isPrivate() { this.hasSpecifier("private") }

--- a/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/CommonType.qll
@@ -6,7 +6,7 @@ import semmle.code.cpp.Type
 class CharPointerType extends PointerType {
   CharPointerType() { this.getBaseType() instanceof CharType }
 
-  override string getCanonicalQLClass() { result = "CharPointerType" }
+  override string getAPrimaryQlClass() { result = "CharPointerType" }
 }
 
 /**
@@ -15,7 +15,7 @@ class CharPointerType extends PointerType {
 class IntPointerType extends PointerType {
   IntPointerType() { this.getBaseType() instanceof IntType }
 
-  override string getCanonicalQLClass() { result = "IntPointerType" }
+  override string getAPrimaryQlClass() { result = "IntPointerType" }
 }
 
 /**
@@ -24,7 +24,7 @@ class IntPointerType extends PointerType {
 class VoidPointerType extends PointerType {
   VoidPointerType() { this.getBaseType() instanceof VoidType }
 
-  override string getCanonicalQLClass() { result = "VoidPointerType" }
+  override string getAPrimaryQlClass() { result = "VoidPointerType" }
 }
 
 /**
@@ -36,7 +36,7 @@ class Size_t extends Type {
     this.hasName("size_t")
   }
 
-  override string getCanonicalQLClass() { result = "Size_t" }
+  override string getAPrimaryQlClass() { result = "Size_t" }
 }
 
 /**
@@ -48,7 +48,7 @@ class Ssize_t extends Type {
     this.hasName("ssize_t")
   }
 
-  override string getCanonicalQLClass() { result = "Ssize_t" }
+  override string getAPrimaryQlClass() { result = "Ssize_t" }
 }
 
 /**
@@ -60,7 +60,7 @@ class Ptrdiff_t extends Type {
     this.hasName("ptrdiff_t")
   }
 
-  override string getCanonicalQLClass() { result = "Ptrdiff_t" }
+  override string getAPrimaryQlClass() { result = "Ptrdiff_t" }
 }
 
 /**
@@ -72,7 +72,7 @@ class Intmax_t extends Type {
     this.hasName("intmax_t")
   }
 
-  override string getCanonicalQLClass() { result = "Intmax_t" }
+  override string getAPrimaryQlClass() { result = "Intmax_t" }
 }
 
 /**
@@ -84,7 +84,7 @@ class Uintmax_t extends Type {
     this.hasName("uintmax_t")
   }
 
-  override string getCanonicalQLClass() { result = "Uintmax_t" }
+  override string getAPrimaryQlClass() { result = "Uintmax_t" }
 }
 
 /**
@@ -100,7 +100,7 @@ class Wchar_t extends Type {
     this.hasName("wchar_t")
   }
 
-  override string getCanonicalQLClass() { result = "Wchar_t" }
+  override string getAPrimaryQlClass() { result = "Wchar_t" }
 }
 
 /**
@@ -176,5 +176,5 @@ class MicrosoftInt64Type extends IntegralType {
 class BuiltInVarArgsList extends Type {
   BuiltInVarArgsList() { this.hasName("__builtin_va_list") }
 
-  override string getCanonicalQLClass() { result = "BuiltInVarArgsList" }
+  override string getAPrimaryQlClass() { result = "BuiltInVarArgsList" }
 }

--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -20,7 +20,7 @@ class PrintfFormatAttribute extends FormatAttribute {
  * function by its use of the GNU `format` attribute.
  */
 class AttributeFormattingFunction extends FormattingFunction {
-  override string getCanonicalQLClass() { result = "AttributeFormattingFunction" }
+  override string getAPrimaryQlClass() { result = "AttributeFormattingFunction" }
 
   AttributeFormattingFunction() {
     exists(PrintfFormatAttribute printf_attrib |
@@ -73,7 +73,7 @@ predicate variadicFormatter(Function f, int formatParamIndex) {
  * string and a variable number of arguments.
  */
 class UserDefinedFormattingFunction extends FormattingFunction {
-  override string getCanonicalQLClass() { result = "UserDefinedFormattingFunction" }
+  override string getAPrimaryQlClass() { result = "UserDefinedFormattingFunction" }
 
   UserDefinedFormattingFunction() { isVarargs() and callsVariadicFormatter(this, _) }
 
@@ -86,7 +86,7 @@ class UserDefinedFormattingFunction extends FormattingFunction {
 class FormattingFunctionCall extends Expr {
   FormattingFunctionCall() { this.(Call).getTarget() instanceof FormattingFunction }
 
-  override string getCanonicalQLClass() { result = "FormattingFunctionCall" }
+  override string getAPrimaryQlClass() { result = "FormattingFunctionCall" }
 
   /**
    * Gets the formatting function being called.

--- a/cpp/ql/src/semmle/code/cpp/exprs/Access.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Access.qll
@@ -36,7 +36,7 @@ class Access extends Expr, NameQualifiableElement, @access {
  * ```
  */
 class EnumConstantAccess extends Access, @varaccess {
-  override string getCanonicalQLClass() { result = "EnumConstantAccess" }
+  override string getAPrimaryQlClass() { result = "EnumConstantAccess" }
 
   EnumConstantAccess() {
     exists(EnumConstant c | varbind(underlyingElement(this), unresolveElement(c)))
@@ -61,7 +61,7 @@ class EnumConstantAccess extends Access, @varaccess {
  * ```
  */
 class VariableAccess extends Access, @varaccess {
-  override string getCanonicalQLClass() { result = "VariableAccess" }
+  override string getAPrimaryQlClass() { result = "VariableAccess" }
 
   VariableAccess() {
     not exists(EnumConstant c | varbind(underlyingElement(this), unresolveElement(c)))
@@ -166,7 +166,7 @@ class VariableAccess extends Access, @varaccess {
  * ```
  */
 class FieldAccess extends VariableAccess {
-  override string getCanonicalQLClass() { result = "FieldAccess" }
+  override string getAPrimaryQlClass() { result = "FieldAccess" }
 
   FieldAccess() { exists(Field f | varbind(underlyingElement(this), unresolveElement(f))) }
 
@@ -194,7 +194,7 @@ class FieldAccess extends VariableAccess {
  * ```
  */
 class PointerFieldAccess extends FieldAccess {
-  override string getCanonicalQLClass() { result = "PointerFieldAccess" }
+  override string getAPrimaryQlClass() { result = "PointerFieldAccess" }
 
   PointerFieldAccess() {
     exists(PointerType t |
@@ -211,7 +211,7 @@ class PointerFieldAccess extends FieldAccess {
  * distinguish whether or not the type of `obj` is a reference type.
  */
 class DotFieldAccess extends FieldAccess {
-  override string getCanonicalQLClass() { result = "DotFieldAccess" }
+  override string getAPrimaryQlClass() { result = "DotFieldAccess" }
 
   DotFieldAccess() { exists(Class c | c = getQualifier().getFullyConverted().getUnspecifiedType()) }
 }
@@ -232,7 +232,7 @@ class DotFieldAccess extends FieldAccess {
  * ```
  */
 class ReferenceFieldAccess extends DotFieldAccess {
-  override string getCanonicalQLClass() { result = "ReferenceFieldAccess" }
+  override string getAPrimaryQlClass() { result = "ReferenceFieldAccess" }
 
   ReferenceFieldAccess() { exprHasReferenceConversion(this.getQualifier()) }
 }
@@ -253,7 +253,7 @@ class ReferenceFieldAccess extends DotFieldAccess {
  * ```
  */
 class ValueFieldAccess extends DotFieldAccess {
-  override string getCanonicalQLClass() { result = "ValueFieldAccess" }
+  override string getAPrimaryQlClass() { result = "ValueFieldAccess" }
 
   ValueFieldAccess() { not exprHasReferenceConversion(this.getQualifier()) }
 }
@@ -307,7 +307,7 @@ private predicate exprHasReferenceConversion(Expr e) { referenceConversion(e.get
  * `ImplicitThisFieldAccess`.
  */
 class ImplicitThisFieldAccess extends FieldAccess {
-  override string getCanonicalQLClass() { result = "ImplicitThisFieldAccess" }
+  override string getAPrimaryQlClass() { result = "ImplicitThisFieldAccess" }
 
   ImplicitThisFieldAccess() { not exists(this.getQualifier()) }
 }
@@ -332,7 +332,7 @@ class PointerToFieldLiteral extends ImplicitThisFieldAccess {
 
   override predicate isConstant() { any() }
 
-  override string getCanonicalQLClass() { result = "PointerToFieldLiteral" }
+  override string getAPrimaryQlClass() { result = "PointerToFieldLiteral" }
 }
 
 /**
@@ -349,7 +349,7 @@ class PointerToFieldLiteral extends ImplicitThisFieldAccess {
 class FunctionAccess extends Access, @routineexpr {
   FunctionAccess() { not iscall(underlyingElement(this), _) }
 
-  override string getCanonicalQLClass() { result = "FunctionAccess" }
+  override string getAPrimaryQlClass() { result = "FunctionAccess" }
 
   /** Gets the accessed function. */
   override Function getTarget() { funbind(underlyingElement(this), unresolveElement(result)) }
@@ -399,7 +399,7 @@ class ParamAccessForType extends Expr, @param_ref {
  * ```
  */
 class TypeName extends Expr, @type_operand {
-  override string getCanonicalQLClass() { result = "TypeName" }
+  override string getAPrimaryQlClass() { result = "TypeName" }
 
   override string toString() { result = this.getType().getName() }
 }
@@ -418,7 +418,7 @@ class TypeName extends Expr, @type_operand {
  * `OverloadedArrayExpr`.
  */
 class ArrayExpr extends Expr, @subscriptexpr {
-  override string getCanonicalQLClass() { result = "ArrayExpr" }
+  override string getAPrimaryQlClass() { result = "ArrayExpr" }
 
   /**
    * Gets the array or pointer expression being subscripted.

--- a/cpp/ql/src/semmle/code/cpp/exprs/ArithmeticOperation.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/ArithmeticOperation.qll
@@ -14,7 +14,7 @@ class UnaryArithmeticOperation extends UnaryOperation, @un_arith_op_expr { }
 class UnaryMinusExpr extends UnaryArithmeticOperation, @arithnegexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "UnaryMinusExpr" }
+  override string getAPrimaryQlClass() { result = "UnaryMinusExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -28,7 +28,7 @@ class UnaryMinusExpr extends UnaryArithmeticOperation, @arithnegexpr {
 class UnaryPlusExpr extends UnaryArithmeticOperation, @unaryplusexpr {
   override string getOperator() { result = "+" }
 
-  override string getCanonicalQLClass() { result = "UnaryPlusExpr" }
+  override string getAPrimaryQlClass() { result = "UnaryPlusExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -45,7 +45,7 @@ class UnaryPlusExpr extends UnaryArithmeticOperation, @unaryplusexpr {
 class ConjugationExpr extends UnaryArithmeticOperation, @conjugation {
   override string getOperator() { result = "~" }
 
-  override string getCanonicalQLClass() { result = "ConjugationExpr" }
+  override string getAPrimaryQlClass() { result = "ConjugationExpr" }
 }
 
 /**
@@ -107,7 +107,7 @@ class PostfixCrementOperation extends CrementOperation, @postfix_crement_expr { 
 class PrefixIncrExpr extends IncrementOperation, PrefixCrementOperation, @preincrexpr {
   override string getOperator() { result = "++" }
 
-  override string getCanonicalQLClass() { result = "PrefixIncrExpr" }
+  override string getAPrimaryQlClass() { result = "PrefixIncrExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -123,7 +123,7 @@ class PrefixIncrExpr extends IncrementOperation, PrefixCrementOperation, @preinc
 class PrefixDecrExpr extends DecrementOperation, PrefixCrementOperation, @predecrexpr {
   override string getOperator() { result = "--" }
 
-  override string getCanonicalQLClass() { result = "PrefixDecrExpr" }
+  override string getAPrimaryQlClass() { result = "PrefixDecrExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -139,7 +139,7 @@ class PrefixDecrExpr extends DecrementOperation, PrefixCrementOperation, @predec
 class PostfixIncrExpr extends IncrementOperation, PostfixCrementOperation, @postincrexpr {
   override string getOperator() { result = "++" }
 
-  override string getCanonicalQLClass() { result = "PostfixIncrExpr" }
+  override string getAPrimaryQlClass() { result = "PostfixIncrExpr" }
 
   override int getPrecedence() { result = 17 }
 
@@ -157,7 +157,7 @@ class PostfixIncrExpr extends IncrementOperation, PostfixCrementOperation, @post
 class PostfixDecrExpr extends DecrementOperation, PostfixCrementOperation, @postdecrexpr {
   override string getOperator() { result = "--" }
 
-  override string getCanonicalQLClass() { result = "PostfixDecrExpr" }
+  override string getAPrimaryQlClass() { result = "PostfixDecrExpr" }
 
   override int getPrecedence() { result = 17 }
 
@@ -175,7 +175,7 @@ class PostfixDecrExpr extends DecrementOperation, PostfixCrementOperation, @post
 class RealPartExpr extends UnaryArithmeticOperation, @realpartexpr {
   override string getOperator() { result = "__real" }
 
-  override string getCanonicalQLClass() { result = "RealPartExpr" }
+  override string getAPrimaryQlClass() { result = "RealPartExpr" }
 }
 
 /**
@@ -189,7 +189,7 @@ class RealPartExpr extends UnaryArithmeticOperation, @realpartexpr {
 class ImaginaryPartExpr extends UnaryArithmeticOperation, @imagpartexpr {
   override string getOperator() { result = "__imag" }
 
-  override string getCanonicalQLClass() { result = "ImaginaryPartExpr" }
+  override string getAPrimaryQlClass() { result = "ImaginaryPartExpr" }
 }
 
 /**
@@ -208,7 +208,7 @@ class BinaryArithmeticOperation extends BinaryOperation, @bin_arith_op_expr { }
 class AddExpr extends BinaryArithmeticOperation, @addexpr {
   override string getOperator() { result = "+" }
 
-  override string getCanonicalQLClass() { result = "AddExpr" }
+  override string getAPrimaryQlClass() { result = "AddExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -222,7 +222,7 @@ class AddExpr extends BinaryArithmeticOperation, @addexpr {
 class SubExpr extends BinaryArithmeticOperation, @subexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "SubExpr" }
+  override string getAPrimaryQlClass() { result = "SubExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -236,7 +236,7 @@ class SubExpr extends BinaryArithmeticOperation, @subexpr {
 class MulExpr extends BinaryArithmeticOperation, @mulexpr {
   override string getOperator() { result = "*" }
 
-  override string getCanonicalQLClass() { result = "MulExpr" }
+  override string getAPrimaryQlClass() { result = "MulExpr" }
 
   override int getPrecedence() { result = 14 }
 }
@@ -250,7 +250,7 @@ class MulExpr extends BinaryArithmeticOperation, @mulexpr {
 class DivExpr extends BinaryArithmeticOperation, @divexpr {
   override string getOperator() { result = "/" }
 
-  override string getCanonicalQLClass() { result = "DivExpr" }
+  override string getAPrimaryQlClass() { result = "DivExpr" }
 
   override int getPrecedence() { result = 14 }
 }
@@ -264,7 +264,7 @@ class DivExpr extends BinaryArithmeticOperation, @divexpr {
 class RemExpr extends BinaryArithmeticOperation, @remexpr {
   override string getOperator() { result = "%" }
 
-  override string getCanonicalQLClass() { result = "RemExpr" }
+  override string getAPrimaryQlClass() { result = "RemExpr" }
 
   override int getPrecedence() { result = 14 }
 }
@@ -281,7 +281,7 @@ class RemExpr extends BinaryArithmeticOperation, @remexpr {
 class ImaginaryMulExpr extends BinaryArithmeticOperation, @jmulexpr {
   override string getOperator() { result = "*" }
 
-  override string getCanonicalQLClass() { result = "ImaginaryMulExpr" }
+  override string getAPrimaryQlClass() { result = "ImaginaryMulExpr" }
 
   override int getPrecedence() { result = 14 }
 }
@@ -298,7 +298,7 @@ class ImaginaryMulExpr extends BinaryArithmeticOperation, @jmulexpr {
 class ImaginaryDivExpr extends BinaryArithmeticOperation, @jdivexpr {
   override string getOperator() { result = "/" }
 
-  override string getCanonicalQLClass() { result = "ImaginaryDivExpr" }
+  override string getAPrimaryQlClass() { result = "ImaginaryDivExpr" }
 
   override int getPrecedence() { result = 14 }
 }
@@ -316,7 +316,7 @@ class ImaginaryDivExpr extends BinaryArithmeticOperation, @jdivexpr {
 class RealImaginaryAddExpr extends BinaryArithmeticOperation, @fjaddexpr {
   override string getOperator() { result = "+" }
 
-  override string getCanonicalQLClass() { result = "RealImaginaryAddExpr" }
+  override string getAPrimaryQlClass() { result = "RealImaginaryAddExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -334,7 +334,7 @@ class RealImaginaryAddExpr extends BinaryArithmeticOperation, @fjaddexpr {
 class ImaginaryRealAddExpr extends BinaryArithmeticOperation, @jfaddexpr {
   override string getOperator() { result = "+" }
 
-  override string getCanonicalQLClass() { result = "ImaginaryRealAddExpr" }
+  override string getAPrimaryQlClass() { result = "ImaginaryRealAddExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -352,7 +352,7 @@ class ImaginaryRealAddExpr extends BinaryArithmeticOperation, @jfaddexpr {
 class RealImaginarySubExpr extends BinaryArithmeticOperation, @fjsubexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "RealImaginarySubExpr" }
+  override string getAPrimaryQlClass() { result = "RealImaginarySubExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -370,7 +370,7 @@ class RealImaginarySubExpr extends BinaryArithmeticOperation, @fjsubexpr {
 class ImaginaryRealSubExpr extends BinaryArithmeticOperation, @jfsubexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "ImaginaryRealSubExpr" }
+  override string getAPrimaryQlClass() { result = "ImaginaryRealSubExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -384,7 +384,7 @@ class ImaginaryRealSubExpr extends BinaryArithmeticOperation, @jfsubexpr {
 class MinExpr extends BinaryArithmeticOperation, @minexpr {
   override string getOperator() { result = "<?" }
 
-  override string getCanonicalQLClass() { result = "MinExpr" }
+  override string getAPrimaryQlClass() { result = "MinExpr" }
 }
 
 /**
@@ -396,7 +396,7 @@ class MinExpr extends BinaryArithmeticOperation, @minexpr {
 class MaxExpr extends BinaryArithmeticOperation, @maxexpr {
   override string getOperator() { result = ">?" }
 
-  override string getCanonicalQLClass() { result = "MaxExpr" }
+  override string getAPrimaryQlClass() { result = "MaxExpr" }
 }
 
 /**
@@ -414,7 +414,7 @@ class PointerArithmeticOperation extends BinaryArithmeticOperation, @p_arith_op_
 class PointerAddExpr extends PointerArithmeticOperation, @paddexpr {
   override string getOperator() { result = "+" }
 
-  override string getCanonicalQLClass() { result = "PointerAddExpr" }
+  override string getAPrimaryQlClass() { result = "PointerAddExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -429,7 +429,7 @@ class PointerAddExpr extends PointerArithmeticOperation, @paddexpr {
 class PointerSubExpr extends PointerArithmeticOperation, @psubexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "PointerSubExpr" }
+  override string getAPrimaryQlClass() { result = "PointerSubExpr" }
 
   override int getPrecedence() { result = 13 }
 }
@@ -444,7 +444,7 @@ class PointerSubExpr extends PointerArithmeticOperation, @psubexpr {
 class PointerDiffExpr extends PointerArithmeticOperation, @pdiffexpr {
   override string getOperator() { result = "-" }
 
-  override string getCanonicalQLClass() { result = "PointerDiffExpr" }
+  override string getAPrimaryQlClass() { result = "PointerDiffExpr" }
 
   override int getPrecedence() { result = 13 }
 }

--- a/cpp/ql/src/semmle/code/cpp/exprs/Assignment.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Assignment.qll
@@ -38,7 +38,7 @@ class Assignment extends Operation, @assign_expr {
 class AssignExpr extends Assignment, @assignexpr {
   override string getOperator() { result = "=" }
 
-  override string getCanonicalQLClass() { result = "AssignExpr" }
+  override string getAPrimaryQlClass() { result = "AssignExpr" }
 
   /** Gets a textual representation of this assignment. */
   override string toString() { result = "... = ..." }
@@ -64,7 +64,7 @@ class AssignArithmeticOperation extends AssignOperation, @assign_arith_expr { }
  * ```
  */
 class AssignAddExpr extends AssignArithmeticOperation, @assignaddexpr {
-  override string getCanonicalQLClass() { result = "AssignAddExpr" }
+  override string getAPrimaryQlClass() { result = "AssignAddExpr" }
 
   override string getOperator() { result = "+=" }
 }
@@ -76,7 +76,7 @@ class AssignAddExpr extends AssignArithmeticOperation, @assignaddexpr {
  * ```
  */
 class AssignSubExpr extends AssignArithmeticOperation, @assignsubexpr {
-  override string getCanonicalQLClass() { result = "AssignSubExpr" }
+  override string getAPrimaryQlClass() { result = "AssignSubExpr" }
 
   override string getOperator() { result = "-=" }
 }
@@ -88,7 +88,7 @@ class AssignSubExpr extends AssignArithmeticOperation, @assignsubexpr {
  * ```
  */
 class AssignMulExpr extends AssignArithmeticOperation, @assignmulexpr {
-  override string getCanonicalQLClass() { result = "AssignMulExpr" }
+  override string getAPrimaryQlClass() { result = "AssignMulExpr" }
 
   override string getOperator() { result = "*=" }
 }
@@ -100,7 +100,7 @@ class AssignMulExpr extends AssignArithmeticOperation, @assignmulexpr {
  * ```
  */
 class AssignDivExpr extends AssignArithmeticOperation, @assigndivexpr {
-  override string getCanonicalQLClass() { result = "AssignDivExpr" }
+  override string getAPrimaryQlClass() { result = "AssignDivExpr" }
 
   override string getOperator() { result = "/=" }
 }
@@ -112,7 +112,7 @@ class AssignDivExpr extends AssignArithmeticOperation, @assigndivexpr {
  * ```
  */
 class AssignRemExpr extends AssignArithmeticOperation, @assignremexpr {
-  override string getCanonicalQLClass() { result = "AssignRemExpr" }
+  override string getAPrimaryQlClass() { result = "AssignRemExpr" }
 
   override string getOperator() { result = "%=" }
 }
@@ -130,7 +130,7 @@ class AssignBitwiseOperation extends AssignOperation, @assign_bitwise_expr { }
  * ```
  */
 class AssignAndExpr extends AssignBitwiseOperation, @assignandexpr {
-  override string getCanonicalQLClass() { result = "AssignAndExpr" }
+  override string getAPrimaryQlClass() { result = "AssignAndExpr" }
 
   override string getOperator() { result = "&=" }
 }
@@ -142,7 +142,7 @@ class AssignAndExpr extends AssignBitwiseOperation, @assignandexpr {
  * ```
  */
 class AssignOrExpr extends AssignBitwiseOperation, @assignorexpr {
-  override string getCanonicalQLClass() { result = "AssignOrExpr" }
+  override string getAPrimaryQlClass() { result = "AssignOrExpr" }
 
   override string getOperator() { result = "|=" }
 }
@@ -154,7 +154,7 @@ class AssignOrExpr extends AssignBitwiseOperation, @assignorexpr {
  * ```
  */
 class AssignXorExpr extends AssignBitwiseOperation, @assignxorexpr {
-  override string getCanonicalQLClass() { result = "AssignXorExpr" }
+  override string getAPrimaryQlClass() { result = "AssignXorExpr" }
 
   override string getOperator() { result = "^=" }
 }
@@ -166,7 +166,7 @@ class AssignXorExpr extends AssignBitwiseOperation, @assignxorexpr {
  * ```
  */
 class AssignLShiftExpr extends AssignBitwiseOperation, @assignlshiftexpr {
-  override string getCanonicalQLClass() { result = "AssignLShiftExpr" }
+  override string getAPrimaryQlClass() { result = "AssignLShiftExpr" }
 
   override string getOperator() { result = "<<=" }
 }
@@ -178,7 +178,7 @@ class AssignLShiftExpr extends AssignBitwiseOperation, @assignlshiftexpr {
  * ```
  */
 class AssignRShiftExpr extends AssignBitwiseOperation, @assignrshiftexpr {
-  override string getCanonicalQLClass() { result = "AssignRShiftExpr" }
+  override string getAPrimaryQlClass() { result = "AssignRShiftExpr" }
 
   override string getOperator() { result = ">>=" }
 }
@@ -190,7 +190,7 @@ class AssignRShiftExpr extends AssignBitwiseOperation, @assignrshiftexpr {
  * ```
  */
 class AssignPointerAddExpr extends AssignOperation, @assignpaddexpr {
-  override string getCanonicalQLClass() { result = "AssignPointerAddExpr" }
+  override string getAPrimaryQlClass() { result = "AssignPointerAddExpr" }
 
   override string getOperator() { result = "+=" }
 }
@@ -202,7 +202,7 @@ class AssignPointerAddExpr extends AssignOperation, @assignpaddexpr {
  * ```
  */
 class AssignPointerSubExpr extends AssignOperation, @assignpsubexpr {
-  override string getCanonicalQLClass() { result = "AssignPointerSubExpr" }
+  override string getAPrimaryQlClass() { result = "AssignPointerSubExpr" }
 
   override string getOperator() { result = "-=" }
 }
@@ -227,7 +227,7 @@ class ConditionDeclExpr extends Expr, @condition_decl {
    */
   deprecated Expr getExpr() { result = this.getChild(0) }
 
-  override string getCanonicalQLClass() { result = "ConditionDeclExpr" }
+  override string getAPrimaryQlClass() { result = "ConditionDeclExpr" }
 
   /**
    * Gets the compiler-generated variable access that conceptually occurs after

--- a/cpp/ql/src/semmle/code/cpp/exprs/BitwiseOperation.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/BitwiseOperation.qll
@@ -16,7 +16,7 @@ class ComplementExpr extends UnaryBitwiseOperation, @complementexpr {
 
   override int getPrecedence() { result = 16 }
 
-  override string getCanonicalQLClass() { result = "ComplementExpr" }
+  override string getAPrimaryQlClass() { result = "ComplementExpr" }
 }
 
 /**
@@ -35,7 +35,7 @@ class LShiftExpr extends BinaryBitwiseOperation, @lshiftexpr {
 
   override int getPrecedence() { result = 12 }
 
-  override string getCanonicalQLClass() { result = "LShiftExpr" }
+  override string getAPrimaryQlClass() { result = "LShiftExpr" }
 }
 
 /**
@@ -49,7 +49,7 @@ class RShiftExpr extends BinaryBitwiseOperation, @rshiftexpr {
 
   override int getPrecedence() { result = 12 }
 
-  override string getCanonicalQLClass() { result = "RShiftExpr" }
+  override string getAPrimaryQlClass() { result = "RShiftExpr" }
 }
 
 /**
@@ -63,7 +63,7 @@ class BitwiseAndExpr extends BinaryBitwiseOperation, @andexpr {
 
   override int getPrecedence() { result = 8 }
 
-  override string getCanonicalQLClass() { result = "BitwiseAndExpr" }
+  override string getAPrimaryQlClass() { result = "BitwiseAndExpr" }
 }
 
 /**
@@ -77,7 +77,7 @@ class BitwiseOrExpr extends BinaryBitwiseOperation, @orexpr {
 
   override int getPrecedence() { result = 6 }
 
-  override string getCanonicalQLClass() { result = "BitwiseOrExpr" }
+  override string getAPrimaryQlClass() { result = "BitwiseOrExpr" }
 }
 
 /**
@@ -91,5 +91,5 @@ class BitwiseXorExpr extends BinaryBitwiseOperation, @xorexpr {
 
   override int getPrecedence() { result = 7 }
 
-  override string getCanonicalQLClass() { result = "BitwiseXorExpr" }
+  override string getAPrimaryQlClass() { result = "BitwiseXorExpr" }
 }

--- a/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/BuiltInOperations.qll
@@ -5,7 +5,7 @@ import semmle.code.cpp.exprs.Expr
  * built-in functionality.
  */
 class BuiltInOperation extends Expr, @builtin_op {
-  override string getCanonicalQLClass() { result = "BuiltInOperation" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperation" }
 }
 
 /**
@@ -25,7 +25,7 @@ class VarArgsExpr extends BuiltInOperation, @var_args_expr { }
 class BuiltInVarArgsStart extends BuiltInOperation, @vastartexpr {
   override string toString() { result = "__builtin_va_start" }
 
-  override string getCanonicalQLClass() { result = "BuiltInVarArgsStart" }
+  override string getAPrimaryQlClass() { result = "BuiltInVarArgsStart" }
 
   /**
    * Gets the `va_list` argument.
@@ -50,7 +50,7 @@ class BuiltInVarArgsStart extends BuiltInOperation, @vastartexpr {
 class BuiltInVarArgsEnd extends BuiltInOperation, @vaendexpr {
   override string toString() { result = "__builtin_va_end" }
 
-  override string getCanonicalQLClass() { result = "BuiltInVarArgsEnd" }
+  override string getAPrimaryQlClass() { result = "BuiltInVarArgsEnd" }
 
   /**
    * Gets the `va_list` argument.
@@ -68,7 +68,7 @@ class BuiltInVarArgsEnd extends BuiltInOperation, @vaendexpr {
 class BuiltInVarArg extends BuiltInOperation, @vaargexpr {
   override string toString() { result = "__builtin_va_arg" }
 
-  override string getCanonicalQLClass() { result = "BuiltInVarArg" }
+  override string getAPrimaryQlClass() { result = "BuiltInVarArg" }
 
   /**
    * Gets the `va_list` argument.
@@ -88,7 +88,7 @@ class BuiltInVarArg extends BuiltInOperation, @vaargexpr {
 class BuiltInVarArgCopy extends BuiltInOperation, @vacopyexpr {
   override string toString() { result = "__builtin_va_copy" }
 
-  override string getCanonicalQLClass() { result = "BuiltInVarArgCopy" }
+  override string getAPrimaryQlClass() { result = "BuiltInVarArgCopy" }
 
   /**
    * Gets the destination `va_list` argument.
@@ -110,7 +110,7 @@ class BuiltInVarArgCopy extends BuiltInOperation, @vacopyexpr {
 class BuiltInNoOp extends BuiltInOperation, @noopexpr {
   override string toString() { result = "__noop" }
 
-  override string getCanonicalQLClass() { result = "BuiltInNoOp" }
+  override string getAPrimaryQlClass() { result = "BuiltInNoOp" }
 }
 
 /**
@@ -132,7 +132,7 @@ deprecated class BuiltInOperationOffsetOf = BuiltInOperationBuiltInOffsetOf;
 class BuiltInOperationBuiltInOffsetOf extends BuiltInOperation, @offsetofexpr {
   override string toString() { result = "__builtin_offsetof" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationBuiltInOffsetOf" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationBuiltInOffsetOf" }
 }
 
 /**
@@ -149,7 +149,7 @@ class BuiltInOperationBuiltInOffsetOf extends BuiltInOperation, @offsetofexpr {
 class BuiltInIntAddr extends BuiltInOperation, @intaddrexpr {
   override string toString() { result = "__INTADDR__" }
 
-  override string getCanonicalQLClass() { result = "BuiltInIntAddr" }
+  override string getAPrimaryQlClass() { result = "BuiltInIntAddr" }
 }
 
 /**
@@ -164,7 +164,7 @@ class BuiltInIntAddr extends BuiltInOperation, @intaddrexpr {
 class BuiltInOperationHasAssign extends BuiltInOperation, @hasassignexpr {
   override string toString() { result = "__has_assign" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasAssign" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasAssign" }
 }
 
 /**
@@ -179,7 +179,7 @@ class BuiltInOperationHasAssign extends BuiltInOperation, @hasassignexpr {
 class BuiltInOperationHasCopy extends BuiltInOperation, @hascopyexpr {
   override string toString() { result = "__has_copy" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasCopy" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasCopy" }
 }
 
 /**
@@ -195,7 +195,7 @@ class BuiltInOperationHasCopy extends BuiltInOperation, @hascopyexpr {
 class BuiltInOperationHasNoThrowAssign extends BuiltInOperation, @hasnothrowassign {
   override string toString() { result = "__has_nothrow_assign" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasNoThrowAssign" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasNoThrowAssign" }
 }
 
 /**
@@ -211,7 +211,7 @@ class BuiltInOperationHasNoThrowAssign extends BuiltInOperation, @hasnothrowassi
 class BuiltInOperationHasNoThrowConstructor extends BuiltInOperation, @hasnothrowconstr {
   override string toString() { result = "__has_nothrow_constructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasNoThrowConstructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasNoThrowConstructor" }
 }
 
 /**
@@ -226,7 +226,7 @@ class BuiltInOperationHasNoThrowConstructor extends BuiltInOperation, @hasnothro
 class BuiltInOperationHasNoThrowCopy extends BuiltInOperation, @hasnothrowcopy {
   override string toString() { result = "__has_nothrow_copy" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasNoThrowCopy" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasNoThrowCopy" }
 }
 
 /**
@@ -242,7 +242,7 @@ class BuiltInOperationHasNoThrowCopy extends BuiltInOperation, @hasnothrowcopy {
 class BuiltInOperationHasTrivialAssign extends BuiltInOperation, @hastrivialassign {
   override string toString() { result = "__has_trivial_assign" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialAssign" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialAssign" }
 }
 
 /**
@@ -257,7 +257,7 @@ class BuiltInOperationHasTrivialAssign extends BuiltInOperation, @hastrivialassi
 class BuiltInOperationHasTrivialConstructor extends BuiltInOperation, @hastrivialconstr {
   override string toString() { result = "__has_trivial_constructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialConstructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialConstructor" }
 }
 
 /**
@@ -272,7 +272,7 @@ class BuiltInOperationHasTrivialConstructor extends BuiltInOperation, @hastrivia
 class BuiltInOperationHasTrivialCopy extends BuiltInOperation, @hastrivialcopy {
   override string toString() { result = "__has_trivial_copy" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialCopy" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialCopy" }
 }
 
 /**
@@ -287,7 +287,7 @@ class BuiltInOperationHasTrivialCopy extends BuiltInOperation, @hastrivialcopy {
 class BuiltInOperationHasTrivialDestructor extends BuiltInOperation, @hastrivialdestructor {
   override string toString() { result = "__has_trivial_destructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialDestructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialDestructor" }
 }
 
 /**
@@ -302,7 +302,7 @@ class BuiltInOperationHasTrivialDestructor extends BuiltInOperation, @hastrivial
 class BuiltInOperationHasUserDestructor extends BuiltInOperation, @hasuserdestr {
   override string toString() { result = "__has_user_destructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasUserDestructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasUserDestructor" }
 }
 
 /**
@@ -320,7 +320,7 @@ class BuiltInOperationHasUserDestructor extends BuiltInOperation, @hasuserdestr 
 class BuiltInOperationHasVirtualDestructor extends BuiltInOperation, @hasvirtualdestr {
   override string toString() { result = "__has_virtual_destructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasVirtualDestructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasVirtualDestructor" }
 }
 
 /**
@@ -335,7 +335,7 @@ class BuiltInOperationHasVirtualDestructor extends BuiltInOperation, @hasvirtual
 class BuiltInOperationIsAbstract extends BuiltInOperation, @isabstractexpr {
   override string toString() { result = "__is_abstract" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsAbstract" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsAbstract" }
 }
 
 /**
@@ -350,7 +350,7 @@ class BuiltInOperationIsAbstract extends BuiltInOperation, @isabstractexpr {
 class BuiltInOperationIsBaseOf extends BuiltInOperation, @isbaseofexpr {
   override string toString() { result = "__is_base_of" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsBaseOf" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsBaseOf" }
 }
 
 /**
@@ -365,7 +365,7 @@ class BuiltInOperationIsBaseOf extends BuiltInOperation, @isbaseofexpr {
 class BuiltInOperationIsClass extends BuiltInOperation, @isclassexpr {
   override string toString() { result = "__is_class" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsClass" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsClass" }
 }
 
 /**
@@ -380,7 +380,7 @@ class BuiltInOperationIsClass extends BuiltInOperation, @isclassexpr {
 class BuiltInOperationIsConvertibleTo extends BuiltInOperation, @isconvtoexpr {
   override string toString() { result = "__is_convertible_to" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsConvertibleTo" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsConvertibleTo" }
 }
 
 /**
@@ -395,7 +395,7 @@ class BuiltInOperationIsConvertibleTo extends BuiltInOperation, @isconvtoexpr {
 class BuiltInOperationIsEmpty extends BuiltInOperation, @isemptyexpr {
   override string toString() { result = "__is_empty" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsEmpty" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsEmpty" }
 }
 
 /**
@@ -410,7 +410,7 @@ class BuiltInOperationIsEmpty extends BuiltInOperation, @isemptyexpr {
 class BuiltInOperationIsEnum extends BuiltInOperation, @isenumexpr {
   override string toString() { result = "__is_enum" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsEnum" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsEnum" }
 }
 
 /**
@@ -427,7 +427,7 @@ class BuiltInOperationIsEnum extends BuiltInOperation, @isenumexpr {
 class BuiltInOperationIsPod extends BuiltInOperation, @ispodexpr {
   override string toString() { result = "__is_pod" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsPod" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsPod" }
 }
 
 /**
@@ -442,7 +442,7 @@ class BuiltInOperationIsPod extends BuiltInOperation, @ispodexpr {
 class BuiltInOperationIsPolymorphic extends BuiltInOperation, @ispolyexpr {
   override string toString() { result = "__is_polymorphic" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsPolymorphic" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsPolymorphic" }
 }
 
 /**
@@ -457,7 +457,7 @@ class BuiltInOperationIsPolymorphic extends BuiltInOperation, @ispolyexpr {
 class BuiltInOperationIsUnion extends BuiltInOperation, @isunionexpr {
   override string toString() { result = "__is_union" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsUnion" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsUnion" }
 }
 
 /**
@@ -496,7 +496,7 @@ class BuiltInOperationBuiltInTypesCompatibleP extends BuiltInOperation, @typesco
 class BuiltInOperationBuiltInShuffleVector extends BuiltInOperation, @builtinshufflevector {
   override string toString() { result = "__builtin_shufflevector" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationBuiltInShuffleVector" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationBuiltInShuffleVector" }
 }
 
 /**
@@ -516,7 +516,7 @@ class BuiltInOperationBuiltInShuffleVector extends BuiltInOperation, @builtinshu
 class BuiltInOperationBuiltInConvertVector extends BuiltInOperation, @builtinconvertvector {
   override string toString() { result = "__builtin_convertvector" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationBuiltInConvertVector" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationBuiltInConvertVector" }
 }
 
 /**
@@ -538,7 +538,7 @@ class BuiltInOperationBuiltInAddressOf extends UnaryOperation, BuiltInOperation,
     result = this.getOperand().(ReferenceDereferenceExpr).getChild(0).(Access).getTarget()
   }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationBuiltInAddressOf" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationBuiltInAddressOf" }
 
   override string getOperator() { result = "__builtin_addressof" }
 }
@@ -560,7 +560,7 @@ class BuiltInOperationIsTriviallyConstructible extends BuiltInOperation,
   @istriviallyconstructibleexpr {
   override string toString() { result = "__is_trivially_constructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsTriviallyConstructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsTriviallyConstructible" }
 }
 
 /**
@@ -577,7 +577,7 @@ class BuiltInOperationIsTriviallyConstructible extends BuiltInOperation,
 class BuiltInOperationIsDestructible extends BuiltInOperation, @isdestructibleexpr {
   override string toString() { result = "__is_destructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsDestructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsDestructible" }
 }
 
 /**
@@ -594,7 +594,7 @@ class BuiltInOperationIsDestructible extends BuiltInOperation, @isdestructibleex
 class BuiltInOperationIsNothrowDestructible extends BuiltInOperation, @isnothrowdestructibleexpr {
   override string toString() { result = "__is_nothrow_destructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsNothrowDestructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsNothrowDestructible" }
 }
 
 /**
@@ -610,7 +610,7 @@ class BuiltInOperationIsNothrowDestructible extends BuiltInOperation, @isnothrow
 class BuiltInOperationIsTriviallyDestructible extends BuiltInOperation, @istriviallydestructibleexpr {
   override string toString() { result = "__is_trivially_destructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsTriviallyDestructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsTriviallyDestructible" }
 }
 
 /**
@@ -629,7 +629,7 @@ class BuiltInOperationIsTriviallyDestructible extends BuiltInOperation, @istrivi
 class BuiltInOperationIsTriviallyAssignable extends BuiltInOperation, @istriviallyassignableexpr {
   override string toString() { result = "__is_trivially_assignable" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsTriviallyAssignable" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsTriviallyAssignable" }
 }
 
 /**
@@ -645,7 +645,7 @@ class BuiltInOperationIsTriviallyAssignable extends BuiltInOperation, @istrivial
 class BuiltInOperationIsNothrowAssignable extends BuiltInOperation, @isnothrowassignableexpr {
   override string toString() { result = "__is_nothrow_assignable" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsNothrowAssignable" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsNothrowAssignable" }
 }
 
 /**
@@ -665,7 +665,7 @@ class BuiltInOperationIsNothrowAssignable extends BuiltInOperation, @isnothrowas
 class BuiltInOperationIsStandardLayout extends BuiltInOperation, @isstandardlayoutexpr {
   override string toString() { result = "__is_standard_layout" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsStandardLayout" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsStandardLayout" }
 }
 
 /**
@@ -679,7 +679,7 @@ class BuiltInOperationIsStandardLayout extends BuiltInOperation, @isstandardlayo
 class BuiltInOperationIsTriviallyCopyable extends BuiltInOperation, @istriviallycopyableexpr {
   override string toString() { result = "__is_trivially_copyable" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsTriviallyCopyable" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsTriviallyCopyable" }
 }
 
 /**
@@ -699,7 +699,7 @@ class BuiltInOperationIsTriviallyCopyable extends BuiltInOperation, @istrivially
 class BuiltInOperationIsLiteralType extends BuiltInOperation, @isliteraltypeexpr {
   override string toString() { result = "__is_literal_type" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsLiteralType" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsLiteralType" }
 }
 
 /**
@@ -717,7 +717,7 @@ class BuiltInOperationHasTrivialMoveConstructor extends BuiltInOperation,
   @hastrivialmoveconstructorexpr {
   override string toString() { result = "__has_trivial_move_constructor" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialMoveConstructor" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialMoveConstructor" }
 }
 
 /**
@@ -735,7 +735,7 @@ class BuiltInOperationHasTrivialMoveConstructor extends BuiltInOperation,
 class BuiltInOperationHasTrivialMoveAssign extends BuiltInOperation, @hastrivialmoveassignexpr {
   override string toString() { result = "__has_trivial_move_assign" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasTrivialMoveAssign" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasTrivialMoveAssign" }
 }
 
 /**
@@ -751,7 +751,7 @@ class BuiltInOperationHasTrivialMoveAssign extends BuiltInOperation, @hastrivial
 class BuiltInOperationHasNothrowMoveAssign extends BuiltInOperation, @hasnothrowmoveassignexpr {
   override string toString() { result = "__has_nothrow_move_assign" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasNothrowMoveAssign" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasNothrowMoveAssign" }
 }
 
 /**
@@ -770,7 +770,7 @@ class BuiltInOperationHasNothrowMoveAssign extends BuiltInOperation, @hasnothrow
 class BuiltInOperationIsConstructible extends BuiltInOperation, @isconstructibleexpr {
   override string toString() { result = "__is_constructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsConstructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsConstructible" }
 }
 
 /**
@@ -786,7 +786,7 @@ class BuiltInOperationIsConstructible extends BuiltInOperation, @isconstructible
 class BuiltInOperationIsNothrowConstructible extends BuiltInOperation, @isnothrowconstructibleexpr {
   override string toString() { result = "__is_nothrow_constructible" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsNothrowConstructible" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsNothrowConstructible" }
 }
 
 /**
@@ -801,7 +801,7 @@ class BuiltInOperationIsNothrowConstructible extends BuiltInOperation, @isnothro
 class BuiltInOperationHasFinalizer extends BuiltInOperation, @hasfinalizerexpr {
   override string toString() { result = "__has_finalizer" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationHasFinalizer" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationHasFinalizer" }
 }
 
 /**
@@ -815,7 +815,7 @@ class BuiltInOperationHasFinalizer extends BuiltInOperation, @hasfinalizerexpr {
 class BuiltInOperationIsDelegate extends BuiltInOperation, @isdelegateexpr {
   override string toString() { result = "__is_delegate" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsDelegate" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsDelegate" }
 }
 
 /**
@@ -828,7 +828,7 @@ class BuiltInOperationIsDelegate extends BuiltInOperation, @isdelegateexpr {
 class BuiltInOperationIsInterfaceClass extends BuiltInOperation, @isinterfaceclassexpr {
   override string toString() { result = "__is_interface_class" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsInterfaceClass" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsInterfaceClass" }
 }
 
 /**
@@ -845,7 +845,7 @@ class BuiltInOperationIsInterfaceClass extends BuiltInOperation, @isinterfacecla
 class BuiltInOperationIsRefArray extends BuiltInOperation, @isrefarrayexpr {
   override string toString() { result = "__is_ref_array" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsRefArray" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsRefArray" }
 }
 
 /**
@@ -862,7 +862,7 @@ class BuiltInOperationIsRefArray extends BuiltInOperation, @isrefarrayexpr {
 class BuiltInOperationIsRefClass extends BuiltInOperation, @isrefclassexpr {
   override string toString() { result = "__is_ref_class" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsRefClass" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsRefClass" }
 }
 
 /**
@@ -880,7 +880,7 @@ class BuiltInOperationIsRefClass extends BuiltInOperation, @isrefclassexpr {
 class BuiltInOperationIsSealed extends BuiltInOperation, @issealedexpr {
   override string toString() { result = "__is_sealed" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsSealed" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsSealed" }
 }
 
 /**
@@ -899,7 +899,7 @@ class BuiltInOperationIsSealed extends BuiltInOperation, @issealedexpr {
 class BuiltInOperationIsSimpleValueClass extends BuiltInOperation, @issimplevalueclassexpr {
   override string toString() { result = "__is_simple_value_class" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsSimpleValueClass" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsSimpleValueClass" }
 }
 
 /**
@@ -916,7 +916,7 @@ class BuiltInOperationIsSimpleValueClass extends BuiltInOperation, @issimplevalu
 class BuiltInOperationIsValueClass extends BuiltInOperation, @isvalueclassexpr {
   override string toString() { result = "__is_value_class" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsValueClass" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsValueClass" }
 }
 
 /**
@@ -934,7 +934,7 @@ class BuiltInOperationIsValueClass extends BuiltInOperation, @isvalueclassexpr {
 class BuiltInOperationIsFinal extends BuiltInOperation, @isfinalexpr {
   override string toString() { result = "__is_final" }
 
-  override string getCanonicalQLClass() { result = "BuiltInOperationIsFinal" }
+  override string getAPrimaryQlClass() { result = "BuiltInOperationIsFinal" }
 }
 
 /**
@@ -949,7 +949,7 @@ class BuiltInOperationIsFinal extends BuiltInOperation, @isfinalexpr {
 class BuiltInChooseExpr extends BuiltInOperation, @builtinchooseexpr {
   override string toString() { result = "__builtin_choose_expr" }
 
-  override string getCanonicalQLClass() { result = "BuiltInChooseExpr" }
+  override string getAPrimaryQlClass() { result = "BuiltInChooseExpr" }
 }
 
 /**
@@ -966,7 +966,7 @@ class BuiltInChooseExpr extends BuiltInOperation, @builtinchooseexpr {
 class VectorFillOperation extends UnaryOperation, @vec_fill {
   override string getOperator() { result = "(vector fill)" }
 
-  override string getCanonicalQLClass() { result = "VectorFillOperation" }
+  override string getAPrimaryQlClass() { result = "VectorFillOperation" }
 }
 
 /**
@@ -975,7 +975,7 @@ class VectorFillOperation extends UnaryOperation, @vec_fill {
 class BuiltInComplexOperation extends BuiltInOperation, @builtincomplex {
   override string toString() { result = "__builtin_complex" }
 
-  override string getCanonicalQLClass() { result = "BuiltInComplexOperation" }
+  override string getAPrimaryQlClass() { result = "BuiltInComplexOperation" }
 
   /** Gets the operand corresponding to the real part of the complex number. */
   Expr getRealOperand() { this.hasChild(result, 0) }

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -148,7 +148,7 @@ abstract class Call extends Expr, NameQualifiableElement {
 class FunctionCall extends Call, @funbindexpr {
   FunctionCall() { iscall(underlyingElement(this), _) }
 
-  override string getCanonicalQLClass() { result = "FunctionCall" }
+  override string getAPrimaryQlClass() { result = "FunctionCall" }
 
   /** Gets an explicit template argument for this call. */
   Locatable getAnExplicitTemplateArgument() { result = getExplicitTemplateArgument(_) }
@@ -297,7 +297,7 @@ class OverloadedPointerDereferenceExpr extends FunctionCall {
     getTarget().getEffectiveNumberOfParameters() = 1
   }
 
-  override string getCanonicalQLClass() { result = "OverloadedPointerDereferenceExpr" }
+  override string getAPrimaryQlClass() { result = "OverloadedPointerDereferenceExpr" }
 
   /**
    * Gets the expression this operator * applies to.
@@ -345,7 +345,7 @@ class OverloadedPointerDereferenceExpr extends FunctionCall {
 class OverloadedArrayExpr extends FunctionCall {
   OverloadedArrayExpr() { getTarget().hasName("operator[]") }
 
-  override string getCanonicalQLClass() { result = "OverloadedArrayExpr" }
+  override string getAPrimaryQlClass() { result = "OverloadedArrayExpr" }
 
   /**
    * Gets the expression being subscripted.
@@ -377,7 +377,7 @@ class ExprCall extends Call, @callexpr {
    */
   Expr getExpr() { result = this.getChild(0) }
 
-  override string getCanonicalQLClass() { result = "ExprCall" }
+  override string getAPrimaryQlClass() { result = "ExprCall" }
 
   override Expr getAnArgument() { exists(int i | result = this.getChild(i) and i >= 1) }
 
@@ -401,7 +401,7 @@ class ExprCall extends Call, @callexpr {
 class VariableCall extends ExprCall {
   VariableCall() { this.getExpr() instanceof VariableAccess }
 
-  override string getCanonicalQLClass() { result = "VariableCall" }
+  override string getAPrimaryQlClass() { result = "VariableCall" }
 
   /**
    * Gets the variable which yields the function pointer to call.
@@ -419,7 +419,7 @@ class VariableCall extends ExprCall {
 class ConstructorCall extends FunctionCall {
   ConstructorCall() { super.getTarget() instanceof Constructor }
 
-  override string getCanonicalQLClass() { result = "ConstructorCall" }
+  override string getAPrimaryQlClass() { result = "ConstructorCall" }
 
   /** Gets the constructor being called. */
   override Constructor getTarget() { result = super.getTarget() }
@@ -438,7 +438,7 @@ class ThrowExpr extends Expr, @throw_expr {
    */
   Expr getExpr() { result = this.getChild(0) }
 
-  override string getCanonicalQLClass() { result = "ThrowExpr" }
+  override string getAPrimaryQlClass() { result = "ThrowExpr" }
 
   override string toString() { result = "throw ..." }
 
@@ -454,7 +454,7 @@ class ThrowExpr extends Expr, @throw_expr {
 class ReThrowExpr extends ThrowExpr {
   ReThrowExpr() { this.getType() instanceof VoidType }
 
-  override string getCanonicalQLClass() { result = "ReThrowExpr" }
+  override string getAPrimaryQlClass() { result = "ReThrowExpr" }
 
   override string toString() { result = "re-throw exception " }
 }
@@ -469,7 +469,7 @@ class ReThrowExpr extends ThrowExpr {
 class DestructorCall extends FunctionCall {
   DestructorCall() { super.getTarget() instanceof Destructor }
 
-  override string getCanonicalQLClass() { result = "DestructorCall" }
+  override string getAPrimaryQlClass() { result = "DestructorCall" }
 
   /** Gets the destructor being called. */
   override Destructor getTarget() { result = super.getTarget() }
@@ -493,7 +493,7 @@ class VacuousDestructorCall extends Expr, @vacuous_destructor_call {
    */
   Expr getQualifier() { result = this.getChild(0) }
 
-  override string getCanonicalQLClass() { result = "VacuousDestructorCall" }
+  override string getAPrimaryQlClass() { result = "VacuousDestructorCall" }
 
   override string toString() { result = "(vacuous destructor call)" }
 }
@@ -506,7 +506,7 @@ class VacuousDestructorCall extends Expr, @vacuous_destructor_call {
  * initializations.
  */
 class ConstructorInit extends Expr, @ctorinit {
-  override string getCanonicalQLClass() { result = "ConstructorInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorInit" }
 }
 
 /**
@@ -514,7 +514,7 @@ class ConstructorInit extends Expr, @ctorinit {
  * initializer list or compiler-generated actions.
  */
 class ConstructorBaseInit extends ConstructorInit, ConstructorCall {
-  override string getCanonicalQLClass() { result = "ConstructorBaseInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorBaseInit" }
 }
 
 /**
@@ -531,7 +531,7 @@ class ConstructorBaseInit extends ConstructorInit, ConstructorCall {
  * ```
  */
 class ConstructorDirectInit extends ConstructorBaseInit, @ctordirectinit {
-  override string getCanonicalQLClass() { result = "ConstructorDirectInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorDirectInit" }
 }
 
 /**
@@ -551,7 +551,7 @@ class ConstructorDirectInit extends ConstructorBaseInit, @ctordirectinit {
  * ```
  */
 class ConstructorVirtualInit extends ConstructorBaseInit, @ctorvirtualinit {
-  override string getCanonicalQLClass() { result = "ConstructorVirtualInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorVirtualInit" }
 }
 
 /**
@@ -566,7 +566,7 @@ class ConstructorVirtualInit extends ConstructorBaseInit, @ctorvirtualinit {
  * ```
  */
 class ConstructorDelegationInit extends ConstructorBaseInit, @ctordelegatinginit {
-  override string getCanonicalQLClass() { result = "ConstructorDelegationInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorDelegationInit" }
 }
 
 /**
@@ -585,7 +585,7 @@ class ConstructorFieldInit extends ConstructorInit, @ctorfieldinit {
   /** Gets the field being initialized. */
   Field getTarget() { varbind(underlyingElement(this), unresolveElement(result)) }
 
-  override string getCanonicalQLClass() { result = "ConstructorFieldInit" }
+  override string getAPrimaryQlClass() { result = "ConstructorFieldInit" }
 
   /**
    * Gets the expression to which the field is initialized.
@@ -607,7 +607,7 @@ class ConstructorFieldInit extends ConstructorInit, @ctorfieldinit {
  * compiler-generated actions.
  */
 class DestructorDestruction extends Expr, @dtordestruct {
-  override string getCanonicalQLClass() { result = "DestructorDestruction" }
+  override string getAPrimaryQlClass() { result = "DestructorDestruction" }
 }
 
 /**
@@ -615,7 +615,7 @@ class DestructorDestruction extends Expr, @dtordestruct {
  * compiler-generated actions.
  */
 class DestructorBaseDestruction extends DestructorCall, DestructorDestruction {
-  override string getCanonicalQLClass() { result = "DestructorBaseDestruction" }
+  override string getAPrimaryQlClass() { result = "DestructorBaseDestruction" }
 }
 
 /**
@@ -629,7 +629,7 @@ class DestructorBaseDestruction extends DestructorCall, DestructorDestruction {
  * ```
  */
 class DestructorDirectDestruction extends DestructorBaseDestruction, @dtordirectdestruct {
-  override string getCanonicalQLClass() { result = "DestructorDirectDestruction" }
+  override string getAPrimaryQlClass() { result = "DestructorDirectDestruction" }
 }
 
 /**
@@ -646,7 +646,7 @@ class DestructorDirectDestruction extends DestructorBaseDestruction, @dtordirect
  * ```
  */
 class DestructorVirtualDestruction extends DestructorBaseDestruction, @dtorvirtualdestruct {
-  override string getCanonicalQLClass() { result = "DestructorVirtualDestruction" }
+  override string getAPrimaryQlClass() { result = "DestructorVirtualDestruction" }
 }
 
 /**
@@ -664,7 +664,7 @@ class DestructorFieldDestruction extends DestructorDestruction, @dtorfielddestru
   /** Gets the field being destructed. */
   Field getTarget() { varbind(underlyingElement(this), unresolveElement(result)) }
 
-  override string getCanonicalQLClass() { result = "DestructorFieldDestruction" }
+  override string getAPrimaryQlClass() { result = "DestructorFieldDestruction" }
 
   /** Gets the compiler-generated call to the variable's destructor. */
   DestructorCall getExpr() { result = this.getChild(0) }

--- a/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
@@ -289,9 +289,7 @@ class PointerConversion extends Cast {
     isPointerOrNullPointer(getExpr().getUnspecifiedType())
   }
 
-  override string getAPrimaryQlClass() {
-    not exists(qlCast(this)) and result = "PointerConversion"
-  }
+  override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "PointerConversion" }
 
   override string getSemanticConversionString() { result = "pointer conversion" }
 }
@@ -569,9 +567,7 @@ class PointerToMemberDerivedClassConversion extends Cast {
 class GlvalueConversion extends Cast {
   GlvalueConversion() { conversionkinds(underlyingElement(this), 6) }
 
-  override string getAPrimaryQlClass() {
-    not exists(qlCast(this)) and result = "GlvalueConversion"
-  }
+  override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "GlvalueConversion" }
 
   override string getSemanticConversionString() { result = "glvalue conversion" }
 }

--- a/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Cast.qll
@@ -92,7 +92,7 @@ module CastConsistency {
 class CStyleCast extends Cast, @c_style_cast {
   override string toString() { result = "(" + this.getType().getName() + ")..." }
 
-  override string getCanonicalQLClass() { result = "CStyleCast" }
+  override string getAPrimaryQlClass() { result = "CStyleCast" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -111,7 +111,7 @@ class CStyleCast extends Cast, @c_style_cast {
 class StaticCast extends Cast, @static_cast {
   override string toString() { result = "static_cast<" + this.getType().getName() + ">..." }
 
-  override string getCanonicalQLClass() { result = "StaticCast" }
+  override string getAPrimaryQlClass() { result = "StaticCast" }
 
   override int getPrecedence() { result = 17 }
 }
@@ -129,7 +129,7 @@ class StaticCast extends Cast, @static_cast {
 class ConstCast extends Cast, @const_cast {
   override string toString() { result = "const_cast<" + this.getType().getName() + ">..." }
 
-  override string getCanonicalQLClass() { result = "ConstCast" }
+  override string getAPrimaryQlClass() { result = "ConstCast" }
 
   override int getPrecedence() { result = 17 }
 }
@@ -147,7 +147,7 @@ class ConstCast extends Cast, @const_cast {
 class ReinterpretCast extends Cast, @reinterpret_cast {
   override string toString() { result = "reinterpret_cast<" + this.getType().getName() + ">..." }
 
-  override string getCanonicalQLClass() { result = "ReinterpretCast" }
+  override string getAPrimaryQlClass() { result = "ReinterpretCast" }
 
   override int getPrecedence() { result = 17 }
 }
@@ -203,7 +203,7 @@ class IntegralConversion extends ArithmeticConversion {
     isIntegralOrEnum(getExpr().getUnspecifiedType())
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "IntegralConversion"
   }
 
@@ -223,7 +223,7 @@ class FloatingPointConversion extends ArithmeticConversion {
     getExpr().getUnspecifiedType() instanceof FloatingPointType
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "FloatingPointConversion"
   }
 
@@ -243,7 +243,7 @@ class FloatingPointToIntegralConversion extends ArithmeticConversion {
     getExpr().getUnspecifiedType() instanceof FloatingPointType
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "FloatingPointToIntegralConversion"
   }
 
@@ -263,7 +263,7 @@ class IntegralToFloatingPointConversion extends ArithmeticConversion {
     isIntegralOrEnum(getExpr().getUnspecifiedType())
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "IntegralToFloatingPointConversion"
   }
 
@@ -289,7 +289,7 @@ class PointerConversion extends Cast {
     isPointerOrNullPointer(getExpr().getUnspecifiedType())
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PointerConversion"
   }
 
@@ -325,7 +325,7 @@ class PointerToMemberConversion extends Cast {
     )
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PointerToMemberConversion"
   }
 
@@ -346,7 +346,7 @@ class PointerToIntegralConversion extends Cast {
     isPointerOrNullPointer(getExpr().getUnspecifiedType())
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PointerToIntegralConversion"
   }
 
@@ -367,7 +367,7 @@ class IntegralToPointerConversion extends Cast {
     isIntegralOrEnum(getExpr().getUnspecifiedType())
   }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "IntegralToPointerConversion"
   }
 
@@ -385,7 +385,7 @@ class IntegralToPointerConversion extends Cast {
 class BoolConversion extends Cast {
   BoolConversion() { conversionkinds(underlyingElement(this), 1) }
 
-  override string getCanonicalQLClass() { not exists(qlCast(this)) and result = "BoolConversion" }
+  override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "BoolConversion" }
 
   override string getSemanticConversionString() { result = "conversion to bool" }
 }
@@ -403,7 +403,7 @@ class VoidConversion extends Cast {
     getUnspecifiedType() instanceof VoidType
   }
 
-  override string getCanonicalQLClass() { not exists(qlCast(this)) and result = "VoidConversion" }
+  override string getAPrimaryQlClass() { not exists(qlCast(this)) and result = "VoidConversion" }
 
   override string getSemanticConversionString() { result = "conversion to void" }
 }
@@ -479,7 +479,7 @@ private Class getConversionClass(Expr expr) {
 class BaseClassConversion extends InheritanceConversion {
   BaseClassConversion() { conversionkinds(underlyingElement(this), 2) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "BaseClassConversion"
   }
 
@@ -506,7 +506,7 @@ class BaseClassConversion extends InheritanceConversion {
 class DerivedClassConversion extends InheritanceConversion {
   DerivedClassConversion() { conversionkinds(underlyingElement(this), 3) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "DerivedClassConversion"
   }
 
@@ -528,7 +528,7 @@ class DerivedClassConversion extends InheritanceConversion {
 class PointerToMemberBaseClassConversion extends Cast {
   PointerToMemberBaseClassConversion() { conversionkinds(underlyingElement(this), 4) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PointerToMemberBaseClassConversion"
   }
 
@@ -548,7 +548,7 @@ class PointerToMemberBaseClassConversion extends Cast {
 class PointerToMemberDerivedClassConversion extends Cast {
   PointerToMemberDerivedClassConversion() { conversionkinds(underlyingElement(this), 5) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PointerToMemberDerivedClassConversion"
   }
 
@@ -569,7 +569,7 @@ class PointerToMemberDerivedClassConversion extends Cast {
 class GlvalueConversion extends Cast {
   GlvalueConversion() { conversionkinds(underlyingElement(this), 6) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "GlvalueConversion"
   }
 
@@ -597,7 +597,7 @@ class GlvalueConversion extends Cast {
 class PrvalueAdjustmentConversion extends Cast {
   PrvalueAdjustmentConversion() { conversionkinds(underlyingElement(this), 7) }
 
-  override string getCanonicalQLClass() {
+  override string getAPrimaryQlClass() {
     not exists(qlCast(this)) and result = "PrvalueAdjustmentConversion"
   }
 
@@ -620,7 +620,7 @@ class DynamicCast extends Cast, @dynamic_cast {
 
   override int getPrecedence() { result = 17 }
 
-  override string getCanonicalQLClass() { result = "DynamicCast" }
+  override string getAPrimaryQlClass() { result = "DynamicCast" }
 
   override string getSemanticConversionString() { result = "dynamic_cast" }
 }
@@ -669,7 +669,7 @@ class TypeidOperator extends Expr, @type_id {
    */
   deprecated Type getSpecifiedType() { result = this.getResultType() }
 
-  override string getCanonicalQLClass() { result = "TypeidOperator" }
+  override string getAPrimaryQlClass() { result = "TypeidOperator" }
 
   /**
    * Gets the contained expression, if any (if this typeid contains
@@ -699,7 +699,7 @@ class TypeidOperator extends Expr, @type_id {
 class SizeofPackOperator extends Expr, @sizeof_pack {
   override string toString() { result = "sizeof...(...)" }
 
-  override string getCanonicalQLClass() { result = "SizeofPackOperator" }
+  override string getAPrimaryQlClass() { result = "SizeofPackOperator" }
 
   override predicate mayBeImpure() { none() }
 
@@ -722,7 +722,7 @@ class SizeofOperator extends Expr, @runtime_sizeof {
 class SizeofExprOperator extends SizeofOperator {
   SizeofExprOperator() { exists(Expr e | this.getChild(0) = e) }
 
-  override string getCanonicalQLClass() { result = "SizeofExprOperator" }
+  override string getAPrimaryQlClass() { result = "SizeofExprOperator" }
 
   /** Gets the contained expression. */
   Expr getExprOperand() { result = this.getChild(0) }
@@ -750,7 +750,7 @@ class SizeofExprOperator extends SizeofOperator {
 class SizeofTypeOperator extends SizeofOperator {
   SizeofTypeOperator() { sizeof_bind(underlyingElement(this), _) }
 
-  override string getCanonicalQLClass() { result = "SizeofTypeOperator" }
+  override string getAPrimaryQlClass() { result = "SizeofTypeOperator" }
 
   /** Gets the contained type. */
   Type getTypeOperand() { sizeof_bind(underlyingElement(this), unresolveElement(result)) }
@@ -829,7 +829,7 @@ class ArrayToPointerConversion extends Conversion, @array_to_pointer {
   /** Gets a textual representation of this conversion. */
   override string toString() { result = "array to pointer conversion" }
 
-  override string getCanonicalQLClass() { result = "ArrayToPointerConversion" }
+  override string getAPrimaryQlClass() { result = "ArrayToPointerConversion" }
 
   override predicate mayBeImpure() { none() }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/ComparisonOperation.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/ComparisonOperation.qll
@@ -21,7 +21,7 @@ class EqualityOperation extends ComparisonOperation, @eq_op_expr {
  * ```
  */
 class EQExpr extends EqualityOperation, @eqexpr {
-  override string getCanonicalQLClass() { result = "EQExpr" }
+  override string getAPrimaryQlClass() { result = "EQExpr" }
 
   override string getOperator() { result = "==" }
 }
@@ -33,7 +33,7 @@ class EQExpr extends EqualityOperation, @eqexpr {
  * ```
  */
 class NEExpr extends EqualityOperation, @neexpr {
-  override string getCanonicalQLClass() { result = "NEExpr" }
+  override string getAPrimaryQlClass() { result = "NEExpr" }
 
   override string getOperator() { result = "!=" }
 }
@@ -78,7 +78,7 @@ class RelationalOperation extends ComparisonOperation, @rel_op_expr {
  * ```
  */
 class GTExpr extends RelationalOperation, @gtexpr {
-  override string getCanonicalQLClass() { result = "GTExpr" }
+  override string getAPrimaryQlClass() { result = "GTExpr" }
 
   override string getOperator() { result = ">" }
 
@@ -94,7 +94,7 @@ class GTExpr extends RelationalOperation, @gtexpr {
  * ```
  */
 class LTExpr extends RelationalOperation, @ltexpr {
-  override string getCanonicalQLClass() { result = "LTExpr" }
+  override string getAPrimaryQlClass() { result = "LTExpr" }
 
   override string getOperator() { result = "<" }
 
@@ -110,7 +110,7 @@ class LTExpr extends RelationalOperation, @ltexpr {
  * ```
  */
 class GEExpr extends RelationalOperation, @geexpr {
-  override string getCanonicalQLClass() { result = "GEExpr" }
+  override string getAPrimaryQlClass() { result = "GEExpr" }
 
   override string getOperator() { result = ">=" }
 
@@ -126,7 +126,7 @@ class GEExpr extends RelationalOperation, @geexpr {
  * ```
  */
 class LEExpr extends RelationalOperation, @leexpr {
-  override string getCanonicalQLClass() { result = "LEExpr" }
+  override string getAPrimaryQlClass() { result = "LEExpr" }
 
   override string getOperator() { result = "<=" }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -565,7 +565,7 @@ class BinaryOperation extends Operation, @bin_op_expr {
 class ParenthesizedBracedInitializerList extends Expr, @braced_init_list {
   override string toString() { result = "({...})" }
 
-  override string getCanonicalQLClass() { result = "ParenthesizedBracedInitializerList" }
+  override string getAPrimaryQlClass() { result = "ParenthesizedBracedInitializerList" }
 }
 
 /**
@@ -580,7 +580,7 @@ class ParenthesizedBracedInitializerList extends Expr, @braced_init_list {
 class ParenthesisExpr extends Conversion, @parexpr {
   override string toString() { result = "(...)" }
 
-  override string getCanonicalQLClass() { result = "ParenthesisExpr" }
+  override string getAPrimaryQlClass() { result = "ParenthesisExpr" }
 }
 
 /**
@@ -591,7 +591,7 @@ class ParenthesisExpr extends Conversion, @parexpr {
 class ErrorExpr extends Expr, @errorexpr {
   override string toString() { result = "<error expr>" }
 
-  override string getCanonicalQLClass() { result = "ErrorExpr" }
+  override string getAPrimaryQlClass() { result = "ErrorExpr" }
 }
 
 /**
@@ -606,7 +606,7 @@ class ErrorExpr extends Expr, @errorexpr {
 class AssumeExpr extends Expr, @assume {
   override string toString() { result = "__assume(...)" }
 
-  override string getCanonicalQLClass() { result = "AssumeExpr" }
+  override string getAPrimaryQlClass() { result = "AssumeExpr" }
 
   /**
    * Gets the operand of the `__assume` expressions.
@@ -621,7 +621,7 @@ class AssumeExpr extends Expr, @assume {
  * ```
  */
 class CommaExpr extends Expr, @commaexpr {
-  override string getCanonicalQLClass() { result = "CommaExpr" }
+  override string getAPrimaryQlClass() { result = "CommaExpr" }
 
   /**
    * Gets the left operand, which is the one whose value is discarded.
@@ -656,7 +656,7 @@ class CommaExpr extends Expr, @commaexpr {
  * ```
  */
 class AddressOfExpr extends UnaryOperation, @address_of {
-  override string getCanonicalQLClass() { result = "AddressOfExpr" }
+  override string getAPrimaryQlClass() { result = "AddressOfExpr" }
 
   /** Gets the function or variable whose address is taken. */
   Declaration getAddressable() {
@@ -688,7 +688,7 @@ class AddressOfExpr extends UnaryOperation, @address_of {
 class ReferenceToExpr extends Conversion, @reference_to {
   override string toString() { result = "(reference to)" }
 
-  override string getCanonicalQLClass() { result = "ReferenceToExpr" }
+  override string getAPrimaryQlClass() { result = "ReferenceToExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -702,7 +702,7 @@ class ReferenceToExpr extends Conversion, @reference_to {
  * ```
  */
 class PointerDereferenceExpr extends UnaryOperation, @indirect {
-  override string getCanonicalQLClass() { result = "PointerDereferenceExpr" }
+  override string getAPrimaryQlClass() { result = "PointerDereferenceExpr" }
 
   /**
    * DEPRECATED: Use getOperand() instead.
@@ -740,7 +740,7 @@ class PointerDereferenceExpr extends UnaryOperation, @indirect {
 class ReferenceDereferenceExpr extends Conversion, @ref_indirect {
   override string toString() { result = "(reference dereference)" }
 
-  override string getCanonicalQLClass() { result = "ReferenceDereferenceExpr" }
+  override string getAPrimaryQlClass() { result = "ReferenceDereferenceExpr" }
 }
 
 /**
@@ -846,7 +846,7 @@ class NewOrNewArrayExpr extends Expr, @any_new_expr {
 class NewExpr extends NewOrNewArrayExpr, @new_expr {
   override string toString() { result = "new" }
 
-  override string getCanonicalQLClass() { result = "NewExpr" }
+  override string getAPrimaryQlClass() { result = "NewExpr" }
 
   /**
    * Gets the type that is being allocated.
@@ -876,7 +876,7 @@ class NewExpr extends NewOrNewArrayExpr, @new_expr {
 class NewArrayExpr extends NewOrNewArrayExpr, @new_array_expr {
   override string toString() { result = "new[]" }
 
-  override string getCanonicalQLClass() { result = "NewArrayExpr" }
+  override string getAPrimaryQlClass() { result = "NewArrayExpr" }
 
   /**
    * Gets the type that is being allocated.
@@ -924,7 +924,7 @@ class NewArrayExpr extends NewOrNewArrayExpr, @new_array_expr {
 class DeleteExpr extends Expr, @delete_expr {
   override string toString() { result = "delete" }
 
-  override string getCanonicalQLClass() { result = "DeleteExpr" }
+  override string getAPrimaryQlClass() { result = "DeleteExpr" }
 
   override int getPrecedence() { result = 16 }
 
@@ -998,7 +998,7 @@ class DeleteExpr extends Expr, @delete_expr {
 class DeleteArrayExpr extends Expr, @delete_array_expr {
   override string toString() { result = "delete[]" }
 
-  override string getCanonicalQLClass() { result = "DeleteArrayExpr" }
+  override string getAPrimaryQlClass() { result = "DeleteArrayExpr" }
 
   override int getPrecedence() { result = 16 }
 
@@ -1078,7 +1078,7 @@ class StmtExpr extends Expr, @expr_stmt {
    */
   Stmt getStmt() { result.getParent() = this }
 
-  override string getCanonicalQLClass() { result = "StmtExpr" }
+  override string getAPrimaryQlClass() { result = "StmtExpr" }
 
   /**
    * Gets the result expression of the enclosed statement. For example,
@@ -1103,7 +1103,7 @@ private Expr getStmtResultExpr(Stmt stmt) {
 class ThisExpr extends Expr, @thisaccess {
   override string toString() { result = "this" }
 
-  override string getCanonicalQLClass() { result = "ThisExpr" }
+  override string getAPrimaryQlClass() { result = "ThisExpr" }
 
   override predicate mayBeImpure() { none() }
 
@@ -1139,7 +1139,7 @@ class BlockExpr extends Literal {
 class NoExceptExpr extends Expr, @noexceptexpr {
   override string toString() { result = "noexcept(...)" }
 
-  override string getCanonicalQLClass() { result = "NoExceptExpr" }
+  override string getAPrimaryQlClass() { result = "NoExceptExpr" }
 
   /**
    * Gets the expression inside this noexcept expression.
@@ -1171,7 +1171,7 @@ class FoldExpr extends Expr, @foldexpr {
     )
   }
 
-  override string getCanonicalQLClass() { result = "FoldExpr" }
+  override string getAPrimaryQlClass() { result = "FoldExpr" }
 
   /** Gets the binary operator used in this fold expression, as a string. */
   string getOperatorString() { fold(underlyingElement(this), result, _) }
@@ -1247,7 +1247,7 @@ private predicate constantTemplateLiteral(Expr e) {
  * ```
  */
 class SpaceshipExpr extends BinaryOperation, @spaceshipexpr {
-  override string getCanonicalQLClass() { result = "SpaceshipExpr" }
+  override string getAPrimaryQlClass() { result = "SpaceshipExpr" }
 
   override int getPrecedence() { result = 11 }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/Lambda.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Lambda.qll
@@ -15,7 +15,7 @@ import semmle.code.cpp.Class
 class LambdaExpression extends Expr, @lambdaexpr {
   override string toString() { result = "[...](...){...}" }
 
-  override string getCanonicalQLClass() { result = "LambdaExpression" }
+  override string getAPrimaryQlClass() { result = "LambdaExpression" }
 
   /**
    * Gets an implicitly or explicitly captured value of this lambda expression.
@@ -75,7 +75,7 @@ class LambdaExpression extends Expr, @lambdaexpr {
 class Closure extends Class {
   Closure() { exists(LambdaExpression e | this = e.getType()) }
 
-  override string getCanonicalQLClass() { result = "Closure" }
+  override string getAPrimaryQlClass() { result = "Closure" }
 
   /** Gets the lambda expression of which this is the type. */
   LambdaExpression getLambdaExpression() { result.getType() = this }
@@ -101,7 +101,7 @@ class Closure extends Class {
 class LambdaCapture extends Locatable, @lambdacapture {
   override string toString() { result = getField().getName() }
 
-  override string getCanonicalQLClass() { result = "LambdaCapture" }
+  override string getAPrimaryQlClass() { result = "LambdaCapture" }
 
   /**
    * Holds if this capture was made implicitly.

--- a/cpp/ql/src/semmle/code/cpp/exprs/Literal.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Literal.qll
@@ -14,7 +14,7 @@ class Literal extends Expr, @literal {
     result = "Unknown literal"
   }
 
-  override string getCanonicalQLClass() { result = "Literal" }
+  override string getAPrimaryQlClass() { result = "Literal" }
 
   override predicate mayBeImpure() { none() }
 
@@ -35,7 +35,7 @@ class Literal extends Expr, @literal {
 class LabelLiteral extends Literal {
   LabelLiteral() { jumpinfo(underlyingElement(this), _, _) }
 
-  override string getCanonicalQLClass() { result = "LabelLiteral" }
+  override string getAPrimaryQlClass() { result = "LabelLiteral" }
 
   /** Gets the corresponding label statement. */
   LabelStmt getLabel() { jumpinfo(underlyingElement(this), _, unresolveElement(result)) }
@@ -93,7 +93,7 @@ abstract class TextLiteral extends Literal {
 class CharLiteral extends TextLiteral {
   CharLiteral() { this.getValueText().regexpMatch("(?s)\\s*L?'.*") }
 
-  override string getCanonicalQLClass() { result = "CharLiteral" }
+  override string getAPrimaryQlClass() { result = "CharLiteral" }
 
   /**
    * Gets the character of this literal. For example `L'a'` has character `"a"`.
@@ -115,7 +115,7 @@ class StringLiteral extends TextLiteral {
     // @aggregateliteral rather than @literal.
   }
 
-  override string getCanonicalQLClass() { result = "StringLiteral" }
+  override string getAPrimaryQlClass() { result = "StringLiteral" }
 }
 
 /**
@@ -128,7 +128,7 @@ class StringLiteral extends TextLiteral {
 class OctalLiteral extends Literal {
   OctalLiteral() { super.getValueText().regexpMatch("\\s*0[0-7]+[uUlL]*\\s*") }
 
-  override string getCanonicalQLClass() { result = "OctalLiteral" }
+  override string getAPrimaryQlClass() { result = "OctalLiteral" }
 }
 
 /**
@@ -140,14 +140,14 @@ class OctalLiteral extends Literal {
 class HexLiteral extends Literal {
   HexLiteral() { super.getValueText().regexpMatch("\\s*0[xX][0-9a-fA-F]+[uUlL]*\\s*") }
 
-  override string getCanonicalQLClass() { result = "HexLiteral" }
+  override string getAPrimaryQlClass() { result = "HexLiteral" }
 }
 
 /**
  * A C/C++ aggregate literal.
  */
 class AggregateLiteral extends Expr, @aggregateliteral {
-  override string getCanonicalQLClass() { result = "AggregateLiteral" }
+  override string getAPrimaryQlClass() { result = "AggregateLiteral" }
 
   /**
    * DEPRECATED: Use ClassAggregateLiteral.getFieldExpr() instead.
@@ -179,7 +179,7 @@ class ClassAggregateLiteral extends AggregateLiteral {
 
   ClassAggregateLiteral() { classType = this.getUnspecifiedType() }
 
-  override string getCanonicalQLClass() { result = "ClassAggregateLiteral" }
+  override string getAPrimaryQlClass() { result = "ClassAggregateLiteral" }
 
   /**
    * Gets the expression within the aggregate literal that is used to initialize
@@ -299,7 +299,7 @@ class ArrayAggregateLiteral extends ArrayOrVectorAggregateLiteral {
 
   ArrayAggregateLiteral() { arrayType = this.getUnspecifiedType() }
 
-  override string getCanonicalQLClass() { result = "ArrayAggregateLiteral" }
+  override string getAPrimaryQlClass() { result = "ArrayAggregateLiteral" }
 
   override int getArraySize() { result = arrayType.getArraySize() }
 
@@ -323,7 +323,7 @@ class VectorAggregateLiteral extends ArrayOrVectorAggregateLiteral {
 
   VectorAggregateLiteral() { vectorType = this.getUnspecifiedType() }
 
-  override string getCanonicalQLClass() { result = "VectorAggregateLiteral" }
+  override string getAPrimaryQlClass() { result = "VectorAggregateLiteral" }
 
   override int getArraySize() { result = vectorType.getNumElements() }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/LogicalOperation.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/LogicalOperation.qll
@@ -14,7 +14,7 @@ class UnaryLogicalOperation extends UnaryOperation, @un_log_op_expr { }
 class NotExpr extends UnaryLogicalOperation, @notexpr {
   override string getOperator() { result = "!" }
 
-  override string getCanonicalQLClass() { result = "NotExpr" }
+  override string getAPrimaryQlClass() { result = "NotExpr" }
 
   override int getPrecedence() { result = 16 }
 }
@@ -46,7 +46,7 @@ class BinaryLogicalOperation extends BinaryOperation, @bin_log_op_expr {
 class LogicalAndExpr extends BinaryLogicalOperation, @andlogicalexpr {
   override string getOperator() { result = "&&" }
 
-  override string getCanonicalQLClass() { result = "LogicalAndExpr" }
+  override string getAPrimaryQlClass() { result = "LogicalAndExpr" }
 
   override int getPrecedence() { result = 5 }
 
@@ -67,7 +67,7 @@ class LogicalAndExpr extends BinaryLogicalOperation, @andlogicalexpr {
 class LogicalOrExpr extends BinaryLogicalOperation, @orlogicalexpr {
   override string getOperator() { result = "||" }
 
-  override string getCanonicalQLClass() { result = "LogicalOrExpr" }
+  override string getAPrimaryQlClass() { result = "LogicalOrExpr" }
 
   override int getPrecedence() { result = 4 }
 
@@ -89,7 +89,7 @@ class ConditionalExpr extends Operation, @conditionalexpr {
   /** Gets the condition of this conditional expression. */
   Expr getCondition() { expr_cond_guard(underlyingElement(this), unresolveElement(result)) }
 
-  override string getCanonicalQLClass() { result = "ConditionalExpr" }
+  override string getAPrimaryQlClass() { result = "ConditionalExpr" }
 
   /** Gets the 'then' expression of this conditional expression. */
   Expr getThen() {

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FormattingFunction.qll
@@ -44,7 +44,7 @@ abstract class FormattingFunction extends ArrayFunction, TaintFunction {
   /** Gets the position at which the format parameter occurs. */
   abstract int getFormatParameterIndex();
 
-  override string getCanonicalQLClass() { result = "FormattingFunction" }
+  override string getAPrimaryQlClass() { result = "FormattingFunction" }
 
   /**
    * Holds if this `FormattingFunction` is in a context that supports

--- a/cpp/ql/src/semmle/code/cpp/stmts/Block.qll
+++ b/cpp/ql/src/semmle/code/cpp/stmts/Block.qll
@@ -18,7 +18,7 @@ import semmle.code.cpp.stmts.Stmt
  * ```
  */
 class Block extends Stmt, @stmt_block {
-  override string getCanonicalQLClass() { result = "Block" }
+  override string getAPrimaryQlClass() { result = "Block" }
 
   /**
    * Gets a child declaration of this block.

--- a/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
+++ b/cpp/ql/src/semmle/code/cpp/stmts/Stmt.qll
@@ -154,7 +154,7 @@ abstract class StmtParent extends ControlFlowNode { }
  * is an assignment expression inside an 'expression' statement.
  */
 class ExprStmt extends Stmt, @stmt_expr {
-  override string getCanonicalQLClass() { result = "ExprStmt" }
+  override string getAPrimaryQlClass() { result = "ExprStmt" }
 
   /**
    * Gets the expression of this 'expression' statement.
@@ -212,7 +212,7 @@ abstract class ConditionalStmt extends ControlStructure { }
  * ```
  */
 class IfStmt extends ConditionalStmt, @stmt_if {
-  override string getCanonicalQLClass() { result = "IfStmt" }
+  override string getAPrimaryQlClass() { result = "IfStmt" }
 
   /**
    * Gets the condition expression of this 'if' statement.
@@ -298,7 +298,7 @@ class IfStmt extends ConditionalStmt, @stmt_if {
  * ```
  */
 class ConstexprIfStmt extends ConditionalStmt, @stmt_constexpr_if {
-  override string getCanonicalQLClass() { result = "ConstexprIfStmt" }
+  override string getAPrimaryQlClass() { result = "ConstexprIfStmt" }
 
   /**
    * Gets the condition expression of this 'constexpr if' statement.
@@ -397,7 +397,7 @@ abstract class Loop extends ControlStructure {
  * ```
  */
 class WhileStmt extends Loop, @stmt_while {
-  override string getCanonicalQLClass() { result = "WhileStmt" }
+  override string getAPrimaryQlClass() { result = "WhileStmt" }
 
   override Expr getCondition() { result = this.getChild(0) }
 
@@ -462,7 +462,7 @@ class WhileStmt extends Loop, @stmt_while {
  * A C/C++ jump statement.
  */
 abstract class JumpStmt extends Stmt, @jump {
-  override string getCanonicalQLClass() { result = "JumpStmt" }
+  override string getAPrimaryQlClass() { result = "JumpStmt" }
 
   /** Gets the target of this jump statement. */
   Stmt getTarget() { jumpinfo(underlyingElement(this), _, unresolveElement(result)) }
@@ -479,7 +479,7 @@ abstract class JumpStmt extends Stmt, @jump {
  * ```
  */
 class GotoStmt extends JumpStmt, @stmt_goto {
-  override string getCanonicalQLClass() { result = "GotoStmt" }
+  override string getAPrimaryQlClass() { result = "GotoStmt" }
 
   /**
    * Gets the name of the label this 'goto' statement refers to.
@@ -574,7 +574,7 @@ class ComputedGotoStmt extends Stmt, @stmt_assigned_goto {
  * ```
  */
 class ContinueStmt extends JumpStmt, @stmt_continue {
-  override string getCanonicalQLClass() { result = "ContinueStmt" }
+  override string getAPrimaryQlClass() { result = "ContinueStmt" }
 
   override string toString() { result = "continue;" }
 
@@ -606,7 +606,7 @@ private Stmt getEnclosingContinuable(Stmt s) {
  * ```
  */
 class BreakStmt extends JumpStmt, @stmt_break {
-  override string getCanonicalQLClass() { result = "BreakStmt" }
+  override string getAPrimaryQlClass() { result = "BreakStmt" }
 
   override string toString() { result = "break;" }
 
@@ -639,7 +639,7 @@ private Stmt getEnclosingBreakable(Stmt s) {
  * ```
  */
 class LabelStmt extends Stmt, @stmt_label {
-  override string getCanonicalQLClass() { result = "LabelStmt" }
+  override string getAPrimaryQlClass() { result = "LabelStmt" }
 
   /** Gets the name of this 'label' statement. */
   string getName() { jumpinfo(underlyingElement(this), result, _) and result != "" }
@@ -667,7 +667,7 @@ class LabelStmt extends Stmt, @stmt_label {
  * ```
  */
 class ReturnStmt extends Stmt, @stmt_return {
-  override string getCanonicalQLClass() { result = "ReturnStmt" }
+  override string getAPrimaryQlClass() { result = "ReturnStmt" }
 
   /**
    * Gets the expression of this 'return' statement.
@@ -715,7 +715,7 @@ class ReturnStmt extends Stmt, @stmt_return {
  * ```
  */
 class DoStmt extends Loop, @stmt_end_test_while {
-  override string getCanonicalQLClass() { result = "DoStmt" }
+  override string getAPrimaryQlClass() { result = "DoStmt" }
 
   override Expr getCondition() { result = this.getChild(0) }
 
@@ -764,7 +764,7 @@ class DoStmt extends Loop, @stmt_end_test_while {
  * where `begin_expr` and `end_expr` depend on the type of `xs`.
  */
 class RangeBasedForStmt extends Loop, @stmt_range_based_for {
-  override string getCanonicalQLClass() { result = "RangeBasedForStmt" }
+  override string getAPrimaryQlClass() { result = "RangeBasedForStmt" }
 
   /**
    * Gets the 'body' statement of this range-based 'for' statement.
@@ -851,7 +851,7 @@ class RangeBasedForStmt extends Loop, @stmt_range_based_for {
  * ```
  */
 class ForStmt extends Loop, @stmt_for {
-  override string getCanonicalQLClass() { result = "ForStmt" }
+  override string getAPrimaryQlClass() { result = "ForStmt" }
 
   /**
    * Gets the initialization statement of this 'for' statement.
@@ -1082,7 +1082,7 @@ private predicate inForUpdate(Expr forUpdate, Expr child) {
  * ```
  */
 class SwitchCase extends Stmt, @stmt_switch_case {
-  override string getCanonicalQLClass() { result = "SwitchCase" }
+  override string getAPrimaryQlClass() { result = "SwitchCase" }
 
   /**
    * Gets the expression of this 'switch case' statement (or the start of
@@ -1435,7 +1435,7 @@ class DefaultCase extends SwitchCase {
  * ```
  */
 class SwitchStmt extends ConditionalStmt, @stmt_switch {
-  override string getCanonicalQLClass() { result = "SwitchStmt" }
+  override string getAPrimaryQlClass() { result = "SwitchStmt" }
 
   /**
    * Gets the expression that this 'switch' statement switches on.
@@ -1646,7 +1646,7 @@ class EnumSwitch extends SwitchStmt {
 class Handler extends Stmt, @stmt_handler {
   override string toString() { result = "<handler>" }
 
-  override string getCanonicalQLClass() { result = "Handler" }
+  override string getAPrimaryQlClass() { result = "Handler" }
 
   /**
    * Gets the block containing the implementation of this handler.
@@ -1699,7 +1699,7 @@ deprecated class FinallyEnd extends Stmt {
  * ```
  */
 class TryStmt extends Stmt, @stmt_try_block {
-  override string getCanonicalQLClass() { result = "TryStmt" }
+  override string getAPrimaryQlClass() { result = "TryStmt" }
 
   override string toString() { result = "try { ... }" }
 
@@ -1774,7 +1774,7 @@ class TryStmt extends Stmt, @stmt_try_block {
 class FunctionTryStmt extends TryStmt {
   FunctionTryStmt() { not exists(this.getEnclosingBlock()) }
 
-  override string getCanonicalQLClass() { result = "FunctionTryStmt" }
+  override string getAPrimaryQlClass() { result = "FunctionTryStmt" }
 }
 
 /**
@@ -1791,7 +1791,7 @@ class FunctionTryStmt extends TryStmt {
  * ```
  */
 class CatchBlock extends Block {
-  override string getCanonicalQLClass() { result = "CatchBlock" }
+  override string getAPrimaryQlClass() { result = "CatchBlock" }
 
   CatchBlock() { ishandler(underlyingElement(this)) }
 
@@ -1822,7 +1822,7 @@ class CatchBlock extends Block {
 class CatchAnyBlock extends CatchBlock {
   CatchAnyBlock() { not exists(this.getParameter()) }
 
-  override string getCanonicalQLClass() { result = "CatchAnyBlock" }
+  override string getAPrimaryQlClass() { result = "CatchAnyBlock" }
 }
 
 /**
@@ -1859,7 +1859,7 @@ class MicrosoftTryExceptStmt extends MicrosoftTryStmt {
   /** Gets the `__except` statement (usually a `Block`). */
   Stmt getExcept() { result = getChild(2) }
 
-  override string getCanonicalQLClass() { result = "MicrosoftTryExceptStmt" }
+  override string getAPrimaryQlClass() { result = "MicrosoftTryExceptStmt" }
 }
 
 /**
@@ -1883,7 +1883,7 @@ class MicrosoftTryFinallyStmt extends MicrosoftTryStmt {
   /** Gets the `__finally` statement (usually a `Block`). */
   Stmt getFinally() { result = getChild(1) }
 
-  override string getCanonicalQLClass() { result = "MicrosoftTryFinallyStmt" }
+  override string getAPrimaryQlClass() { result = "MicrosoftTryFinallyStmt" }
 }
 
 /**
@@ -1895,7 +1895,7 @@ class MicrosoftTryFinallyStmt extends MicrosoftTryStmt {
  * ```
  */
 class DeclStmt extends Stmt, @stmt_decl {
-  override string getCanonicalQLClass() { result = "DeclStmt" }
+  override string getAPrimaryQlClass() { result = "DeclStmt" }
 
   /**
    * Gets the `i`th declaration entry declared by this 'declaration' statement.
@@ -1976,7 +1976,7 @@ class DeclStmt extends Stmt, @stmt_decl {
  * ```
  */
 class EmptyStmt extends Stmt, @stmt_empty {
-  override string getCanonicalQLClass() { result = "EmptyStmt" }
+  override string getAPrimaryQlClass() { result = "EmptyStmt" }
 
   override string toString() { result = ";" }
 
@@ -1996,7 +1996,7 @@ class EmptyStmt extends Stmt, @stmt_empty {
 class AsmStmt extends Stmt, @stmt_asm {
   override string toString() { result = "asm statement" }
 
-  override string getCanonicalQLClass() { result = "AsmStmt" }
+  override string getAPrimaryQlClass() { result = "AsmStmt" }
 }
 
 /**
@@ -2013,7 +2013,7 @@ class AsmStmt extends Stmt, @stmt_asm {
 class VlaDimensionStmt extends Stmt, @stmt_set_vla_size {
   override string toString() { result = "VLA dimension size" }
 
-  override string getCanonicalQLClass() { result = "VlaDimensionStmt" }
+  override string getAPrimaryQlClass() { result = "VlaDimensionStmt" }
 
   /** Gets the expression which gives the size. */
   Expr getDimensionExpr() { result = this.getChild(0) }
@@ -2032,7 +2032,7 @@ class VlaDimensionStmt extends Stmt, @stmt_set_vla_size {
 class VlaDeclStmt extends Stmt, @stmt_vla_decl {
   override string toString() { result = "VLA declaration" }
 
-  override string getCanonicalQLClass() { result = "VlaDeclStmt" }
+  override string getAPrimaryQlClass() { result = "VlaDeclStmt" }
 
   /**
    * Gets the number of VLA dimension statements in this VLA

--- a/cpp/ql/test/library-tests/complex_numbers/expr.ql
+++ b/cpp/ql/test/library-tests/complex_numbers/expr.ql
@@ -1,4 +1,4 @@
 import cpp
 
 from Expr e
-select e, e.getCanonicalQLClass()
+select e, e.getAPrimaryQlClass()

--- a/cpp/ql/test/library-tests/using-aliases/using-alias.ql
+++ b/cpp/ql/test/library-tests/using-aliases/using-alias.ql
@@ -1,4 +1,4 @@
 import cpp
 
 from TypedefType t
-select t, t.getCanonicalQLClass(), t.getUnderlyingType()
+select t, t.getAPrimaryQlClass(), t.getUnderlyingType()


### PR DESCRIPTION
As discussed in https://github.com/github/codeql-c-analysis-team/issues/101. The old name is now deprecated.