### PR TITLE
Python: ZipSlip

### DIFF
--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.qhelp
@@ -1,0 +1,61 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Extracting files from a malicious zip archive without validating that the destination file path
+is within the destination directory can cause files outside the destination directory to be
+overwritten, due to the possible presence of directory traversal elements (<code>..</code>) in
+archive paths.</p>
+
+<p>Zip archives contain archive entries representing each file in the archive. These entries
+include a file path for the entry, but these file paths are not restricted and may contain
+unexpected special elements such as the directory traversal element (<code>..</code>). If these
+file paths are used to determine an output file to write the contents of the archive item to, then
+the file may be written to an unexpected location. This can result in sensitive information being
+revealed or deleted, or an attacker being able to influence behavior by modifying unexpected
+files.</p>
+
+<p>For example, if a zip archive contains a file entry <code>..\sneaky-file</code>, and the zip archive
+is extracted to the directory <code>c:\output</code>, then naively combining the paths would result
+in an output file path of <code>c:\output\..\sneaky-file</code>, which would cause the file to be
+written to <code>c:\sneaky-file</code>.</p>
+
+</overview>
+<recommendation>
+
+<p>Ensure that output paths constructed from zip archive entries are validated
+to prevent writing files to unexpected locations.</p>
+
+<p>The recommended way of writing an output file from a zip archive entry is to check that
+<code>".."</code> does not occur in the path.
+</p>
+
+</recommendation>
+
+<p>To fix this vulnerability, we need to check that the path does not
+contain any <code>".."</code> elements in it.
+</p>
+
+<references>
+
+<li>
+Snyk:
+<a href="https://snyk.io/research/zip-slip-vulnerability">Zip Slip Vulnerability</a>.
+</li>
+<li>
+OWASP:
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
+</li>
+<li>
+Python Library Reference:
+<a href="https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extract">ZipFile.extract</a>.
+</li>
+<li>
+Python Library Reference:
+<a href="https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.extractall">ZipFile.extractall</a>.
+</li>
+
+</references>
+</qhelp>

