### PR TITLE
Java: add query to detect web.xml auth bypass through verb tampering

### DIFF
--- a/java/ql/src/experimental/Security/CWE/CWE-275/plutoRce.ql
+++ b/java/ql/src/experimental/Security/CWE/CWE-275/plutoRce.ql
@@ -1,0 +1,25 @@
+import java
+import semmle.code.xml.WebXML
+
+class ValidHTTPMethods extends string {
+  ValidHTTPMethods() {
+    this = "OPTIONS" or
+    this = "GET" or
+    this = "HEAD" or
+    this = "POST" or
+    this = "PUT" or
+    this = "DELETE" or
+    this = "TRACE" or
+    this = "CONNECT"
+  }
+}
+
+from WebResourceCollectionClass c, ValidHTTPMethods m
+where
+  // get all instances where
+  // the parent security-constraint declares an auth-constraint
+  exists(c.getDeclaringConstraint().getAuthConstraint()) and
+  // there is atleast one valid HTTP method which is not included
+  not forex( | m = c.getHTTPMethods())
+select c, "Auth constraint applied to $@ does not check for $@ verb", c, "web resource collection",
+  m, m

--- a/java/ql/src/semmle/code/xml/WebXML.qll
+++ b/java/ql/src/semmle/code/xml/WebXML.qll
@@ -130,3 +130,59 @@ class WebListenerClass extends WebXMLElement {
    */
   Class getClass() { result.getQualifiedName() = getValue() }
 }
+
+/**
+ * A `<security-constraint>` element in a `web.xml` file.
+ */
+class SecurityConstraint extends WebXMLElement {
+  SecurityConstraint() { getName() = "security-constraint" }
+
+  XMLElement getAuthConstraint() { result = getAChild("auth-constraint") }
+}
+
+/**
+ * A `<web-resource-collection>` element in a `web.xml` file,
+ * nested under a `<security-constraint>` element.
+ */
+class WebResourceCollectionClass extends WebXMLElement {
+  WebResourceCollectionClass() {
+    getName() = "web-resource-collection" and
+    getParent() instanceof SecurityConstraint
+  }
+
+  Class getClass() { result.getQualifiedName() = getValue() }
+
+  /**Gets the security constraint to which this belongs */
+  SecurityConstraint getDeclaringConstraint() { result = getParent() }
+
+  /** Returns all HTTP methods listed in this collection */
+  string getHTTPMethods() {
+    exists(HttpMethodAttribute a | this = a.getParent() | result = a.getValue())
+  }
+}
+
+/**
+ * A `<auth-constraint>` element in a `web.xml` file,
+ * nested under a `<security-constraint>` element.
+ */
+class AuthConstraintClass extends WebXMLElement {
+  AuthConstraintClass() {
+    getName() = "auth-constraint" and
+    getParent() instanceof SecurityConstraint
+  }
+
+  Class getClass() { result.getQualifiedName() = getValue() }
+}
+
+/**
+ * A `<http-method>` attribute in a `web.xml` file,
+ * nested under a `<web-resource-collection>` element.
+ */
+class HttpMethodAttribute extends WebXMLElement {
+  HttpMethodAttribute() {
+    getName() = "http-method" and
+    getParent() instanceof WebResourceCollectionClass
+  }
+
+  Class getClass() { result.getQualifiedName() = getValue() }
+}

--- a/java/ql/test/experimental/query-tests/security/CWE-275/Test.java
+++ b/java/ql/test/experimental/query-tests/security/CWE-275/Test.java
@@ -1,0 +1,1 @@
+public class Test{}

--- a/java/ql/test/experimental/query-tests/security/CWE-275/plutoRce.qlref
+++ b/java/ql/test/experimental/query-tests/security/CWE-275/plutoRce.qlref
@@ -1,0 +1,1 @@
+experimental/Security/CWE/CWE-275/plutoRce.ql

--- a/java/ql/test/experimental/query-tests/security/CWE-275/web.xml
+++ b/java/ql/test/experimental/query-tests/security/CWE-275/web.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+
+  <!-- Locale Filter -->
+  <filter>
+    <filter-name>LocaleFilter</filter-name>
+    <filter-class>io.apiman.common.servlet.LocaleFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>LocaleFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- CORS Filter -->
+  <filter>
+    <filter-name>CorsFilter</filter-name>
+    <filter-class>io.apiman.common.servlet.ApimanCorsFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>CorsFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Disable Caching Filter -->
+  <filter>
+    <filter-name>NoCacheFilter</filter-name>
+    <filter-class>io.apiman.common.servlet.DisableCachingFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>NoCacheFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Security Context Filter -->
+  <filter>
+    <filter-name>SecurityContext</filter-name>
+    <filter-class>io.apiman.manager.api.security.impl.DefaultSecurityContextFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>SecurityContext</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Transaction Watchdog -->
+  <filter>
+    <filter-name>TransactionWatchdog</filter-name>
+    <filter-class>io.apiman.manager.api.war.TransactionWatchdogFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>TransactionWatchdog</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Root Resource Filter -->
+  <filter>
+    <filter-name>RootResourceFilter</filter-name>
+    <filter-class>io.apiman.common.servlet.RootResourceFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>RootResourceFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- Bootstrapper -->
+  <servlet>
+    <servlet-name>BootstrapperServlet</servlet-name>
+    <servlet-class>io.apiman.manager.api.war.WarApiManagerBootstrapperServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/actions/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/system/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/currentuser/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/gateways/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/organizations/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/permissions/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/plugins/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/policyDefs/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/roles/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/search/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>DELETE</http-method>
+      <http-method>HEAD</http-method>
+    </web-resource-collection>
+    <web-resource-collection>
+      <web-resource-name>apiman</web-resource-name>
+      <url-pattern>/users/*</url-pattern>
+      <http-method>GET</http-method>
+      <http-method>POST</http-method>
+      <http-method>PUT</http-method>
+      <http-method>DELETE</http-method>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>apiuser</role-name>
+    </auth-constraint>
+  </security-constraint>
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>apiman</realm-name>
+  </login-config>
+  <security-role>
+    <role-name>apiuser</role-name>
+  </security-role>
+
+</web-app>


### PR DESCRIPTION
This query detects the case where an `auth-constraint` is present for a particular HTTP verb but does not include some other verb.

The most common example for this case is CVE-2018-1306, the Apache Pluto 3.0.0 RCE. 

Consider the config as shown below
```xml
  <security-constraint>
    <web-resource-collection>
      <web-resource-name>portal</web-resource-name>
      <url-pattern>/portal</url-pattern>
      <url-pattern>/portal/*</url-pattern>
      <http-method>GET</http-method>
      <http-method>POST</http-method>
      <http-method>PUT</http-method>
    </web-resource-collection>
    <auth-constraint>
      <role-name>pluto</role-name>
    </auth-constraint>
  </security-constraint>
```

In this case, the `auth-constraint` check for `GET`,`POST` and `PUT` methods but not for the `HEAD` method. Essentially resulting in a full authentication bypass and eventually RCE.