### PR TITLE
Data flow: Replace `getErasedRepr()` and `Node::getTypeBound()` with `getNodeType()`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -22,7 +22,7 @@ private module Cached {
     exists(int i |
       viableParam(call, i, p) and
       arg.argumentOf(call, i) and
-      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
+      compatibleTypes(getNodeType(arg), getNodeType(p))
     )
   }
 
@@ -218,10 +218,10 @@ private module Cached {
         then
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          compatibleTypes(getNodeType(p), getNodeType(node))
           or
           // getter
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(node))
+          compatibleTypes(read.getContentType(), getNodeType(node))
         else any()
       }
 
@@ -243,7 +243,7 @@ private module Cached {
           readStepWithTypes(mid, read.getContainerType(), read.getContent(), node,
             read.getContentType()) and
           Cand::parameterValueFlowReturnCand(p, _, true) and
-          compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
+          compatibleTypes(getNodeType(p), read.getContainerType())
         )
         or
         // flow through: no prior read
@@ -292,11 +292,11 @@ private module Cached {
         |
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), getNodeType(out))
           or
           // getter
-          compatibleTypes(getErasedNodeTypeBound(arg), read.getContainerType()) and
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), read.getContainerType()) and
+          compatibleTypes(read.getContentType(), getNodeType(out))
         )
       }
 
@@ -405,8 +405,8 @@ private module Cached {
   ) {
     storeStep(node1, c, node2) and
     readStep(_, c, _) and
-    contentType = getErasedNodeTypeBound(node1) and
-    containerType = getErasedNodeTypeBound(node2)
+    contentType = getNodeType(node1) and
+    containerType = getNodeType(node2)
     or
     exists(Node n1, Node n2 |
       n1 = node1.(PostUpdateNode).getPreUpdateNode() and
@@ -415,8 +415,8 @@ private module Cached {
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or
       readStep(n2, c, n1) and
-      contentType = getErasedNodeTypeBound(n1) and
-      containerType = getErasedNodeTypeBound(n2)
+      contentType = getNodeType(n1) and
+      containerType = getNodeType(n2)
     )
   }
 
@@ -507,8 +507,8 @@ private predicate readStepWithTypes(
   Node n1, DataFlowType container, Content c, Node n2, DataFlowType content
 ) {
   readStep(n1, c, n2) and
-  container = getErasedNodeTypeBound(n1) and
-  content = getErasedNodeTypeBound(n2)
+  container = getNodeType(n1) and
+  content = getNodeType(n2)
 }
 
 private newtype TReadStepTypesOption =
@@ -770,9 +770,6 @@ DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
   or
   result = viableCallable(call) and cc instanceof CallContextReturn
 }
-
-pragma[noinline]
-DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
 
 predicate read = readStep/3;
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -37,21 +37,12 @@ module Consistency {
     )
   }
 
