### PR TITLE
C#: Fix false-positives in `cs/dereferenced-value-may-be-null`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/Guards.qll
@@ -876,6 +876,8 @@ module Internal {
     not e.(QualifiableExpr).isConditional()
     or
     e instanceof SuppressNullableWarningExpr
+    or
+    e.stripCasts().getType() = any(ValueType t | not t instanceof NullableType)
   }
 
   /** Holds if expression `e2` is a non-`null` value whenever `e1` is. */

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -231,6 +231,7 @@ private predicate defMaybeNull(Ssa::Definition def, string msg, Element reason) 
   exists(Dereference d | dereferenceAt(_, _, def, d) |
     d.hasNullableType() and
     not def instanceof Ssa::PseudoDefinition and
+    not nonNullDef(def) and
     reason = def.getSourceVariable().getAssignable() and
     msg = "because it has a nullable type"
   )

--- a/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/Nullness.qll
@@ -197,43 +197,44 @@ private predicate isNullDefaultArgument(Ssa::ExplicitDefinition def, AlwaysNullE
 
 /** Holds if `def` is an SSA definition that may be `null`. */
 private predicate defMaybeNull(Ssa::Definition def, string msg, Element reason) {
-  // A variable compared to `null` might be `null`
-  exists(G::DereferenceableExpr de | de = def.getARead() |
-    reason = de.getANullCheck(_, true) and
-    msg = "as suggested by $@ null check" and
-    not de = any(Ssa::PseudoDefinition pdef).getARead() and
-    strictcount(Element e | e = any(Ssa::Definition def0 | de = def0.getARead()).getElement()) = 1 and
-    not nonNullDef(def) and
-    // Don't use a check as reason if there is a `null` assignment
-    // or argument
-    not def.(Ssa::ExplicitDefinition).getADefinition().getSource() instanceof MaybeNullExpr and
-    not isMaybeNullArgument(def, _)
-  )
-  or
-  // A parameter might be `null` if there is a `null` argument somewhere
-  isMaybeNullArgument(def, reason) and
+  not nonNullDef(def) and
   (
-    if reason instanceof AlwaysNullExpr
-    then msg = "because of $@ null argument"
-    else msg = "because of $@ potential null argument"
-  )
-  or
-  isNullDefaultArgument(def, reason) and msg = "because the parameter has a null default value"
-  or
-  // If the source of a variable is `null` then the variable may be `null`
-  exists(AssignableDefinition adef | adef = def.(Ssa::ExplicitDefinition).getADefinition() |
-    adef.getSource() instanceof MaybeNullExpr and
-    reason = adef.getExpr() and
-    msg = "because of $@ assignment"
-  )
-  or
-  // A variable of nullable type may be null
-  exists(Dereference d | dereferenceAt(_, _, def, d) |
-    d.hasNullableType() and
-    not def instanceof Ssa::PseudoDefinition and
-    not nonNullDef(def) and
-    reason = def.getSourceVariable().getAssignable() and
-    msg = "because it has a nullable type"
+    // A variable compared to `null` might be `null`
+    exists(G::DereferenceableExpr de | de = def.getARead() |
+      reason = de.getANullCheck(_, true) and
+      msg = "as suggested by $@ null check" and
+      not de = any(Ssa::PseudoDefinition pdef).getARead() and
+      strictcount(Element e | e = any(Ssa::Definition def0 | de = def0.getARead()).getElement()) = 1 and
+      // Don't use a check as reason if there is a `null` assignment
+      // or argument
+      not def.(Ssa::ExplicitDefinition).getADefinition().getSource() instanceof MaybeNullExpr and
+      not isMaybeNullArgument(def, _)
+    )
+    or
+    // A parameter might be `null` if there is a `null` argument somewhere
+    isMaybeNullArgument(def, reason) and
+    (
+      if reason instanceof AlwaysNullExpr
+      then msg = "because of $@ null argument"
+      else msg = "because of $@ potential null argument"
+    )
+    or
+    isNullDefaultArgument(def, reason) and msg = "because the parameter has a null default value"
+    or
+    // If the source of a variable is `null` then the variable may be `null`
+    exists(AssignableDefinition adef | adef = def.(Ssa::ExplicitDefinition).getADefinition() |
+      adef.getSource() instanceof MaybeNullExpr and
+      reason = adef.getExpr() and
+      msg = "because of $@ assignment"
+    )
+    or
+    // A variable of nullable type may be null
+    exists(Dereference d | dereferenceAt(_, _, def, d) |
+      d.hasNullableType() and
+      not def instanceof Ssa::PseudoDefinition and
+      reason = def.getSourceVariable().getAssignable() and
+      msg = "because it has a nullable type"
+    )
   )
 }
 

--- a/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
+++ b/csharp/ql/test/library-tests/cil/dataflow/Nullness.expected
@@ -8,7 +8,10 @@ alwaysNull
 | dataflow.cs:80:21:80:44 | access to property NullProperty |
 | dataflow.cs:89:31:89:44 | call to method NullFunction |
 alwaysNotNull
+| dataflow.cs:71:13:71:20 | access to local variable nonNull1 |
+| dataflow.cs:71:13:71:35 | Int32 nonNull1 = ... |
 | dataflow.cs:71:24:71:35 | default(...) |
+| dataflow.cs:71:32:71:34 | access to type Int32 |
 | dataflow.cs:72:27:72:30 | this access |
 | dataflow.cs:72:27:72:40 | call to method GetType |
 | dataflow.cs:73:30:73:33 | true |
@@ -25,6 +28,7 @@ alwaysNotNull
 | dataflow.cs:85:24:85:30 | access to local variable nonNull |
 | dataflow.cs:85:24:85:55 | call to method ReturnsNonNullIndirect |
 | dataflow.cs:86:24:86:30 | access to local variable nonNull |
+| dataflow.cs:89:24:89:27 | access to field cond |
 | dataflow.cs:89:24:89:27 | this access |
 | dataflow.cs:89:31:89:44 | this access |
 | dataflow.cs:89:48:89:51 | this access |

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -385,6 +385,18 @@ public class E
             return true;
         return e1.Long == e2.Long; // GOOD (false positive)
     }
