### PR TITLE
JS: only include named topmost package.json files for js/shell-command-constructed-from-input

### DIFF
--- a/javascript/ql/src/semmle/javascript/PackageExports.qll
+++ b/javascript/ql/src/semmle/javascript/PackageExports.qll
@@ -13,7 +13,7 @@ bindingset[path]
 private int countSlashes(string path) { result = count(path.splitAt("/")) - 1 }
 
 /**
- * Gets the topmost package.json that appears in the project.
+ * Gets the topmost named package.json that appears in the project.
  *
  * There can be multiple results if the there exists multiple package.json that are equally deeply nested in the folder structure.
  * Results are limited to package.json files that are at most nested 2 directories deep.
@@ -21,7 +21,8 @@ private int countSlashes(string path) { result = count(path.splitAt("/")) - 1 }
 PackageJSON getTopmostPackageJSON() {
   result =
     min(PackageJSON j |
-      countSlashes(j.getFile().getRelativePath()) <= 3
+      countSlashes(j.getFile().getRelativePath()) <= 3 and
+      exists(j.getPackageName())
     |
       j order by countSlashes(j.getFile().getRelativePath())
     )

--- a/javascript/ql/test/library-tests/PackageExports/tests.expected
+++ b/javascript/ql/test/library-tests/PackageExports/tests.expected
@@ -1,7 +1,4 @@
 getTopmostPackageJSON
-| absent_main/package.json:1:1:3:1 | {\\n    " ... t.js"\\n} |
-| esmodules/package.json:1:1:3:1 | {\\n    " ... n.js"\\n} |
-| lib1/package.json:1:1:3:1 | {\\n    " ... n.js"\\n} |
 getAValueExportedBy
 | absent_main/package.json:1:1:3:1 | {\\n    " ... t.js"\\n} | absent_main/index.js:1:1:1:0 | this |
 | absent_main/package.json:1:1:3:1 | {\\n    " ... t.js"\\n} | absent_main/index.js:1:1:1:14 | module.exports |


### PR DESCRIPTION
Some monorepos like https://github.com/acornjs/acorn keep a `package.json` without a `name` field in their root directory. Since `js/shell-command-constructed-from-input` only considers topmost `package.json` files, it ignores the `package.json` files for the individual packages, and hence cannot find any external input sources.

With this change it instead considers all the topmost _named_ packages.  

I checked in our [usual suspects](https://lgtm.com/query/1377701949832041953/).  
And for all of them, either the topmost `package.json` has a name, or the repo is a monorepo similar to `acorn` where the topmost `package.json` has no name. 