### PR TITLE
JavaScript: Make access paths more reusable

### DIFF
--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -124,171 +124,180 @@ module AccessPath {
   }
 
   /**
-   * Gets the access path relative to `root` referred to by `node`.
-   *
-   * This holds for direct references as well as for aliases
-   * established through local data flow.
-   *
-   * Examples:
-   * ```
-   * function f(x) {
-   *   let a = x.f.g; // access path relative to 'x' is 'f.g'
-   *   let b = a.h;   // access path relative to 'x' is 'f.g.h'
-   * }
-   * ```
+   * An internal module for caching a few related predicates together.
    */
   cached
-  private string fromReference(DataFlow::Node node, Root root) {
-    root = node and
-    not root.isGlobal() and
-    result = ""
-    or
-    result = fromReference(node.getImmediatePredecessor(), root)
-    or
-    exists(EffectivelyConstantVariable var |
-      var.isCaptured() and
-      node.asExpr() = var.getAnAccess() and
-      result = fromReference(var.getValue(), root)
-    )
-    or
-    node.accessesGlobal(result) and
-    result != "undefined" and
-    root.isGlobal()
-    or
-    not node.accessesGlobal(_) and
-    exists(DataFlow::PropRead prop | node = prop |
-      result = join(fromReference(prop.getBase(), root), prop.getPropertyName())
+  private module Impl {
+    /**
+     * Gets the access path relative to `root` referred to by `node`.
+     *
+     * This holds for direct references as well as for aliases
+     * established through local data flow.
+     *
+     * Examples:
+     * ```
+     * function f(x) {
+     *   let a = x.f.g; // access path relative to 'x' is 'f.g'
+     *   let b = a.h;   // access path relative to 'x' is 'f.g.h'
+     * }
+     * ```
+     */
+    cached
+    string fromReference(DataFlow::Node node, Root root) {
+      root = node and
+      not root.isGlobal() and
+      result = ""
       or
-      isLikelyDynamicArrayAccess(prop) and
-      result = join(fromReference(prop.getBase(), root), "[number]")
-    )
-    or
-    exists(Closure::ClosureNamespaceAccess acc | node = acc |
-      result = acc.getClosureNamespace() and
+      result = fromReference(node.getImmediatePredecessor(), root)
+      or
+      exists(EffectivelyConstantVariable var |
+        var.isCaptured() and
+        node.asExpr() = var.getAnAccess() and
+        result = fromReference(var.getValue(), root)
+      )
+      or
+      node.accessesGlobal(result) and
+      result != "undefined" and
       root.isGlobal()
-    )
-    or
-    exists(PropertyProjection proj | node = proj |
-      proj.isSingletonProjection() and
-      result = join(fromReference(proj.getObject(), root), proj.getASelector().getStringValue())
-    )
-    or
-    // Treat 'e || {}' as having the same name as 'e'
-    exists(LogOrExpr e | node.asExpr() = e |
-      e.getRightOperand().(ObjectExpr).getNumProperty() = 0 and
-      result = fromReference(e.getLeftOperand().flow(), root)
-    )
-    or
-    // Treat 'e && e.f' as having the same name as 'e.f'
-    exists(LogAndExpr e, Expr lhs, PropAccess rhs | node.asExpr() = e |
-      lhs = e.getLeftOperand() and
-      rhs = e.getRightOperand() and
-      (
-        exists(Variable v |
-          lhs = v.getAnAccess() and
-          rhs.getBase() = v.getAnAccess()
-        )
+      or
+      not node.accessesGlobal(_) and
+      exists(DataFlow::PropRead prop | node = prop |
+        result = join(fromReference(prop.getBase(), root), prop.getPropertyName())
         or
-        exists(string name |
-          lhs.(PropAccess).getQualifiedName() = name and
-          rhs.getBase().(PropAccess).getQualifiedName() = name
-        )
-      ) and
-      result = fromReference(rhs.flow(), root)
-    )
-  }
-
-  /**
-   * Holds if `rhs` is the right-hand side of a self-assignment.
-   *
-   * This usually happens in defensive initialization, for example:
-   * ```
-   * foo = foo || {};
-   * ```
-   */
-  private predicate isSelfAssignment(DataFlow::Node rhs) {
-    fromRhs(rhs, DataFlow::globalAccessPathRootPseudoNode()) =
-      fromReference(rhs, DataFlow::globalAccessPathRootPseudoNode())
-  }
-
-  /**
-   * Holds if there is an assignment to the global `accessPath` in `file`, not counting
-   * self-assignments.
-   */
-  private predicate isAssignedInFile(string accessPath, File file) {
-    exists(DataFlow::Node rhs |
-      fromRhs(rhs, DataFlow::globalAccessPathRootPseudoNode()) = accessPath and
-      not isSelfAssignment(rhs) and
-      // Note: Avoid unneeded materialization of DataFlow::Node.getFile()
-      rhs.getAstNode().getFile() = file
-    )
-  }
-
-  /**
-   * Holds if the global `accessPath` is only assigned to from one file, not counting
-   * self-assignments.
-   */
-  predicate isAssignedInUniqueFile(string accessPath) {
-    strictcount(File f | isAssignedInFile(accessPath, f)) = 1
-  }
-
-  /**
-   * Gets the access path relative to `root`, which `node` is being assigned to, if any.
-   *
-   * Only holds for the immediate right-hand side of an assignment or property, not
-   * for nodes that transitively flow there.
-   *
-   * For example, the class nodes below all map to `foo.bar` relative to `x`:
-   * ```
-   * function f(x) {
-   *   x.foo.bar = class {};
-   *   x.foo = { bar: class {} };
-   *   let alias = x;
-   *   alias.foo.bar = class {};
-   * }
-   * ```
-   */
-  cached
-  private string fromRhs(DataFlow::Node node, Root root) {
-    exists(DataFlow::PropWrite write, string baseName |
-      node = write.getRhs() and
-      result = join(baseName, write.getPropertyName())
-    |
-      baseName = fromReference(write.getBase(), root)
+        isLikelyDynamicArrayAccess(prop) and
+        result = join(fromReference(prop.getBase(), root), "[number]")
+      )
       or
-      baseName = fromRhs(write.getBase(), root)
-    )
-    or
-    exists(GlobalVariable var |
-      node = var.getAnAssignedExpr().flow() and
-      result = var.getName() and
-      root.isGlobal()
-    )
-    or
-    exists(FunctionDeclStmt fun |
-      node = DataFlow::valueNode(fun) and
-      result = fun.getId().(GlobalVarDecl).getName() and
-      root.isGlobal()
-    )
-    or
-    exists(ClassDeclStmt cls |
-      node = DataFlow::valueNode(cls) and
-      result = cls.getIdentifier().(GlobalVarDecl).getName() and
-      root.isGlobal()
-    )
-    or
-    exists(EnumDeclaration decl |
-      node = DataFlow::valueNode(decl) and
-      result = decl.getIdentifier().(GlobalVarDecl).getName() and
-      root.isGlobal()
-    )
-    or
-    exists(NamespaceDeclaration decl |
-      node = DataFlow::valueNode(decl) and
-      result = decl.getId().(GlobalVarDecl).getName() and
-      root.isGlobal()
-    )
+      exists(Closure::ClosureNamespaceAccess acc | node = acc |
+        result = acc.getClosureNamespace() and
+        root.isGlobal()
+      )
+      or
+      exists(PropertyProjection proj | node = proj |
+        proj.isSingletonProjection() and
+        result = join(fromReference(proj.getObject(), root), proj.getASelector().getStringValue())
+      )
+      or
+      // Treat 'e || {}' as having the same name as 'e'
+      exists(LogOrExpr e | node.asExpr() = e |
+        e.getRightOperand().(ObjectExpr).getNumProperty() = 0 and
+        result = fromReference(e.getLeftOperand().flow(), root)
+      )
+      or
+      // Treat 'e && e.f' as having the same name as 'e.f'
+      exists(LogAndExpr e, Expr lhs, PropAccess rhs | node.asExpr() = e |
+        lhs = e.getLeftOperand() and
+        rhs = e.getRightOperand() and
+        (
+          exists(Variable v |
+            lhs = v.getAnAccess() and
+            rhs.getBase() = v.getAnAccess()
+          )
+          or
+          exists(string name |
+            lhs.(PropAccess).getQualifiedName() = name and
+            rhs.getBase().(PropAccess).getQualifiedName() = name
+          )
+        ) and
+        result = fromReference(rhs.flow(), root)
+      )
+    }
+
+    /**
+     * Holds if `rhs` is the right-hand side of a self-assignment.
+     *
+     * This usually happens in defensive initialization, for example:
+     * ```
+     * foo = foo || {};
+     * ```
+     */
+    private predicate isSelfAssignment(DataFlow::Node rhs) {
+      fromRhs(rhs, DataFlow::globalAccessPathRootPseudoNode()) =
+        fromReference(rhs, DataFlow::globalAccessPathRootPseudoNode())
+    }
+
+    /**
+     * Holds if there is an assignment to the global `accessPath` in `file`, not counting
+     * self-assignments.
+     */
+    private predicate isAssignedInFile(string accessPath, File file) {
+      exists(DataFlow::Node rhs |
+        fromRhs(rhs, DataFlow::globalAccessPathRootPseudoNode()) = accessPath and
+        not isSelfAssignment(rhs) and
+        // Note: Avoid unneeded materialization of DataFlow::Node.getFile()
+        rhs.getAstNode().getFile() = file
+      )
+    }
+
+    /**
+     * Holds if the global `accessPath` is only assigned to from one file, not counting
+     * self-assignments.
+     */
+    cached
+    predicate isAssignedInUniqueFile(string accessPath) {
+      strictcount(File f | isAssignedInFile(accessPath, f)) = 1
+    }
+
+    /**
+     * Gets the access path relative to `root`, which `node` is being assigned to, if any.
+     *
+     * Only holds for the immediate right-hand side of an assignment or property, not
+     * for nodes that transitively flow there.
+     *
+     * For example, the class nodes below all map to `foo.bar` relative to `x`:
+     * ```
+     * function f(x) {
+     *   x.foo.bar = class {};
+     *   x.foo = { bar: class {} };
+     *   let alias = x;
+     *   alias.foo.bar = class {};
+     * }
+     * ```
+     */
+    cached
+    string fromRhs(DataFlow::Node node, Root root) {
+      exists(DataFlow::PropWrite write, string baseName |
+        node = write.getRhs() and
+        result = join(baseName, write.getPropertyName())
+      |
+        baseName = fromReference(write.getBase(), root)
+        or
+        baseName = fromRhs(write.getBase(), root)
+      )
+      or
+      exists(GlobalVariable var |
+        node = var.getAnAssignedExpr().flow() and
+        result = var.getName() and
+        root.isGlobal()
+      )
+      or
+      exists(FunctionDeclStmt fun |
+        node = DataFlow::valueNode(fun) and
+        result = fun.getId().(GlobalVarDecl).getName() and
+        root.isGlobal()
+      )
+      or
+      exists(ClassDeclStmt cls |
+        node = DataFlow::valueNode(cls) and
+        result = cls.getIdentifier().(GlobalVarDecl).getName() and
+        root.isGlobal()
+      )
+      or
+      exists(EnumDeclaration decl |
+        node = DataFlow::valueNode(decl) and
+        result = decl.getIdentifier().(GlobalVarDecl).getName() and
+        root.isGlobal()
+      )
+      or
+      exists(NamespaceDeclaration decl |
+        node = DataFlow::valueNode(decl) and
+        result = decl.getId().(GlobalVarDecl).getName() and
+        root.isGlobal()
+      )
+    }
   }
+
+  import Impl
 
   /**
    * Gets a node that refers to the given access path relative to the given `root` node,

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -319,16 +319,6 @@ module AccessPath {
     }
 
     /**
-     * Holds if `succ` is assigned to the same access path as `pred`, but with `step` appended.
-     *
-     * This predicate is mostly for internal use.
-     */
-    cached
-    predicate rhs2rhs(DataFlow::Node pred, DataFlow::Node succ, string step) {
-      any(DataFlow::PropWrite pw).writes(pred, step, succ)
-    }
-
-    /**
      * Gets the access path relative to `root`, which `node` is being assigned to, if any.
      *
      * Only holds for the immediate right-hand side of an assignment or property, not
@@ -349,11 +339,9 @@ module AccessPath {
       globalRhs(node, result) and
       root.isGlobal()
       or
-      exists(DataFlow::Node pred, string step |
-        ref2rhs(pred, node, step) and
+      exists(DataFlow::Node pred, string step | ref2rhs(pred, node, step) |
         result = join(fromReference(pred, root), step)
         or
-        rhs2rhs(pred, node, step) and
         result = join(fromRhs(pred, root), step)
       )
     }

--- a/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
+++ b/javascript/ql/src/semmle/javascript/GlobalAccessPaths.qll
@@ -518,7 +518,8 @@ module AccessPath {
         rank[ranking](ControlFlowNode ref |
           ref = getAccessTo(root, path, _) and
           ref.getBasicBlock() = bb and
-          // Prunes the accesses where there does not exists a read and write within the same basicblock.
+          // Prunes the accesses where there does not exist a read and write within the same
+          // basic block.
           // This could be more precise, but doing it like this avoids massive joins.
           hasRead(bb) and
           hasWrite(bb)

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
@@ -61,33 +61,33 @@ test_getAReferenceTo
 | test.js:39:14:39:16 | foo | foo |
 | test.js:39:14:39:20 | foo.bar | foo.bar |
 | test.js:40:3:40:10 | lazyInit | foo.bar |
-| test.js:44:13:44:18 | Object | Object |
-| test.js:44:13:44:25 | Object.create | Object.create |
-| test.js:50:7:50:12 | random | random |
-| test.js:56:7:56:12 | random | random |
-| test.js:67:11:67:16 | Object | Object |
-| test.js:67:11:67:23 | Object.freeze | Object.freeze |
-| test.js:67:11:67:32 | Object. ... oo.bar) | foo.bar |
-| test.js:67:11:67:36 | Object. ... ar).baz | foo.bar.baz |
-| test.js:67:25:67:27 | foo | foo |
-| test.js:67:25:67:31 | foo.bar | foo.bar |
-| test.js:68:11:68:16 | Object | Object |
-| test.js:68:11:68:21 | Object.seal | Object.seal |
-| test.js:68:11:68:30 | Object.seal(foo.bar) | foo.bar |
-| test.js:68:11:68:34 | Object. ... ar).baz | foo.bar.baz |
-| test.js:68:23:68:25 | foo | foo |
-| test.js:68:23:68:29 | foo.bar | foo.bar |
-| test.js:69:6:69:15 | O | Object |
-| test.js:69:10:69:15 | Object | Object |
-| test.js:70:11:70:11 | O | Object |
-| test.js:70:11:70:16 | O.seal | Object.seal |
-| test.js:70:18:70:20 | foo | foo |
-| test.js:70:18:70:24 | foo.bar | foo.bar |
 | test.js:41:3:41:5 | foo | foo |
 | test.js:41:3:41:16 | foo && foo.bar | foo |
 | test.js:41:3:41:16 | foo && foo.bar | foo.bar |
 | test.js:41:10:41:12 | foo | foo |
 | test.js:41:10:41:16 | foo.bar | foo.bar |
+| test.js:45:13:45:18 | Object | Object |
+| test.js:45:13:45:25 | Object.create | Object.create |
+| test.js:51:7:51:12 | random | random |
+| test.js:57:7:57:12 | random | random |
+| test.js:68:11:68:16 | Object | Object |
+| test.js:68:11:68:23 | Object.freeze | Object.freeze |
+| test.js:68:11:68:32 | Object. ... oo.bar) | foo.bar |
+| test.js:68:11:68:36 | Object. ... ar).baz | foo.bar.baz |
+| test.js:68:25:68:27 | foo | foo |
+| test.js:68:25:68:31 | foo.bar | foo.bar |
+| test.js:69:11:69:16 | Object | Object |
+| test.js:69:11:69:21 | Object.seal | Object.seal |
+| test.js:69:11:69:30 | Object.seal(foo.bar) | foo.bar |
+| test.js:69:11:69:34 | Object. ... ar).baz | foo.bar.baz |
+| test.js:69:23:69:25 | foo | foo |
+| test.js:69:23:69:29 | foo.bar | foo.bar |
+| test.js:70:6:70:15 | O | Object |
+| test.js:70:10:70:15 | Object | Object |
+| test.js:71:11:71:11 | O | Object |
+| test.js:71:11:71:16 | O.seal | Object.seal |
+| test.js:71:18:71:20 | foo | foo |
+| test.js:71:18:71:24 | foo.bar | foo.bar |
 test_getAnAssignmentTo
 | other_ns.js:4:9:4:16 | NS \|\| {} | NS |
 | other_ns.js:6:12:6:13 | {} | Conflict |
@@ -98,7 +98,7 @@ test_getAnAssignmentTo
 | test.js:30:1:30:28 | functio ... on() {} | globalFunction |
 | test.js:32:1:35:1 | functio ... .baz'\\n} | destruct |
 | test.js:37:1:42:1 | functio ... .bar'\\n} | lazy |
-| test.js:43:1:64:1 | functio ... // no\\n} | dominatingWrite |
+| test.js:44:1:65:1 | functio ... // no\\n} | dominatingWrite |
 test_assignedUnique
 | GlobalClass |
 | destruct |
@@ -107,6 +107,6 @@ test_assignedUnique
 | globalFunction |
 | lazy |
 hasDominatingWrite
-| test.js:48:3:48:11 | obj.prop1 |
-| test.js:57:5:57:13 | obj.prop3 |
-| test.js:62:29:62:37 | obj.prop5 |
+| test.js:49:3:49:11 | obj.prop1 |
+| test.js:58:5:58:13 | obj.prop3 |
+| test.js:63:29:63:37 | obj.prop5 |

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/GlobalAccessPaths.expected
@@ -83,6 +83,11 @@ test_getAReferenceTo
 | test.js:70:11:70:16 | O.seal | Object.seal |
 | test.js:70:18:70:20 | foo | foo |
 | test.js:70:18:70:24 | foo.bar | foo.bar |
+| test.js:41:3:41:5 | foo | foo |
+| test.js:41:3:41:16 | foo && foo.bar | foo |
+| test.js:41:3:41:16 | foo && foo.bar | foo.bar |
+| test.js:41:10:41:12 | foo | foo |
+| test.js:41:10:41:16 | foo.bar | foo.bar |
 test_getAnAssignmentTo
 | other_ns.js:4:9:4:16 | NS \|\| {} | NS |
 | other_ns.js:6:12:6:13 | {} | Conflict |
@@ -92,7 +97,7 @@ test_getAnAssignmentTo
 | test.js:28:1:28:20 | class GlobalClass {} | GlobalClass |
 | test.js:30:1:30:28 | functio ... on() {} | globalFunction |
 | test.js:32:1:35:1 | functio ... .baz'\\n} | destruct |
-| test.js:37:1:41:1 | functio ... Init;\\n} | lazy |
+| test.js:37:1:42:1 | functio ... .bar'\\n} | lazy |
 | test.js:43:1:64:1 | functio ... // no\\n} | dominatingWrite |
 test_assignedUnique
 | GlobalClass |

--- a/javascript/ql/test/library-tests/GlobalAccessPaths/test.js
+++ b/javascript/ql/test/library-tests/GlobalAccessPaths/test.js
@@ -38,6 +38,7 @@ function lazy() {
   var lazyInit;
   lazyInit = foo.bar; // 'foo.bar'
   lazyInit;
+  foo && foo.bar; // 'foo.bar'
 }
 
 function dominatingWrite() {


### PR DESCRIPTION
As discussed, this factors out a few reusable predicates from the access-path computation. The API graphs currently don't use this yet, so there is no particular rush to merge this, I just wanted to put it up for visibility and discussion.

An [evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/master/js/make-access-paths-more-reusable/report.md) (internal link) shows a slight performance degradation. The massive apparent slowdown on gecko for the first run was due to the base SHA timing out on `definitions.ql` and the tip SHA timing out on a later query; on rerun, both timed out on `definitions.ql`.