### PR TITLE
Add missing java.nio.file.Files methods to FileReadWrite.qll

### DIFF
--- a/java/ql/src/semmle/code/java/security/FileReadWrite.qll
+++ b/java/ql/src/semmle/code/java/security/FileReadWrite.qll
@@ -24,7 +24,7 @@ private predicate fileRead(VarAccess fileAccess, Expr fileReadingExpr) {
       fileAccess = ma.getArgument(0) and
       filesMethod
           .hasName(["readAllBytes", "readAllLines", "readString", "lines", "newBufferedReader",
-                "newInputReader", "newByteChannel"])
+                "newInputStream", "newByteChannel"])
     )
   )
   or

--- a/java/ql/src/semmle/code/java/security/FileReadWrite.qll
+++ b/java/ql/src/semmle/code/java/security/FileReadWrite.qll
@@ -9,9 +9,9 @@ private predicate fileRead(VarAccess fileAccess, Expr fileReadingExpr) {
     cie = fileReadingExpr and
     cie.getArgument(0) = fileAccess
   |
-    cie.getConstructedType().hasQualifiedName("java.io", "RandomAccessFile") or
-    cie.getConstructedType().hasQualifiedName("java.io", "FileReader") or
-    cie.getConstructedType().hasQualifiedName("java.io", "FileInputStream")
+    cie
+        .getConstructedType()
+        .hasQualifiedName("java.io", ["RandomAccessFile", "FileReader", "FileInputStream"])
   )
   or
   exists(MethodAccess ma, Method filesMethod |
@@ -22,13 +22,9 @@ private predicate fileRead(VarAccess fileAccess, Expr fileReadingExpr) {
       // represented by the first argument.
       filesMethod.getDeclaringType().hasQualifiedName("java.nio.file", "Files") and
       fileAccess = ma.getArgument(0) and
-      (
-        filesMethod.hasName("readAllBytes") or
-        filesMethod.hasName("readAllLines") or
-        filesMethod.hasName("newBufferedReader") or
-        filesMethod.hasName("newInputReader") or
-        filesMethod.hasName("newByteChannel")
-      )
+      filesMethod
+          .hasName(["readAllBytes", "readAllLines", "readString", "lines", "newBufferedReader",
+                "newInputReader", "newByteChannel"])
     )
   )
   or


### PR DESCRIPTION
Adds:
- [`Files.lines`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#lines(java.nio.file.Path,java.nio.charset.Charset))
- [`Files.readString`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readString(java.nio.file.Path,java.nio.charset.Charset))