### PR TITLE
JS: Use local name resolution in TypeAnnotation.hasQualifiedName

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -32,3 +32,4 @@
 
 
 ## Changes to libraries
+* The predicate `TypeAnnotation.hasQualifiedName` now works in more cases when the imported library was not present during extraction.

--- a/javascript/ql/src/meta/types/TypesWithQualifiedName.ql
+++ b/javascript/ql/src/meta/types/TypesWithQualifiedName.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Types with qualified name
+ * @description The number of type annotations with a qualified name
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/types-with-qualified-name
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(), count(TypeAnnotation t | t.hasQualifiedName(_) or t.hasQualifiedName(_, _))

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -697,7 +697,11 @@ class TypeAccess extends @typeaccess, TypeExpr, TypeRef {
     exists(ImportEqualsDeclaration imprt |
       moduleName = getImportName(imprt.getImportedEntity()) and
       this =
-        imprt.getIdentifier().(LocalNamespaceDecl).getLocalNamespaceName().getAMemberAccess(exportedName)
+        imprt
+            .getIdentifier()
+            .(LocalNamespaceDecl)
+            .getLocalNamespaceName()
+            .getAMemberAccess(exportedName)
     )
   }
 }

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -697,7 +697,7 @@ class TypeAccess extends @typeaccess, TypeExpr, TypeRef {
     exists(ImportEqualsDeclaration imprt |
       moduleName = getImportName(imprt.getImportedEntity()) and
       this =
-        imprt.getId().(LocalNamespaceDecl).getLocalNamespaceName().getAMemberAccess(exportedName)
+        imprt.getIdentifier().(LocalNamespaceDecl).getLocalNamespaceName().getAMemberAccess(exportedName)
     )
   }
 }

--- a/javascript/ql/test/library-tests/TypeAnnotations/TSUnresolvedQualifiedName/QualifiedNames.expected
+++ b/javascript/ql/test/library-tests/TypeAnnotations/TSUnresolvedQualifiedName/QualifiedNames.expected
@@ -1,1 +1,2 @@
+| tst.ts:4:8:4:21 | UnresolvedType | unresolved | UnresolvedType |
 | tst.ts:5:8:5:19 | ResolvedType | resolved | ResolvedType |

--- a/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/Test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/Test.expected
@@ -1,0 +1,14 @@
+hasQualifiedNameModule
+| default-import | default | tst.ts:11:9:11:21 | DefaultImport |
+| import-assign | Foo | tst.ts:10:9:10:15 | asn.Foo |
+| library-tests/TypeScript/HasQualifiedNameFallback/tst.ts | ExportedClass | relative.ts:4:8:4:20 | ExportedClass |
+| named-import | Name1 | tst.ts:7:9:7:13 | Name1 |
+| named-import | Name1 | tst.ts:13:9:13:13 | Name1 |
+| named-import | Name1 | tst.ts:13:9:13:21 | Name1<number> |
+| named-import | Name2 | tst.ts:8:9:8:13 | Name2 |
+| namespace-import | Foo | tst.ts:9:9:9:21 | namespace.Foo |
+hasQualifiedNameGlobal
+| UnresolvedName | tst.ts:12:9:12:22 | UnresolvedName |
+paramExample
+| tst.ts:7:5:7:6 | x1 |
+| tst.ts:13:5:13:6 | x8 |

--- a/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/Test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/Test.ql
@@ -1,0 +1,13 @@
+import javascript
+
+query TypeAnnotation hasQualifiedNameModule(string moduleName, string member) {
+  result.hasQualifiedName(moduleName, member)
+}
+
+query TypeAnnotation hasQualifiedNameGlobal(string globalName) {
+  result.hasQualifiedName(globalName)
+}
+
+query Parameter paramExample() {
+  result.getTypeAnnotation().hasQualifiedName("named-import", "Name1")
+}

--- a/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/relative.ts
+++ b/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/relative.ts
@@ -1,0 +1,4 @@
+import * as foo from "./tst";
+import { ExportedClass } from "./tst";
+
+var x: ExportedClass;

--- a/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/HasQualifiedNameFallback/tst.ts
@@ -1,0 +1,16 @@
+import * as namespace from "namespace-import";
+import { Name1, Name2 } from "named-import";
+import DefaultImport from "default-import";
+import asn = require("import-assign");
+
+function foo(
+    x1: Name1,
+    x2: Name2,
+    x3: namespace.Foo,
+    x5: asn.Foo,
+    x6: DefaultImport,
+    x7: UnresolvedName,
+    x8: Name1<number>
+) {}
+
+export class ExportedClass {};


### PR DESCRIPTION
Recognizing type annotations by name can be a bit painful in cases where the type system fails to resolve it for some reason (mainly missing dependencies).

This makes `TypeAnnotation.hasQualifiedName` include names found through local name resolution, in addition to consulting the type system.

- [Examples of results](https://lgtm.com/query/6680887137953845229/)

There are [not many](https://lgtm.com/query/6680887137953845229/) cases where we get results from both the type system and from local resolution, but there is an example in [kibana](https://lgtm.com/query/2481082903372775794/). Here it happens because the file is part of a package (kibana is a monorepo), so we get both the snapshot-relative path and the package-relative path, which I think is fine, as `hasQualifiedName` does not imply uniqueness.

