### PR TITLE
JavaScript: Make `getADefinition` and `getAnAccess` available on all `CanonicalName`s.

### DIFF
--- a/javascript/ql/src/semmle/javascript/CanonicalNames.qll
+++ b/javascript/ql/src/semmle/javascript/CanonicalNames.qll
@@ -139,7 +139,7 @@ class CanonicalName extends @symbol {
       else
         if exists(root.getGlobalName())
         then result instanceof GlobalScope
-        else result = getADefinitionNode().getContainer().getScope()
+        else result = getADefinition().getContainer().getScope()
     )
   }
 
@@ -149,10 +149,15 @@ class CanonicalName extends @symbol {
     else result = getParent().getRootName()
   }
 
-  private ExprOrStmt getADefinitionNode() {
-    result = this.(TypeName).getADefinition() or
-    result = this.(Namespace).getADefinition()
-  }
+  /**
+   * Gets a definition of the entity with this canonical name.
+   */
+  ASTNode getADefinition() { none() }
+
+  /**
+   * Gets a use that refers to the entity with this canonical name.
+   */
+  ExprOrType getAnAccess() { none() }
 
   /**
    * Gets a string describing the root scope of this canonical name.
@@ -168,11 +173,9 @@ class CanonicalName extends @symbol {
           if exists(root.getGlobalName())
           then result = "global scope"
           else
-            if exists(root.getADefinitionNode())
+            if exists(root.getADefinition())
             then
-              exists(StmtContainer container |
-                container = root.getADefinitionNode().getContainer()
-              |
+              exists(StmtContainer container | container = root.getADefinition().getContainer() |
                 result = container.(TopLevel).getFile().getRelativePath()
                 or
                 not container instanceof TopLevel and
@@ -218,12 +221,12 @@ class TypeName extends CanonicalName {
   /**
    * Gets a definition of the type with this canonical name, if any.
    */
-  TypeDefinition getADefinition() { ast_node_symbol(result, this) }
+  override TypeDefinition getADefinition() { ast_node_symbol(result, this) }
 
   /**
    * Gets a type annotation that refers to this type name.
    */
-  TypeAccess getAnAccess() { result.getTypeName() = this }
+  override TypeAccess getAnAccess() { result.getTypeName() = this }
 
   /**
    * Gets a type that refers to this canonical name.
@@ -258,14 +261,14 @@ class Namespace extends CanonicalName {
   }
 
   /**
-   * Gets a definition of the type with this canonical name, if any.
+   * Gets a definition of the namespace with this canonical name, if any.
    */
-  NamespaceDefinition getADefinition() { ast_node_symbol(result, this) }
+  override NamespaceDefinition getADefinition() { ast_node_symbol(result, this) }
 
   /**
    * Gets a part of a type annotation that refers to this namespace.
    */
-  NamespaceAccess getAnAccess() { result.getNamespace() = this }
+  override NamespaceAccess getAnAccess() { result.getNamespace() = this }
 
   /** Gets a namespace nested in this one. */
   Namespace getNamespaceMember(string name) {
@@ -307,7 +310,18 @@ class CanonicalFunctionName extends CanonicalName {
   /**
    * Gets a function with this canonical name.
    */
-  Function getADefinition() { ast_node_symbol(result, this) }
+  override Function getADefinition() { ast_node_symbol(result, this) }
+
+  /**
+   * Gets an expression (such as a callee expression in a function call or `new` expression)
+   * that refers to a function with this canonical name.
+   */
+  override Expr getAnAccess() {
+    exists(InvokeExpr invk | ast_node_symbol(invk, this) | result = invk.getCallee())
+    or
+    ast_node_symbol(result, this) and
+    not result instanceof InvokeExpr
+  }
 
   /**
    * Gets the implementation of this function, if it exists.


### PR DESCRIPTION
`getADefinition` was already implemented on all three subclasses, and `getAnAccess` on two out of three.

I've added `CanonicalFunctionName.getAnAccess`; while TypeScript considers the entire `InvokeExpr` to refer to the canonical name, I felt that it would be more consistent with how we usually think about calls to consider the callee expression to be the reference instead of the entire call.

I've also replaced uses of the private `getADefinitionNode` predicate, which looked like an ad hoc 2/3 implementation of `getADefinition`. @asgerf, is there a good reason for this predicate not to consider `CanonicalFunctionName`s?

I haven't done an evaluation yet, but happy to do that if this makes sense and once workers become available.