### PR TITLE
Fix outdated query console link

### DIFF
--- a/docs/language/learn-ql/java/types-class-hierarchy.rst
+++ b/docs/language/learn-ql/java/types-class-hierarchy.rst
@@ -141,7 +141,7 @@ Using these new classes we can extend our query to exclude calls to ``toArray`` 
        not ce.getExpr().(CollectionToArrayCall).getActualReturnType() = target
    select ce, "Potentially problematic array downcast."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/668700471/>`__. Notice that fewer results are found by this improved query.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/3150404889854131463/>`__. Notice that fewer results are found by this improved query.
 
 Example: Finding mismatched contains checks
 -------------------------------------------


### PR DESCRIPTION
#3546 changed the query but did not adjust the query link.

Additionally the old query cannot be re-run because some of the projects it targeted (`gradle/gradle` and `eclipse-cdt/cdt`) cannot be queried currently.
The new query now queries all available demo projects of the query console instead.
Note that this affects some of the other query links as well, should the be updated too for consistency? Otherwise one part of the tutorial shows result for projects which the next part does not show.