### PR TITLE
Link to QL style guide in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ If you have an idea for a query that you would like to share with other CodeQL u
 
 3. **Formatting**
 
-    - The queries and libraries must be autoformatted, for example using the "Format Document" command in [CodeQL for Visual Studio Code](https://help.semmle.com/codeql/codeql-for-vscode/procedures/about-codeql-for-vscode.html).
+    - The queries and libraries must formatted according to our [style guide](docs/ql-style-guide.md).
 
 4. **Compilation**
 


### PR DESCRIPTION
Link to the style guide instead of the VSCode extension in case someone is not using the extension.
Additionally the style guide has a link to the VSCode extension so there is probably no need to add an extra link to it here.