--- a/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
+++ b/python/ql/src/experimental/Security/CWE-022/ZipSlip.ql
@@ -1,0 +1,183 @@
+/**
+ * @name Arbitrary file write during zipfile extraction
+ * @description Extracting files from a malicious zip archive without validating that the
+ *              destination file path is within the destination directory can cause files outside
+ *              the destination directory to be overwritten.
+ * @kind path-problem
+ * @id py/zipslip
+ * @problem.severity error
+ * @precision medium
+ * @tags security
+ *       external/cwe/cwe-022
+ */
+
+import python
+import semmle.python.security.Paths
+import semmle.python.security.TaintTracking
+import semmle.python.security.strings.Basic
+
+/** A TaintKind to represent open zipfile objects. That is, the result of calling `zipfile.ZipFile(...)` */
+class OpenZipFile extends TaintKind {
+  OpenZipFile() { this = "zipfile.ZipFile" }
+
+  override TaintKind getTaintOfMethodResult(string name) {
+    name = "getinfo" and result instanceof ZipFileInfo
+    or
+    name = "infolist" and result.(SequenceKind).getItem() instanceof ZipFileInfo
+    or
+    name = "namelist" and result.(SequenceKind).getItem() instanceof ZipFileInfo
+  }
+
+  override ClassValue getType() { result = Value::named("zipfile.ZipFile") }
+
+  override TaintKind getTaintForIteration() { result instanceof ZipFileInfo }
+}
+
+/** The source of open zipfile objects. That is, any call to `zipfile.ZipFile(...)` */
+class ZipfileOpen extends TaintSource {
+  ZipfileOpen() {
+    Value::named("zipfile.ZipFile").getACall() = this and
+    /*
+     * If argument refers to a string object, then it's a hardcoded path and
+     * this zipfile is safe.
+     */
+
+    not this.(CallNode).getAnArg().pointsTo(any(StringValue str)) and
+    /* Ignore opens within the zipfile module itself */
+    not this.(ControlFlowNode).getLocation().getFile().getBaseName() = "zipfile.py"
+  }
+
+  override predicate isSourceOf(TaintKind kind) { kind instanceof OpenZipFile }
+}
+
+class ZipFileInfo extends TaintKind {
+  ZipFileInfo() { this = "zipfile.entry" }
+
+  override TaintKind getTaintOfMethodResult(string name) { name = "next" and result = this }
+
+  override TaintKind getTaintOfAttribute(string name) {
+    name = "name" and result instanceof ZipFileInfo
+  }
+}
+
+/*
+ * For efficiency we don't want to track the flow of taint
+ * around the zipfile module.
+ */
+
+class ExcludeZipFilePy extends Sanitizer {
+  ExcludeZipFilePy() { this = "Zip sanitizer" }
+
+  override predicate sanitizingNode(TaintKind taint, ControlFlowNode node) {
+    node.getLocation().getFile().getBaseName() = "zipfile.py" and
+    (
+      taint instanceof OpenZipFile
+      or
+      taint instanceof ZipFileInfo
+      or
+      taint.(SequenceKind).getItem() instanceof ZipFileInfo
+    )
+  }
+}
+
+/* Any call to an extractall method */
+class ExtractAllSink extends TaintSink {
+  CallNode call;
+
+  ExtractAllSink() {
+    this = call.getFunction().(AttrNode).getObject("extractall") and
+    count(call.getAnArg()) = 0
+  }
+
+  override predicate sinks(TaintKind kind) { kind instanceof OpenZipFile }
+}
+
+/* Argument to extract method */
+class ExtractSink extends TaintSink {
+  CallNode call;
+
+  ExtractSink() {
+    call.getFunction().(AttrNode).getName() = "extract" and
+    this = call.getArg(0)
+  }
+
+  override predicate sinks(TaintKind kind) { kind instanceof ZipFileInfo }
+}
+
+/* Members argument to extract method */
+class ExtractMembersSink extends TaintSink {
+  CallNode call;
+
+  ExtractMembersSink() {
+    call.getFunction().(AttrNode).getName() = "extractall" and
+    (this = call.getArg(0) or this = call.getArgByName("members"))
+  }
+
+  override predicate sinks(TaintKind kind) {
+    kind.(SequenceKind).getItem() instanceof ZipFileInfo
+    or
+    kind instanceof OpenZipFile
+  }
+}
+
+class ZipFileInfoSanitizer extends Sanitizer {
+  ZipFileInfoSanitizer() { this = "ZipInfo sanitizer" }
+
+  /** The test `if <path_sanitizing_test>:` clears taint on its `false` edge. */
+  override predicate sanitizingEdge(TaintKind taint, PyEdgeRefinement test) {
+    taint instanceof ZipFileInfo and
+    clears_taint_on_false_edge(test.getTest(), test.getSense())
+  }
+
+  private predicate clears_taint_on_false_edge(ControlFlowNode test, boolean sense) {
+    path_sanitizing_test(test) and
+    sense = false
+    or
+    // handle `not` (also nested)
+    test.(UnaryExprNode).getNode().getOp() instanceof Not and
+    clears_taint_on_false_edge(test.(UnaryExprNode).getOperand(), sense.booleanNot())
+  }
+}
+
+private predicate path_sanitizing_test(ControlFlowNode test) {
+  /* Assume that any test with "path" in it is a sanitizer */
+  test.getAChild+().(AttrNode).getName().matches("%path")
+  or
+  test.getAChild+().(NameNode).getId().matches("%path")
+}
+
+class ZipSlipConfiguration extends TaintTracking::Configuration {
+  ZipSlipConfiguration() { this = "ZipSlip configuration" }
+
+  override predicate isSource(TaintTracking::Source source) { source instanceof ZipfileOpen }
+
+  override predicate isSink(TaintTracking::Sink sink) {
+    sink instanceof ExtractSink or
+    sink instanceof ExtractAllSink or
+    sink instanceof ExtractMembersSink
+  }
+
+  override predicate isSanitizer(Sanitizer sanitizer) {
+    sanitizer instanceof ZipFileInfoSanitizer
+    or
+    sanitizer instanceof ExcludeZipFilePy
+  }
+
+  override predicate isBarrier(DataFlow::Node node) {
+    // Avoid flow into the zipfile module
+    exists(ParameterDefinition def |
+      node.asVariable().getDefinition() = def
+      or
+      node.asCfgNode() = def.getDefiningNode()
+    |
+      def.getScope() = Value::named("zipfile.ZipFile").(CallableValue).getScope()
+      or
+      def.isSelf() and def.getScope().getEnclosingModule().getName() = "zipfile"
+    )
+  }
+}
+
+from ZipSlipConfiguration config, TaintedPathSource src, TaintedPathSink sink
+where config.hasFlowPath(src, sink)
+select sink.getSink(), src, sink, "Extraction of zipfile from $@", src.getSource(),
+  "a potentially untrusted source"

