### PR TITLE
Python: BufferedRWPair Undefined Behavior

### DIFF
--- a/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.qhelp
+++ b/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.qhelp
@@ -1,0 +1,24 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+
+    <overview>
+        <p>
+            <code>BufferedRWPair</code> does not attempt to synchronize accesses to its underlying raw streams. 
+            You should not pass it the same object as reader and writer.
+        </p>
+    </overview>
+
+    <recommendation>
+        <p>
+
+            Use <code>BufferedRandom</code> instead.
+
+        </p>
+    </recommendation>
+
+    <references>
+        <li>Python Documentation: <a href="https://docs.python.org/3/library/io.html#io.BufferedRWPair">BufferedRWPair</a></li>
+    </references>
+</qhelp>

--- a/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.ql
+++ b/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.ql
@@ -1,0 +1,23 @@
+/**
+ * @name Same parameter used as reader and writer in BufferedRWPair
+ * @description Use of same parameter as reader and writer in BufferedRWPair.
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id python/bufferedrwpair-undefined-behavior
+ * @tags reliability
+ *       security
+ */
+
+import python
+
+ClassValue requestFunction() { result = Module::named("io").attr("BufferedRWPair") }
+
+from CallNode call, ClassValue func, ControlFlowNode read, ControlFlowNode write
+where
+  func = requestFunction() and
+  func.getACall() = call and
+  read = call.getArg(0) and
+  write = call.getArg(1) and
+  read.getNode().toString() = write.getNode().toString()
+select call, "BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams"

--- a/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.ql
+++ b/python/ql/src/experimental/Security/BufferedRWPairUndefinedBehavior.ql
@@ -3,10 +3,11 @@
  * @description Use of same parameter as reader and writer in BufferedRWPair.
  * @kind problem
  * @problem.severity warning
- * @precision medium
- * @id python/bufferedrwpair-undefined-behavior
+ * @id py/bufferedrwpair-undefined-behavior
  * @tags reliability
  *       security
+ *       external/cwe/cwe-475
+ *       external/cwe/cwe-758
  */
 
 import python
@@ -19,5 +20,5 @@ where
   func.getACall() = call and
   read = call.getArg(0) and
   write = call.getArg(1) and
-  read.getNode().toString() = write.getNode().toString()
-select call, "BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams"
+  read.pointsTo() = write.pointsTo()
+select call, "Using the same reader and writer for BufferedRWPair may cause unexpected behavior"

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
@@ -1,0 +1,1 @@
+| BufferedRWPairUndefinedBehavior.py:7:5:7:37 | ControlFlowNode for Attribute() | BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams |

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
@@ -1,1 +1,1 @@
-| BufferedRWPairUndefinedBehavior.py:7:5:7:37 | ControlFlowNode for Attribute() | BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams |
+| BufferedRWPairUndefinedBehavior.py:7:13:7:45 | ControlFlowNode for Attribute() | BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams |

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.expected
@@ -1,1 +1,1 @@
-| BufferedRWPairUndefinedBehavior.py:7:13:7:45 | ControlFlowNode for Attribute() | BufferedRWPair does not attempt to synchronize accesses to its underlying raw streams |
+| BufferedRWPairUndefinedBehavior.py:7:13:7:45 | ControlFlowNode for Attribute() | Using the same reader and writer for BufferedRWPair may cause unexpected behavior |

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.py
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.py
@@ -4,8 +4,13 @@ def buffer_rw_pair_test():
 
     reader = io.BufferedReader(io.RawIOBase)
     # BAD, uses reader for both parameters
-    io.BufferedRWPair(reader, reader)
+    pair1 = io.BufferedRWPair(reader, reader)
 
     writer = io.BufferedWriter(io.RawIOBase)
     # GOOD, uses different reader/writer
-    io.BufferedRWPair(reader, writer)
+    pair2 = io.BufferedRWPair(reader, writer)
+
+    # GOOD, uses reader variable as both reader and writer for random access
+    random = io.BufferedRandom(reader)
+
+    return (pair1, pair2, random)

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.py
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.py
@@ -1,0 +1,11 @@
+import io
+
+def buffer_rw_pair_test():
+
+    reader = io.BufferedReader(io.RawIOBase)
+    # BAD, uses reader for both parameters
+    io.BufferedRWPair(reader, reader)
+
+    writer = io.BufferedWriter(io.RawIOBase)
+    # GOOD, uses different reader/writer
+    io.BufferedRWPair(reader, writer)

--- a/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.qlref
+++ b/python/ql/test/experimental/query-tests/BufferedRWPairUndefinedBehavior.qlref
@@ -1,0 +1,1 @@
+experimental/Security/BufferedRWPairUndefinedBehavior.ql


### PR DESCRIPTION
The BufferedRWPair class in the io module does not synchronize accesses to its streams. As noted in the official Python 3 documentation, passing in the same object as the reader and writer is a security warning as it generally leads to undefined/undesired behavior. Should a developer want to use an interface for random access streams, it is recommended to use BufferedRandom instead, which creates both a reader and writer for a singular raw stream, and is generally more tailored for this purpose.