### PR TITLE
C++: Remove big-step relation in flow-through code

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -147,54 +147,6 @@ private module Cached {
       }
     }
 
-    private module LocalFlowBigStep {
-      private predicate localFlowEntry(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ParameterNode or
-          n instanceof OutNode or
-          readStep(_, _, n) or
-          n instanceof CastNode
-        )
-      }
-
-      private predicate localFlowExit(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ArgumentNode
-          or
-          n instanceof ReturnNode
-          or
-          readStep(n, _, _)
-          or
-          n instanceof CastNode
-          or
-          n =
-            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
-                .getPreUpdateNode()
-        )
-      }
-
-      pragma[nomagic]
-      private predicate localFlowStepPlus(Node node1, Node node2) {
-        localFlowEntry(node1) and
-        simpleLocalFlowStep(node1, node2) and
-        node1 != node2
-        or
-        exists(Node mid |
-          localFlowStepPlus(node1, mid) and
-          simpleLocalFlowStep(mid, node2) and
-          not mid instanceof CastNode
-        )
-      }
-
-      pragma[nomagic]
-      predicate localFlowBigStep(Node node1, Node node2) {
-        localFlowStepPlus(node1, node2) and
-        localFlowExit(node2)
-      }
-    }
-
     /**
      * The final flow-through calculation:
      *
@@ -234,7 +186,7 @@ private module Cached {
         // local flow
         exists(Node mid |
           parameterValueFlow(p, mid, read) and
-          LocalFlowBigStep::localFlowBigStep(mid, node)
+          simpleLocalFlowStep(mid, node)
         )
         or
         // read

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -198,16 +198,23 @@ private module Cached {
           compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
         )
         or
+        parameterValueFlow0_0(TReadStepTypesNone(), p, node, read)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0_0(
+        ReadStepTypesOption mustBeNone, ParameterNode p, Node node, ReadStepTypesOption read
+      ) {
         // flow through: no prior read
         exists(ArgumentNode arg |
-          parameterValueFlowArg(p, arg, TReadStepTypesNone()) and
+          parameterValueFlowArg(p, arg, mustBeNone) and
           argumentValueFlowsThrough(arg, read, node)
         )
         or
         // flow through: no read inside method
         exists(ArgumentNode arg |
           parameterValueFlowArg(p, arg, read) and
-          argumentValueFlowsThrough(arg, TReadStepTypesNone(), node)
+          argumentValueFlowsThrough(arg, mustBeNone, node)
         )
       }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -147,54 +147,6 @@ private module Cached {
       }
     }
 
-    private module LocalFlowBigStep {
-      private predicate localFlowEntry(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ParameterNode or
-          n instanceof OutNode or
-          readStep(_, _, n) or
-          n instanceof CastNode
-        )
-      }
-
-      private predicate localFlowExit(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ArgumentNode
-          or
-          n instanceof ReturnNode
-          or
-          readStep(n, _, _)
-          or
-          n instanceof CastNode
-          or
-          n =
-            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
-                .getPreUpdateNode()
-        )
-      }
-
-      pragma[nomagic]
-      private predicate localFlowStepPlus(Node node1, Node node2) {
-        localFlowEntry(node1) and
-        simpleLocalFlowStep(node1, node2) and
-        node1 != node2
-        or
-        exists(Node mid |
-          localFlowStepPlus(node1, mid) and
-          simpleLocalFlowStep(mid, node2) and
-          not mid instanceof CastNode
-        )
-      }
-
-      pragma[nomagic]
-      predicate localFlowBigStep(Node node1, Node node2) {
-        localFlowStepPlus(node1, node2) and
-        localFlowExit(node2)
-      }
-    }
-
     /**
      * The final flow-through calculation:
      *
@@ -234,7 +186,7 @@ private module Cached {
         // local flow
         exists(Node mid |
           parameterValueFlow(p, mid, read) and
-          LocalFlowBigStep::localFlowBigStep(mid, node)
+          simpleLocalFlowStep(mid, node)
         )
         or
         // read

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -198,16 +198,23 @@ private module Cached {
           compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
         )
         or
+        parameterValueFlow0_0(TReadStepTypesNone(), p, node, read)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0_0(
+        ReadStepTypesOption mustBeNone, ParameterNode p, Node node, ReadStepTypesOption read
+      ) {
         // flow through: no prior read
         exists(ArgumentNode arg |
-          parameterValueFlowArg(p, arg, TReadStepTypesNone()) and
+          parameterValueFlowArg(p, arg, mustBeNone) and
           argumentValueFlowsThrough(arg, read, node)
         )
         or
         // flow through: no read inside method
         exists(ArgumentNode arg |
           parameterValueFlowArg(p, arg, read) and
-          argumentValueFlowsThrough(arg, TReadStepTypesNone(), node)
+          argumentValueFlowsThrough(arg, mustBeNone, node)
         )
       }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -147,54 +147,6 @@ private module Cached {
       }
     }
 
-    private module LocalFlowBigStep {
-      private predicate localFlowEntry(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ParameterNode or
-          n instanceof OutNode or
-          readStep(_, _, n) or
-          n instanceof CastNode
-        )
-      }
-
-      private predicate localFlowExit(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ArgumentNode
-          or
-          n instanceof ReturnNode
-          or
-          readStep(n, _, _)
-          or
-          n instanceof CastNode
-          or
-          n =
-            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
-                .getPreUpdateNode()
-        )
-      }
-
-      pragma[nomagic]
-      private predicate localFlowStepPlus(Node node1, Node node2) {
-        localFlowEntry(node1) and
-        simpleLocalFlowStep(node1, node2) and
-        node1 != node2
-        or
-        exists(Node mid |
-          localFlowStepPlus(node1, mid) and
-          simpleLocalFlowStep(mid, node2) and
-          not mid instanceof CastNode
-        )
-      }
-
-      pragma[nomagic]
-      predicate localFlowBigStep(Node node1, Node node2) {
-        localFlowStepPlus(node1, node2) and
-        localFlowExit(node2)
-      }
-    }
-
     /**
      * The final flow-through calculation:
      *
@@ -234,7 +186,7 @@ private module Cached {
         // local flow
         exists(Node mid |
           parameterValueFlow(p, mid, read) and
-          LocalFlowBigStep::localFlowBigStep(mid, node)
+          simpleLocalFlowStep(mid, node)
         )
         or
         // read

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -198,16 +198,23 @@ private module Cached {
           compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
         )
         or
+        parameterValueFlow0_0(TReadStepTypesNone(), p, node, read)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0_0(
+        ReadStepTypesOption mustBeNone, ParameterNode p, Node node, ReadStepTypesOption read
+      ) {
         // flow through: no prior read
         exists(ArgumentNode arg |
-          parameterValueFlowArg(p, arg, TReadStepTypesNone()) and
+          parameterValueFlowArg(p, arg, mustBeNone) and
           argumentValueFlowsThrough(arg, read, node)
         )
         or
         // flow through: no read inside method
         exists(ArgumentNode arg |
           parameterValueFlowArg(p, arg, read) and
-          argumentValueFlowsThrough(arg, TReadStepTypesNone(), node)
+          argumentValueFlowsThrough(arg, mustBeNone, node)
         )
       }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -147,54 +147,6 @@ private module Cached {
       }
     }
 
-    private module LocalFlowBigStep {
-      private predicate localFlowEntry(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ParameterNode or
-          n instanceof OutNode or
-          readStep(_, _, n) or
-          n instanceof CastNode
-        )
-      }
-
-      private predicate localFlowExit(Node n) {
-        Cand::cand(_, n) and
-        (
-          n instanceof ArgumentNode
-          or
-          n instanceof ReturnNode
-          or
-          readStep(n, _, _)
-          or
-          n instanceof CastNode
-          or
-          n =
-            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
-                .getPreUpdateNode()
-        )
-      }
-
-      pragma[nomagic]
-      private predicate localFlowStepPlus(Node node1, Node node2) {
-        localFlowEntry(node1) and
-        simpleLocalFlowStep(node1, node2) and
-        node1 != node2
-        or
-        exists(Node mid |
-          localFlowStepPlus(node1, mid) and
-          simpleLocalFlowStep(mid, node2) and
-          not mid instanceof CastNode
-        )
-      }
-
-      pragma[nomagic]
-      predicate localFlowBigStep(Node node1, Node node2) {
-        localFlowStepPlus(node1, node2) and
-        localFlowExit(node2)
-      }
-    }
-
     /**
      * The final flow-through calculation:
      *
@@ -234,7 +186,7 @@ private module Cached {
         // local flow
         exists(Node mid |
           parameterValueFlow(p, mid, read) and
-          LocalFlowBigStep::localFlowBigStep(mid, node)
+          simpleLocalFlowStep(mid, node)
         )
         or
         // read

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -198,16 +198,23 @@ private module Cached {
           compatibleTypes(getErasedNodeTypeBound(p), read.getContainerType())
         )
         or
+        parameterValueFlow0_0(TReadStepTypesNone(), p, node, read)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0_0(
+        ReadStepTypesOption mustBeNone, ParameterNode p, Node node, ReadStepTypesOption read
+      ) {
         // flow through: no prior read
         exists(ArgumentNode arg |
-          parameterValueFlowArg(p, arg, TReadStepTypesNone()) and
+          parameterValueFlowArg(p, arg, mustBeNone) and
           argumentValueFlowsThrough(arg, read, node)
         )
         or
         // flow through: no read inside method
         exists(ArgumentNode arg |
           parameterValueFlowArg(p, arg, read) and
-          argumentValueFlowsThrough(arg, TReadStepTypesNone(), node)
+          argumentValueFlowsThrough(arg, mustBeNone, node)
         )
       }
 


### PR DESCRIPTION
The first commit makes it feasible to run C++ IR data-flow queries on oneapi-src/oneDNN, and the second makes it fast.

The second commit works around a join order problem that I've reported as https://github.com/github/codeql-coreql-team/issues/453.

I'll take this PR out of draft mode if *-Differences show no performance regressions.