### PR TITLE
Improve VariableAssign.getSource documentation

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1243,7 +1243,7 @@ class VariableAssign extends VariableUpdate {
   }
 
   /**
-   * Gets the source of this assignment, if any.
+   * Gets the source (right-hand side) of this assignment, if any.
    *
    * An initialization in a `CatchClause` or `EnhancedForStmt` is implicit and
    * does not have a source.


### PR DESCRIPTION
Similarly to how `Assignment.getSource` describes what the "source" is, `VariableAssign` should probably explain it as well.