### PR TITLE
C++: Replace getResultType() with getResultIRType()

### DIFF
--- a/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/Bound.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/Bound.qll
@@ -8,8 +8,8 @@ private newtype TBound =
     exists(Instruction i |
       vn.getAnInstruction() = i and
       (
-        i.getResultType() instanceof IntegralType or
-        i.getResultType() instanceof PointerType
+        i.getResultIRType() instanceof IRIntegerType or
+        i.getResultIRType() instanceof IRAddressType
       ) and
       not vn.getAnInstruction() instanceof ConstantInstruction
     |

--- a/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -244,14 +244,14 @@ class CondReason extends Reason, TCondReason {
 /**
  * Holds if `typ` is a small integral type with the given lower and upper bounds.
  */
-private predicate typeBound(IntegralType typ, int lowerbound, int upperbound) {
-  typ.isSigned() and typ.getSize() = 1 and lowerbound = -128 and upperbound = 127
+private predicate typeBound(IRIntegerType typ, int lowerbound, int upperbound) {
+  typ.isSigned() and typ.getByteSize() = 1 and lowerbound = -128 and upperbound = 127
   or
-  typ.isUnsigned() and typ.getSize() = 1 and lowerbound = 0 and upperbound = 255
+  typ.isUnsigned() and typ.getByteSize() = 1 and lowerbound = 0 and upperbound = 255
   or
-  typ.isSigned() and typ.getSize() = 2 and lowerbound = -32768 and upperbound = 32767
+  typ.isSigned() and typ.getByteSize() = 2 and lowerbound = -32768 and upperbound = 32767
   or
-  typ.isUnsigned() and typ.getSize() = 2 and lowerbound = 0 and upperbound = 65535
+  typ.isUnsigned() and typ.getByteSize() = 2 and lowerbound = 0 and upperbound = 65535
 }
 
 /**
@@ -260,14 +260,14 @@ private predicate typeBound(IntegralType typ, int lowerbound, int upperbound) {
 private class NarrowingCastInstruction extends ConvertInstruction {
   NarrowingCastInstruction() {
     not this instanceof SafeCastInstruction and
-    typeBound(getResultType(), _, _)
+    typeBound(getResultIRType(), _, _)
   }
 
   /** Gets the lower bound of the resulting type. */
-  int getLowerBound() { typeBound(getResultType(), result, _) }
+  int getLowerBound() { typeBound(getResultIRType(), result, _) }
 
   /** Gets the upper bound of the resulting type. */
-  int getUpperBound() { typeBound(getResultType(), _, result) }
+  int getUpperBound() { typeBound(getResultIRType(), _, result) }
 }
 
 /**

--- a/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/RangeUtils.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/RangeUtils.qll
@@ -86,15 +86,15 @@ predicate backEdge(PhiInstruction phi, PhiInputOperand op) {
  * range analysis.
  */
 pragma[inline]
-private predicate safeCast(IntegralType fromtyp, IntegralType totyp) {
-  fromtyp.getSize() < totyp.getSize() and
+private predicate safeCast(IRIntegerType fromtyp, IRIntegerType totyp) {
+  fromtyp.getByteSize() < totyp.getByteSize() and
   (
     fromtyp.isUnsigned()
     or
     totyp.isSigned()
   )
   or
-  fromtyp.getSize() <= totyp.getSize() and
+  fromtyp.getByteSize() <= totyp.getByteSize() and
   (
     fromtyp.isSigned() and
     totyp.isSigned()
@@ -109,8 +109,8 @@ private predicate safeCast(IntegralType fromtyp, IntegralType totyp) {
  */
 class PtrToPtrCastInstruction extends ConvertInstruction {
   PtrToPtrCastInstruction() {
-    getResultType() instanceof PointerType and
-    getUnary().getResultType() instanceof PointerType
+    getResultIRType() instanceof IRAddressType and
+    getUnary().getResultIRType() instanceof IRAddressType
   }
 }
 
@@ -119,7 +119,7 @@ class PtrToPtrCastInstruction extends ConvertInstruction {
  * that cannot overflow or underflow.
  */
 class SafeIntCastInstruction extends ConvertInstruction {
-  SafeIntCastInstruction() { safeCast(getUnary().getResultType(), getResultType()) }
+  SafeIntCastInstruction() { safeCast(getUnary().getResultIRType(), getResultIRType()) }
 }
 
 /**

--- a/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/SignAnalysis.qll
@@ -469,7 +469,7 @@ module SignAnalysisCached {
     not exists(certainInstructionSign(i)) and
     not (
       result = TNeg() and
-      i.getResultType().(IntegralType).isUnsigned()
+      i.getResultIRType().(IRIntegerType).isUnsigned()
     ) and
     (
       unknownSign(i)
@@ -477,9 +477,13 @@ module SignAnalysisCached {
       exists(ConvertInstruction ci, Instruction prior, boolean fromSigned, boolean toSigned |
         i = ci and
         prior = ci.getUnary() and
-        (if ci.getResultType().(IntegralType).isSigned() then toSigned = true else toSigned = false) and
         (
-          if prior.getResultType().(IntegralType).isSigned()
+          if ci.getResultIRType().(IRIntegerType).isSigned()
+          then toSigned = true
+          else toSigned = false
+        ) and
+        (
+          if prior.getResultIRType().(IRIntegerType).isSigned()
           then fromSigned = true
           else fromSigned = false
         ) and
@@ -512,11 +516,11 @@ module SignAnalysisCached {
         i instanceof ShiftLeftInstruction and result = s1.lshift(s2)
         or
         i instanceof ShiftRightInstruction and
-        i.getResultType().(IntegralType).isSigned() and
+        i.getResultIRType().(IRIntegerType).isSigned() and
         result = s1.rshift(s2)
         or
         i instanceof ShiftRightInstruction and
-        not i.getResultType().(IntegralType).isSigned() and
+        not i.getResultIRType().(IRIntegerType).isSigned() and
         result = s1.urshift(s2)
       )
       or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -234,20 +234,20 @@ predicate clearsContent(Node n, Content c) {
 }
 
 /** Gets the type of `n` used for type pruning. */
-Type getNodeType(Node n) {
+IRType getNodeType(Node n) {
   suppressUnusedNode(n) and
-  result instanceof VoidType // stub implementation
+  result instanceof IRVoidType // stub implementation
 }
 
 /** Gets a string representation of a type returned by `getNodeType`. */
-string ppReprType(Type t) { none() } // stub implementation
+string ppReprType(IRType t) { none() } // stub implementation
 
 /**
  * Holds if `t1` and `t2` are compatible, that is, whether data can flow from
  * a node of type `t1` to a node of type `t2`.
  */
 pragma[inline]
-predicate compatibleTypes(Type t1, Type t2) {
+predicate compatibleTypes(IRType t1, IRType t2) {
   any() // stub implementation
 }
 
@@ -271,7 +271,7 @@ class DataFlowCallable = Declaration;
 
 class DataFlowExpr = Expr;
 
-class DataFlowType = Type;
+class DataFlowType = IRType;
 
 /** A function call relevant for data flow. */
 class DataFlowCall extends CallInstruction {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -33,7 +33,7 @@ class Node extends TIRDataFlowNode {
   Function getFunction() { none() } // overridden in subclasses
 
   /** Gets the type of this node. */
-  Type getType() { none() } // overridden in subclasses
+  IRType getType() { none() } // overridden in subclasses
 
   /** Gets the instruction corresponding to this node, if any. */
   Instruction asInstruction() { result = this.(InstructionNode).getInstruction() }
@@ -88,7 +88,7 @@ class Node extends TIRDataFlowNode {
   /**
    * Gets an upper bound on the type of this node.
    */
-  Type getTypeBound() { result = getType() }
+  IRType getTypeBound() { result = getType() }
 
   /** Gets the location of this element. */
   Location getLocation() { none() } // overridden by subclasses
@@ -125,7 +125,7 @@ class InstructionNode extends Node, TInstructionNode {
 
   override Function getFunction() { result = instr.getEnclosingFunction() }
 
-  override Type getType() { result = instr.getResultType() }
+  override IRType getType() { result = instr.getResultIRType() }
 
   override Location getLocation() { result = instr.getLocation() }
 
@@ -151,7 +151,7 @@ class OperandNode extends Node, TOperandNode {
 
   override Function getFunction() { result = op.getUse().getEnclosingFunction() }
 
-  override Type getType() { result = op.getType() }
+  override IRType getType() { result = op.getIRType() }
 
   override Location getLocation() { result = op.getLocation() }
 
@@ -449,7 +449,7 @@ class VariableNode extends Node, TVariableNode {
     result = v
   }
 
-  override Type getType() { result = v.getType() }
+  override IRType getType() { result.getCanonicalLanguageType().hasUnspecifiedType(v.getType(), _) }
 
   override Location getLocation() { result = v.getLocation() }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/IRType.qll
@@ -152,6 +152,12 @@ class IRIntegerType extends IRNumericType {
     this = TIRSignedIntegerType(byteSize) or
     this = TIRUnsignedIntegerType(byteSize)
   }
+
+  /** Holds if this integer type is signed. */
+  predicate isSigned() { none() }
+
+  /** Holds if this integer type is unsigned. */
+  predicate isUnsigned() { none() }
   // Don't override `getByteSize()` here. The optimizer seems to generate better code when this is
   // overridden only in the leaf classes.
 }
@@ -169,6 +175,8 @@ class IRSignedIntegerType extends IRIntegerType, TIRSignedIntegerType {
 
   pragma[noinline]
   final override int getByteSize() { result = byteSize }
+
+  override predicate isSigned() { any() }
 }
 
 /**
@@ -184,6 +192,8 @@ class IRUnsignedIntegerType extends IRIntegerType, TIRUnsignedIntegerType {
 
   pragma[noinline]
   final override int getByteSize() { result = byteSize }
+
+  override predicate isUnsigned() { any() }
 }
 
 /**

--- a/csharp/ql/src/experimental/ir/implementation/IRType.qll
+++ b/csharp/ql/src/experimental/ir/implementation/IRType.qll
@@ -152,6 +152,12 @@ class IRIntegerType extends IRNumericType {
     this = TIRSignedIntegerType(byteSize) or
     this = TIRUnsignedIntegerType(byteSize)
   }
+
+  /** Holds if this integer type is signed. */
+  predicate isSigned() { none() }
+
+  /** Holds if this integer type is unsigned. */
+  predicate isUnsigned() { none() }
   // Don't override `getByteSize()` here. The optimizer seems to generate better code when this is
   // overridden only in the leaf classes.
 }
@@ -169,6 +175,8 @@ class IRSignedIntegerType extends IRIntegerType, TIRSignedIntegerType {
 
   pragma[noinline]
   final override int getByteSize() { result = byteSize }
+
+  override predicate isSigned() { any() }
 }
 
 /**
@@ -184,6 +192,8 @@ class IRUnsignedIntegerType extends IRIntegerType, TIRUnsignedIntegerType {
 
   pragma[noinline]
   final override int getByteSize() { result = byteSize }
+
+  override predicate isUnsigned() { any() }
 }
 
 /**


### PR DESCRIPTION
The easy cases of https://github.com/github/codeql-c-analysis-team/issues/93.

After this change, the only occurrences of `Instruction.getResultType()` that remain either requires modifying the IR type system (i.e., [DefaultTaintTracking](https://github.com/github/codeql/blob/master/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll#L238) and [TaintTrackingUtil](https://github.com/github/codeql/blob/master/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/TaintTrackingUtil.qll#L58), or requires slightly more investigation (i.e., [here](https://github.com/github/codeql/blob/master/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll#L564) and [here](https://github.com/github/codeql/blob/master/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll#L608)).

CPP-Difference should hopefully not reveal anything surprising, but just to make sure: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1264/