### PR TITLE
Java: Clean up ContainerFlow: address outstanding comments

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/ContainerFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/ContainerFlow.qll
@@ -270,9 +270,6 @@ private predicate taintPreservingArgumentToQualifier(Method method, int arg) {
  * `arg`th argument is tainted.
  */
 private predicate taintPreservingArgumentToMethod(Method method, int arg) {
-  // java.util.Stack
-  method.(CollectionMethod).hasName("push") and arg = 0
-  or
   method.getDeclaringType().hasQualifiedName("java.util", "Collections") and
   (
     method

--- a/java/ql/src/semmle/code/java/dataflow/internal/ContainerFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/ContainerFlow.qll
@@ -130,6 +130,7 @@ private predicate taintPreservingQualifierToMethod(Method m) {
   m.(CollectionMethod).hasName(["peek", "pop"])
   or
   // java.util.Queue
+  // covered by Stack: peek()
   m.(CollectionMethod).hasName(["element", "poll"])
   or
   m.(CollectionMethod).hasName("remove") and m.getNumberOfParameters() = 0
@@ -254,7 +255,7 @@ private predicate taintPreservingArgumentToQualifier(Method method, int arg) {
   // covered by Deque: offerFirst(E, long, TimeUnit), offerLast(E, long, TimeUnit)
   method.(CollectionMethod).hasName(["putFirst", "putLast"]) and arg = 0
   or
-  //java.util.Dictionary
+  // java.util.Dictionary
   method
       .getDeclaringType()
       .getSourceDeclaration()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -413,6 +413,18 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
       m.hasName("toString") and node1.asExpr() = ma.getArgument(1)
     )
   )
+  or
+  exists(MethodAccess ma, Method m |
+    ma = node2.asExpr() and
+    m = ma.getMethod() and
+    m
+        .getDeclaringType()
+        .getSourceDeclaration()
+        .getASourceSupertype*()
+        .hasQualifiedName("java.util", "Stack") and
+    m.hasName("push") and
+    node1.asExpr() = ma.getArgument(0)
+  )
 }
 
 /**


### PR DESCRIPTION
Addresses outstanding comments by @Marcono1234  on https://github.com/github/codeql/pull/3918 .

* make `sink = Stack.push(source)` a dataflow step instead of a taint step.
* improve some comments