+
+    int Ex38(int? i)
+    {
+        i ??= 0;
+        return i.Value; // GOOD (false positive)
+    }
+
+    System.Drawing.Color Ex39(System.Drawing.Color? color)
+    {
+        color ??= System.Drawing.Color.White;
+        return color.Value; // GOOD (false positive)
+    }
 }
 
 public static class Extensions
@@ -393,4 +405,4 @@ public static class Extensions
     public static int M2(this string s) => s.Length;
 }
 
-// semmle-extractor-options: /r:System.Linq.dll
+// semmle-extractor-options: /r:System.Linq.dll /r:System.Drawing.Primitives.dll

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -409,7 +409,7 @@ public class E
     {
         int? i = 1;
         i ??= null;
-        return i.Value; // GOOD (false positive)
+        return i.Value; // GOOD
     }
 }
 

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -389,13 +389,13 @@ public class E
     int Ex38(int? i)
     {
         i ??= 0;
-        return i.Value; // GOOD (false positive)
+        return i.Value; // GOOD
     }
 
     System.Drawing.Color Ex39(System.Drawing.Color? color)
     {
         color ??= System.Drawing.Color.White;
-        return color.Value; // GOOD (false positive)
+        return color.Value; // GOOD
     }
 }
 

--- a/csharp/ql/test/query-tests/Nullness/E.cs
+++ b/csharp/ql/test/query-tests/Nullness/E.cs
@@ -397,6 +397,20 @@ public class E
         color ??= System.Drawing.Color.White;
         return color.Value; // GOOD
     }
+
+    int Ex40()
+    {
+        int? i = null;
+        i ??= null;
+        return i.Value; // BAD (always)
+    }
+
+    int Ex41()
+    {
+        int? i = 1;
+        i ??= null;
+        return i.Value; // GOOD (false positive)
+    }
 }
 
 public static class Extensions

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1115,12 +1115,14 @@
 | E.cs:176:13:176:14 | access to local variable b2 | true | E.cs:175:19:175:42 | ... ? ... : ... | true |
 | E.cs:176:13:176:22 | ... == ... | false | E.cs:176:13:176:14 | (...) ... | non-null |
 | E.cs:176:13:176:22 | ... == ... | true | E.cs:176:13:176:14 | (...) ... | null |
