### PR TITLE
[Java] CodeQL query to detect Log Injection

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
@@ -33,11 +33,11 @@ other forms of HTML injection.
 <p>In the example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). 
 In the first case (`/bad` endpoint), the username is logged without any sanitization.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
-the log entry will be splitted in two different lines, where the first line will be `User:'Guest'`, while the second one will be `User:'Admin'`.
+the log entry will be splitted in two separate lines, where the first line will be `User:'Guest'`, while the second one will be `User:'Admin'`.
 </p>
 <p> In the second case (`/good` endpoint), <code>replace</code> is used to ensure no line endings are present in the user input.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
-the log entry will not be splitted in two different lines, resulting in a single line `User:'Guest'User:'Admin'`.
+the log entry will not be splitted in two separate lines, resulting in a single line `User:'Guest'User:'Admin'`.
 </p>
 
 <sample src="examples/LogInjection.java" />

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
@@ -31,11 +31,11 @@ other forms of HTML injection.
 
 <example>
 <p>In the example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). 
-In the first case (`\bad` endpoint), the username is logged without any sanitization.
+In the first case (`/bad` endpoint), the username is logged without any sanitization.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
 the log entry will be splitted in two different lines, where the first line will be `User:'Guest', while the second one will be `User:'Admin'`.
 </p>
-<p> In the second case (`\good` endpoint), <code>replace</code> is used to ensure no line endings are present in the user input.
+<p> In the second case (`/good` endpoint), <code>replace</code> is used to ensure no line endings are present in the user input.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
 the log entry will not be splitted in two different lines, resulting in a single line `User:'Guest'User:'Admin'`.
 </p>

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
@@ -1,0 +1,49 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+
+<p>If unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries.</p>
+
+<p>Forgery can occur if a user provides some input with characters that are interpreted
+when the log output is displayed. If the log is displayed as a plain text file, then new
+line characters can be used by a malicious user. If the log is displayed as HTML, then
+arbitrary HTML may be included to spoof log entries.</p>
+</overview>
+
+<recommendation>
+<p>
+User input should be suitably sanitized before it is logged.
+</p>
+<p>
+If the log entries are plain text then line breaks should be removed from user input, using for example
+<code>String replace(char oldChar, char newChar)</code> or similar. Care should also be taken that user input is clearly marked
+in log entries, and that a malicious user cannot cause confusion in other ways.
+</p>
+<p>
+For log entries that will be displayed in HTML, user input should be HTML encoded before being logged, to prevent forgery and
+other forms of HTML injection.
+</p>
+
+</recommendation>
+
+<example>
+<p>In the example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). 
+In the first case (`\bad` endpoint), the username is logged without any sanitization.
+If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
+the log entry will be splitted in two different lines, where the first line will be `User:'Guest', while the second one will be `User:'Admin'`.
+</p>
+<p> In the second case (`\good` endpoint), <code>replace</code> is used to ensure no line endings are present in the user input.
+If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
+the log entry will not be splitted in two different lines, resulting in a single line `User:'Guest'User:'Admin'`.
+</p>
+
+<sample src="examples/LogInjection.java" />
+</example>
+
+<references>
+<li>OWASP: <a href="https://www.owasp.org/index.php/Log_Injection">Log Injection</a>.</li>
+</references>
+</qhelp>

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.help
@@ -33,7 +33,7 @@ other forms of HTML injection.
 <p>In the example, a username, provided by the user, is logged using `logger.warn` (from `org.slf4j.Logger`). 
 In the first case (`/bad` endpoint), the username is logged without any sanitization.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 
