### PR TITLE
Add VS Code tasks to build and test the C# bits

### DIFF
--- a/csharp/.vscode/extensions.json
+++ b/csharp/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "github.vscode-codeql",
+        "ms-dotnettools.csharp",
+        "formulahendry.dotnet-test-explorer",
+        "hbenl.vscode-test-explorer"
+    ],
+    "unwantedRecommendations": []
+}

--- a/csharp/.vscode/settings.json
+++ b/csharp/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "dotnet-test-explorer.enableTelemetry": false,
+    "dotnet-test-explorer.testProjectPath": "**/*Tests.@(csproj|vbproj|fsproj)",
+    "dotnet-test-explorer.testArguments": "/property:GenerateTargetFrameworkAttribute=false",
+    "csharp.supressBuildAssetsNotification": true,
+    "csharp.suppressDotnetRestoreNotification": true
+}

--- a/csharp/.vscode/tasks.json
+++ b/csharp/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "dotnet build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                // Ask dotnet build to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "dotnet rebuild",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--no-incremental",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "dotnet test",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "test",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "test",
+            "presentation": {
+                "reveal": "always"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Added 
* tasks.json to have build and test command
* settings to disable some prompts, and set some parameters so that tests are found and they generate no build errors