### PR TITLE
Java: data flow for `java.util.Objects`

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -400,6 +400,19 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
   node2.asExpr().(ChooseExpr).getAResultExpr() = node1.asExpr()
   or
   node2.asExpr().(AssignExpr).getSource() = node1.asExpr()
+  or
+  exists(MethodAccess ma, Method m |
+    ma = node2.asExpr() and
+    m = ma.getMethod() and
+    m.getDeclaringType().hasQualifiedName("java.util", "Objects") and
+    (
+      m.hasName(["requireNonNull", "requireNonNullElseGet"]) and node1.asExpr() = ma.getArgument(0)
+      or
+      m.hasName("requireNonNullElse") and node1.asExpr() = ma.getAnArgument()
+      or
+      m.hasName("toString") and node1.asExpr() = ma.getArgument(1)
+    )
+  )
 }
 
 /**

--- a/java/ql/test/library-tests/dataflow/local-flow/ObjectsTest.java
+++ b/java/ql/test/library-tests/dataflow/local-flow/ObjectsTest.java
@@ -1,0 +1,15 @@
+import java.util.Objects;
+
+class ObjectsTest {
+	public static void taintSteps() {
+		sink(Objects.requireNonNull(source()));
+		sink(Objects.requireNonNull(source(), "message"));
+		sink(Objects.requireNonNull(source(), () -> "value1"));
+		sink(Objects.requireNonNullElse(source(), source()));
+		sink(Objects.requireNonNullElseGet(source(), () -> "value2"));
+		sink(Objects.toString(null, source()));
+	}
+	private static <T> T source() { return null; }
+	private static void sink(Object o) {}
+}
+

--- a/java/ql/test/library-tests/dataflow/local-flow/ObjectsTest.java
+++ b/java/ql/test/library-tests/dataflow/local-flow/ObjectsTest.java
@@ -1,7 +1,7 @@
 import java.util.Objects;
 
 class ObjectsTest {
-	public static void taintSteps() {
+	public static void valueSteps() {
 		sink(Objects.requireNonNull(source()));
 		sink(Objects.requireNonNull(source(), "message"));
 		sink(Objects.requireNonNull(source(), () -> "value1"));
@@ -12,4 +12,3 @@ class ObjectsTest {
 	private static <T> T source() { return null; }
 	private static void sink(Object o) {}
 }
-

--- a/java/ql/test/library-tests/dataflow/local-flow/flow.expected
+++ b/java/ql/test/library-tests/dataflow/local-flow/flow.expected
@@ -1,0 +1,7 @@
+| ObjectsTest.java:5:31:5:38 | source(...) | ObjectsTest.java:5:8:5:39 | requireNonNull(...) |
+| ObjectsTest.java:6:31:6:38 | source(...) | ObjectsTest.java:6:8:6:50 | requireNonNull(...) |
+| ObjectsTest.java:7:31:7:38 | source(...) | ObjectsTest.java:7:8:7:55 | requireNonNull(...) |
+| ObjectsTest.java:8:35:8:42 | source(...) | ObjectsTest.java:8:8:8:53 | requireNonNullElse(...) |
+| ObjectsTest.java:8:45:8:52 | source(...) | ObjectsTest.java:8:8:8:53 | requireNonNullElse(...) |
+| ObjectsTest.java:9:38:9:45 | source(...) | ObjectsTest.java:9:8:9:62 | requireNonNullElseGet(...) |
+| ObjectsTest.java:10:31:10:38 | source(...) | ObjectsTest.java:10:8:10:39 | toString(...) |

--- a/java/ql/test/library-tests/dataflow/local-flow/flow.ql
+++ b/java/ql/test/library-tests/dataflow/local-flow/flow.ql
@@ -1,7 +1,7 @@
 import java
-import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.DataFlow
 
-class Conf extends TaintTracking::Configuration {
+class Conf extends DataFlow::Configuration {
   Conf() { this = "conf" }
 
   override predicate isSource(DataFlow::Node src) {

--- a/java/ql/test/library-tests/dataflow/local-flow/flow.ql
+++ b/java/ql/test/library-tests/dataflow/local-flow/flow.ql
@@ -1,0 +1,21 @@
+import java
+import semmle.code.java.dataflow.TaintTracking
+
+class Conf extends TaintTracking::Configuration {
+  Conf() { this = "conf" }
+
+  override predicate isSource(DataFlow::Node src) {
+    src.asExpr().(MethodAccess).getMethod().hasName("source")
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      sink.asExpr() = ma.getAnArgument() and
+      ma.getMethod().hasName("sink")
+    )
+  }
+}
+
+from Conf c, DataFlow::Node src, DataFlow::Node sink
+where c.hasFlow(src, sink)
+select src, sink

--- a/java/ql/test/library-tests/dataflow/local-flow/options
+++ b/java/ql/test/library-tests/dataflow/local-flow/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -source 14 -target 14


### PR DESCRIPTION
Model taint propagation to return values  for methods of `java.util.Objects` [`java.util.Objects`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/util/Objects.html) 

Methods:
- `requireNonNull(T)`
- `requireNonNull​(T, String)`
- `requireNonNull​(T, Supplier<String>)`
- `requireNonNullElse​(T, T)` (taint both arguments)
- `requireNonNullElseGet​(T, Supplier<T>)`
- ~~`toString(Object)`~~
- `toString(Object, String)` (taint only second argument)

Fixes #3895 