+| E.cs:176:13:176:22 | ... == ... | true | E.cs:176:19:176:22 | null | non-null |
 | E.cs:180:13:180:23 | ... == ... | false | E.cs:180:13:180:15 | access to parameter obj | non-null |
 | E.cs:180:13:180:23 | ... == ... | true | E.cs:180:13:180:15 | access to parameter obj | null |
 | E.cs:184:13:184:14 | (...) ... | non-null | E.cs:184:13:184:14 | access to parameter b1 | non-null |
 | E.cs:184:13:184:14 | (...) ... | null | E.cs:184:13:184:14 | access to parameter b1 | null |
 | E.cs:184:13:184:22 | ... == ... | false | E.cs:184:13:184:14 | (...) ... | non-null |
 | E.cs:184:13:184:22 | ... == ... | true | E.cs:184:13:184:14 | (...) ... | null |
+| E.cs:184:13:184:22 | ... == ... | true | E.cs:184:19:184:22 | null | non-null |
 | E.cs:193:19:193:29 | call to method ToString | non-null | E.cs:193:17:193:17 | access to parameter o | non-null |
 | E.cs:198:17:198:29 | ... ? ... : ... | non-null | E.cs:198:17:198:17 | access to parameter b | false |
 | E.cs:198:17:198:29 | ... ? ... : ... | non-null | E.cs:198:28:198:29 | "" | non-null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -1258,6 +1258,26 @@
 | E.cs:384:13:384:36 | ... && ... | true | E.cs:384:27:384:36 | ... == ... | true |
 | E.cs:384:27:384:36 | ... == ... | false | E.cs:384:27:384:28 | access to parameter e2 | non-null |
 | E.cs:384:27:384:36 | ... == ... | true | E.cs:384:27:384:28 | access to parameter e2 | null |
+| E.cs:404:9:404:9 | access to local variable i | non-null | E.cs:403:18:403:21 | null | non-null |
+| E.cs:404:9:404:9 | access to local variable i | null | E.cs:403:18:403:21 | null | null |
+| E.cs:404:9:404:18 | ... = ... | non-null | E.cs:404:9:404:9 | access to local variable i | non-null |
+| E.cs:404:9:404:18 | ... = ... | non-null | E.cs:404:9:404:18 | ... ?? ... | non-null |
+| E.cs:404:9:404:18 | ... = ... | null | E.cs:404:9:404:9 | access to local variable i | null |
+| E.cs:404:9:404:18 | ... = ... | null | E.cs:404:9:404:18 | ... ?? ... | null |
+| E.cs:404:9:404:18 | ... ?? ... | null | E.cs:404:9:404:9 | access to local variable i | null |
+| E.cs:404:9:404:18 | ... ?? ... | null | E.cs:404:15:404:18 | null | null |
+| E.cs:405:16:405:16 | access to local variable i | non-null | E.cs:404:9:404:18 | ... ?? ... | non-null |
+| E.cs:405:16:405:16 | access to local variable i | null | E.cs:404:9:404:18 | ... ?? ... | null |
+| E.cs:411:9:411:9 | access to local variable i | non-null | E.cs:410:18:410:18 | (...) ... | non-null |
+| E.cs:411:9:411:9 | access to local variable i | null | E.cs:410:18:410:18 | (...) ... | null |
+| E.cs:411:9:411:18 | ... = ... | non-null | E.cs:411:9:411:9 | access to local variable i | non-null |
+| E.cs:411:9:411:18 | ... = ... | non-null | E.cs:411:9:411:18 | ... ?? ... | non-null |
+| E.cs:411:9:411:18 | ... = ... | null | E.cs:411:9:411:9 | access to local variable i | null |
+| E.cs:411:9:411:18 | ... = ... | null | E.cs:411:9:411:18 | ... ?? ... | null |
+| E.cs:411:9:411:18 | ... ?? ... | null | E.cs:411:9:411:9 | access to local variable i | null |
+| E.cs:411:9:411:18 | ... ?? ... | null | E.cs:411:15:411:18 | null | null |
+| E.cs:412:16:412:16 | access to local variable i | non-null | E.cs:411:9:411:18 | ... ?? ... | non-null |
+| E.cs:412:16:412:16 | access to local variable i | null | E.cs:411:9:411:18 | ... ?? ... | null |
 | Forwarding.cs:9:13:9:30 | !... | false | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | true |
 | Forwarding.cs:9:13:9:30 | !... | true | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | false |
 | Forwarding.cs:9:14:9:14 | access to local variable s | empty | Forwarding.cs:7:20:7:23 | null | empty |

