### PR TITLE
C++: make MemberFunction::getTypeOfThis() return PointerType

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
+++ b/cpp/ql/src/semmle/code/cpp/MemberFunction.qll
@@ -72,10 +72,10 @@ class MemberFunction extends Function {
   }
 
   /**
-   * Gets the type of the `this` parameter associated with this member function, if any. Typically,
-   * this will be a `PointerType`, possibly with `const` and/or `volatile` qualifiers.
+   * Gets the type of the `this` parameter associated with this member function, if any. The type
+   * may have `const` and/or `volatile` qualifiers, matching the function declaration.
    */
-  Type getTypeOfThis() {
+  PointerType getTypeOfThis() {
     member_function_this_type(underlyingElement(this), unresolveElement(result))
   }
 }


### PR DESCRIPTION
This is a quick followup to #3814.

The dbscheme technically allows for any `Type`, but in practice it will always be a `PointerType`, so this should make it easier for users to understand.