### PR TITLE
C++: Remove abstract classes from Preprocessor.qll

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
+++ b/cpp/ql/src/semmle/code/cpp/Preprocessor.qll
@@ -33,11 +33,13 @@ class PreprocessorDirective extends Locatable, @preprocdirect {
   }
 }
 
+private class TPreprocessorBranchDirective = @ppd_branch or @ppd_else or @ppd_endif;
+
 /**
  * A C/C++ preprocessor branch related directive: `#if`, `#ifdef`,
  * `#ifndef`, `#elif`, `#else` or `#endif`.
  */
-abstract class PreprocessorBranchDirective extends PreprocessorDirective {
+class PreprocessorBranchDirective extends PreprocessorDirective, TPreprocessorBranchDirective {
   /**
    * Gets the `#if`, `#ifdef` or `#ifndef` directive which matches this
    * branching directive.


### PR DESCRIPTION
One of the final pieces of https://github.com/github/codeql-c-analysis-team/issues/60.