### PR TITLE
JS: rewriting DeadStoreOfProperty.ql to avoid bad worst-case runtime

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -98,12 +98,20 @@ predicate maybeAccessesProperty(Expr e, string name) {
  */
 predicate isDeadAssignment(string name, DataFlow::PropWrite assign1, DataFlow::PropWrite assign2) {
   (
-    assign2.getWriteNode() = getANodeWithNoPropAccessBetweenInsideBlock(name, assign1) and
-    postDominatedPropWrite(name, assign1, assign2, true)
-    or
-    noPropAccessBetweenGlobal(name, assign1, assign2)
+    noPropAccessBetweenInsideBasicBlock(name, assign1, assign2) or
+    noPropAccessBetweenAcrossBasicBlocks(name, assign1, assign2)
   ) and
   not isDOMProperty(name)
+}
+
+/**
+ * Holds if `assign1` and `assign2` are in the same basicblock and both assign property `name`, and the assigned property is not accessed between the two assignments.
+ */
+predicate noPropAccessBetweenInsideBasicBlock(
+  string name, DataFlow::PropWrite assign1, DataFlow::PropWrite assign2
+) {
+  assign2.getWriteNode() = getANodeWithNoPropAccessBetweenInsideBlock(name, assign1) and
+  postDominatedPropWrite(name, assign1, assign2, true)
 }
 
 /**
@@ -234,7 +242,7 @@ ControlFlowNode getANodeWithNoPropAccessBetweenInsideBlock(string name, DataFlow
  * Holds if `assign1` and `assign2` are in different basicblocks and both assign property `name`, and the assigned property is not accessed between the two assignments.
  */
 pragma[nomagic]
-predicate noPropAccessBetweenGlobal(
+predicate noPropAccessBetweenAcrossBasicBlocks(
   string name, DataFlow::PropWrite assign1, DataFlow::PropWrite assign2
 ) {
   exists(

--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -115,20 +115,22 @@ predicate maybeAssignsAccessedPropInBlock(DataFlow::PropWrite assign, boolean af
     or
     after = false and postDominatedPropWrite(_, _, assign, false)
   ) and
-  exists(ReachableBasicBlock block, int i, int j, Expr e, string name |
-    i = getRank(block, assign.getWriteNode(), name) and
-    j = getRank(block, e, name) and
-    isAPropertyRead(e, name)
-  |
-    after = true and i < j
+  (
+    exists(ReachableBasicBlock block, int i, int j, Expr e, string name |
+      i = getRank(block, assign.getWriteNode(), name) and
+      j = getRank(block, e, name) and
+      isAPropertyRead(e, name)
+    |
+      after = true and i < j
+      or
+      after = false and j < i
+    )
     or
-    after = false and j < i
-  )
-  or
-  exists(ReachableBasicBlock block | assign.getWriteNode().getBasicBlock() = block |
-    after = true and isBeforeImpure(assign, block)
-    or
-    after = false and isAfterImpure(assign, block)
+    exists(ReachableBasicBlock block | assign.getWriteNode().getBasicBlock() = block |
+      after = true and isBeforeImpure(assign, block)
+      or
+      after = false and isAfterImpure(assign, block)
+    )
   )
 }
 

--- a/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfProperty.ql
@@ -107,6 +107,9 @@ predicate isDeadAssignment(string name, DataFlow::PropWrite assign1, DataFlow::P
 /**
  * Holds if `assign` assigns a property that may be accessed somewhere else in the same block,
  * `after` indicates if the access happens before or after the node for `assign`.
+ *
+ * The access can either be a direct property access of the same name,
+ * or an impure expression where we assume that the expression can access the property.
  */
 predicate maybeAssignsAccessedPropInBlock(DataFlow::PropWrite assign, boolean after) {
   (
@@ -116,6 +119,7 @@ predicate maybeAssignsAccessedPropInBlock(DataFlow::PropWrite assign, boolean af
     after = false and postDominatedPropWrite(_, _, assign, false)
   ) and
   (
+    // direct property write before/after assign
     exists(ReachableBasicBlock block, int i, int j, Expr e, string name |
       i = getRank(block, assign.getWriteNode(), name) and
       j = getRank(block, e, name) and
@@ -126,6 +130,7 @@ predicate maybeAssignsAccessedPropInBlock(DataFlow::PropWrite assign, boolean af
       after = false and j < i
     )
     or
+    // impure expression that might access the property before/after assign
     exists(ReachableBasicBlock block | assign.getWriteNode().getBasicBlock() = block |
       after = true and isBeforeImpure(assign, block)
       or

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -440,7 +440,7 @@ module AccessPath {
      *
      * Only has a result if there exists both a read and write of the access-path within `bb`.
      */
-    private ControlFlowNode rankedAccessPath(
+    ControlFlowNode rankedAccessPath(
       ReachableBasicBlock bb, Root root, string path, int ranking, AccessPathKind type
     ) {
       result =

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -440,7 +440,7 @@ module AccessPath {
      *
      * Only has a result if there exists both a read and write of the access-path within `bb`.
      */
-    ControlFlowNode rankedAccessPath(
+    private ControlFlowNode rankedAccessPath(
       ReachableBasicBlock bb, Root root, string path, int ranking, AccessPathKind type
     ) {
       result =

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,6 +1,5 @@
 | fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
 | fieldInit.ts:18:22:18:22 | h | This write to property 'h' is useless, since $@ always overrides it. | fieldInit.ts:19:5:19:14 | this.h = h | another property write |
-| fieldInit.ts:24:3:24:20 | static static() {} | This write to property 'static' is useless, since $@ always overrides it. | fieldInit.ts:30:3:30:20 | static static() {} | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |
 | real-world-examples.js:16:11:16:20 | o.p2 *= 42 | This write to property 'p2' is useless, since $@ always overrides it. | real-world-examples.js:16:2:16:21 | o.p2 -= (o.p2 *= 42) | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/DeadStoreOfProperty.expected
@@ -1,4 +1,6 @@
 | fieldInit.ts:10:3:10:8 | f = 4; | This write to property 'f' is useless, since $@ always overrides it. | fieldInit.ts:13:5:13:14 | this.f = 5 | another property write |
+| fieldInit.ts:18:22:18:22 | h | This write to property 'h' is useless, since $@ always overrides it. | fieldInit.ts:19:5:19:14 | this.h = h | another property write |
+| fieldInit.ts:24:3:24:20 | static static() {} | This write to property 'static' is useless, since $@ always overrides it. | fieldInit.ts:30:3:30:20 | static static() {} | another property write |
 | real-world-examples.js:5:4:5:11 | o.p = 42 | This write to property 'p' is useless, since $@ always overrides it. | real-world-examples.js:10:2:10:9 | o.p = 42 | another property write |
 | real-world-examples.js:15:9:15:18 | o.p1 += 42 | This write to property 'p1' is useless, since $@ always overrides it. | real-world-examples.js:15:2:15:18 | o.p1 = o.p1 += 42 | another property write |
 | real-world-examples.js:16:11:16:20 | o.p2 *= 42 | This write to property 'p2' is useless, since $@ always overrides it. | real-world-examples.js:16:2:16:21 | o.p2 -= (o.p2 *= 42) | another property write |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
@@ -19,13 +19,3 @@ class G {
     this.h = h;
   }
 }
-
-class Foo {
-  static static() {}
-
-  static *foo() {}
-
-  static set() {}
-
-  static static() {}
-}

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/fieldInit.ts
@@ -13,3 +13,19 @@ class D {
     this.f = 5;
   }
 }
+
+class G {
+  constructor(public h: string) { // NOT OK
+    this.h = h;
+  }
+}
+
+class Foo {
+  static static() {}
+
+  static *foo() {}
+
+  static set() {}
+
+  static static() {}
+}

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
@@ -92,7 +92,7 @@
     o.defaulted2 = 42;
 
     var o = {};
-    o.pure18 = 42; // NOT OK
+    o.pure18 = 42; // NOT OK TODO: Currently have duplicate result.
     o.pure18 = 42; // NOT OK
     o.pure18 = 42;
 
@@ -124,5 +124,15 @@
 
 	var o = {};
 	Object.defineProperty(o, "prop", {writable:!0,configurable:!0,enumerable:!1}) // OK
-	o.prop = 42;
+    o.prop = 42;
+    
+    var o = {};
+    o.pure19 = 42; // OK
+    o.some_other_property = 42;
+    o.pure19 = 42;
+
+    var o = {};
+    o.pure20 = 42; // OK
+    some_other_obj.some_other_property = 42;
+    o.pure20 = 42;
 });

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfProperty/tst.js
@@ -92,7 +92,7 @@
     o.defaulted2 = 42;
 
     var o = {};
-    o.pure18 = 42; // NOT OK TODO: Currently have duplicate result.
+    o.pure18 = 42; // NOT OK
     o.pure18 = 42; // NOT OK
     o.pure18 = 42;
 


### PR DESCRIPTION
[This file](https://github.com/gliffy/canvas2svg/blob/master/test/example/tiger.js) would previously cause `DeadStoreOfProperty.ql` to time out.  
Now that project takes ~6 seconds to analyze on my laptop. 

The bad joins (there were multiple) seemed to be related to joining on `BasicBlock::getNode(i)`. So I removed all of those and did almost a complete rewrite.   

For example: The previous version of the query did the below to ensure that no side-effects could happen between two writes (that were within the same basicblock): 
```CodeQL
not exists(int w1, int w2, int i | 
  write1 = bb.getNode(w1) and
  write2 = bb.getNode(w2) and
  any(Expr e | e.isImpure()) = bb.getNode(i)
  |
  w1 < i and i < w2
)
```
That basically runs in `O(n^2)` due to the joins, and there is no join-order that makes it perform well in the worst case.  

But if we instead ask the question: can we get from `write1`  to `write2` without passing through an impure expression, then we get a small predicate that is fast to compute.   

I also split up the code into "within a single basicblock" and "between multiple basicblocks" cases, because the rewrite works very differently between the two, and I avoided some bad joins by doing it. (The `pragma[nomagic]` on `noPropAccessBetweenGlobal` is to avoid a bad join-order that happened when the two cases were handled in the same predicate where the optimizer was a little to clever is creating a `#shared` helper predicate). 

It ended up taking quite a while, because I encountered several rounds of bad joins during the rewrite. 

[Here is an evaluation on nightly](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-esben.northeurope.cloudapp.azure.com_1594390481811), and [here is big-apps](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1594396059119). 
The result difference is due to a small difference in how duplicate dead property writes are reported.