### PR TITLE
CodeQL: complete LGTM suites

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -1,5 +1,6 @@
 { "provide": [ "*/ql/src/qlpack.yml",
                "*/ql/test/qlpack.yml",
+               "*/ql/examples/qlpack.yml",
                "*/upgrades/qlpack.yml",
                "misc/legacy-support/*/qlpack.yml",
                "misc/suite-helpers/qlpack.yml" ] }

--- a/cpp/ql/examples/qlpack.yml
+++ b/cpp/ql/examples/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-cpp-examples
+version: 0.0.0
+libraryPathDependencies: codeql-cpp

--- a/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
+++ b/cpp/ql/src/codeql-suites/cpp-lgtm-full.qls
@@ -9,3 +9,10 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Metrics/Dependencies/ExternalDependencies.ql
+- query: Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+- query: Metrics/Files/FLinesOfCode.ql
+- query: Metrics/Files/FLinesOfCommentedOutCode.ql
+- query: Metrics/Files/FLinesOfComments.ql
+- query: Metrics/Files/FLinesOfDuplicatedCode.ql
+- query: Metrics/Files/FNumberOfTests.ql

--- a/csharp/ql/examples/qlpack.yml
+++ b/csharp/ql/examples/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-csharp-examples
+version: 0.0.0
+libraryPathDependencies: codeql-csharp

--- a/csharp/ql/src/codeql-suites/csharp-lgtm-full.qls
+++ b/csharp/ql/src/codeql-suites/csharp-lgtm-full.qls
@@ -7,3 +7,10 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Metrics/Dependencies/ExternalDependencies.ql
+- query: Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+- query: Metrics/Files/FLinesOfCode.ql
+- query: Metrics/Files/FLinesOfCommentedCode.ql
+- query: Metrics/Files/FLinesOfComment.ql
+- query: Metrics/Files/FLinesOfDuplicatedCode.ql
+- query: Metrics/Files/FNumberOfTests.ql

--- a/java/ql/examples/qlpack.yml
+++ b/java/ql/examples/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-java-examples
+version: 0.0.0
+libraryPathDependencies: codeql-java

--- a/java/ql/src/codeql-suites/java-lgtm-full.qls
+++ b/java/ql/src/codeql-suites/java-lgtm-full.qls
@@ -7,3 +7,10 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Metrics/Dependencies/ExternalDependencies.ql
+- query: Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+- query: Metrics/Files/FLinesOfCode.ql
+- query: Metrics/Files/FLinesOfCommentedCode.ql
+- query: Metrics/Files/FLinesOfComment.ql
+- query: Metrics/Files/FLinesOfDuplicatedCode.ql
+- query: Metrics/Files/FNumberOfTests.ql

--- a/javascript/ql/examples/qlpack.yml
+++ b/javascript/ql/examples/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-javascript-examples
+version: 0.0.0
+libraryPathDependencies: codeql-javascript

--- a/javascript/ql/src/codeql-suites/javascript-lgtm-full.qls
+++ b/javascript/ql/src/codeql-suites/javascript-lgtm-full.qls
@@ -7,3 +7,11 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Comments/FCommentedOutCode.ql
+- query: Metrics/Dependencies/ExternalDependencies.ql
+- query: Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+- query: Metrics/FLinesOfCode.ql
+- query: Metrics/FLinesOfComment.ql
+- query: Metrics/FLinesOfDuplicatedCode.ql
+- query: Metrics/FLinesOfSimilarCode.ql
+- query: Metrics/FNumberOfTests.ql

--- a/python/ql/examples/qlpack.yml
+++ b/python/ql/examples/qlpack.yml
@@ -1,0 +1,3 @@
+name: codeql-python-examples
+version: 0.0.0
+libraryPathDependencies: codeql-python

--- a/python/ql/src/codeql-suites/python-lgtm-full.qls
+++ b/python/ql/src/codeql-suites/python-lgtm-full.qls
@@ -7,3 +7,11 @@
     tags contain:
       - ide-contextual-queries/local-definitions
       - ide-contextual-queries/local-references
+- query: Lexical/FCommentedOutCode.ql
+- query: Metrics/Dependencies/ExternalDependencies.ql
+- query: Metrics/Dependencies/ExternalDependenciesSourceLinks.ql
+- query: Metrics/FLinesOfCode.ql
+- query: Metrics/FLinesOfComments.ql
+- query: Metrics/FLinesOfDuplicatedCode.ql
+- query: Metrics/FLinesOfSimilarCode.ql
+- query: Metrics/FNumberOfTests.ql


### PR DESCRIPTION
This PR extends the lgtm-full.qls suite to also include the non-alert queries that LGTM runs. This is important when we switch to using CodeQL instead of ODASA in LGTM.

This PR also converts the `examples` folders to proper packs by adding some `qlpack.yml` files.