### PR TITLE
Java: Update query console links in "Learning CodeQL" docs

### DIFF
--- a/docs/language/learn-ql/java/annotations.rst
+++ b/docs/language/learn-ql/java/annotations.rst
@@ -49,7 +49,7 @@ We could then write this query to find all ``@SuppressWarnings`` annotations att
        anntp.hasQualifiedName("java.lang", "SuppressWarnings")
    select ann, ann.getValue("value")
 
-➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/632150601>`__. Several of the LGTM.com demo projects use the ``@SuppressWarnings`` annotation. Looking at the ``value``\ s of the annotation element returned by the query, we can see that the *apache/activemq* project uses the ``"rawtypes"`` value described above.
+➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/1775658606775222283/>`__. Several of the LGTM.com demo projects use the ``@SuppressWarnings`` annotation. Looking at the ``value``\ s of the annotation element returned by the query, we can see that the *apache/activemq* project uses the ``"rawtypes"`` value described above.
 
 As another example, this query finds all annotation types that only have a single annotation element, which has name ``value``:
 
@@ -64,7 +64,7 @@ As another example, this query finds all annotation types that only have a singl
    )
    select anntp
 
-➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/669220001>`__.
+➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/2145264152490258283/>`__.
 
 Example: Finding missing ``@Override`` annotations
 --------------------------------------------------
@@ -122,7 +122,7 @@ This makes it very easy to write our query for finding methods that override ano
        not overriding.getAnAnnotation() instanceof OverrideAnnotation
    select overriding, "Method overrides another method, but does not have an @Override annotation."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1505752756202/>`__. In practice, this query may yield many results from compiled library code, which aren't very interesting. It's therefore a good idea to add another conjunct ``overriding.fromSource()`` to restrict the result to only report methods for which source code is available.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/7419756266089837339/>`__. In practice, this query may yield many results from compiled library code, which aren't very interesting. It's therefore a good idea to add another conjunct ``overriding.fromSource()`` to restrict the result to only report methods for which source code is available.
 
 Example: Finding calls to deprecated methods
 --------------------------------------------