--- a/csharp/ql/test/query-tests/Nullness/NullAlways.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullAlways.expected
@@ -36,6 +36,7 @@
 | E.cs:323:13:323:14 | access to parameter s1 | Variable $@ is always null here. | E.cs:319:29:319:30 | s1 | s1 |
 | E.cs:324:13:324:14 | access to parameter s2 | Variable $@ is always null here. | E.cs:319:40:319:41 | s2 | s2 |
 | E.cs:331:9:331:9 | access to local variable x | Variable $@ is always null here. | E.cs:330:13:330:13 | x | x |
+| E.cs:405:16:405:16 | access to local variable i | Variable $@ is always null here. | E.cs:403:14:403:14 | i | i |
 | Forwarding.cs:36:31:36:31 | access to local variable s | Variable $@ is always null here. | Forwarding.cs:7:16:7:16 | s | s |
 | Forwarding.cs:40:27:40:27 | access to local variable s | Variable $@ is always null here. | Forwarding.cs:7:16:7:16 | s | s |
 | NullAlwaysBad.cs:9:30:9:30 | access to parameter s | Variable $@ is always null here. | NullAlwaysBad.cs:7:29:7:29 | s | s |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -219,10 +219,12 @@
 | E.cs:175:19:175:29 | ... == ... | E.cs:175:19:175:21 | access to parameter obj | true | true |
 | E.cs:176:13:176:22 | ... == ... | E.cs:176:13:176:14 | (...) ... | false | false |
 | E.cs:176:13:176:22 | ... == ... | E.cs:176:13:176:14 | (...) ... | true | true |
+| E.cs:176:13:176:22 | ... == ... | E.cs:176:19:176:22 | null | true | false |
 | E.cs:180:13:180:23 | ... == ... | E.cs:180:13:180:15 | access to parameter obj | false | false |
 | E.cs:180:13:180:23 | ... == ... | E.cs:180:13:180:15 | access to parameter obj | true | true |
 | E.cs:184:13:184:22 | ... == ... | E.cs:184:13:184:14 | (...) ... | false | false |
 | E.cs:184:13:184:22 | ... == ... | E.cs:184:13:184:14 | (...) ... | true | true |
+| E.cs:184:13:184:22 | ... == ... | E.cs:184:19:184:22 | null | true | false |
 | E.cs:193:17:193:17 | access to parameter o | E.cs:193:17:193:17 | access to parameter o | non-null | false |
 | E.cs:193:17:193:17 | access to parameter o | E.cs:193:17:193:17 | access to parameter o | null | true |
 | E.cs:208:13:208:23 | ... is ... | E.cs:208:13:208:13 | access to parameter s | false | true |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -276,6 +276,10 @@
 | E.cs:384:13:384:22 | ... == ... | E.cs:384:13:384:14 | access to parameter e1 | true | true |
 | E.cs:384:27:384:36 | ... == ... | E.cs:384:27:384:28 | access to parameter e2 | false | false |
 | E.cs:384:27:384:36 | ... == ... | E.cs:384:27:384:28 | access to parameter e2 | true | true |
+| E.cs:391:9:391:9 | access to parameter i | E.cs:391:9:391:9 | access to parameter i | non-null | false |
+| E.cs:391:9:391:9 | access to parameter i | E.cs:391:9:391:9 | access to parameter i | null | true |
+| E.cs:397:9:397:13 | access to parameter color | E.cs:397:9:397:13 | access to parameter color | non-null | false |
+| E.cs:397:9:397:13 | access to parameter color | E.cs:397:9:397:13 | access to parameter color | null | true |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |
 | Forwarding.cs:14:13:14:32 | call to method IsNotNullOrEmpty | Forwarding.cs:14:13:14:13 | access to local variable s | true | false |
 | Forwarding.cs:19:14:19:23 | call to method IsNull | Forwarding.cs:19:14:19:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -282,6 +282,10 @@
 | E.cs:391:9:391:9 | access to parameter i | E.cs:391:9:391:9 | access to parameter i | null | true |
 | E.cs:397:9:397:13 | access to parameter color | E.cs:397:9:397:13 | access to parameter color | non-null | false |
 | E.cs:397:9:397:13 | access to parameter color | E.cs:397:9:397:13 | access to parameter color | null | true |
