### PR TITLE
Java: model Object.clone

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -292,6 +292,8 @@ private predicate qualifierToMethodStep(Expr tracked, MethodAccess sink) {
  * Methods that return tainted data when called on tainted data.
  */
 private predicate taintPreservingQualifierToMethod(Method m) {
+  m instanceof CloneMethod
+  or
   m.getDeclaringType() instanceof TypeString and
   (
     m.getName() = "concat" or

--- a/java/ql/test/library-tests/dataflow/local-additional-taint/Test.java
+++ b/java/ql/test/library-tests/dataflow/local-additional-taint/Test.java
@@ -4,11 +4,11 @@ import org.apache.commons.codec.BinaryEncoder;
 import org.apache.commons.codec.BinaryDecoder;
 import org.apache.commons.codec.StringEncoder;
 import org.apache.commons.codec.StringDecoder;
-
-
+import java.util.Date;
 
 class Test {
 	public static void taintSteps(
+                Date date,
 		Decoder decoder,
 		Encoder encoder,
 		StringEncoder stringEncoder,
@@ -29,5 +29,7 @@ class Test {
 
 		bytes1 = binEncoder.encode(bytes2);
 		bytes1 = binDecoder.decode(bytes2);
+
+		Object clone = date.clone();
 	}
 }

--- a/java/ql/test/library-tests/dataflow/local-additional-taint/localAdditionalTaintStep.expected
+++ b/java/ql/test/library-tests/dataflow/local-additional-taint/localAdditionalTaintStep.expected
@@ -41,3 +41,4 @@
 | Test.java:28:34:28:40 | string2 | Test.java:28:13:28:41 | encode(...) |
 | Test.java:30:30:30:35 | bytes2 | Test.java:30:12:30:36 | encode(...) |
 | Test.java:31:30:31:35 | bytes2 | Test.java:31:12:31:36 | decode(...) |
+| Test.java:33:18:33:21 | date | Test.java:33:18:33:29 | clone(...) |


### PR DESCRIPTION
A simple flow step for Object.clone. Perhaps we should model flow from the fields of the Object to the cloned object somehow, but this should do as a first step.