### PR TITLE
C++: Accept test changes for is_constexpr

### DIFF
--- a/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
+++ b/cpp/ql/test/library-tests/specifiers2/specifiers2.expected
@@ -62,6 +62,8 @@
 | Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | extern |
 | Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | inline |
 | Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | inline |
+| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | is_constexpr |
+| Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | is_constexpr |
 | Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | public |
 | Function | specifiers2pp.cpp:29:7:29:7 | operator= | operator= | public |
 | Function | specifiers2pp.cpp:33:5:33:18 | fun | fun | public |
@@ -69,6 +71,8 @@
 | Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | extern |
 | Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | inline |
 | Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | inline |
+| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | is_constexpr |
+| Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | is_constexpr |
 | Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | public |
 | Function | specifiers2pp.cpp:35:7:35:7 | operator= | operator= | public |
 | Function | specifiers2pp.cpp:40:12:40:18 | someFun | someFun | extern |


### PR DESCRIPTION
Generated copy and move constructors may now be marked as constexpr.

https://git.semmle.com/Semmle/code/pull/37234