### PR TITLE
JS: Support @Component classes in Vue

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -22,6 +22,7 @@
   - [sqlite](https://www.npmjs.com/package/sqlite)
   - [ssh2-streams](https://www.npmjs.com/package/ssh2-streams)
   - [ssh2](https://www.npmjs.com/package/ssh2)
+  - [vue](https://www.npmjs.com/package/vue)
   - [yargs](https://www.npmjs.com/package/yargs)
   - [webpack-dev-server](https://www.npmjs.com/package/webpack-dev-server)
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -726,6 +726,18 @@ DataFlow::SourceNode moduleMember(string path, string m) {
  */
 class MemberKind extends string {
   MemberKind() { this = "method" or this = "getter" or this = "setter" }
+
+  /** Holds if this is the `method` kind. */
+  predicate isMethod() { this = MemberKind::method() }
+
+  /** Holds if this is the `getter` kind. */
+  predicate isGetter() { this = MemberKind::getter() }
+
+  /** Holds if this is the `setter` kind. */
+  predicate isSetter() { this = MemberKind::setter() }
+
+  /** Holds if this is the `getter` or `setter` kind. */
+  predicate isAccessor() { this = MemberKind::accessor() }
 }
 
 module MemberKind {

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance.expected
@@ -1,6 +1,8 @@
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue |
 | single-file-component-2.vue:0:0:0:0 | single-file-component-2.vue |
 | single-file-component-3.vue:0:0:0:0 | single-file-component-3.vue |
+| single-file-component-4.vue:0:0:0:0 | single-file-component-4.vue |
+| single-file-component-5.vue:0:0:0:0 | single-file-component-5.vue |
 | tst.js:3:1:10:2 | new Vue ... 2\\n\\t}\\n}) |
 | tst.js:12:1:16:2 | new Vue ... \\t}),\\n}) |
 | tst.js:18:1:27:2 | Vue.com ... }\\n\\t}\\n}) |

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance_getAPropertyValue.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance_getAPropertyValue.expected
@@ -1,5 +1,9 @@
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue | dataA | single-component-file-1.vue:6:40:6:41 | 42 |
 | single-file-component-3.vue:0:0:0:0 | single-file-component-3.vue | dataA | single-file-component-3-script.js:4:37:4:38 | 42 |
+| single-file-component-4.vue:0:0:0:0 | single-file-component-4.vue | dataA | single-file-component-4.vue:15:14:15:15 | 42 |
+| single-file-component-4.vue:0:0:0:0 | single-file-component-4.vue | message | single-file-component-4.vue:12:23:12:30 | 'Hello!' |
+| single-file-component-5.vue:0:0:0:0 | single-file-component-5.vue | dataA | single-file-component-5.vue:13:14:13:15 | 42 |
+| single-file-component-5.vue:0:0:0:0 | single-file-component-5.vue | message | single-file-component-5.vue:10:23:10:30 | 'Hello!' |
 | tst.js:3:1:10:2 | new Vue ... 2\\n\\t}\\n}) | dataA | tst.js:8:10:8:11 | 42 |
 | tst.js:12:1:16:2 | new Vue ... \\t}),\\n}) | dataA | tst.js:14:10:14:11 | 42 |
 | tst.js:18:1:27:2 | Vue.com ... }\\n\\t}\\n}) | dataA | tst.js:20:10:20:11 | 42 |

--- a/javascript/ql/test/library-tests/frameworks/Vue/Instance_getOption.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/Instance_getOption.expected
@@ -1,5 +1,6 @@
 | single-component-file-1.vue:0:0:0:0 | single-component-file-1.vue | data | single-component-file-1.vue:6:11:6:45 | functio ...  42 } } |
 | single-file-component-3.vue:0:0:0:0 | single-file-component-3.vue | data | single-file-component-3-script.js:4:8:4:42 | functio ...  42 } } |
