### PR TITLE
JS: support simple callbacks for setting up Express route handlers

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -130,6 +130,12 @@ module Express {
         ) and
         t = t2
       )
+      or
+      exists(DataFlow::CallNode call, int i, DataFlow::FunctionNode forwarder | 
+        result.(HTTP::RouteHandlerCandidate).flowsTo(call.getArgument(i)) and
+        call = getARouteHandler(t.continue()) and
+        forwarder.getFunction() = unique(Function f | f = call.getACallee())
+      )
     }
 
     override Expr getServer() { result.(Application).getARouteHandler() = getARouteHandler() }
@@ -766,7 +772,7 @@ module Express {
     /**
      * Gets a `RouteSetup` that was used for setting up a route on this router.
      */
-    private RouteSetup getARouteSetup() { this.flowsTo(result.getReceiver()) }
+    RouteSetup getARouteSetup() { this.flowsTo(result.getReceiver()) }
 
     /**
      * Gets a sub-router registered on this router.

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -131,7 +131,7 @@ module Express {
         t = t2
       )
       or
-      exists(DataFlow::CallNode call, int i, DataFlow::FunctionNode forwarder | 
+      exists(DataFlow::CallNode call, int i, DataFlow::FunctionNode forwarder |
         result.(HTTP::RouteHandlerCandidate).flowsTo(call.getArgument(i)) and
         call = getARouteHandler(t.continue()) and
         forwarder.getFunction() = unique(Function f | f = call.getACallee())

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -130,12 +130,6 @@ module Express {
         ) and
         t = t2
       )
-      or
-      exists(DataFlow::CallNode call, int i, DataFlow::FunctionNode forwarder |
-        result.(HTTP::RouteHandlerCandidate).flowsTo(call.getArgument(i)) and
-        call = getARouteHandler(t.continue()) and
-        forwarder.getFunction() = unique(Function f | f = call.getACallee())
-      )
     }
 
     override Expr getServer() { result.(Application).getARouteHandler() = getARouteHandler() }

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -320,6 +320,20 @@ module HTTP {
         result = this
         or
         exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
+        or
+        // simple callbacks
+        exists(DataFlow::FunctionNode function, Function forwarder, int i, int arg |
+          ref(t.continue()) =
+            DataFlow::parameterNode(forwarder.getParameter(i))
+                .getACall()
+                .getArgument(arg)
+                .getALocalSource() and
+          exists(DataFlow::CallNode forwardingCall |
+            unique(Function f | f = forwardingCall.getACallee()) = forwarder and
+            function = forwardingCall.getCallback(i) and
+            result = function.getParameter(arg)
+          )
+        )
       }
 
       /** Gets a `SourceNode` that refers to this request object. */

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/DatabaseAccesses.expected
@@ -35,5 +35,6 @@
 | tst2.js:9:3:9:85 | new sql ...  + "'") |
 | tst3.js:10:3:12:4 | pool.qu ... ts\\n  }) |
 | tst3.js:17:3:19:4 | pool.qu ... ts\\n  }) |
+| tst3.js:33:5:33:53 | pool.qu ... ts) {}) |
 | tst4.js:8:3:8:67 | db.get( ...  + '"') |
 | tst.js:10:3:10:65 | db.get( ...  + '"') |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -162,6 +162,12 @@ nodes
 | tst3.js:9:16:9:34 | req.params.category |
 | tst3.js:10:14:10:19 | query1 |
 | tst3.js:10:14:10:19 | query1 |
+| tst3.js:32:9:32:114 | query1 |
+| tst3.js:32:18:32:114 | "SELECT ...  PRICE" |
+| tst3.js:32:75:32:93 | req.params.category |
+| tst3.js:32:75:32:93 | req.params.category |
+| tst3.js:33:16:33:21 | query1 |
+| tst3.js:33:16:33:21 | query1 |
 | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:46:8:60 | $routeParams.id |
