### PR TITLE
Python: Add basic call-graph metric queries

### DIFF
--- a/python/ql/src/meta/MetaMetrics.qll
+++ b/python/ql/src/meta/MetaMetrics.qll
@@ -1,5 +1,5 @@
 /**
- * Helpers to generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
+ * Helpers for generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
  */
 
 import python

--- a/python/ql/src/meta/MetaMetrics.qll
+++ b/python/ql/src/meta/MetaMetrics.qll
@@ -14,7 +14,7 @@ private import semmle.python.filters.Tests
  */
 Folder projectRoot() { result.getRelativePath() = "" }
 
-/** A file we ignore because it is a test file, part of a third-part library, or compiled/generated/bundled code. */
+/** A file we ignore because it is a test file, part of a third-party library, or compiled/generated/bundled code. */
 class IgnoredFile extends File {
   IgnoredFile() {
     any(TestScope ts).getLocation().getFile() = this

--- a/python/ql/src/meta/MetaMetrics.qll
+++ b/python/ql/src/meta/MetaMetrics.qll
@@ -3,7 +3,6 @@
  */
 
 import python
-
 private import semmle.python.filters.GeneratedCode
 private import semmle.python.filters.Tests
 

--- a/python/ql/src/meta/MetaMetrics.qll
+++ b/python/ql/src/meta/MetaMetrics.qll
@@ -1,0 +1,27 @@
+/**
+ * Helpers to generating meta metrics, that is, metrics about the CodeQL analysis and extractor.
+ */
+
+import python
+
+private import semmle.python.filters.GeneratedCode
+private import semmle.python.filters.Tests
+
+/**
+ * Gets the root folder of the snapshot.
+ *
+ * This is selected as the location for project-wide metrics.
+ */
+Folder projectRoot() { result.getRelativePath() = "" }
+
+/** A file we ignore because it is a test file, part of a third-part library, or compiled/generated/bundled code. */
+class IgnoredFile extends File {
+  IgnoredFile() {
+    any(TestScope ts).getLocation().getFile() = this
+    or
+    this instanceof GeneratedFile
+    or
+    // outside source root (inspired by `Scope.inSource`)
+    not exists(this.getRelativePath())
+  }
+}

--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -15,7 +15,7 @@ class RelevantCall extends Call {
 }
 
 /** Provides classes for call-graph resolution by using points-to. */
-module PointsTo {
+module PointsToBasedCallGraph {
   /** A call that can be resolved by points-to. */
   class ResolvableCall extends RelevantCall {
     Value target;

--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -18,12 +18,12 @@ class RelevantCall extends Call {
 module PointsToBasedCallGraph {
   /** A call that can be resolved by points-to. */
   class ResolvableCall extends RelevantCall {
-    Value target;
+    Value callee;
 
-    ResolvableCall() { target.getACall() = this.getAFlowNode() }
+    ResolvableCall() { callee.getACall() = this.getAFlowNode() }
 
-    /** Gets a resolved target of this call. */
-    Value getTarget() { result = target }
+    /** Gets a resolved callee of this call. */
+    Value getCallee() { result = callee }
   }
 
   /** A call that cannot be resolved by points-to. */
@@ -32,20 +32,20 @@ module PointsToBasedCallGraph {
   }
 
   /**
-   * A call that can be resolved by points-to, where the resolved target is relevant.
-   * Relevant targets include:
+   * A call that can be resolved by points-to, where the resolved callee is relevant.
+   * Relevant callees include:
    * - builtins
    * - standard library
    * - source code of the project
    */
-  class ResolvableCallRelevantTarget extends ResolvableCall {
-    ResolvableCallRelevantTarget() {
-      target.isBuiltin()
+  class ResolvableCallRelevantCallee extends ResolvableCall {
+    ResolvableCallRelevantCallee() {
+      callee.isBuiltin()
       or
       exists(File file |
-        file = target.(CallableValue).getScope().getLocation().getFile()
+        file = callee.(CallableValue).getScope().getLocation().getFile()
         or
-        file = target.(ClassValue).getScope().getLocation().getFile()
+        file = callee.(ClassValue).getScope().getLocation().getFile()
       |
         file.inStdlib()
         or
@@ -56,10 +56,10 @@ module PointsToBasedCallGraph {
   }
 
   /**
-   * A call that can be resolved by points-to, where the resolved target is not considered relevant.
-   * See `ResolvableCallRelevantTarget` for the definition of relevance.
+   * A call that can be resolved by points-to, where the resolved callee is not considered relevant.
+   * See `ResolvableCallRelevantCallee` for the definition of relevance.
    */
-  class ResolvableCallIrrelevantTarget extends ResolvableCall {
-    ResolvableCallIrrelevantTarget() { not this instanceof ResolvableCallRelevantTarget }
+  class ResolvableCallIrrelevantCallee extends ResolvableCall {
+    ResolvableCallIrrelevantCallee() { not this instanceof ResolvableCallRelevantCallee }
   }
 }

--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -1,0 +1,65 @@
+/**
+ * Provides predicates for measuring the quality of the call graph, that is,
+ * the number of calls that could be resolved to a callee.
+ */
+
+import python
+import meta.MetaMetrics
+
+/**
+ * A call that is (possibly) relevant for analysis quality.
+ * See `IgnoredFile` for details on what is excluded.
+ */
+class RelevantCall extends Call {
+  RelevantCall() { not this.getLocation().getFile() instanceof IgnoredFile }
+}
+
+/** Provides classes for call-graph resolution by using points-to */
+module PointsTo {
+  /** A call that can be resolved by points-to. */
+  class ResolvableCall extends RelevantCall {
+    Value target;
+
+    ResolvableCall() { target.getACall() = this.getAFlowNode() }
+
+    /** Gets a resolved target of this call */
+    Value getTarget() { result = target }
+  }
+
+  /** A call that cannot be resolved by points-to. */
+  class UnresolvableCall extends RelevantCall {
+    UnresolvableCall() { not this instanceof ResolvableCall }
+  }
+
+  /**
+   * A call that can be resolved by points-to, where the resolved target is relevant.
+   * Relevant targets include:
+   * - builtins
+   * - standard library
+   * - source code of the project
+   */
+  class ResolvableCallRelevantTarget extends ResolvableCall {
+    ResolvableCallRelevantTarget() {
+      target.isBuiltin()
+      or
+      exists(File file |
+        file = target.(CallableValue).getScope().getLocation().getFile()
+        or
+        file = target.(ClassValue).getScope().getLocation().getFile()
+      |
+        file.inStdlib()
+        or
+        // part of the source code of the project
+        exists(file.getRelativePath())
+      )
+    }
+  }
+
+  /**
+   * A call that can be resolved by points-to, where resolved target is not considered relevant.
+   * See `ResolvableCallRelevantTarget` for definition of relevance.
+   */
+  class ResolvableCallIrrelevantTarget extends ResolvableCall {
+    ResolvableCallIrrelevantTarget() { not this instanceof ResolvableCallRelevantTarget }
+  }
+}

--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -14,7 +14,7 @@ class RelevantCall extends Call {
   RelevantCall() { not this.getLocation().getFile() instanceof IgnoredFile }
 }
 
-/** Provides classes for call-graph resolution by using points-to */
+/** Provides classes for call-graph resolution by using points-to. */
 module PointsTo {
   /** A call that can be resolved by points-to. */
   class ResolvableCall extends RelevantCall {
@@ -22,7 +22,7 @@ module PointsTo {
 
     ResolvableCall() { target.getACall() = this.getAFlowNode() }
 
-    /** Gets a resolved target of this call */
+    /** Gets a resolved target of this call. */
     Value getTarget() { result = target }
   }
 
@@ -56,7 +56,7 @@ module PointsTo {
   }
 
   /**
-   * A call that can be resolved by points-to, where resolved target is not considered relevant.
+   * A call that can be resolved by points-to, where the resolved target is not considered relevant.
    * See `ResolvableCallRelevantTarget` for definition of relevance.
    */
   class ResolvableCallIrrelevantTarget extends ResolvableCall {

--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -57,7 +57,7 @@ module PointsTo {
 
   /**
    * A call that can be resolved by points-to, where the resolved target is not considered relevant.
-   * See `ResolvableCallRelevantTarget` for definition of relevance.
+   * See `ResolvableCallRelevantTarget` for the definition of relevance.
    */
   class ResolvableCallIrrelevantTarget extends ResolvableCall {
     ResolvableCallIrrelevantTarget() { not this instanceof ResolvableCallRelevantTarget }

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Ratio of resolvable call by points-to
+ * @description The percentage (relevant) calls that can be resolved to a target.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum min max avg
+ * @tags meta
+ * @id py/meta/points-to-resolvable-call-ratio
+ */
+
+import python
+import CallGraphQuality
+
+select projectRoot(), 100.0 * count(PointsTo::ResolvableCall call) / count(RelevantCall call).(float)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
@@ -11,4 +11,5 @@
 import python
 import CallGraphQuality
 
-select projectRoot(), 100.0 * count(PointsTo::ResolvableCall call) / count(RelevantCall call).(float)
+select projectRoot(),
+  100.0 * count(PointsToBasedCallGraph::ResolvableCall call) / count(RelevantCall call).(float)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
@@ -1,6 +1,6 @@
 /**
  * @name Ratio of resolvable call by points-to
- * @description The percentage (relevant) calls that can be resolved to a target.
+ * @description The percentage of (relevant) calls that can be resolved to a target.
  * @kind metric
  * @metricType project
  * @metricAggregate sum min max avg

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallRatio.ql
@@ -1,6 +1,6 @@
 /**
  * @name Ratio of resolvable call by points-to
- * @description The percentage of (relevant) calls that can be resolved to a target.
+ * @description The percentage of (relevant) calls that can be resolved to a callee.
  * @kind metric
  * @metricType project
  * @metricAggregate sum min max avg

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
@@ -11,4 +11,4 @@
 import python
 import CallGraphQuality
 
-select projectRoot(), count(PointsTo::ResolvableCall call)
+select projectRoot(), count(PointsToBasedCallGraph::ResolvableCall call)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
@@ -1,6 +1,6 @@
 /**
  * @name Resolvable calls by points-to
- * @description The number of (relevant) calls that can be resolved to a target.
+ * @description The number of (relevant) calls that can be resolved to a callee.
  * @kind metric
  * @metricType project
  * @metricAggregate sum

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Resolvable calls by points-to
+ * @description The number of (relevant) calls that could be resolved to its target.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id py/meta/points-to-resolvable-calls
+ */
+
+import python
+import CallGraphQuality
+
+select projectRoot(), count(PointsTo::ResolvableCall call)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCalls.ql
@@ -1,6 +1,6 @@
 /**
  * @name Resolvable calls by points-to
- * @description The number of (relevant) calls that could be resolved to its target.
+ * @description The number of (relevant) calls that can be resolved to a target.
  * @kind metric
  * @metricType project
  * @metricAggregate sum

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
@@ -11,4 +11,4 @@
 import python
 import CallGraphQuality
 
-select projectRoot(), count(PointsTo::ResolvableCallRelevantTarget call)
+select projectRoot(), count(PointsToBasedCallGraph::ResolvableCallRelevantTarget call)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
@@ -1,14 +1,14 @@
 /**
- * @name Resolvable calls by points-to, to relevant target
- * @description The number of (relevant) calls that could be resolved to a target that is relevant.
+ * @name Resolvable calls by points-to, to relevant callee
+ * @description The number of (relevant) calls that could be resolved to a callee that is relevant.
  * @kind metric
  * @metricType project
  * @metricAggregate sum
  * @tags meta
- * @id py/meta/points-to-resolvable-calls-relevant-target
+ * @id py/meta/points-to-resolvable-calls-relevant-callee
  */
 
 import python
 import CallGraphQuality
 
-select projectRoot(), count(PointsToBasedCallGraph::ResolvableCallRelevantTarget call)
+select projectRoot(), count(PointsToBasedCallGraph::ResolvableCallRelevantCallee call)

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
@@ -1,6 +1,6 @@
 /**
  * @name Resolvable calls by points-to, to relevant target
- * @description The number of (relevant) calls that could be resolved to its target that is relevant.
+ * @description The number of (relevant) calls that could be resolved to a target that is relevant.
  * @kind metric
  * @metricType project
  * @metricAggregate sum

--- a/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
+++ b/python/ql/src/meta/analysis-quality/PointsToResolvableCallsRelevantTarget.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Resolvable calls by points-to, to relevant target
+ * @description The number of (relevant) calls that could be resolved to its target that is relevant.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id py/meta/points-to-resolvable-calls-relevant-target
+ */
+
+import python
+import CallGraphQuality
+
+select projectRoot(), count(PointsTo::ResolvableCallRelevantTarget call)

--- a/python/ql/src/meta/analysis-quality/ResolvableCallCandidates.ql
+++ b/python/ql/src/meta/analysis-quality/ResolvableCallCandidates.ql
@@ -1,6 +1,6 @@
 /**
  * @name Resolvable call candidates
- * @description The number (relevant) calls in the program.
+ * @description The number of (relevant) calls in the program.
  * @kind metric
  * @metricType project
  * @metricAggregate sum

--- a/python/ql/src/meta/analysis-quality/ResolvableCallCandidates.ql
+++ b/python/ql/src/meta/analysis-quality/ResolvableCallCandidates.ql
@@ -1,0 +1,14 @@
+/**
+ * @name Resolvable call candidates
+ * @description The number (relevant) calls in the program.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id py/meta/resolvable-call-candidates
+ */
+
+import python
+import CallGraphQuality
+
+select projectRoot(), count(RelevantCall call)


### PR DESCRIPTION
For use with dist-compare. [Results from running against smoke-tests](https://git.semmle.com/rasmuswl/dist-compare-reports/tree/python-metrics-queries-for-dist-compare_1594212471686#metrics). (I don't know what is up with youtube-dl)

This is just a port of the queries from JS, like https://github.com/github/codeql/blob/master/javascript/ql/src/meta/analysis-quality/ResolvableCalls.ql (I even adopted their folder structure).