@@ -192,13 +192,13 @@ For instance, consider this slightly updated example:
 .. code-block:: java
 
    class A {
-   @Deprecated void m() {}
+       @Deprecated void m() {}
 
-   @Deprecated void n() {
-       m();
-   }
+       @Deprecated void n() {
+           m();
+       }
 
-   @SuppressWarnings("deprecated")
+       @SuppressWarnings("deprecated")
        void r() {
            m();
        }
@@ -235,7 +235,7 @@ Now we can extend our query to filter out calls in methods carrying a ``Suppress
        and not call.getCaller().getAnAnnotation() instanceof SuppressDeprecationWarningAnnotation
    select call, "This call invokes a deprecated method."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/665760001>`__. It's fairly common for projects to contain calls to methods that appear to be deprecated.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8706367340403790260/>`__. It's fairly common for projects to contain calls to methods that appear to be deprecated.
 
 Further reading
 ---------------

--- a/docs/language/learn-ql/java/call-graph.rst
+++ b/docs/language/learn-ql/java/call-graph.rst
@@ -78,7 +78,7 @@ We can use the ``Callable`` class to write a query that finds methods that are n
    where not exists(Callable caller | caller.polyCalls(callee))
    select callee
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/665280012/>`__. This simple query typically returns a large number of results.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8376915232270534450/>`__. This simple query typically returns a large number of results.
 
 .. pull-quote::
 
@@ -97,7 +97,7 @@ Running this query on a typical Java project results in lots of hits in the Java
        callee.getCompilationUnit().fromSource()
    select callee, "Not called."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/668510015/>`__. This change reduces the number of results returned for most projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8711624074465690976/>`__. This change reduces the number of results returned for most projects.
 
 We might also notice several unused methods with the somewhat strange name ``<clinit>``: these are class initializers; while they are not explicitly called anywhere in the code, they are called implicitly whenever the surrounding class is loaded. Hence it makes sense to exclude them from our query. While we are at it, we can also exclude finalizers, which are similarly invoked implicitly:
 
@@ -111,7 +111,7 @@ We might also notice several unused methods with the somewhat strange name ``<cl
        not callee.hasName("<clinit>") and not callee.hasName("finalize")
    select callee, "Not called."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/672230002/>`__. This also reduces the number of results returned by most projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/925473733866047471/>`__. This also reduces the number of results returned by most projects.
 
 We may also want to exclude public methods from our query, since they may be external API entry points:
 
@@ -126,7 +126,7 @@ We may also want to exclude public methods from our query, since they may be ext
        not callee.isPublic()
    select callee, "Not called."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/667290016/>`__. This should have a more noticeable effect on the number of results returned.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/6284320987237954610/>`__. This should have a more noticeable effect on the number of results returned.
 
 A further special case is non-public default constructors: in the singleton pattern, for example, a class is provided with private empty default constructor to prevent it from being instantiated. Since the very purpose of such constructors is their not being called, they should not be flagged up:
 
@@ -142,7 +142,7 @@ A further special case is non-public default constructors: in the singleton patt
        not callee.(Constructor).getNumberOfParameters() = 0
    select callee, "Not called."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/673060008/>`__. This change has a large effect on the results for some projects but little effect on the results for others. Use of this pattern varies widely between different projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/2625028545869146918/>`__. This change has a large effect on the results for some projects but little effect on the results for others. Use of this pattern varies widely between different projects.
 
 Finally, on many Java projects there are methods that are invoked indirectly by reflection. So, while there are no calls invoking these methods, they are, in fact, used. It is in general very hard to identify such methods. A very common special case, however, is JUnit test methods, which are reflectively invoked by a test runner. The CodeQL library for Java has support for recognizing test classes of JUnit and other testing frameworks, which we can employ to filter out methods defined in such classes:
 
@@ -159,7 +159,7 @@ Finally, on many Java projects there are methods that are invoked indirectly by 
        not callee.getDeclaringType() instanceof TestClass
    select callee, "Not called."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/665760002/>`__. This should give a further reduction in the number of results returned.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/2055862421970264112/>`__. This should give a further reduction in the number of results returned.
 
 Further reading
 ---------------

--- a/docs/language/learn-ql/java/expressions-statements.rst
+++ b/docs/language/learn-ql/java/expressions-statements.rst
@@ -42,7 +42,7 @@ We'll start by writing a query that finds less-than expressions (CodeQL class ``
        expr.getRightOperand().getType().hasName("long")
    select expr
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/672320008/>`__. This query usually finds results on most projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/490866529746563234/>`__. This query usually finds results on most projects.
 
 Notice that we use the predicate ``getType`` (available on all subclasses of ``Expr``) to determine the type of the operands. Types, in turn, define the ``hasName`` predicate, which allows us to identify the primitive types ``int`` and ``long``. As it stands, this query finds *all* less-than expressions comparing ``int`` and ``long``, but in fact we are only interested in comparisons that are part of a loop condition. Also, we want to filter out comparisons where either operand is constant, since these are less likely to be real bugs. The revised query looks like this:
 
@@ -57,7 +57,7 @@ Notice that we use the predicate ``getType`` (available on all subclasses of ``E
        not expr.getAnOperand().isCompileTimeConstant()
    select expr
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/690010001/>`__. Notice that fewer results are found.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/4315986481180063825/>`__. Notice that fewer results are found.
 
 The class ``LoopStmt`` is a common superclass of all loops, including, in particular, ``for`` loops as in our example above. While different kinds of loops have different syntax, they all have a loop condition, which can be accessed through predicate ``getCondition``. We use the reflexive transitive closure operator ``*`` applied to the ``getAChildExpr`` predicate to express the requirement that ``expr`` should be nested inside the loop condition. In particular, it can be the loop condition itself.
 
@@ -120,7 +120,7 @@ Now we rewrite our query to make use of these new classes:
    not expr.getAnOperand().isCompileTimeConstant()
    select expr
 
-➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/1951710018/lang:java/>`__.
+➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/506868054626167462/>`__.
 
 Further reading
 ---------------

--- a/docs/language/learn-ql/java/introduce-libraries-java.rst
+++ b/docs/language/learn-ql/java/introduce-libraries-java.rst
@@ -49,7 +49,7 @@ Types
 
 Class ``Type`` has a number of subclasses for representing different kinds of types:
 
--  ``PrimitiveType`` represents a `primitive type <http://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html>`__, that is, one of ``boolean``, ``byte``, ``char``, ``double``, ``float``, ``int``, ``long``, ``short``; QL also classifies ``void`` and ``<nulltype>`` (the type of the ``null`` literal) as primitive types.
+-  ``PrimitiveType`` represents a `primitive type <https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html>`__, that is, one of ``boolean``, ``byte``, ``char``, ``double``, ``float``, ``int``, ``long``, ``short``; QL also classifies ``void`` and ``<nulltype>`` (the type of the ``null`` literal) as primitive types.
 -  ``RefType`` represents a reference (that is, non-primitive) type; it in turn has several subclasses:
 
    -  ``Class`` represents a Java class.
@@ -68,7 +68,7 @@ For example, the following query finds all variables of type ``int`` in the prog
        pt.hasName("int")
    select v
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/660700018/>`__. You're likely to get many results when you run this query because most projects contain many variables of type ``int``.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/860076406167044435/>`__. You're likely to get many results when you run this query because most projects contain many variables of type ``int``.
 
 Reference types are also categorized according to their declaration scope:
 
@@ -85,15 +85,15 @@ For instance, this query finds all top-level types whose name is not the same as
    where tl.getName() != tl.getCompilationUnit().getName()
    select tl
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/674620002/>`__. This pattern is seen in many projects. When we ran it on the LGTM.com demo projects, most of the projects had at least one instance of this problem in the source code. There were many more instances in the files referenced by the source code.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/4340983612585284460/>`__. This pattern is seen in many projects. When we ran it on the LGTM.com demo projects, most of the projects had at least one instance of this problem in the source code. There were many more instances in the files referenced by the source code.
 
 Several more specialized classes are available as well:
 
 -  ``TopLevelClass`` represents a class declared at the top-level of a compilation unit.
--  ``NestedClass`` represents `a class declared inside another type <http://docs.oracle.com/javase/tutorial/java/javaOO/nested.html>`__, such as:
+-  ``NestedClass`` represents `a class declared inside another type <https://docs.oracle.com/javase/tutorial/java/javaOO/nested.html>`__, such as:
 
-   -  A ``LocalClass``, which is `a class declared inside a method or constructor <http://docs.oracle.com/javase/tutorial/java/javaOO/localclasses.html>`__.
-   -  An ``AnonymousClass``, which is an `anonymous class <http://docs.oracle.com/javase/tutorial/java/javaOO/anonymousclasses.html>`__.
+   -  A ``LocalClass``, which is `a class declared inside a method or constructor <https://docs.oracle.com/javase/tutorial/java/javaOO/localclasses.html>`__.
+   -  An ``AnonymousClass``, which is an `anonymous class <https://docs.oracle.com/javase/tutorial/java/javaOO/anonymousclasses.html>`__.
 
 Finally, the library also has a number of singleton classes that wrap frequently used Java standard library classes: ``TypeObject``, ``TypeCloneable``, ``TypeRuntime``, ``TypeSerializable``, ``TypeString``, ``TypeSystem`` and ``TypeClass``. Each CodeQL class represents the standard Java class suggested by its name.
 
@@ -107,7 +107,7 @@ As an example, we can write a query that finds all nested classes that directly 
    where nc.getASupertype() instanceof TypeObject
    select nc
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/672230026/>`__. You're likely to get many results when you run this query because many projects include nested classes that extend ``Object`` directly.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8482509736206423238/>`__. You're likely to get many results when you run this query because many projects include nested classes that extend ``Object`` directly.
 
 Generics
 ~~~~~~~~
@@ -141,7 +141,7 @@ For instance, we could use the following query to find all parameterized instanc
        pt.getSourceDeclaration() = map
    select pt
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/660700019/>`__. None of the LGTM.com demo projects contain parameterized instances of ``java.util.Map`` in their source code, but they all have results in reference files.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/7863873821043873550/>`__. None of the LGTM.com demo projects contain parameterized instances of ``java.util.Map`` in their source code, but they all have results in reference files.
 
 In general, generic types may restrict which types a type parameter can be bound to. For instance, a type of maps from strings to numbers could be declared as follows:
 
@@ -164,7 +164,7 @@ As an example, the following query finds all type variables with type bound ``Nu
        tb.getType().hasQualifiedName("java.lang", "Number")
    select tv
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/690010016/>`__. When we ran it on the LGTM.com demo projects, the *neo4j/neo4j*, *gradle/gradle* and *hibernate/hibernate-orm* projects all contained examples of this pattern.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/6740696080876162817/>`__. When we ran it on the LGTM.com demo projects, the *neo4j/neo4j*, *hibernate/hibernate-orm* and *apache/hadoop* projects all contained examples of this pattern.
 
 For dealing with legacy code that is unaware of generics, every generic type has a "raw" version without any type parameters. In the CodeQL libraries, raw types are represented using class ``RawType``, which has the expected subclasses ``RawClass`` and ``RawInterface``. Again, there is a predicate ``getSourceDeclaration`` for obtaining the corresponding generic type. As an example, we can find variables of (raw) type ``Map``:
 
@@ -177,7 +177,7 @@ For dealing with legacy code that is unaware of generics, every generic type has
        rt.getSourceDeclaration().hasQualifiedName("java.util", "Map")
    select v
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/686320008/>`__. Many projects have variables of raw type ``Map``.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/4032913402499547882/>`__. Many projects have variables of raw type ``Map``.
 
 For example, in the following code snippet this query would find ``m1``, but not ``m2``:
 
@@ -186,7 +186,7 @@ For example, in the following code snippet this query would find ``m1``, but not
    Map m1 = new HashMap();
    Map<String, String> m2 = new HashMap<String, String>();
 
-Finally, variables can be declared to be of a `wildcard type <http://docs.oracle.com/javase/tutorial/java/generics/wildcards.html>`__:
+Finally, variables can be declared to be of a `wildcard type <https://docs.oracle.com/javase/tutorial/java/generics/wildcards.html>`__:
 
 .. code-block:: java
 
@@ -201,7 +201,7 @@ For more information on working with types, see the :doc:`article on Java types 
 Variables
 ~~~~~~~~~
 
-Class ``Variable`` represents a variable `in the Java sense <http://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html>`__, which is either a member field of a class (whether static or not), or a local variable, or a parameter. Consequently, there are three subclasses catering to these special cases:
+Class ``Variable`` represents a variable `in the Java sense <https://docs.oracle.com/javase/tutorial/java/nutsandbolts/variables.html>`__, which is either a member field of a class (whether static or not), or a local variable, or a parameter. Consequently, there are three subclasses catering to these special cases:
 
 -  ``Field`` represents a Java field.
 -  ``LocalVariableDecl`` represents a local variable.
@@ -228,7 +228,7 @@ For example, the following query finds all expressions whose parents are ``retur
    where e.getParent() instanceof ReturnStmt
    select e
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/668700463/>`__. Many projects have examples of ``return`` statements with child statements.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1947757851560375919/>`__. Many projects have examples of ``return`` statements with child expressions.
 
 Therefore, if the program contains a return statement ``return x + y;``, this query will return ``x + y``.
 
@@ -242,7 +242,7 @@ As another example, the following query finds statements whose parent is an ``if
    where s.getParent() instanceof IfStmt
    select s
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/670720173/>`__. Many projects have examples of ``if`` statements with child statements.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1989464153689219612/>`__. Many projects have examples of ``if`` statements with child statements.
 
 This query will find both ``then`` branches and ``else`` branches of all ``if`` statements in the program.
 
@@ -256,7 +256,7 @@ Finally, here is a query that finds method bodies:
    where s.getParent() instanceof Method
    select s
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/663740023/>`__. Most projects have many method bodies.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1016821702972128245/>`__. Most projects have many method bodies.
 
 As these examples show, the parent node of an expression is not always an expression: it may also be a statement, for example, an ``IfStmt``. Similarly, the parent node of a statement is not always a statement: it may also be a method or a constructor. To capture this, the QL Java library provides two abstract class ``ExprParent`` and ``StmtParent``, the former representing any node that may be the parent node of an expression, and the latter any node that may be the parent node of a statement.
 
@@ -265,7 +265,7 @@ For more information on working with AST classes, see the :doc:`article on overf
 Metadata
 --------
 
-Java programs have several kinds of metadata, in addition to the program code proper. In particular, there are `annotations <http://docs.oracle.com/javase/tutorial/java/annotations/>`__ and `Javadoc <http://en.wikipedia.org/wiki/Javadoc>`__ comments. Since this metadata is interesting both for enhancing code analysis and as an analysis subject in its own right, the QL library defines classes for accessing it.
+Java programs have several kinds of metadata, in addition to the program code proper. In particular, there are `annotations <https://docs.oracle.com/javase/tutorial/java/annotations/>`__ and `Javadoc <https://en.wikipedia.org/wiki/Javadoc>`__ comments. Since this metadata is interesting both for enhancing code analysis and as an analysis subject in its own right, the QL library defines classes for accessing it.
 
 For annotations, class ``Annotatable`` is a superclass of all program elements that can be annotated. This includes packages, reference types, fields, methods, constructors, and local variable declarations. For every such element, its predicate ``getAnAnnotation`` allows you to retrieve any annotations the element may have. For example, the following query finds all annotations on constructors:
 
@@ -276,7 +276,7 @@ For annotations, class ``Annotatable`` is a superclass of all program elements t
    from Constructor c
    select c.getAnAnnotation()
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/665620008/>`__. The LGTM.com demo projects all use annotations, you can see examples where they are used to suppress warnings and mark code as deprecated.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/3206112561297137365/>`__. The LGTM.com demo projects all use annotations, you can see examples where they are used to suppress warnings and mark code as deprecated.
 
 These annotations are represented by class ``Annotation``. An annotation is simply an expression whose type is an ``AnnotationType``. For example, you can amend this query so that it only reports deprecated constructors:
 
@@ -290,7 +290,7 @@ These annotations are represented by class ``Annotation``. An annotation is simp
        anntp.hasQualifiedName("java.lang", "Deprecated")
    select ann
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/659662167/>`__. Only constructors with the ``@deprecated`` annotation are reported this time.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/5393027107459215059/`__. Only constructors with the ``@Deprecated`` annotation are reported this time.
 
 For more information on working with annotations, see the :doc:`article on annotations <annotations>`.
 
@@ -305,7 +305,7 @@ For Javadoc, class ``Element`` has a member predicate ``getDoc`` that returns a 
        jdoc = f.getDoc().getJavadoc()
    select jdoc
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/663330296/>`__. You can see this pattern in many projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/6022769142134600659/>`__. You can see this pattern in many projects.
 
 Class ``Javadoc`` represents an entire Javadoc comment as a tree of ``JavadocElement`` nodes, which can be traversed using member predicates ``getAChild`` and ``getParent``. For instance, you could edit the query so that it finds all ``@author`` tags in Javadoc comments on private fields:
 
@@ -319,7 +319,7 @@ Class ``Javadoc`` represents an entire Javadoc comment as a tree of ``JavadocEle
        at.getParent+() = jdoc
    select at
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/670490015/>`__. None of the LGTM.com demo projects uses the ``@author`` tag on private fields.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/2510220694395289111/>`__. None of the LGTM.com demo projects uses the ``@author`` tag on private fields.
 
 .. pull-quote::
 
@@ -336,7 +336,7 @@ The standard QL Java library provides extensive support for computing metrics on
 
 Altogether, there are six such classes: ``MetricElement``, ``MetricPackage``, ``MetricRefType``, ``MetricField``, ``MetricCallable``, and ``MetricStmt``. The corresponding element classes each provide a member predicate ``getMetrics`` that can be used to obtain an instance of the delegate class, on which metric computations can then be performed.
 
-For example, the following query finds methods with a `cyclomatic complexity <http://en.wikipedia.org/wiki/Cyclomatic_complexity>`__ greater than 40:
+For example, the following query finds methods with a `cyclomatic complexity <https://en.wikipedia.org/wiki/Cyclomatic_complexity>`__ greater than 40:
 
 .. code-block:: ql
 
@@ -347,7 +347,7 @@ For example, the following query finds methods with a `cyclomatic complexity <ht
        mc.getCyclomaticComplexity() > 40
    select m
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/670720174/>`__. Most large projects include some methods with a very high cyclomatic complexity. These methods are likely to be difficult to understand and test.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/6566950741051181919/>`__. Most large projects include some methods with a very high cyclomatic complexity. These methods are likely to be difficult to understand and test.
 
 Call graph
 ----------
@@ -367,7 +367,7 @@ We can use predicate ``Call.getCallee`` to find out which method or constructor 
        m.hasName("println")
    select c
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/669220009/>`__. The LGTM.com demo projects all include many calls to methods of this name.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/5861255162551917595/>`__. The LGTM.com demo projects all include many calls to methods of this name.
 
 Conversely, ``Callable.getAReference`` returns a ``Call`` that refers to it. So we can find methods and constructors that are never called using this query:
 
@@ -379,7 +379,7 @@ Conversely, ``Callable.getAReference`` returns a ``Call`` that refers to it. So 
    where not exists(c.getAReference())
    select c
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/666680036/>`__. The LGTM.com demo projects all appear to have many methods that are not called directly, but this is unlikely to be the whole story. To explore this area further, see :doc:`Navigating the call graph <call-graph>`.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/7261739919657747703/>`__. The LGTM.com demo projects all appear to have many methods that are not called directly, but this is unlikely to be the whole story. To explore this area further, see :doc:`Navigating the call graph <call-graph>`.
 
 For more information about callables and calls, see the :doc:`article on the call graph <call-graph>`.
 

--- a/docs/language/learn-ql/java/introduce-libraries-java.rst
+++ b/docs/language/learn-ql/java/introduce-libraries-java.rst
@@ -290,7 +290,7 @@ These annotations are represented by class ``Annotation``. An annotation is simp
        anntp.hasQualifiedName("java.lang", "Deprecated")
    select ann
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/5393027107459215059/`__. Only constructors with the ``@Deprecated`` annotation are reported this time.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/5393027107459215059/>`__. Only constructors with the ``@Deprecated`` annotation are reported this time.
 
 For more information on working with annotations, see the :doc:`article on annotations <annotations>`.
 

--- a/docs/language/learn-ql/java/javadoc.rst
+++ b/docs/language/learn-ql/java/javadoc.rst
@@ -147,7 +147,7 @@ Now we can write a query for finding all callables ``c`` and ``@throws`` tags ``
        not mayThrow(c, exn)
    select tt, "Spurious @throws tag."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1505752646058/>`__. This finds several results in the LGTM.com demo projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1258570917227966396/>`__. This finds several results in the LGTM.com demo projects.
 
 Improvements
 ~~~~~~~~~~~~
@@ -214,7 +214,7 @@ The first case can be covered by changing ``getDocumentedException`` to use the 
        (result.hasName(tt.getExceptionName()) and visibleIn(tt.getFile(), result))
    }
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1505751136101/>`__. This finds many fewer, more interesting results in the LGTM.com demo projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8016848987103345329/>`__. This finds many fewer, more interesting results in the LGTM.com demo projects.
 
 Currently, ``visibleIn`` only considers single-type imports, but you could extend it with support for other kinds of imports.
 

--- a/docs/language/learn-ql/java/source-locations.rst
+++ b/docs/language/learn-ql/java/source-locations.rst
@@ -54,17 +54,17 @@ In our example, the expression statement starts at line 5, column 3 (the first t
 
 Class ``File`` defines these member predicates:
 
--  ``getFullName`` returns the fully qualified name of the file.
+-  ``getAbsolutePath`` returns the fully qualified name of the file.
 -  ``getRelativePath`` returns the path of the file relative to the base directory of the source code.
 -  ``getExtension`` returns the extension of the file.
--  ``getShortName`` returns the base name of the file, without its extension.
+-  ``getStem`` returns the base name of the file, without its extension.
 
 In our example, assume file ``A.java`` is located in directory ``/home/testuser/code/pkg``, where ``/home/testuser/code`` is the base directory of the program being analyzed. Then, a ``File`` object for ``A.java`` returns:
 
--  ``getFullName`` is ``/home/testuser/code/pkg/A.java``.
+-  ``getAbsolutePath`` is ``/home/testuser/code/pkg/A.java``.
 -  ``getRelativePath`` is ``pkg/A.java``.
 -  ``getExtension`` is ``java``.
--  ``getShortName`` is ``A``.
+-  ``getStem`` is ``A``.
 
 Determining white space around an operator
 ------------------------------------------
@@ -110,7 +110,7 @@ Here's a first version of our query:
        wsinner > wsouter
    select outer, "Whitespace around nested operators contradicts precedence."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/672230027/>`__. This query is likely to find results on most projects.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8141155897270480914/>`__. This query is likely to find results on most projects.
 
 The first conjunct of the ``where`` clause restricts ``inner`` to be an operand of ``outer``, the second conjunct binds ``wsinner`` and ``wsouter``, while the last conjunct selects the suspicious cases.
 
@@ -141,9 +141,9 @@ Note that our predicate ``operatorWS`` computes the **total** amount of white sp
        wsinner > wsouter
    select outer, "Whitespace around nested operators contradicts precedence."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/665761067/>`__. Any results will be refined by our changes to the query.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/3151720037708691205/>`__. Any results will be refined by our changes to the query.
 
-Another source of false positives are associative operators: in an expression of the form ``x + y+z``, the first plus is syntactically nested inside the second, since + in Java associates to the left; hence the expression is flagged as suspicious. But since + is associative to begin with, it does not matter which way around the operators are nested, so this is a false positive.To exclude these cases, let us define a new class identifying binary expressions with an associative operator:
+Another source of false positives are associative operators: in an expression of the form ``x + y+z``, the first plus is syntactically nested inside the second, since + in Java associates to the left; hence the expression is flagged as suspicious. But since + is associative to begin with, it does not matter which way around the operators are nested, so this is a false positive. To exclude these cases, let us define a new class identifying binary expressions with an associative operator:
 
 .. code-block:: ql
 
@@ -173,9 +173,9 @@ Now we can extend our query to discard results where the outer and the inner exp
        wsinner > wsouter
    select outer, "Whitespace around nested operators contradicts precedence."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/659662169/>`__.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/5714614966569401039/>`__.
 
-Notice that we again use ``getOp``, this time to determine whether two binary expressions have the same operator. Running our improved query now finds the Java standard library bug described in the Overview. It also flags up the following suspicious code in `Hadoop HBase <http://hbase.apache.org/>`__:
+Notice that we again use ``getOp``, this time to determine whether two binary expressions have the same operator. Running our improved query now finds the Java standard library bug described in the Overview. It also flags up the following suspicious code in `Hadoop HBase <https://hbase.apache.org/>`__:
 
 .. code-block:: java
 

--- a/docs/language/learn-ql/java/types-class-hierarchy.rst
+++ b/docs/language/learn-ql/java/types-class-hierarchy.rst
@@ -32,7 +32,7 @@ To determine ancestor types (including immediate super types, and also *their* s
    where B.hasName("B")
    select B.getASupertype+()
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/674620010/>`__. If this query were run on the example snippet above, the query would return ``A``, ``I``, and ``java.lang.Object``.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1506430738755934285/>`__. If this query were run on the example snippet above, the query would return ``A``, ``I``, and ``java.lang.Object``.
 
 .. pull-quote::
 
@@ -78,7 +78,7 @@ This recipe is not too difficult to translate into a query:
        target.getElementType().(RefType).getASupertype+() = source.getElementType()
    select ce, "Potentially problematic array downcast."
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/666680038/>`__. Many projects return results for this query.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/8378564667548381869/>`__. Many projects return results for this query.
 
 Note that by casting ``target.getElementType()`` to a ``RefType``, we eliminate all cases where the element type is a primitive type, that is, ``target`` is an array of primitive type: the problem we are looking for cannot arise in that case. Unlike in Java, a cast in QL never fails: if an expression cannot be cast to the desired type, it is simply excluded from the query results, which is exactly what we want.
 
@@ -97,7 +97,7 @@ In code that does not use generics, this method is often used in the following w
 
 Here, ``l`` has the raw type ``List``, so ``l.toArray`` has return type ``Object[]``, independent of the type of its argument array. Hence the cast goes from ``Object[]`` to ``A[]`` and will be flagged as problematic by our query, although at runtime this cast can never go wrong.
 
-To identify these cases, we can create two CodeQL classes that represent, respectively, the ``Collection.toArray`` class, and calls to this method or any method that overrides it:
+To identify these cases, we can create two CodeQL classes that represent, respectively, the ``Collection.toArray`` method, and calls to this method or any method that overrides it:
 
 .. code-block:: ql
 
@@ -148,7 +148,7 @@ Example: Finding mismatched contains checks
 
 We'll now develop a query that finds uses of ``Collection.contains`` where the type of the queried element is unrelated to the element type of the collection, which guarantees that the test will always return ``false``.
 
-For example, `Apache Zookeeper <http://zookeeper.apache.org/>`__ used to have a snippet of code similar to the following in class ``QuorumPeerConfig``:
+For example, `Apache Zookeeper <https://zookeeper.apache.org/>`__ used to have a snippet of code similar to the following in class ``QuorumPeerConfig``:
 
 .. code-block:: java
 
@@ -267,7 +267,7 @@ Now we are ready to write a first version of our query:
        not haveCommonDescendant(collEltType, argType)
    select juccc, "Element type " + collEltType + " is incompatible with argument type " + argType
 
-➤ `See this in the query console on LGTM.com <https://lgtm.com/query/1505750556420/>`__.
+➤ `See this in the query console on LGTM.com <https://lgtm.com/query/7947831380785106258/>`__.
 
 Improvements
 ~~~~~~~~~~~~
@@ -294,7 +294,7 @@ Adding these three improvements, our final query becomes:
        not argType.hasName("<nulltype>")
    select juccc, "Element type " + collEltType + " is incompatible with argument type " + argType
 
-➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/1505753056300/>`__.
+➤ `See the full query in the query console on LGTM.com <https://lgtm.com/query/8846334903769538099/>`__.
 
 Further reading
 ---------------


### PR DESCRIPTION
Follow-up for #3817. The currently used query console links selected the projects `gradle/gradle` and `eclipse-cdt/cdt` which can both currently not be queried. This prevents the user to re-run the query after applying their own changes.
This pull request updates the query console links to run on all currently available demo projects.

It also fixes some minor typos and formatting issues and replaces outdated predicates in `source-locations.rst`.