### PR TITLE
Java: Clarify documentation for Location predicate results

### DIFF
--- a/java/ql/src/semmle/code/Location.qll
+++ b/java/ql/src/semmle/code/Location.qll
@@ -90,16 +90,16 @@ class Top extends @top {
 
 /** A location maps language elements to positions in source files. */
 class Location extends @location {
-  /** Gets the line number where this location starts. */
+  /** Gets the 1-based line number (inclusive) where this location starts. */
   int getStartLine() { locations_default(this, _, result, _, _, _) }
 
-  /** Gets the column number where this location starts. */
+  /** Gets the 1-based column number (inclusive) where this location starts. */
   int getStartColumn() { locations_default(this, _, _, result, _, _) }
 
-  /** Gets the line number where this location ends. */
+  /** Gets the 1-based line number (inclusive) where this location ends. */
   int getEndLine() { locations_default(this, _, _, _, result, _) }
 
-  /** Gets the column number where this location ends. */
+  /** Gets the 1-based column number (inclusive) where this location ends. */
   int getEndColumn() { locations_default(this, _, _, _, _, result) }
 
   /**


### PR DESCRIPTION
The way numbering is performed and ranges are expressed differs between programming languages and contexts. E.g. often numbering starts at `0` and the start of a range is _inclusive_ while the end of a range is _exclusive_.
For the `Location` class of QL, it appears numbering starts at 1 and start and end of line and column ranges are inclusive.
This pull request adds this information to the respective predicate documentations.

Note: Maybe the text "(inclusive)", added by this pull request, is not meaningful enough. Any feedback suggesting a different solution is welcome.