-  query predicate uniqueTypeBound(Node n, string msg) {
+  query predicate uniqueType(Node n, string msg) {
     exists(int c |
       n instanceof RelevantNode and
-      c = count(n.getTypeBound()) and
+      c = count(getNodeType(n)) and
       c != 1 and
-      msg = "Node should have one type bound but has " + c + "."
-    )
-  }
-
-  query predicate uniqueTypeRepr(Node n, string msg) {
-    exists(int c |
-      n instanceof RelevantNode and
-      c = count(getErasedRepr(n.getTypeBound())) and
-      c != 1 and
-      msg = "Node should have one type representation but has " + c + "."
+      msg = "Node should have one type but has " + c + "."
     )
   }
 
@@ -104,7 +95,7 @@ module Consistency {
     msg = "Local flow step does not preserve enclosing callable."
   }
 
-  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+  private DataFlowType typeRepr() { result = getNodeType(_) }
 
   query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
     t = typeRepr() and

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -223,17 +223,13 @@ predicate clearsContent(Node n, Content c) {
   none() // stub implementation
 }
 
-/**
- * Gets a representative (boxed) type for `t` for the purpose of pruning
- * possible flow. A single type is used for all numeric types to account for
- * numeric conversions, and otherwise the erasure is used.
- */
-Type getErasedRepr(Type t) {
-  suppressUnusedType(t) and
+/** Gets the type of `n` used for type pruning. */
+Type getNodeType(Node n) {
+  suppressUnusedNode(n) and
   result instanceof VoidType // stub implementation
 }
 
-/** Gets a string representation of a type returned by `getErasedRepr`. */
+/** Gets a string representation of a type returned by `getNodeType`. */
 string ppReprType(Type t) { none() } // stub implementation
 
 /**
@@ -245,7 +241,7 @@ predicate compatibleTypes(Type t1, Type t2) {
   any() // stub implementation
 }
 
-private predicate suppressUnusedType(Type t) { any() }
+private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -22,7 +22,7 @@ private module Cached {
     exists(int i |
       viableParam(call, i, p) and
       arg.argumentOf(call, i) and
-      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
+      compatibleTypes(getNodeType(arg), getNodeType(p))
     )
   }
 
@@ -218,10 +218,10 @@ private module Cached {
         then
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          compatibleTypes(getNodeType(p), getNodeType(node))
           or
           // getter
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(node))
+          compatibleTypes(read.getContentType(), getNodeType(node))
         else any()
       }
 
@@ -243,7 +243,7 @@ private module Cached {
           readStepWithTypes(mid, read.getContainerType(), read.getContent(), node,
             read.getContentType()) and
           Cand::parameterValueFlowReturnCand(p, _, true) and
-          compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
+          compatibleTypes(getNodeType(p), read.getContainerType())
         )
         or
         // flow through: no prior read
@@ -292,11 +292,11 @@ private module Cached {
         |
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), getNodeType(out))
           or
           // getter
-          compatibleTypes(getErasedNodeTypeBound(arg), read.getContainerType()) and
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), read.getContainerType()) and
+          compatibleTypes(read.getContentType(), getNodeType(out))
         )
       }
 
@@ -405,8 +405,8 @@ private module Cached {
   ) {
     storeStep(node1, c, node2) and
     readStep(_, c, _) and
-    contentType = getErasedNodeTypeBound(node1) and
-    containerType = getErasedNodeTypeBound(node2)
+    contentType = getNodeType(node1) and
+    containerType = getNodeType(node2)
     or
     exists(Node n1, Node n2 |
       n1 = node1.(PostUpdateNode).getPreUpdateNode() and
@@ -415,8 +415,8 @@ private module Cached {
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or
       readStep(n2, c, n1) and
-      contentType = getErasedNodeTypeBound(n1) and
-      containerType = getErasedNodeTypeBound(n2)
+      contentType = getNodeType(n1) and
+      containerType = getNodeType(n2)
     )
   }
 
@@ -507,8 +507,8 @@ private predicate readStepWithTypes(
   Node n1, DataFlowType container, Content c, Node n2, DataFlowType content
 ) {
   readStep(n1, c, n2) and
-  container = getErasedNodeTypeBound(n1) and
-  content = getErasedNodeTypeBound(n2)
+  container = getNodeType(n1) and
+  content = getNodeType(n2)
 }
 
 private newtype TReadStepTypesOption =
@@ -770,9 +770,6 @@ DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
   or
   result = viableCallable(call) and cc instanceof CallContextReturn
 }
-
-pragma[noinline]
-DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
 
 predicate read = readStep/3;
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -37,21 +37,12 @@ module Consistency {
     )
   }
 
-  query predicate uniqueTypeBound(Node n, string msg) {
+  query predicate uniqueType(Node n, string msg) {
     exists(int c |
       n instanceof RelevantNode and
-      c = count(n.getTypeBound()) and
+      c = count(getNodeType(n)) and
       c != 1 and
-      msg = "Node should have one type bound but has " + c + "."
-    )
-  }
-
-  query predicate uniqueTypeRepr(Node n, string msg) {
-    exists(int c |
-      n instanceof RelevantNode and
-      c = count(getErasedRepr(n.getTypeBound())) and
-      c != 1 and
-      msg = "Node should have one type representation but has " + c + "."
+      msg = "Node should have one type but has " + c + "."
     )
   }
 
@@ -104,7 +95,7 @@ module Consistency {
     msg = "Local flow step does not preserve enclosing callable."
   }
 
-  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+  private DataFlowType typeRepr() { result = getNodeType(_) }
 
   query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
     t = typeRepr() and

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -233,17 +233,13 @@ predicate clearsContent(Node n, Content c) {
   none() // stub implementation
 }
 
-/**
- * Gets a representative (boxed) type for `t` for the purpose of pruning
- * possible flow. A single type is used for all numeric types to account for
- * numeric conversions, and otherwise the erasure is used.
- */
-Type getErasedRepr(Type t) {
-  suppressUnusedType(t) and
+/** Gets the type of `n` used for type pruning. */
+Type getNodeType(Node n) {
+  suppressUnusedNode(n) and
   result instanceof VoidType // stub implementation
 }
 
-/** Gets a string representation of a type returned by `getErasedRepr`. */
+/** Gets a string representation of a type returned by `getNodeType`. */
 string ppReprType(Type t) { none() } // stub implementation
 
 /**
@@ -255,7 +251,7 @@ predicate compatibleTypes(Type t1, Type t2) {
   any() // stub implementation
 }
 
-private predicate suppressUnusedType(Type t) { any() }
+private predicate suppressUnusedNode(Node n) { any() }
 
 //////////////////////////////////////////////////////////////////////////////
 // Java QL library compatibility wrappers

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -1,6 +1,5 @@
 uniqueEnclosingCallable
-uniqueTypeBound
-uniqueTypeRepr
+uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -1,6 +1,5 @@
 uniqueEnclosingCallable
-uniqueTypeBound
-uniqueTypeRepr
+uniqueType
 uniqueNodeLocation
 | BarrierGuard.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
 | acrossLinkTargets.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -1,8 +1,7 @@
 uniqueEnclosingCallable
 | C.cpp:37:24:37:33 | 0 | Node should have one enclosing callable but has 0. |
 | C.cpp:37:24:37:33 | new | Node should have one enclosing callable but has 0. |
-uniqueTypeBound
-uniqueTypeRepr
+uniqueType
 uniqueNodeLocation
 missingLocation
 uniqueNodeToString

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
@@ -1,6 +1,5 @@
 uniqueEnclosingCallable
-uniqueTypeBound
-uniqueTypeRepr
+uniqueType
 uniqueNodeLocation
 | D.cpp:1:17:1:17 | o | Node should have one location but has 3. |
 | by_reference.cpp:1:17:1:17 | o | Node should have one location but has 3. |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -8,10 +8,7 @@ uniqueEnclosingCallable
 | misc.c:210:24:210:24 | 0 | Node should have one enclosing callable but has 0. |
 | misc.c:210:24:210:28 | ... + ... | Node should have one enclosing callable but has 0. |
 | misc.c:210:28:210:28 | 1 | Node should have one enclosing callable but has 0. |
-uniqueTypeBound
-| cpp17.cpp:15:5:15:45 | call to unknown function | Node should have one type bound but has 0. |
-uniqueTypeRepr
-| cpp17.cpp:15:5:15:45 | call to unknown function | Node should have one type representation but has 0. |
+uniqueType
 uniqueNodeLocation
 | break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
 | break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -1,6 +1,5 @@
 uniqueEnclosingCallable
-uniqueTypeBound
-uniqueTypeRepr
+uniqueType
 uniqueNodeLocation
 | aggregateinitializer.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
 | aggregateinitializer.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |

--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -68,7 +68,7 @@ module Stages {
       or
       exists(any(DataFlow::Node n).getType())
       or
-      exists(any(DataFlow::Node n).getTypeBound())
+      exists(any(NodeImpl n).getDataFlowType())
       or
       exists(any(DataFlow::Node n).getLocation())
       or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -22,7 +22,7 @@ private module Cached {
     exists(int i |
       viableParam(call, i, p) and
       arg.argumentOf(call, i) and
-      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
+      compatibleTypes(getNodeType(arg), getNodeType(p))
     )
   }
 
@@ -218,10 +218,10 @@ private module Cached {
         then
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          compatibleTypes(getNodeType(p), getNodeType(node))
           or
           // getter
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(node))
+          compatibleTypes(read.getContentType(), getNodeType(node))
         else any()
       }
 
@@ -243,7 +243,7 @@ private module Cached {
           readStepWithTypes(mid, read.getContainerType(), read.getContent(), node,
             read.getContentType()) and
           Cand::parameterValueFlowReturnCand(p, _, true) and
-          compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
+          compatibleTypes(getNodeType(p), read.getContainerType())
         )
         or
         // flow through: no prior read
@@ -292,11 +292,11 @@ private module Cached {
         |
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), getNodeType(out))
           or
           // getter
-          compatibleTypes(getErasedNodeTypeBound(arg), read.getContainerType()) and
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), read.getContainerType()) and
+          compatibleTypes(read.getContentType(), getNodeType(out))
         )
       }
 
@@ -405,8 +405,8 @@ private module Cached {
   ) {
     storeStep(node1, c, node2) and
     readStep(_, c, _) and
-    contentType = getErasedNodeTypeBound(node1) and
-    containerType = getErasedNodeTypeBound(node2)
+    contentType = getNodeType(node1) and
+    containerType = getNodeType(node2)
     or
     exists(Node n1, Node n2 |
       n1 = node1.(PostUpdateNode).getPreUpdateNode() and
@@ -415,8 +415,8 @@ private module Cached {
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or
       readStep(n2, c, n1) and
-      contentType = getErasedNodeTypeBound(n1) and
-      containerType = getErasedNodeTypeBound(n2)
+      contentType = getNodeType(n1) and
+      containerType = getNodeType(n2)
     )
   }
 
@@ -507,8 +507,8 @@ private predicate readStepWithTypes(
   Node n1, DataFlowType container, Content c, Node n2, DataFlowType content
 ) {
   readStep(n1, c, n2) and
-  container = getErasedNodeTypeBound(n1) and
-  content = getErasedNodeTypeBound(n2)
+  container = getNodeType(n1) and
+  content = getNodeType(n2)
 }
 
 private newtype TReadStepTypesOption =
@@ -770,9 +770,6 @@ DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
   or
   result = viableCallable(call) and cc instanceof CallContextReturn
 }
-
-pragma[noinline]
-DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
 
 predicate read = readStep/3;
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -37,21 +37,12 @@ module Consistency {
     )
   }
 
-  query predicate uniqueTypeBound(Node n, string msg) {
+  query predicate uniqueType(Node n, string msg) {
     exists(int c |
       n instanceof RelevantNode and
-      c = count(n.getTypeBound()) and
+      c = count(getNodeType(n)) and
       c != 1 and
-      msg = "Node should have one type bound but has " + c + "."
-    )
-  }
-
-  query predicate uniqueTypeRepr(Node n, string msg) {
-    exists(int c |
-      n instanceof RelevantNode and
-      c = count(getErasedRepr(n.getTypeBound())) and
-      c != 1 and
-      msg = "Node should have one type representation but has " + c + "."
+      msg = "Node should have one type but has " + c + "."
     )
   }
 
@@ -104,7 +95,7 @@ module Consistency {
     msg = "Local flow step does not preserve enclosing callable."
   }
 
-  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+  private DataFlowType typeRepr() { result = getNodeType(_) }
 
   query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
     t = typeRepr() and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -43,18 +43,6 @@ class Node extends TNode {
     Stages::DataFlowStage::forceCachingInSameStage() and result = this.(NodeImpl).getTypeImpl()
   }
 
-  /** INTERNAL: Do not use. Gets an upper bound on the type of this node. */
-  cached
-  DataFlowType getTypeBound() {
-    Stages::DataFlowStage::forceCachingInSameStage() and
-    exists(Type t0 | result = Gvn::getGlobalValueNumber(t0) |
-      t0 = getCSharpType(this.getType())
-      or
-      not exists(getCSharpType(this.getType())) and
-      t0 instanceof ObjectType
-    )
-  }
-
   /** Gets the enclosing callable of this node. */
   cached
   final DataFlowCallable getEnclosingCallable() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1124,11 +1124,11 @@ private module LocalFlowBigStep {
       (
         localFlowStepNodeCand1(node1, node2, config) and
         preservesValue = true and
-        t = getErasedNodeTypeBound(node1)
+        t = getNodeType(node1)
         or
         additionalLocalFlowStepNodeCand2(node1, node2, config) and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2)
+        t = getNodeType(node2)
       ) and
       node1 != node2 and
       cc.relevantFor(node1.getEnclosingCallable()) and
@@ -1147,7 +1147,7 @@ private module LocalFlowBigStep {
         additionalLocalFlowStepNodeCand2(mid, node2, config) and
         not mid instanceof FlowCheckNode and
         preservesValue = false and
-        t = getErasedNodeTypeBound(node2) and
+        t = getNodeType(node2) and
         nodeCand2(node2, unbind(config))
       )
     )
@@ -1202,9 +1202,7 @@ private predicate flowCandFwd(
 ) {
   flowCandFwd0(node, fromArg, argApf, apf, config) and
   not apf.isClearedAt(node) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeTypeBound(node), apf.getType())
-  else any()
+  if node instanceof CastingNode then compatibleTypes(getNodeType(node), apf.getType()) else any()
 }
 
 pragma[nomagic]
@@ -1216,7 +1214,7 @@ private predicate flowCandFwd0(
   config.isSource(node) and
   fromArg = false and
   argApf = TAccessPathFrontNone() and
-  apf = TFrontNil(getErasedNodeTypeBound(node))
+  apf = TFrontNil(getNodeType(node))
   or
   exists(Node mid |
     flowCandFwd(mid, fromArg, argApf, apf, config) and
@@ -1242,7 +1240,7 @@ private predicate flowCandFwd0(
     additionalJumpStep(mid, node, config) and
     fromArg = false and
     argApf = TAccessPathFrontNone() and
-    apf = TFrontNil(getErasedNodeTypeBound(node))
+    apf = TFrontNil(getNodeType(node))
   )
   or
   // store
@@ -1672,7 +1670,7 @@ private predicate flowFwd0(
   config.isSource(node) and
   fromArg = false and
   argAp = TAccessPathNone() and
-  ap = TNil(getErasedNodeTypeBound(node)) and
+  ap = TNil(getNodeType(node)) and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, _, unbind(config)) and
@@ -1700,7 +1698,7 @@ private predicate flowFwd0(
       additionalJumpStep(mid, node, config) and
       fromArg = false and
       argAp = TAccessPathNone() and
-      ap = TNil(getErasedNodeTypeBound(node)) and
+      ap = TNil(getNodeType(node)) and
       apf = ap.(AccessPathNil).getFront()
     )
   )
@@ -2077,7 +2075,7 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = TNil(getErasedNodeTypeBound(node))
+    ap = TNil(getNodeType(node))
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
@@ -2304,7 +2302,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = TNil(getErasedNodeTypeBound(node))
+  ap = TNil(getNodeType(node))
   or
   exists(TypedContent tc | pathStoreStep(mid, node, pop(tc, ap), tc, cc)) and
   sc = mid.getSummaryCtx()
@@ -2646,7 +2644,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2663,7 +2661,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
+      then compatibleTypes(getNodeType(node), ap.getType())
       else any()
     )
   }
