### PR TITLE
[Java] Clarify Wildcard.hasUpperBound() doc

### DIFF
--- a/java/ql/src/semmle/code/java/Generics.qll
+++ b/java/ql/src/semmle/code/java/Generics.qll
@@ -196,6 +196,12 @@ class TypeVariable extends BoundedType, @typevariable {
 class Wildcard extends BoundedType, @wildcard {
   /**
    * Holds if this wildcard is either unconstrained (i.e. `?`) or
+   * has a type bound.
+   */
+  override predicate hasTypeBound() { BoundedType.super.hasTypeBound() }
+
+  /**
+   * Holds if this wildcard is either unconstrained (i.e. `?`) or
    * has an upper bound.
    */
   predicate hasUpperBound() { wildcards(this, _, 1) }

--- a/java/ql/src/semmle/code/java/Generics.qll
+++ b/java/ql/src/semmle/code/java/Generics.qll
@@ -194,7 +194,10 @@ class TypeVariable extends BoundedType, @typevariable {
  * and the second wildcard has a lower bound of `Float`.
  */
 class Wildcard extends BoundedType, @wildcard {
-  /** Holds if this wildcard has an upper bound. */
+  /**
+   * Holds if this wildcard is either unconstrained (i.e. `?`) or
+   * has an upper bound.
+   */
   predicate hasUpperBound() { wildcards(this, _, 1) }
 
   /** Holds if this wildcard has a lower bound. */


### PR DESCRIPTION
For a wildcard without bounds (i.e. `?`) `hasUpperBound()` matches as well, e.g:
```ql
import java

from Wildcard w
where
  w.hasUpperBound()
  and w.isUnconstrained()
select w
```
[Query console link](https://lgtm.com/query/7753487847698698330/)