### PR TITLE
C++: 'modelling' -> 'modeling' part 2.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -59,7 +59,7 @@ class Node extends TIRDataFlowNode {
 
   /**
    * Gets the variable corresponding to this node, if any. This can be used for
-   * modelling flow in and out of global variables.
+   * modeling flow in and out of global variables.
    */
   Variable asVariable() { result = this.(VariableNode).getVariable() }
 
@@ -402,7 +402,7 @@ private class ArgumentIndirectionNode extends InstructionNode {
 /**
  * A `Node` corresponding to a variable in the program, as opposed to the
  * value of that variable at some particular point. This can be used for
- * modelling flow in and out of global variables.
+ * modeling flow in and out of global variables.
  */
 class VariableNode extends Node, TVariableNode {
   Variable v;

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling various methods of allocation
+ * Provides implementation classes modeling various methods of allocation
  * (`malloc`, `new` etc). See `semmle.code.cpp.models.interfaces.Allocation`
  * for usage information.
  */

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes  modelling various methods of deallocation
+ * Provides implementation classes  modeling various methods of deallocation
  * (`free`, `delete` etc). See `semmle.code.cpp.models.interfaces.Deallocation`
  * for usage information.
  */

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `gets` and various similar
+ * Provides implementation classes modeling `gets` and various similar
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Memcpy.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `memcpy` and various similar
+ * Provides implementation classes modeling `memcpy` and various similar
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Memset.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Memset.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `memset` and various similar
+ * Provides implementation classes modeling `memset` and various similar
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Printf.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling various standard formatting
+ * Provides implementation classes modeling various standard formatting
  * functions (`printf`, `snprintf` etc).
  * See `semmle.code.cpp.models.interfaces.FormattingFunction` for usage
  * information.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcat.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcat.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `strcat` and various similar functions.
+ * Provides implementation classes modeling `strcat` and various similar functions.
  * See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `strcpy` and various similar
+ * Provides implementation classes modeling `strcpy` and various similar
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
@@ -1,5 +1,5 @@
 /**
- * Provides implementation classes modelling `strdup` and various similar
+ * Provides implementation classes modeling `strdup` and various similar
  * functions. See `semmle.code.cpp.models.Models` for usage information.
  */
 

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/Allocation.qll
@@ -1,5 +1,5 @@
 /**
- * Provides an abstract class for modelling functions and expressions that
+ * Provides an abstract class for modeling functions and expressions that
  * allocate memory, such as the standard `malloc` function.  To use this QL
  * library, create one or more QL classes extending a class here with a
  * characteristic predicate that selects the functions or expressions you are

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/Deallocation.qll
@@ -1,5 +1,5 @@
 /**
- * Provides an abstract class for modelling functions and expressions that
+ * Provides an abstract class for modeling functions and expressions that
  * deallocate memory, such as the standard `free` function.  To use this QL
  * library, create one or more QL classes extending a class here with a
  * characteristic predicate that selects the functions or expressions you are

--- a/cpp/ql/src/semmle/code/cpp/security/FileWrite.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FileWrite.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes for modelling writing of data to files through various standard mechanisms such as `fprintf`, `fwrite` and `operator<<`.
+ * Provides classes for modeling writing of data to files through various standard mechanisms such as `fprintf`, `fwrite` and `operator<<`.
  */
 
 import cpp

--- a/cpp/ql/src/semmle/code/cpp/security/OutputWrite.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/OutputWrite.qll
@@ -1,5 +1,5 @@
 /**
- * Provides classes for modelling output to standard output / standard error through various mechanisms such as `printf`, `puts` and `operator<<`.
+ * Provides classes for modeling output to standard output / standard error through various mechanisms such as `printf`, `puts` and `operator<<`.
  */
 
 import cpp


### PR DESCRIPTION
It looks like I've been writing 'modelling' (the UK spelling) again in a couple of the QLDoc PRs.

@MathiasVP 