--- a/python/ql/test/experimental/query-tests/Security/CWE-022/ZipSlip.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-022/ZipSlip.expected
@@ -1,0 +1,46 @@
+edges
+| zipslip.py:18:6:18:41 | zipfile.ZipFile | zipslip.py:19:18:19:20 | zipfile.ZipFile |
+| zipslip.py:18:6:18:41 | zipfile.ZipFile | zipslip.py:19:18:19:20 | zipfile.ZipFile |
+| zipslip.py:19:5:19:32 | zipfile.entry | zipslip.py:20:21:20:25 | zipfile.entry |
+| zipslip.py:19:5:19:32 | zipfile.entry | zipslip.py:20:21:20:25 | zipfile.entry |
+| zipslip.py:19:18:19:20 | zipfile.ZipFile | zipslip.py:19:18:19:31 | sequence of zipfile.entry |
+| zipslip.py:19:18:19:20 | zipfile.ZipFile | zipslip.py:19:18:19:31 | sequence of zipfile.entry |
+| zipslip.py:19:18:19:31 | sequence of zipfile.entry | zipslip.py:19:5:19:32 | zipfile.entry |
+| zipslip.py:19:18:19:31 | sequence of zipfile.entry | zipslip.py:19:5:19:32 | zipfile.entry |
+| zipslip.py:23:6:23:41 | zipfile.ZipFile | zipslip.py:24:18:24:20 | zipfile.ZipFile |
+| zipslip.py:23:6:23:41 | zipfile.ZipFile | zipslip.py:24:18:24:20 | zipfile.ZipFile |
+| zipslip.py:24:5:24:32 | zipfile.entry | zipslip.py:25:21:25:25 | zipfile.entry |
+| zipslip.py:24:5:24:32 | zipfile.entry | zipslip.py:25:21:25:25 | zipfile.entry |
+| zipslip.py:24:18:24:20 | zipfile.ZipFile | zipslip.py:24:18:24:31 | sequence of zipfile.entry |
+| zipslip.py:24:18:24:20 | zipfile.ZipFile | zipslip.py:24:18:24:31 | sequence of zipfile.entry |
+| zipslip.py:24:18:24:31 | sequence of zipfile.entry | zipslip.py:24:5:24:32 | zipfile.entry |
+| zipslip.py:24:18:24:31 | sequence of zipfile.entry | zipslip.py:24:5:24:32 | zipfile.entry |
+| zipslip.py:28:6:28:41 | zipfile.ZipFile | zipslip.py:29:5:29:7 | zipfile.ZipFile |
+| zipslip.py:28:6:28:41 | zipfile.ZipFile | zipslip.py:29:5:29:7 | zipfile.ZipFile |
+| zipslip.py:43:6:43:41 | zipfile.ZipFile | zipslip.py:44:18:44:20 | zipfile.ZipFile |
+| zipslip.py:43:6:43:41 | zipfile.ZipFile | zipslip.py:44:18:44:20 | zipfile.ZipFile |
+| zipslip.py:44:5:44:32 | zipfile.entry | zipslip.py:47:21:47:25 | zipfile.entry |
+| zipslip.py:44:5:44:32 | zipfile.entry | zipslip.py:47:21:47:25 | zipfile.entry |
+| zipslip.py:44:18:44:20 | zipfile.ZipFile | zipslip.py:44:18:44:31 | sequence of zipfile.entry |
+| zipslip.py:44:18:44:20 | zipfile.ZipFile | zipslip.py:44:18:44:31 | sequence of zipfile.entry |
+| zipslip.py:44:18:44:31 | sequence of zipfile.entry | zipslip.py:44:5:44:32 | zipfile.entry |
+| zipslip.py:44:18:44:31 | sequence of zipfile.entry | zipslip.py:44:5:44:32 | zipfile.entry |
+| zipslip.py:50:6:50:41 | zipfile.ZipFile | zipslip.py:51:28:51:30 | zipfile.ZipFile |
+| zipslip.py:50:6:50:41 | zipfile.ZipFile | zipslip.py:51:28:51:30 | zipfile.ZipFile |
+| zipslip.py:51:28:51:30 | zipfile.ZipFile | zipslip.py:51:28:51:41 | sequence of zipfile.entry |
+| zipslip.py:51:28:51:30 | zipfile.ZipFile | zipslip.py:51:28:51:41 | sequence of zipfile.entry |
+| zipslip.py:54:6:54:41 | zipfile.ZipFile | zipslip.py:55:18:55:20 | zipfile.ZipFile |
+| zipslip.py:54:6:54:41 | zipfile.ZipFile | zipslip.py:55:18:55:20 | zipfile.ZipFile |
+| zipslip.py:55:5:55:32 | zipfile.entry | zipslip.py:57:25:57:29 | zipfile.entry |
+| zipslip.py:55:5:55:32 | zipfile.entry | zipslip.py:57:25:57:29 | zipfile.entry |
+| zipslip.py:55:18:55:20 | zipfile.ZipFile | zipslip.py:55:18:55:31 | sequence of zipfile.entry |
+| zipslip.py:55:18:55:20 | zipfile.ZipFile | zipslip.py:55:18:55:31 | sequence of zipfile.entry |
+| zipslip.py:55:18:55:31 | sequence of zipfile.entry | zipslip.py:55:5:55:32 | zipfile.entry |
+| zipslip.py:55:18:55:31 | sequence of zipfile.entry | zipslip.py:55:5:55:32 | zipfile.entry |
+#select
+| zipslip.py:20:21:20:25 | entry | zipslip.py:18:6:18:41 | zipfile.ZipFile | zipslip.py:20:21:20:25 | zipfile.entry | Extraction of zipfile from $@ | zipslip.py:18:6:18:41 | Attribute() | a potentially untrusted source |
+| zipslip.py:25:21:25:25 | entry | zipslip.py:23:6:23:41 | zipfile.ZipFile | zipslip.py:25:21:25:25 | zipfile.entry | Extraction of zipfile from $@ | zipslip.py:23:6:23:41 | Attribute() | a potentially untrusted source |
+| zipslip.py:29:5:29:7 | zip | zipslip.py:28:6:28:41 | zipfile.ZipFile | zipslip.py:29:5:29:7 | zipfile.ZipFile | Extraction of zipfile from $@ | zipslip.py:28:6:28:41 | Attribute() | a potentially untrusted source |
+| zipslip.py:47:21:47:25 | entry | zipslip.py:43:6:43:41 | zipfile.ZipFile | zipslip.py:47:21:47:25 | zipfile.entry | Extraction of zipfile from $@ | zipslip.py:43:6:43:41 | Attribute() | a potentially untrusted source |
+| zipslip.py:51:28:51:41 | Attribute() | zipslip.py:50:6:50:41 | zipfile.ZipFile | zipslip.py:51:28:51:41 | sequence of zipfile.entry | Extraction of zipfile from $@ | zipslip.py:50:6:50:41 | Attribute() | a potentially untrusted source |
+| zipslip.py:57:25:57:29 | entry | zipslip.py:54:6:54:41 | zipfile.ZipFile | zipslip.py:57:25:57:29 | zipfile.entry | Extraction of zipfile from $@ | zipslip.py:54:6:54:41 | Attribute() | a potentially untrusted source |

