### PR TITLE
JavaScript: Add a few minor extensions to the portals library

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Portals.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Portals.qll
@@ -181,7 +181,7 @@ private module NpmPackagePortal {
   predicate imports(DataFlow::SourceNode imp, string pkgName) {
     exists(NPMPackage pkg |
       imp = getAModuleImport(pkg, pkgName) and
-      pkg.declaresDependency(pkgName, _)
+      pkgName.regexpMatch("[^./].*")
     )
   }
 
@@ -189,7 +189,7 @@ private module NpmPackagePortal {
   predicate imports(DataFlow::SourceNode imp, string pkgName, string member) {
     exists(NPMPackage pkg |
       imp = getAModuleMemberImport(pkg, pkgName, member) and
-      pkg.declaresDependency(pkgName, _)
+      pkgName.regexpMatch("[^./].*")
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Portals.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Portals.qll
@@ -97,6 +97,20 @@ class Portal extends TPortal {
   ReturnPortal getReturn() { result.getBasePortal() = this }
 
   /**
+   * Gets the `i`th base portal of this portal.
+   *
+   * The `0`th base portal is the portal itself, the `n+1`st base portal is the `n`th base portal
+   * of the portal `p` of which this is a member, instance, parameter, or return portal.
+   */
+  cached
+  Portal getBasePortal(int i) {
+    i = 0 and
+    result = this
+    or
+    result = this.(CompoundPortal).getBasePortal().getBasePortal(i - 1)
+  }
+
+  /**
    * Gets a textual representation of this portal.
    *
    * Different portals must have different `toString`s, so the result of

--- a/javascript/ql/test/library-tests/Portals/PortalEntry.expected
+++ b/javascript/ql/test/library-tests/Portals/PortalEntry.expected
@@ -707,9 +707,14 @@
 | (member x (parameter 0 (member foo (root https://www.npmjs.com/package/m2)))) | src/m3/tst2.js:5:10:5:10 | o | false |
 | (member y (member x (parameter 0 (member foo (root https://www.npmjs.com/package/m2))))) | src/m3/tst2.js:3:6:3:8 | "?" | false |
 | (member z (parameter 0 (member foo (root https://www.npmjs.com/package/m2)))) | src/m2/main.js:3:9:3:12 | "hi" | true |
+| (parameter 0 (member String (global))) | src/m5/index.js:5:33:5:50 | fs.readFileSync(f) | true |
 | (parameter 0 (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:7:4:10 | "me" | false |
 | (parameter 0 (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:7:5:10 | "me" | false |
+| (parameter 0 (member encode (root https://www.npmjs.com/package/base-64/base64.js))) | src/m5/index.js:5:26:5:51 | String( ... ync(f)) | false |
 | (parameter 0 (member foo (root https://www.npmjs.com/package/m2))) | src/m3/tst2.js:5:5:5:12 | { x: o } | false |
+| (parameter 0 (member log (member console (global)))) | src/m2/main.js:2:15:2:19 | p.x.y | true |
+| (parameter 0 (member log (member console (global)))) | src/m2/main.js:12:17:12:35 | x + " " + this.name | true |
+| (parameter 0 (member log (member console (global)))) | src/m3/index.js:3:43:3:61 | m1("Hello, world!") | true |
 | (parameter 0 (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
 | (parameter 0 (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | true |
 | (parameter 0 (member m (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
@@ -717,6 +722,7 @@
 | (parameter 0 (member m (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
 | (parameter 0 (member m (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:15:4:18 | "hi" | false |
 | (parameter 0 (member m (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:2:5:2:8 | "hi" | false |
+| (parameter 0 (member readFileSync (root https://www.npmjs.com/package/fs))) | src/m5/index.js:5:49:5:49 | f | false |
 | (parameter 0 (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:15:5:21 | "there" | false |
 | (parameter 0 (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:15:5:21 | "there" | true |
 | (parameter 0 (member s (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:15:5:21 | "there" | false |

--- a/javascript/ql/test/library-tests/Portals/PortalExit.expected
+++ b/javascript/ql/test/library-tests/Portals/PortalExit.expected
@@ -1,3 +1,14 @@
+| (global) | src/bluebird/index.js:1:1:1:0 | this | true |
+| (global) | src/bluebird/tst.js:1:1:1:0 | this | true |
+| (global) | src/cyclic/index.js:1:1:1:0 | this | true |
+| (global) | src/m1/index.js:1:1:1:0 | this | true |
+| (global) | src/m2/main.js:1:1:1:0 | this | true |
+| (global) | src/m3/index.js:1:1:1:0 | this | true |
+| (global) | src/m3/tst2.js:1:1:1:0 | this | true |
+| (global) | src/m3/tst3.js:1:1:1:0 | this | true |
+| (global) | src/m3/tst.js:1:1:1:0 | this | true |
+| (global) | src/m4/index.js:1:1:1:0 | this | true |
+| (global) | src/m5/index.js:1:1:1:0 | this | true |
 | (instance (member Promise (root https://www.npmjs.com/package/bluebird))) | src/bluebird/index.js:1:1:1:0 | this | true |
 | (instance (member Promise (root https://www.npmjs.com/package/bluebird))) | src/bluebird/index.js:5:1:5:17 | Promise.prototype | true |
 | (instance (member Promise (root https://www.npmjs.com/package/bluebird))) | src/bluebird/index.js:5:26:5:25 | this | true |
@@ -11,8 +22,16 @@
 | (instance (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:11 | new A("me") | true |
 | (instance (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:4:1:4:11 | new A("me") | false |
 | (instance (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
+| (member String (global)) | src/m5/index.js:5:26:5:31 | String | true |
+| (member console (global)) | src/m2/main.js:2:3:2:9 | console | true |
+| (member console (global)) | src/m2/main.js:12:5:12:11 | console | true |
+| (member console (global)) | src/m3/index.js:3:31:3:37 | console | true |
 | (member default (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:1:8:1:8 | A | false |
+| (member encode (root https://www.npmjs.com/package/base-64/base64.js)) | src/m5/index.js:5:12:5:24 | base64.encode | false |
 | (member foo (root https://www.npmjs.com/package/m2)) | src/m3/tst2.js:1:10:1:12 | foo | false |
+| (member log (member console (global))) | src/m2/main.js:2:3:2:13 | console.log | true |
+| (member log (member console (global))) | src/m2/main.js:12:5:12:15 | console.log | true |
+| (member log (member console (global))) | src/m3/index.js:3:31:3:41 | console.log | true |
 | (member m (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
 | (member m (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | true |
 | (member m (instance (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
@@ -21,6 +40,7 @@
 | (member m (return (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:13 | new A("me").m | false |
 | (member m (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:2:1:2:3 | A.m | false |
 | (member name (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m2/main.js:12:27:12:35 | this.name | true |
+| (member readFileSync (root https://www.npmjs.com/package/fs)) | src/m5/index.js:5:33:5:47 | fs.readFileSync | false |
 | (member s (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
 | (member s (instance (member default (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | true |
 | (member s (instance (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:13 | new A("me").s | false |
@@ -734,9 +754,14 @@
 | (parameter 0 (return (return (return (return (return (return (return (member foo (root https://www.npmjs.com/package/cyclic)))))))))) | src/cyclic/index.js:1:14:1:15 | cb | true |
 | (parameter 0 (root https://www.npmjs.com/package/m1)) | src/m1/index.js:1:19:1:19 | x | true |
 | (parameter 1 (member then (instance (member Promise (root https://www.npmjs.com/package/bluebird))))) | src/bluebird/index.js:5:46:5:53 | rejected | true |
+| (return (member String (global))) | src/m5/index.js:5:26:5:51 | String( ... ync(f)) | true |
 | (return (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:4:1:4:11 | new A("me") | false |
 | (return (member default (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
+| (return (member encode (root https://www.npmjs.com/package/base-64/base64.js))) | src/m5/index.js:5:12:5:52 | base64. ... nc(f))) | false |
 | (return (member foo (root https://www.npmjs.com/package/m2))) | src/m3/tst2.js:5:1:5:13 | foo({ x: o }) | false |
+| (return (member log (member console (global)))) | src/m2/main.js:2:3:2:20 | console.log(p.x.y) | true |
+| (return (member log (member console (global)))) | src/m2/main.js:12:5:12:36 | console ... s.name) | true |
+| (return (member log (member console (global)))) | src/m3/index.js:3:31:3:62 | console ... rld!")) | true |
 | (return (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
 | (return (member m (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | true |
 | (return (member m (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
@@ -744,6 +769,7 @@
 | (return (member m (return (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
 | (return (member m (return (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:4:1:4:19 | new A("me").m("hi") | false |
 | (return (member m (root https://www.npmjs.com/package/m2))) | src/m3/tst3.js:2:1:2:9 | A.m("hi") | false |
+| (return (member readFileSync (root https://www.npmjs.com/package/fs))) | src/m5/index.js:5:33:5:50 | fs.readFileSync(f) | false |
 | (return (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
 | (return (member s (instance (member default (root https://www.npmjs.com/package/m2))))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | true |
 | (return (member s (instance (root https://www.npmjs.com/package/m2)))) | src/m3/tst3.js:5:1:5:22 | new A(" ... there") | false |
@@ -1043,6 +1069,8 @@
 | (return (root https://www.npmjs.com/package/m1)) | src/m3/index.js:3:43:3:61 | m1("Hello, world!") | false |
 | (return (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:4:1:4:11 | new A("me") | false |
 | (return (root https://www.npmjs.com/package/m2)) | src/m3/tst3.js:5:1:5:11 | new A("me") | false |
+| (root https://www.npmjs.com/package/base-64/base64.js) | src/m5/index.js:2:14:2:41 | require ... 64.js") | false |
+| (root https://www.npmjs.com/package/fs) | src/m5/index.js:1:12:1:24 | require("fs") | false |
 | (root https://www.npmjs.com/package/m1) | src/m3/index.js:1:10:1:22 | require("m1") | false |
 | (root https://www.npmjs.com/package/m2) | src/m3/tst2.js:1:1:1:25 | import  ... m "m2"; | false |
 | (root https://www.npmjs.com/package/m2) | src/m3/tst3.js:1:1:1:19 | import A from "m2"; | false |

--- a/javascript/ql/test/library-tests/Portals/src/m5/index.js
+++ b/javascript/ql/test/library-tests/Portals/src/m5/index.js
@@ -1,0 +1,6 @@
+const fs = require("fs"),
+    base64 = require("base-64/base64.js");
+
+module.exports.readBase64 = function (f) {
+    return base64.encode(String(fs.readFileSync(f)));
+};

--- a/javascript/ql/test/library-tests/Portals/src/m5/package.json
+++ b/javascript/ql/test/library-tests/Portals/src/m5/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "m5",
+    "dependencies": {
+        "base-64": "*"
+    }
+}


### PR DESCRIPTION
While hopefully portals will soon be superseded by API graphs, we are still using them in an OCTO project. To facilitate experiments, I would like to upstream three extensions we made to the library.

Note that the portals library is not used by any of our production queries or libraries, so these changes will not affect them in any way.