### PR TITLE
JS: Fix classification of .vue files

### DIFF
--- a/javascript/ql/src/filters/ClassifyFiles.qll
+++ b/javascript/ql/src/filters/ClassifyFiles.qll
@@ -80,6 +80,8 @@ predicate classify(File f, string category) {
   or
   // Polymer templates
   exists(HTML::Element elt | elt.getName() = "template" |
-    f = elt.getFile() and category = "template"
+    f = elt.getFile() and
+    category = "template" and
+    not f.getExtension() = "vue"
   )
 }

--- a/javascript/ql/src/semmle/javascript/GeneratedCode.qll
+++ b/javascript/ql/src/semmle/javascript/GeneratedCode.qll
@@ -164,7 +164,10 @@ private int countStartingHtmlElements(File f, int l) {
 /**
  * Holds if the base name of `f` is a number followed by a single extension.
  */
-predicate isGeneratedFileName(File f) { f.getStem().regexpMatch("[0-9]+") }
+predicate isGeneratedFileName(File f) {
+  f.getStem().regexpMatch("[0-9]+") and
+  not f.getExtension() = "vue"
+}
 
 /**
  * Holds if `tl` looks like it contains generated code.

--- a/javascript/ql/test/query-tests/filters/ClassifyFiles/MyComponent.vue
+++ b/javascript/ql/test/query-tests/filters/ClassifyFiles/MyComponent.vue
@@ -1,0 +1,6 @@
+<template>
+  <span>hey</span>
+</template>
+<script>
+export default { data: 42 }
+</script>


### PR DESCRIPTION
Vue files were often misclassified as templates due to the presence of a `<template>` element.

Will evaluate together with https://github.com/github/codeql/pull/3833 and https://github.com/github/codeql/pull/3832.