+| single-file-component-4.vue:0:0:0:0 | single-file-component-4.vue | render | single-file-component-4.vue:9:13:9:22 | (h) => { } |
 | tst.js:3:1:10:2 | new Vue ... 2\\n\\t}\\n}) | data | tst.js:7:8:9:2 | {\\n\\t\\tdataA: 42\\n\\t} |
 | tst.js:3:1:10:2 | new Vue ... 2\\n\\t}\\n}) | render | tst.js:4:10:6:2 | functio ...  c);\\n\\t} |
 | tst.js:12:1:16:2 | new Vue ... \\t}),\\n}) | data | tst.js:13:8:15:3 | () => ( ...  42\\n\\t}) |

--- a/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/TemplateElement.expected
@@ -10,3 +10,11 @@
 | single-file-component-3.vue:2:5:7:8 | <p>...</> |
 | single-file-component-3.vue:4:1:5:9 | <script>...</> |
 | single-file-component-3.vue:6:1:7:8 | <style>...</> |
+| single-file-component-4.vue:1:1:3:11 | <template>...</> |
+| single-file-component-4.vue:2:5:20:9 | <p>...</> |
+| single-file-component-4.vue:4:1:18:9 | <script>...</> |
+| single-file-component-4.vue:19:1:20:8 | <style>...</> |
+| single-file-component-5.vue:1:1:3:11 | <template>...</> |
+| single-file-component-5.vue:2:5:18:9 | <p>...</> |
+| single-file-component-5.vue:4:1:16:9 | <script>...</> |
+| single-file-component-5.vue:17:1:18:8 | <style>...</> |

--- a/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/VHtmlSourceWrite.expected
@@ -1,2 +1,4 @@
 | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:6:40:6:41 | 42 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
 | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3-script.js:4:37:4:38 | 42 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:15:14:15:15 | 42 | single-file-component-4.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:13:14:13:15 | 42 | single-file-component-5.vue:2:8:2:21 | v-html=dataA |

--- a/javascript/ql/test/library-tests/frameworks/Vue/XssSink.expected
+++ b/javascript/ql/test/library-tests/frameworks/Vue/XssSink.expected
@@ -1,5 +1,7 @@
 | single-component-file-1.vue:2:8:2:21 | v-html=dataA |
 | single-file-component-2.vue:2:8:2:21 | v-html=dataA |
 | single-file-component-3.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-4.vue:2:8:2:21 | v-html=dataA |
+| single-file-component-5.vue:2:8:2:21 | v-html=dataA |
 | tst.js:5:13:5:13 | a |
 | tst.js:38:12:38:17 | danger |

--- a/javascript/ql/test/library-tests/frameworks/Vue/single-file-component-4.vue
+++ b/javascript/ql/test/library-tests/frameworks/Vue/single-file-component-4.vue
@@ -1,0 +1,20 @@
+<template>
+    <p v-html="dataA"/>
+</template>
+<script>
+  import Vue from 'vue'
+  import Component from 'vue-class-component'
+
+  @Component({
+    render: (h) => { }
+  })
+  export default class MyComponent extends Vue {
+    message: string = 'Hello!'
+
+    get dataA() {
+      return 42;
+    }
+  }
+</script>
+<style>
+</style>

--- a/javascript/ql/test/library-tests/frameworks/Vue/single-file-component-5.vue
+++ b/javascript/ql/test/library-tests/frameworks/Vue/single-file-component-5.vue
@@ -1,0 +1,18 @@
+<template>
+    <p v-html="dataA"/>
+</template>
+<script>
+  import Vue from 'vue'
+  import Component from 'vue-class-component'
+
+  @Component
+  export default class MyComponent extends Vue {
+    message: string = 'Hello!'
+
+    get dataA() {
+      return 42;
+    }
+  }
+</script>
+<style>
+</style>


### PR DESCRIPTION
Adds support for Vue component implemented as a class decorated with `@Component`

For example
```js
<template>
    <p v-html="dataA"/>
</template>
<script>
  import Vue from 'vue'
  import Component from 'vue-class-component'

  @Component
  export default class MyComponent extends Vue {
    message: string = 'Hello!'

    get dataA() {
      return 42; // flows to 'dataA`
    }
  }
</script>
<style>
</style>
``` 