-the log entry will be splitted in two different lines, where the first line will be `User:'Guest', while the second one will be `User:'Admin'`.
+the log entry will be splitted in two different lines, where the first line will be `User:'Guest'`, while the second one will be `User:'Admin'`.
 </p>
 <p> In the second case (`/good` endpoint), <code>replace</code> is used to ensure no line endings are present in the user input.
 If a malicious user provides `Guest'%0AUser:'Admin` as a username parameter, 

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
@@ -17,5 +17,5 @@ import DataFlow::PathGraph
 
 from LogInjectionConfiguration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
 where cfg.hasFlowPath(source, sink)
-select sink.getNode(), source, sink, "Outputting $@ to log.", source.getNode(),
-  "sensitive information"
+select sink.getNode(), source, sink, "$@ flows to log entry.", source.getNode(),
+  "User-provided value"

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.ql
@@ -1,0 +1,21 @@
+/**
+ * @name Log Injection
+ * @description Building log entries from user-controlled sources is vulnerable to
+ *              insertion of forged log entries by a malicious user.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/log-injection
+ * @tags security
+ *       external/cwe/cwe-117
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import LogInjection::LogInjection
+import DataFlow::PathGraph
+
+from LogInjectionConfiguration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink, "Outputting $@ to log.", source.getNode(),
+  "sensitive information"

--- a/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.qll
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/LogInjection.qll
@@ -1,0 +1,84 @@
+/**
+ * Provides a taint-tracking configuration for reasoning about untrusted user input used in log entries.
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+
+module LogInjection {
+  string logLevel() {
+    result = "trace" or
+    result = "info" or
+    result = "warn" or
+    result = "error" or
+    result = "fatal"
+  }
+
+  /**
+   * A data flow source for user input used in log entries.
+   */
+  abstract class Source extends DataFlow::Node { }
+
+  /**
+   * A data flow sink for user input used in log entries.
+   */
+  abstract class Sink extends DataFlow::Node { }
+
+  /**
+   * A sanitizer for malicious user input used in log entries.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /**
+   * A taint-tracking configuration for untrusted user input used in log entries.
+   */
+  class LogInjectionConfiguration extends TaintTracking::Configuration {
+    LogInjectionConfiguration() { this = "LogInjection" }
+
+    override predicate isSource(DataFlow::Node source) { source instanceof Source }
+
+    override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+    override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+  }
+
+  /**
+   * A source of remote user controlled input.
+   */
+  class RemoteSource extends Source {
+    RemoteSource() { this instanceof RemoteFlowSource }
+  }
+
+  /**
+   * A class of popular logging utilities.
+   */
+  class LoggingType extends RefType {
+    LoggingType() {
+      this.hasQualifiedName("org.apache.logging.log4j", "Logger") or
+      this.hasQualifiedName("org.slf4j", "Logger")
+    }
+  }
+
+  /**
+   * A method call to a logging mechanism.
+   */
+  class LoggingCall extends MethodAccess {
+    LoggingCall() {
+      this.getMethod().getDeclaringType() instanceof LoggingType and
+      this.getMethod().hasName(logLevel())
+    }
+  }
+
+  /**
+   * An argument to a logging mechanism.
+   */
+  class LoggingSink extends Sink {
+    LoggingSink() { this.asExpr() = any(LoggingCall console).getAnArgument() }
+  }
+
+  class TypeSanitizer extends Sanitizer {
+    TypeSanitizer() {
+      this.getType() instanceof PrimitiveType or this.getType() instanceof BoxedType
+    }
+  }
+}

--- a/java/ql/src/experimental/Security/CWE/CWE-117/examples/LogInjection.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/examples/LogInjection.java
@@ -16,7 +16,7 @@ public class LogInjection {
     public String good(@RequestParam(value = "username", defaultValue = "name") String username) {
         username = username.replace("\n", "");
         log.warn("User:'{}'", username);
-        return new String(username);
+        return username;
         // User:'Guest'User:'Admin'
     }
 
@@ -24,7 +24,7 @@ public class LogInjection {
     @GetMapping("/bad")
     public String bad(@RequestParam(value = "username", defaultValue = "name") String username) {
         log.warn("User:'{}'", username);
-        return new String(username);
+        return username;
         // User:'Guest'
         // User:'Admin'
 

--- a/java/ql/src/experimental/Security/CWE/CWE-117/examples/LogInjection.java
+++ b/java/ql/src/experimental/Security/CWE/CWE-117/examples/LogInjection.java
@@ -1,0 +1,33 @@
+package com.example.restservice;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LogInjection {
+
+    private final Logger log = LoggerFactory.getLogger(LogInjection.class);
+
+    // /good?username=Guest'%0AUser:'Admin
+    @GetMapping("/good")
+    public String good(@RequestParam(value = "username", defaultValue = "name") String username) {
+        username = username.replace("\n", "");
+        log.warn("User:'{}'", username);
+        return new String(username);
+        // User:'Guest'User:'Admin'
+    }
+
+    // /bad?username=Guest'%0AUser:'Admin
+    @GetMapping("/bad")
+    public String bad(@RequestParam(value = "username", defaultValue = "name") String username) {
+        log.warn("User:'{}'", username);
+        return new String(username);
+        // User:'Guest'
+        // User:'Admin'
+
+    }
+
+}


### PR DESCRIPTION
Log Injection query is available in c# query, javascript (experimental) query but it is not available in java query.
I created a query to detect a log injection vulnerability in java code.

This query addresses the scenario where user controlled input is logged-as is.

Examples of scenarios detected:

```java
    private final Logger log = LoggerFactory.getLogger(LogInjection.class);

    @GetMapping("/bad")
    public String bad(@RequestParam(value = "username", defaultValue = "name") String username) {
        log.warn("User:'{}'", username);
        return username;
    }
```

Any feedback is welcome.
I hope this will help.