@@ -2776,7 +2774,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeTypeBound(node)) and
+      ap = TPartialNil(getNodeType(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2792,7 +2790,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeTypeBound(node)) and
+    ap = TPartialNil(getNodeType(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2806,7 +2804,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       apConsFwd(ap, tc, ap0, config) and
-      compatibleTypes(ap.getType(), getErasedNodeTypeBound(node))
+      compatibleTypes(ap.getType(), getNodeType(node))
     )
     or
     partialPathIntoCallable(mid, node, _, cc, sc1, sc2, _, ap, config)

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -22,7 +22,7 @@ private module Cached {
     exists(int i |
       viableParam(call, i, p) and
       arg.argumentOf(call, i) and
-      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
+      compatibleTypes(getNodeType(arg), getNodeType(p))
     )
   }
 
@@ -218,10 +218,10 @@ private module Cached {
         then
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          compatibleTypes(getNodeType(p), getNodeType(node))
           or
           // getter
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(node))
+          compatibleTypes(read.getContentType(), getNodeType(node))
         else any()
       }
 
@@ -243,7 +243,7 @@ private module Cached {
           readStepWithTypes(mid, read.getContainerType(), read.getContent(), node,
             read.getContentType()) and
           Cand::parameterValueFlowReturnCand(p, _, true) and
-          compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
+          compatibleTypes(getNodeType(p), read.getContainerType())
         )
         or
         // flow through: no prior read
@@ -292,11 +292,11 @@ private module Cached {
         |
           // normal flow through
           read = TReadStepTypesNone() and
-          compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), getNodeType(out))
           or
           // getter
