### PR TITLE
Python: XML RPC Dotted Names

### DIFF
--- a/python/ql/src/experimental/Security/XmlRpcDottedNames.qhelp
+++ b/python/ql/src/experimental/Security/XmlRpcDottedNames.qhelp
@@ -1,0 +1,17 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>Enabling the <code>allow_dotted_names</code> option allows intruders to access your module’s global
+ variables and may allow intruders to execute arbitrary code on your machine. Only use this example only within a secure, closed network.
+</p>
+
+<references>
+
+<li>Python Language Reference: <a href="https://docs.python.org/3/library/xmlrpc.server.html#xmlrpc.server.SimpleXMLRPCServer">
+Basic XML-RPC servers</a>.
+</li>
+
+</references>
+</qhelp>

--- a/python/ql/src/experimental/Security/XmlRpcDottedNames.ql
+++ b/python/ql/src/experimental/Security/XmlRpcDottedNames.ql
@@ -3,7 +3,6 @@
  * @description Enabling the allow_dotted_names option allows intruders to access your module’s global variables and may allow intruders to execute arbitrary code on your machine.
  * @kind problem
  * @problem.severity warning
- * @precision medium
  * @id python/xml-rpc-dotted-names
  * @tags reliability
  *       security

--- a/python/ql/src/experimental/Security/XmlRpcDottedNames.ql
+++ b/python/ql/src/experimental/Security/XmlRpcDottedNames.ql
@@ -1,0 +1,25 @@
+/**
+ * @name The allow_dotted_names option may allow intruders to execute arbitrary code
+ * @description Enabling the allow_dotted_names option allows intruders to access your module’s global variables and may allow intruders to execute arbitrary code on your machine.
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id python/xml-rpc-dotted-names
+ * @tags reliability
+ *       security
+ */
+
+import python
+
+from CallNode call, ControlFlowNode allow_dotted_names, Attribute a
+where
+  a.getLocation().getStartLine() = call.getLocation().getStartLine() and
+  a.getName() = "register_instance" and
+  not call.getLocation().getFile().inStdlib() and
+  (
+    allow_dotted_names = call.getArgByName("allow_dotted_names") or
+    allow_dotted_names = call.getArg(1)
+  ) and
+  allow_dotted_names.getNode().toString() = "True"
+select a,
+  "Enabling the allow_dotted_names option allows intruders to access your module’s global variables and may allow intruders to execute arbitrary code on your machine."

--- a/python/ql/test/experimental/Security/XmlRpcDottedNames.expected
+++ b/python/ql/test/experimental/Security/XmlRpcDottedNames.expected
@@ -1,0 +1,1 @@
+| XmlRpcDottedNames.py:19:5:19:28 | Attribute | Enabling the allow_dotted_names option allows intruders to access your module\u2019s global variables and may allow intruders to execute arbitrary code on your machine. |

--- a/python/ql/test/experimental/Security/XmlRpcDottedNames.py
+++ b/python/ql/test/experimental/Security/XmlRpcDottedNames.py
@@ -1,0 +1,26 @@
+# Copied from official python 3 documentation, at https://docs.python.org/3/library/xmlrpc.server.html#xmlrpc.server.SimpleXMLRPCServer
+
+import sys, datetime
+from xmlrpc.server import SimpleXMLRPCServer
+
+class ExampleService:
+    def getData(self):
+        return '42'
+
+    class currentTime:
+        @staticmethod
+        def getCurrentTime():
+            return datetime.datetime.now()
+
+with SimpleXMLRPCServer(("localhost", 8000)) as server:
+    server.register_function(pow)
+    server.register_function(lambda x,y: x+y, 'add')
+    # WARNING: Only set the allow_dotted_names flag to true within a secure, closed network.
+    server.register_instance(ExampleService(), allow_dotted_names=True)
+    server.register_multicall_functions()
+    print('Serving XML-RPC on localhost port 8000')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nKeyboard interrupt received, exiting.")
+        sys.exit(0)

--- a/python/ql/test/experimental/Security/XmlRpcDottedNames.qlref
+++ b/python/ql/test/experimental/Security/XmlRpcDottedNames.qlref
@@ -1,0 +1,1 @@
+experimental/Security/XmlRpcDottedNames.ql


### PR DESCRIPTION
This query warns against enabling the allow_dotted_names option when registering an instance of SimpleXMLRPCServer, as this allows intruders to access your module’s global variables and may execute arbitrary code on your machine. This should only be used within a secure, closed network.