+| E.cs:404:9:404:9 | access to local variable i | E.cs:404:9:404:9 | access to local variable i | non-null | false |
+| E.cs:404:9:404:9 | access to local variable i | E.cs:404:9:404:9 | access to local variable i | null | true |
+| E.cs:411:9:411:9 | access to local variable i | E.cs:411:9:411:9 | access to local variable i | non-null | false |
+| E.cs:411:9:411:9 | access to local variable i | E.cs:411:9:411:9 | access to local variable i | null | true |
 | Forwarding.cs:9:14:9:30 | call to method IsNullOrEmpty | Forwarding.cs:9:14:9:14 | access to local variable s | false | false |
 | Forwarding.cs:14:13:14:32 | call to method IsNotNullOrEmpty | Forwarding.cs:14:13:14:13 | access to local variable s | true | false |
 | Forwarding.cs:19:14:19:23 | call to method IsNull | Forwarding.cs:19:14:19:14 | access to local variable s | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -370,6 +370,10 @@ nodes
 | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:386:27:386:28 | access to parameter e2 |
+| E.cs:391:9:391:15 | SSA def(i) |
+| E.cs:392:16:392:16 | access to parameter i |
+| E.cs:397:9:397:44 | SSA def(color) |
+| E.cs:398:16:398:20 | access to parameter color |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -719,6 +723,8 @@ edges
 | E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:384:9:385:24 | if (...) ... | E.cs:386:27:386:28 | access to parameter e2 |
 | E.cs:384:27:384:28 | access to parameter e2 | E.cs:386:16:386:17 | access to parameter e1 |
+| E.cs:391:9:391:15 | SSA def(i) | E.cs:392:16:392:16 | access to parameter i |
+| E.cs:397:9:397:44 | SSA def(color) | E.cs:398:16:398:20 | access to parameter color |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -827,6 +833,8 @@ edges
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
+| E.cs:392:16:392:16 | access to parameter i | E.cs:391:9:391:15 | SSA def(i) | E.cs:392:16:392:16 | access to parameter i | Variable $@ may be null here because it has a nullable type. | E.cs:389:19:389:19 | i | i | E.cs:389:19:389:19 | i | this |
+| E.cs:398:16:398:20 | access to parameter color | E.cs:397:9:397:44 | SSA def(color) | E.cs:398:16:398:20 | access to parameter color | Variable $@ may be null here because it has a nullable type. | E.cs:395:53:395:57 | color | color | E.cs:395:53:395:57 | color | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -370,6 +370,11 @@ nodes
 | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:386:27:386:28 | access to parameter e2 |
+| E.cs:404:9:404:18 | SSA def(i) |
+| E.cs:404:9:404:18 | SSA def(i) |
+| E.cs:405:16:405:16 | access to local variable i |
+| E.cs:411:9:411:18 | SSA def(i) |
+| E.cs:412:16:412:16 | access to local variable i |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -719,6 +724,9 @@ edges
 | E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:384:9:385:24 | if (...) ... | E.cs:386:27:386:28 | access to parameter e2 |
 | E.cs:384:27:384:28 | access to parameter e2 | E.cs:386:16:386:17 | access to parameter e1 |
+| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
+| E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
+| E.cs:411:9:411:18 | SSA def(i) | E.cs:412:16:412:16 | access to local variable i |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -827,6 +835,7 @@ edges
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
+| E.cs:412:16:412:16 | access to local variable i | E.cs:411:9:411:18 | SSA def(i) | E.cs:412:16:412:16 | access to local variable i | Variable $@ may be null here because of $@ assignment. | E.cs:410:14:410:14 | i | i | E.cs:411:9:411:18 | ... = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -373,8 +373,6 @@ nodes
 | E.cs:404:9:404:18 | SSA def(i) |
 | E.cs:404:9:404:18 | SSA def(i) |
 | E.cs:405:16:405:16 | access to local variable i |
-| E.cs:411:9:411:18 | SSA def(i) |
-| E.cs:412:16:412:16 | access to local variable i |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -726,7 +724,6 @@ edges
 | E.cs:384:27:384:28 | access to parameter e2 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
 | E.cs:404:9:404:18 | SSA def(i) | E.cs:405:16:405:16 | access to local variable i |