-          compatibleTypes(getErasedNodeTypeBound(arg), read.getContainerType()) and
-          compatibleTypes(read.getContentType(), getErasedNodeTypeBound(out))
+          compatibleTypes(getNodeType(arg), read.getContainerType()) and
+          compatibleTypes(read.getContentType(), getNodeType(out))
         )
       }
 
@@ -405,8 +405,8 @@ private module Cached {
   ) {
     storeStep(node1, c, node2) and
     readStep(_, c, _) and
-    contentType = getErasedNodeTypeBound(node1) and
-    containerType = getErasedNodeTypeBound(node2)
+    contentType = getNodeType(node1) and
+    containerType = getNodeType(node2)
     or
     exists(Node n1, Node n2 |
       n1 = node1.(PostUpdateNode).getPreUpdateNode() and
@@ -415,8 +415,8 @@ private module Cached {
       argumentValueFlowsThrough(n2, TReadStepTypesSome(containerType, c, contentType), n1)
       or
       readStep(n2, c, n1) and
-      contentType = getErasedNodeTypeBound(n1) and
-      containerType = getErasedNodeTypeBound(n2)
+      contentType = getNodeType(n1) and
+      containerType = getNodeType(n2)
     )
   }
 
@@ -507,8 +507,8 @@ private predicate readStepWithTypes(
   Node n1, DataFlowType container, Content c, Node n2, DataFlowType content
 ) {
   readStep(n1, c, n2) and
-  container = getErasedNodeTypeBound(n1) and
-  content = getErasedNodeTypeBound(n2)
+  container = getNodeType(n1) and
+  content = getNodeType(n2)
 }
 
 private newtype TReadStepTypesOption =
@@ -770,9 +770,6 @@ DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
   or
   result = viableCallable(call) and cc instanceof CallContextReturn
 }