--- a/python/ql/test/experimental/query-tests/Security/CWE-022/ZipSlip.qlref
+++ b/python/ql/test/experimental/query-tests/Security/CWE-022/ZipSlip.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE-022/ZipSlip.ql

--- a/python/ql/test/experimental/query-tests/Security/CWE-022/zipslip.py
+++ b/python/ql/test/experimental/query-tests/Security/CWE-022/zipslip.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+import sys, os, zipfile
+
+unsafe_filename_zip = sys.argv[1]
+safe_filename_zip = "safe_path.zip"
+
+# GOOD, extract from infolist using safe name
+with zipfile.ZipFile(safe_filename_zip) as zip:
+    for entry in zip.infolist():
+        zip.extract(entry)
+
+# GOOD, extract from namelist using safe name
+with zipfile.ZipFile(safe_filename_zip) as zip:
+    for entry in zip.namelist():
+        zip.extract(entry)
+
+# BAD, extract from infolist using unsafe name
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        zip.extract(entry)
+
+# BAD, extract from namelist using unsafe name
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.namelist():
+        zip.extract(entry)
+
+# BAD, extractall using unsafe name
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    zip.extractall()
+
+# GOOD, extractall using safe name
+with zipfile.ZipFile(safe_filename_zip) as zip:
+    zip.extractall()
+
+#Sanitized
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if os.path.isabs(entry) or ".." in entry:
+            raise ValueError("Illegal zip archive entry")
+        zip.extract(entry, "/tmp/unpack/")
+
+#Part Sanitized
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if ".." in entry:
+            raise ValueError("Illegal zip archive entry")
+        zip.extract(entry, "/tmp/unpack/")
+
+#Unsanitized members
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    zip.extractall(members=zip.infolist())
+
+# Wrong sanitizer (is missing not)
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if os.path.isabs(entry) or ".." in entry:
+            zip.extract(entry, "/tmp/unpack/")
+
+
+# OK Sanitized using not
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if not (os.path.isabs(entry) or ".." in entry):
+            zip.extract(entry, "/tmp/unpack/")
+
+# The following two variants are included by purpose, since by default there is a
+# difference in handling `not x` and `not (x or False)` when overriding
+# Sanitizer.sanitizingEdge. We want to ensure we handle both consistently.
+
+# Not reported, although vulnerable to '..'
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if not (os.path.isabs(entry) or False):
+            zip.extract(entry, "/tmp/unpack/")
+
+# Not reported, although vulnerable to '..'
+with zipfile.ZipFile(unsafe_filename_zip) as zip:
+    for entry in zip.infolist():
+        if not os.path.isabs(entry):
+            zip.extract(entry, "/tmp/unpack/")


### PR DESCRIPTION
Query that detects path traversal vulnerability during extraction of zip archives. Extracting files from a malicious zip archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be
overwritten, due to the possible presence of directory traversal elements in archive paths.