### PR TITLE
Python: Fix typo in qhelp file

### DIFF
--- a/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
+++ b/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
@@ -15,7 +15,7 @@ arguments on the right hand side of the expression. Otherwise, a <code>TypeError
 </p></recommendation>
 <example>
 <p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.</p>
-</p><sample src="WrongNumberArgumentsForFormat.py" />
+<sample src="WrongNumberArgumentsForFormat.py" />
 
 </example>
 <references>

--- a/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
+++ b/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
@@ -14,7 +14,7 @@ arguments on the right hand side of the expression. Otherwise, a <code>TypeError
 
 </p></recommendation>
 <example>
-<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.</p>
+<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.
 <sample src="WrongNumberArgumentsForFormat.py" />
 
 </example>

--- a/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
+++ b/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
@@ -14,7 +14,7 @@ arguments on the right hand side of the expression. Otherwise, a <code>TypeError
 
 </p></recommendation>
 <example>
-<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.
+<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.</p>
 <sample src="WrongNumberArgumentsForFormat.py" />
 
 </example>

--- a/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
+++ b/python/ql/src/Expressions/WrongNumberArgumentsForFormat.qhelp
@@ -14,7 +14,7 @@ arguments on the right hand side of the expression. Otherwise, a <code>TypeError
 
 </p></recommendation>
 <example>
-<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string&lt;./p>
+<p>In the following example the right hand side of the formatting operation can be of length 2, which does not match the format string.</p>
 </p><sample src="WrongNumberArgumentsForFormat.py" />
 
 </example>


### PR DESCRIPTION
Noticed a typo when reading the generated HTML page - https://lgtm.com/rules/2970098/. 

![Screenshot 2020-07-22 at 15 41 29](https://user-images.githubusercontent.com/59651540/88190268-fb4fdb80-cc31-11ea-977d-7c5e441eb923.png)


This commit should have this fixed on the next generation of the HTML pages.