-
-pragma[noinline]
-DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
 
 predicate read = readStep/3;
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -37,21 +37,12 @@ module Consistency {
     )
   }
 
-  query predicate uniqueTypeBound(Node n, string msg) {
+  query predicate uniqueType(Node n, string msg) {
     exists(int c |
       n instanceof RelevantNode and
-      c = count(n.getTypeBound()) and
+      c = count(getNodeType(n)) and
       c != 1 and
-      msg = "Node should have one type bound but has " + c + "."
-    )
-  }
-
-  query predicate uniqueTypeRepr(Node n, string msg) {
-    exists(int c |
-      n instanceof RelevantNode and
-      c = count(getErasedRepr(n.getTypeBound())) and
-      c != 1 and
-      msg = "Node should have one type representation but has " + c + "."
+      msg = "Node should have one type but has " + c + "."
     )
   }
 
@@ -104,7 +95,7 @@ module Consistency {
     msg = "Local flow step does not preserve enclosing callable."
   }
 
-  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+  private DataFlowType typeRepr() { result = getNodeType(_) }
 
   query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
     t = typeRepr() and

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -209,7 +209,7 @@ predicate clearsContent(Node n, Content c) {
  * possible flow. A single type is used for all numeric types to account for
  * numeric conversions, and otherwise the erasure is used.
  */
-DataFlowType getErasedRepr(Type t) {
+private DataFlowType getErasedRepr(Type t) {
   exists(Type e | e = t.getErasure() |
     if e instanceof NumericOrCharType
     then result.(BoxedType).getPrimitiveType().getName() = "double"
@@ -221,6 +221,9 @@ DataFlowType getErasedRepr(Type t) {
   or
   t instanceof NullType and result instanceof TypeObject
 }
+
+pragma[noinline]
+DataFlowType getNodeType(Node n) { result = getErasedRepr(n.getTypeBound()) }
 
 /** Gets a string representation of a type returned by `getErasedRepr`. */
 string ppReprType(Type t) {


### PR DESCRIPTION
This PR simplifies the interface to the shared data-flow library by combining `getErasedRepr()` and `Node::getTypeBound()` to a single `getNodeType()` predicate.

This means that we no longer require `getTypeBound()` to be exposed via the public class `Node`, and it has consequently been removed for C# (it was already marked with an `INTERNAL` comment). The predicates are still there for C++ and Java, and they will have to be deprecated before removal, but I'll let the C++ and Java teams decide on that.