@@ -410,6 +416,11 @@ edges
 | tst3.js:8:16:9:55 | "SELECT ...  PRICE" | tst3.js:8:7:9:55 | query1 |
 | tst3.js:9:16:9:34 | req.params.category | tst3.js:8:16:9:55 | "SELECT ...  PRICE" |
 | tst3.js:9:16:9:34 | req.params.category | tst3.js:8:16:9:55 | "SELECT ...  PRICE" |
+| tst3.js:32:9:32:114 | query1 | tst3.js:33:16:33:21 | query1 |
+| tst3.js:32:9:32:114 | query1 | tst3.js:33:16:33:21 | query1 |
+| tst3.js:32:18:32:114 | "SELECT ...  PRICE" | tst3.js:32:9:32:114 | query1 |
+| tst3.js:32:75:32:93 | req.params.category | tst3.js:32:18:32:114 | "SELECT ...  PRICE" |
+| tst3.js:32:75:32:93 | req.params.category | tst3.js:32:18:32:114 | "SELECT ...  PRICE" |
 | tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
 | tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' |
@@ -464,5 +475,6 @@ edges
 | socketio.js:11:12:11:53 | `INSERT ... andle}` | socketio.js:10:25:10:30 | handle | socketio.js:11:12:11:53 | `INSERT ... andle}` | This query depends on $@. | socketio.js:10:25:10:30 | handle | a user-provided value |
 | tst2.js:9:27:9:84 | "select ... d + "'" | tst2.js:9:66:9:78 | req.params.id | tst2.js:9:27:9:84 | "select ... d + "'" | This query depends on $@. | tst2.js:9:66:9:78 | req.params.id | a user-provided value |
 | tst3.js:10:14:10:19 | query1 | tst3.js:9:16:9:34 | req.params.category | tst3.js:10:14:10:19 | query1 | This query depends on $@. | tst3.js:9:16:9:34 | req.params.category | a user-provided value |
+| tst3.js:33:16:33:21 | query1 | tst3.js:32:75:32:93 | req.params.category | tst3.js:33:16:33:21 | query1 | This query depends on $@. | tst3.js:32:75:32:93 | req.params.category | a user-provided value |
 | tst4.js:8:10:8:66 | 'SELECT ... d + '"' | tst4.js:8:46:8:60 | $routeParams.id | tst4.js:8:10:8:66 | 'SELECT ... d + '"' | This query depends on $@. | tst4.js:8:46:8:60 | $routeParams.id | a user-provided value |
 | tst.js:10:10:10:64 | 'SELECT ... d + '"' | tst.js:10:46:10:58 | req.params.id | tst.js:10:10:10:64 | 'SELECT ... d + '"' | This query depends on $@. | tst.js:10:46:10:58 | req.params.id | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst3.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/tst3.js
@@ -20,3 +20,17 @@ function handler(req, res) {
 }
 
 require('express')().get('/foo', handler);
+
+
+const am = fn => (req, res) => {
+  Promise.resolve(fn(req, res)).catch(console.error);
+};
+
+async function foo() {
+  const callback = async (req, res) => {
+    // BAD: the category might have SQL special characters in it
+    var query1 = "SELECT ITEM,PRICE FROM PRODUCT WHERE ITEM_CATEGORY='" + req.params.category + "' ORDER BY PRICE";
+    pool.query(query1, [], function(err, results) {});
+  };
+  require('express')().get("/foo", am(callback));
+}


### PR DESCRIPTION
Inspired by [this route handler](https://github.com/jakealbaugh/discogs-aggregator/blob/25efb4169f5082dd97b1e4e80869b42bf9b16fc5/app/server/components/Routes.js#L78). (Found using ATM)

I tried to see if I could [find more route-handlers using this addition](https://lgtm.com/query/8471273632731467076/).  
But so far I've not found anything other than the motivating-example. 

TODO: 
 - [x] Add test
 - [ ] Evaluation