-| E.cs:411:9:411:18 | SSA def(i) | E.cs:412:16:412:16 | access to local variable i |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -835,7 +832,6 @@ edges
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
-| E.cs:412:16:412:16 | access to local variable i | E.cs:411:9:411:18 | SSA def(i) | E.cs:412:16:412:16 | access to local variable i | Variable $@ may be null here because of $@ assignment. | E.cs:410:14:410:14 | i | i | E.cs:411:9:411:18 | ... = ... | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -370,10 +370,6 @@ nodes
 | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:386:16:386:17 | access to parameter e1 |
 | E.cs:386:27:386:28 | access to parameter e2 |
-| E.cs:391:9:391:15 | SSA def(i) |
-| E.cs:392:16:392:16 | access to parameter i |
-| E.cs:397:9:397:44 | SSA def(color) |
-| E.cs:398:16:398:20 | access to parameter color |
 | Forwarding.cs:7:16:7:23 | SSA def(s) |
 | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... |
@@ -723,8 +719,6 @@ edges
 | E.cs:384:9:385:24 | if (...) ... | E.cs:384:27:384:28 | access to parameter e2 |
 | E.cs:384:9:385:24 | if (...) ... | E.cs:386:27:386:28 | access to parameter e2 |
 | E.cs:384:27:384:28 | access to parameter e2 | E.cs:386:16:386:17 | access to parameter e1 |
-| E.cs:391:9:391:15 | SSA def(i) | E.cs:392:16:392:16 | access to parameter i |
-| E.cs:397:9:397:44 | SSA def(color) | E.cs:398:16:398:20 | access to parameter color |
 | Forwarding.cs:7:16:7:23 | SSA def(s) | Forwarding.cs:14:9:17:9 | if (...) ... |
 | Forwarding.cs:14:9:17:9 | if (...) ... | Forwarding.cs:19:9:22:9 | if (...) ... |
 | Forwarding.cs:19:9:22:9 | if (...) ... | Forwarding.cs:24:9:27:9 | if (...) ... |
@@ -833,8 +827,6 @@ edges
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:28:382:37 | ... != ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:382:58:382:67 | ... == ... | this |
 | E.cs:386:27:386:28 | access to parameter e2 | E.cs:380:30:380:31 | SSA param(e2) | E.cs:386:27:386:28 | access to parameter e2 | Variable $@ may be null here as suggested by $@ null check. | E.cs:380:30:380:31 | e2 | e2 | E.cs:384:27:384:36 | ... == ... | this |
-| E.cs:392:16:392:16 | access to parameter i | E.cs:391:9:391:15 | SSA def(i) | E.cs:392:16:392:16 | access to parameter i | Variable $@ may be null here because it has a nullable type. | E.cs:389:19:389:19 | i | i | E.cs:389:19:389:19 | i | this |
-| E.cs:398:16:398:20 | access to parameter color | E.cs:397:9:397:44 | SSA def(color) | E.cs:398:16:398:20 | access to parameter color | Variable $@ may be null here because it has a nullable type. | E.cs:395:53:395:57 | color | color | E.cs:395:53:395:57 | color | this |
 | GuardedString.cs:35:31:35:31 | access to local variable s | GuardedString.cs:7:16:7:32 | SSA def(s) | GuardedString.cs:35:31:35:31 | access to local variable s | Variable $@ may be null here because of $@ assignment. | GuardedString.cs:7:16:7:16 | s | s | GuardedString.cs:7:16:7:32 | String s = ... | this |
 | NullMaybeBad.cs:7:27:7:27 | access to parameter o | NullMaybeBad.cs:13:17:13:20 | null | NullMaybeBad.cs:7:27:7:27 | access to parameter o | Variable $@ may be null here because of $@ null argument. | NullMaybeBad.cs:5:25:5:25 | o | o | NullMaybeBad.cs:13:17:13:20 | null | this |
 | StringConcatenation.cs:16:17:16:17 | access to local variable s | StringConcatenation.cs:14:16:14:23 | SSA def(s) | StringConcatenation.cs:16:17:16:17 | access to local variable s | Variable $@ may be null here because of $@ assignment. | StringConcatenation.cs:14:16:14:16 | s | s | StringConcatenation.cs:14:16:14:23 | String s = ... | this |


### PR DESCRIPTION
Dereferencing an expression of a nullable type should only be reported when the expression is not clearly non-null.

Fixes https://github.com/github/codeql/issues/3982.