### PR TITLE
C++: Remove abstractness from DeclarationEntry, AccessHolder and Call

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/src/semmle/code/cpp/Declaration.qll
@@ -289,7 +289,7 @@ class Declaration extends Locatable, @declaration {
   }
 }
 
-class DeclarationEntryDB = @var_decl or @type_decl or @fun_decl;
+private class TDeclarationEntry = @var_decl or @type_decl or @fun_decl;
 
 /**
  * A C/C++ declaration entry. For example the following code contains five
@@ -306,7 +306,7 @@ class DeclarationEntryDB = @var_decl or @type_decl or @fun_decl;
  * See the comment above `Declaration` for an explanation of the relationship
  * between `Declaration` and `DeclarationEntry`.
  */
-class DeclarationEntry extends Locatable, DeclarationEntryDB {
+class DeclarationEntry extends Locatable, TDeclarationEntry {
   /** Gets a specifier associated with this declaration entry. */
   string getASpecifier() { none() }
 
@@ -373,7 +373,7 @@ class DeclarationEntry extends Locatable, DeclarationEntryDB {
   }
 }
 
-class AccessHolderDB = @function or @usertype;
+private class TAccessHolder = @function or @usertype;
 
 /**
  * A declaration that can potentially have more C++ access rights than its
@@ -396,7 +396,7 @@ class AccessHolderDB = @function or @usertype;
  * the informal phrase "_R_ occurs in a member or friend of class C", where
  * `AccessHolder` corresponds to this _R_.
  */
-class AccessHolder extends Declaration, AccessHolderDB {
+class AccessHolder extends Declaration, TAccessHolder {
   /**
    * Holds if `this` can access private members of class `c`.
    *

--- a/cpp/ql/src/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/src/semmle/code/cpp/Declaration.qll
@@ -124,7 +124,7 @@ class Declaration extends Locatable, @declaration {
    * To test whether this declaration has a particular name in the global
    * namespace, use `hasGlobalName`.
    */
-  string getName() { none() }
+  string getName() { none() } // overridden in subclasses
 
   /** Holds if this declaration has the given name. */
   predicate hasName(string name) { name = this.getName() }
@@ -140,7 +140,7 @@ class Declaration extends Locatable, @declaration {
   }
 
   /** Gets a specifier of this declaration. */
-  Specifier getASpecifier() { none() }
+  Specifier getASpecifier() { none() } // overridden in subclasses
 
   /** Holds if this declaration has a specifier with the given name. */
   predicate hasSpecifier(string name) { this.getASpecifier().hasName(name) }
@@ -156,7 +156,7 @@ class Declaration extends Locatable, @declaration {
    * Gets the location of a declaration entry corresponding to this
    * declaration.
    */
-  Location getADeclarationLocation() { none() }
+  Location getADeclarationLocation() { none() } // overridden in subclasses
 
   /**
    * Gets the declaration entry corresponding to this declaration that is a
@@ -165,7 +165,7 @@ class Declaration extends Locatable, @declaration {
   DeclarationEntry getDefinition() { none() }
 
   /** Gets the location of the definition, if any. */
-  Location getDefinitionLocation() { none() }
+  Location getDefinitionLocation() { none() } // overridden in subclasses
 
   /** Holds if the declaration has a definition. */
   predicate hasDefinition() { exists(this.getDefinition()) }
@@ -308,7 +308,7 @@ private class TDeclarationEntry = @var_decl or @type_decl or @fun_decl;
  */
 class DeclarationEntry extends Locatable, TDeclarationEntry {
   /** Gets a specifier associated with this declaration entry. */
-  string getASpecifier() { none() }
+  string getASpecifier() { none() } // overridden in subclasses
 
   /**
    * Gets the name associated with the corresponding definition (where
@@ -331,10 +331,10 @@ class DeclarationEntry extends Locatable, TDeclarationEntry {
    *  `I.getADeclarationEntry()` returns `D`
    *  but `D.getDeclaration()` only returns `C`
    */
-  Declaration getDeclaration() { none() }
+  Declaration getDeclaration() { none() } // overridden in subclasses
 
   /** Gets the name associated with this declaration entry, if any. */
-  string getName() { none() }
+  string getName() { none() } // overridden in subclasses
 
   /**
    * Gets the type associated with this declaration entry.
@@ -343,7 +343,7 @@ class DeclarationEntry extends Locatable, TDeclarationEntry {
    * For function declarations, get the return type of the function.
    * For type declarations, get the type being declared.
    */
-  Type getType() { none() }
+  Type getType() { none() } // overridden in subclasses
 
   /**
    * Gets the type associated with this declaration entry after specifiers
@@ -361,7 +361,7 @@ class DeclarationEntry extends Locatable, TDeclarationEntry {
   predicate hasSpecifier(string specifier) { getASpecifier() = specifier }
 
   /** Holds if this declaration entry is a definition. */
-  predicate isDefinition() { none() }
+  predicate isDefinition() { none() } // overridden in subclasses
 
   override string toString() {
     if isDefinition()
@@ -414,7 +414,7 @@ class AccessHolder extends Declaration, TAccessHolder {
   /**
    * Gets the nearest enclosing `AccessHolder`.
    */
-  AccessHolder getEnclosingAccessHolder() { none() }
+  AccessHolder getEnclosingAccessHolder() { none() } // overridden in subclasses
 
   /**
    * Holds if a base class `base` of `derived` _is accessible at_ `this` (N4140

--- a/cpp/ql/src/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/src/semmle/code/cpp/Declaration.qll
@@ -124,7 +124,7 @@ class Declaration extends Locatable, @declaration {
    * To test whether this declaration has a particular name in the global
    * namespace, use `hasGlobalName`.
    */
-  abstract string getName();
+  string getName() { none() }
 
   /** Holds if this declaration has the given name. */
   predicate hasName(string name) { name = this.getName() }
@@ -140,7 +140,7 @@ class Declaration extends Locatable, @declaration {
   }
 
   /** Gets a specifier of this declaration. */
-  abstract Specifier getASpecifier();
+  Specifier getASpecifier() { none() }
 
   /** Holds if this declaration has a specifier with the given name. */
   predicate hasSpecifier(string name) { this.getASpecifier().hasName(name) }
@@ -156,7 +156,7 @@ class Declaration extends Locatable, @declaration {
    * Gets the location of a declaration entry corresponding to this
    * declaration.
    */
-  abstract Location getADeclarationLocation();
+  Location getADeclarationLocation() { none() }
 
   /**
    * Gets the declaration entry corresponding to this declaration that is a
@@ -165,7 +165,7 @@ class Declaration extends Locatable, @declaration {
   DeclarationEntry getDefinition() { none() }
 
   /** Gets the location of the definition, if any. */
-  abstract Location getDefinitionLocation();
+  Location getDefinitionLocation() { none() }
 
   /** Holds if the declaration has a definition. */
   predicate hasDefinition() { exists(this.getDefinition()) }
@@ -289,6 +289,8 @@ class Declaration extends Locatable, @declaration {
   }
 }
 
+class DeclarationEntryDB = @var_decl or @type_decl or @fun_decl;
+
 /**
  * A C/C++ declaration entry. For example the following code contains five
  * declaration entries:
@@ -304,9 +306,9 @@ class Declaration extends Locatable, @declaration {
  * See the comment above `Declaration` for an explanation of the relationship
  * between `Declaration` and `DeclarationEntry`.
  */
-abstract class DeclarationEntry extends Locatable {
+class DeclarationEntry extends Locatable, DeclarationEntryDB {
   /** Gets a specifier associated with this declaration entry. */
-  abstract string getASpecifier();
+  string getASpecifier() { none() }
 
   /**
    * Gets the name associated with the corresponding definition (where
@@ -329,10 +331,10 @@ abstract class DeclarationEntry extends Locatable {
    *  `I.getADeclarationEntry()` returns `D`
    *  but `D.getDeclaration()` only returns `C`
    */
-  abstract Declaration getDeclaration();
+  Declaration getDeclaration() { none() }
 
   /** Gets the name associated with this declaration entry, if any. */
-  abstract string getName();
+  string getName() { none() }
 
   /**
    * Gets the type associated with this declaration entry.
@@ -341,7 +343,7 @@ abstract class DeclarationEntry extends Locatable {
    * For function declarations, get the return type of the function.
    * For type declarations, get the type being declared.
    */
-  abstract Type getType();
+  Type getType() { none() }
 
   /**
    * Gets the type associated with this declaration entry after specifiers
@@ -359,7 +361,7 @@ abstract class DeclarationEntry extends Locatable {
   predicate hasSpecifier(string specifier) { getASpecifier() = specifier }
 
   /** Holds if this declaration entry is a definition. */
-  abstract predicate isDefinition();
+  predicate isDefinition() { none() }
 
   override string toString() {
     if isDefinition()
@@ -370,6 +372,8 @@ abstract class DeclarationEntry extends Locatable {
       else result = "declaration of " + getCanonicalName() + " as " + getName()
   }
 }
+
+class AccessHolderDB = @function or @usertype;
 
 /**
  * A declaration that can potentially have more C++ access rights than its
@@ -392,7 +396,7 @@ abstract class DeclarationEntry extends Locatable {
  * the informal phrase "_R_ occurs in a member or friend of class C", where
  * `AccessHolder` corresponds to this _R_.
  */
-abstract class AccessHolder extends Declaration {
+class AccessHolder extends Declaration, AccessHolderDB {
   /**
    * Holds if `this` can access private members of class `c`.
    *
@@ -410,7 +414,7 @@ abstract class AccessHolder extends Declaration {
   /**
    * Gets the nearest enclosing `AccessHolder`.
    */
-  abstract AccessHolder getEnclosingAccessHolder();
+  AccessHolder getEnclosingAccessHolder() { none() }
 
   /**
    * Holds if a base class `base` of `derived` _is accessible at_ `this` (N4140

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -325,7 +325,7 @@ class ParameterDeclarationEntry extends VariableDeclarationEntry {
  */
 class LocalScopeVariable extends Variable, @localscopevariable {
   /** Gets the function to which this variable belongs. */
-  /*abstract*/ Function getFunction() { none() }
+  Function getFunction() { none() }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -325,7 +325,7 @@ class ParameterDeclarationEntry extends VariableDeclarationEntry {
  */
 class LocalScopeVariable extends Variable, @localscopevariable {
   /** Gets the function to which this variable belongs. */
-  Function getFunction() { none() }
+  Function getFunction() { none() } // overridden in subclasses
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -2,12 +2,22 @@ import semmle.code.cpp.exprs.Expr
 import semmle.code.cpp.Function
 private import semmle.code.cpp.dataflow.EscapesTree
 
+class CallDB = @funbindexpr or @callexpr;
+
 /**
  * A C/C++ call.
- *
- * This is the abstract root QL class for all types of calls.
  */
-abstract class Call extends Expr, NameQualifiableElement {
+class Call extends Expr, NameQualifiableElement, CallDB {
+  // `@funbindexpr` (which is the dbscheme type for FunctionCall) is a union type that includes
+  // `@routineexpr. This dbscheme type includes accesses to functions that are not necessarily calls to
+  // that function. That's why the charpred for `FunctionCall` requires:
+  // ```
+  // iscall(underlyingElement(this), _)
+  // ```
+  // So for the charpred for `Call` we include the requirement that if this is an instance of
+  // `@funbindexpr` it must be a _call_ to the function.
+  Call() { this instanceof @funbindexpr implies iscall(underlyingElement(this), _) }
+
   /**
    * Gets the number of arguments (actual parameters) of this call. The count
    * does _not_ include the qualifier of the call, if any.
@@ -74,7 +84,7 @@ abstract class Call extends Expr, NameQualifiableElement {
    *   method, and it might not exist.
    * - For a variable call, it never exists.
    */
-  abstract Function getTarget();
+  Function getTarget() { none() }
 
   override int getPrecedence() { result = 17 }
 

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -16,7 +16,7 @@ class Call extends Expr, NameQualifiableElement, TCall {
   // ```
   // So for the charpred for `Call` we include the requirement that if this is an instance of
   // `@funbindexpr` it must be a _call_ to the function.
-  Call() { this instanceof @funbindexpr implies iscall(underlyingElement(this), _) }
+  Call() { this instanceof @callexpr or iscall(underlyingElement(this), _) }
 
   /**
    * Gets the number of arguments (actual parameters) of this call. The count

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -2,12 +2,12 @@ import semmle.code.cpp.exprs.Expr
 import semmle.code.cpp.Function
 private import semmle.code.cpp.dataflow.EscapesTree
 
-class CallDB = @funbindexpr or @callexpr;
+private class TCall = @funbindexpr or @callexpr;
 
 /**
  * A C/C++ call.
  */
-class Call extends Expr, NameQualifiableElement, CallDB {
+class Call extends Expr, NameQualifiableElement, TCall {
   // `@funbindexpr` (which is the dbscheme type for FunctionCall) is a union type that includes
   // `@routineexpr. This dbscheme type includes accesses to functions that are not necessarily calls to
   // that function. That's why the charpred for `FunctionCall` requires:

--- a/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Call.qll
@@ -84,7 +84,7 @@ class Call extends Expr, NameQualifiableElement, TCall {
    *   method, and it might not exist.
    * - For a variable call, it never exists.
    */
-  Function getTarget() { none() }
+  Function getTarget() { none() } // overridden in subclasses
 
   override int getPrecedence() { result = 17 }
 


### PR DESCRIPTION
Now that the class union syntax has been merged we can do these changes entirely within the ql repo (🎉!)

It does bring the possibility of some lovely bikeshedding, though:

Previously, when we made changes to the dbscheme we named our base classes following a convention that favored names like `@call` and `@decl_entry`. But now that we define these classes in qll files we need to come up with a name that satisfies the requirements for a [class type identifier](https://help.semmle.com/QL/ql-handbook/types.html#defining-a-class).

For the base class of something like `DeclarationEntry` it seems reasonable to mimic the old dbscheme convention (which would have named it `@decl_entry`) and call it `DeclEntry`. But for the base class of `Call` this is more problematic.

I've chosen the name `DeclarationEntryDB` (and similar for the other new base classes in this PR). I'm totally open to a different convention, though.