### PR TITLE
JS: Add Vue to list of supported frameworks

### DIFF
--- a/docs/language/support/reusables/frameworks.rst
+++ b/docs/language/support/reusables/frameworks.rst
@@ -71,6 +71,7 @@ JavaScript and TypeScript built-in support
    sqlite3, Database
    superagent, Network communicator
    underscore, Utility library
+   vue, HTML framework
 
 
 


### PR DESCRIPTION
We already supported Vue to some degree, it was just never added to this list.

When https://github.com/github/codeql/pull/3832, https://github.com/github/codeql/pull/3833, https://github.com/github/codeql/pull/3834 land we'll have greatly improved our support for Vue, so let's go ahead and put it on the list.

@jf205 do you know if this file is generated or can I just edit it directly?