### PR TITLE
JS: model fancy-log (and recognize the 'dir' log level)

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -6,6 +6,7 @@
   - [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
   - [bluebird](http://bluebirdjs.com/)
   - [express](https://www.npmjs.com/package/express)
+  - [fancy-log](https://www.npmjs.com/package/fancy-log)
   - [fastify](https://www.npmjs.com/package/fastify)
   - [fstream](https://www.npmjs.com/package/fstream)
   - [jGrowl](https://github.com/stanlemon/jGrowl)

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -162,7 +162,7 @@ private module Npmlog {
 }
 
 /**
- * Provides classes for working with [fancy-log](https://github.com/gulpjs/fancy-log)
+ * Provides classes for working with [fancy-log](https://github.com/gulpjs/fancy-log).
  */
 private module Fancylog {
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Logging.qll
@@ -19,6 +19,7 @@ abstract class LoggerCall extends DataFlow::CallNode {
  */
 string getAStandardLoggerMethodName() {
   result = "crit" or
+  result = "dir" or
   result = "debug" or
   result = "error" or
   result = "emerg" or
@@ -157,5 +158,22 @@ private module Npmlog {
       or
       result = getASpreadArgument()
     }
+  }
+}
+
+/**
+ * Provides classes for working with [fancy-log](https://github.com/gulpjs/fancy-log)
+ */
+private module Fancylog {
+  /**
+   * A call to the fancy-log logging mechanism.
+   */
+  class Fancylog extends LoggerCall {
+    Fancylog() {
+      this = DataFlow::moduleMember("fancy-log", getAStandardLoggerMethodName()).getACall() or
+      this = DataFlow::moduleImport("fancy-log").getACall()
+    }
+
+    override DataFlow::Node getAMessageComponent() { result = getAnArgument() }
   }
 }

--- a/javascript/ql/test/library-tests/frameworks/Logging/LoggerCall.expected
+++ b/javascript/ql/test/library-tests/frameworks/Logging/LoggerCall.expected
@@ -23,3 +23,13 @@
 | tst.js:22:1:22:37 | require ... ", arg) | tst.js:22:34:22:36 | arg |
 | tst.js:23:1:23:40 | require ... ", arg) | tst.js:23:27:23:34 | "msg %s" |
 | tst.js:23:1:23:40 | require ... ", arg) | tst.js:23:37:23:39 | arg |
+| tst.js:25:1:25:35 | require ... ", arg) | tst.js:25:22:25:29 | "msg %s" |
+| tst.js:25:1:25:35 | require ... ", arg) | tst.js:25:32:25:34 | arg |
+| tst.js:26:1:26:39 | require ... ", arg) | tst.js:26:26:26:33 | "msg %s" |
+| tst.js:26:1:26:39 | require ... ", arg) | tst.js:26:36:26:38 | arg |
+| tst.js:27:1:27:40 | require ... ", arg) | tst.js:27:27:27:34 | "msg %s" |
+| tst.js:27:1:27:40 | require ... ", arg) | tst.js:27:37:27:39 | arg |
+| tst.js:28:1:28:40 | require ... ", arg) | tst.js:28:27:28:34 | "msg %s" |
+| tst.js:28:1:28:40 | require ... ", arg) | tst.js:28:37:28:39 | arg |
+| tst.js:29:1:29:41 | require ... ", arg) | tst.js:29:28:29:35 | "msg %s" |
+| tst.js:29:1:29:41 | require ... ", arg) | tst.js:29:38:29:40 | arg |

--- a/javascript/ql/test/library-tests/frameworks/Logging/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/Logging/tst.js
@@ -21,3 +21,9 @@ log("msg %s", arg);
 require("npmlog").log("info", "msg %s", arg);
 require("npmlog").info("msg %s", arg);
 require("npmlog").verbose("msg %s", arg);
+
+require("fancy-log")("msg %s", arg);
+require("fancy-log").dir("msg %s", arg);
+require("fancy-log").warn("msg %s", arg);
+require("fancy-log").info("msg %s", arg);
+require("fancy-log").error("msg %s", arg);


### PR DESCRIPTION
Inspired by [#3800](https://github.com/github/codeql/pull/3800) and to expand the support of logging calls (it could be useful for example for this [#3734](https://github.com/github/codeql/pull/3734)), I found [`fancy-log`](https://www.npmjs.com/package/fancy-log), that has 1.8M downloads/week and 1400 dependents. It seems worth modelling.
Any feedback is welcome.