### PR TITLE
JS: Make AST classses non-abstract

### DIFF
--- a/javascript/ql/src/LanguageFeatures/NonLinearPattern.ql
+++ b/javascript/ql/src/LanguageFeatures/NonLinearPattern.ql
@@ -14,9 +14,8 @@
 
 import javascript
 
-class RootDestructuringPattern extends BindingPattern {
+class RootDestructuringPattern extends DestructuringPattern {
   RootDestructuringPattern() {
-    this instanceof DestructuringPattern and
     not this = any(PropertyPattern p).getValuePattern() and
     not this = any(ArrayPattern p).getAnElement()
   }

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -1848,6 +1848,11 @@ class AssignExpr extends @assignexpr, Assignment {
   override Expr getUnderlyingValue() { result = getRhs().getUnderlyingValue() }
 }
 
+private class TCompoundAssignExpr =
+  @assignaddexpr or @assignsubexpr or @assignmulexpr or @assigndivexpr or @assignmodexpr or
+      @assignexpexpr or @assignlshiftexpr or @assignrshiftexpr or @assignurshiftexpr or
+      @assignorexpr or @assignxorexpr or @assignandexpr;
+
 /**
  * A compound assign expression.
  *
@@ -1858,7 +1863,7 @@ class AssignExpr extends @assignexpr, Assignment {
  * x /= 2
  * ```
  */
-abstract class CompoundAssignExpr extends Assignment { }
+class CompoundAssignExpr extends TCompoundAssignExpr, Assignment { }
 
 /**
  * A compound add-assign expression.

--- a/javascript/ql/src/semmle/javascript/Stmt.qll
+++ b/javascript/ql/src/semmle/javascript/Stmt.qll
@@ -64,6 +64,13 @@ class Stmt extends @stmt, ExprOrStmt, Documentable {
   }
 }
 
+private class TControlStmt =
+  TLoopStmt or @ifstmt or @withstmt or @switchstmt or @trystmt or @catchclause;
+
+private class TLoopStmt = TEnhancedForLoop or @whilestmt or @dowhilestmt or @forstmt;
+
+private class TEnhancedForLoop = @forinstmt or @foreachstmt or @forofstmt;
+
 /**
  * A control statement, that is, is a loop, an if statement, a switch statement,
  * a with statement, a try statement, or a catch clause.
@@ -82,7 +89,7 @@ class Stmt extends @stmt, ExprOrStmt, Documentable {
  * }
  * ```
  */
-abstract class ControlStmt extends Stmt {
+class ControlStmt extends TControlStmt, Stmt {
   /** Gets a statement controlled by this control statement. */
   abstract Stmt getAControlledStmt();
 }
@@ -102,7 +109,7 @@ abstract class ControlStmt extends Stmt {
  * } while(++i < lines.length);
  * ```
  */
-abstract class LoopStmt extends ControlStmt {
+class LoopStmt extends TLoopStmt, ControlStmt {
   /** Gets the body of this loop. */
   abstract Stmt getBody();
 
@@ -801,7 +808,7 @@ class ForStmt extends @forstmt, LoopStmt {
  * }
  * ```
  */
-abstract class EnhancedForLoop extends LoopStmt {
+class EnhancedForLoop extends TEnhancedForLoop, LoopStmt {
   /**
    * Gets the iterator of this `for`-`in` or `for`-`of` loop; this can be either a
    * pattern, a property reference, or a variable declaration statement.

--- a/javascript/ql/src/semmle/javascript/Stmt.qll
+++ b/javascript/ql/src/semmle/javascript/Stmt.qll
@@ -457,6 +457,10 @@ class LabeledStmt extends @labeledstmt, Stmt {
   Stmt getStmt() { result = getChildStmt(1) }
 }
 
+private class TJumpStmt = TBreakOrContinueStmt or @returnstmt or @throwstmt;
+
+private class TBreakOrContinueStmt = @breakstmt or @continuestmt;
+
 /**
  * A statement that disrupts structured control flow, that is, a `continue` statement,
  * a `break` statement, a `throw` statement, or a `return` statement.
@@ -470,7 +474,7 @@ class LabeledStmt extends @labeledstmt, Stmt {
  * return -1;
  * ```
  */
-abstract class JumpStmt extends Stmt {
+class JumpStmt extends TJumpStmt, Stmt {
   /**
    * Gets the target of this jump.
    *
@@ -497,7 +501,7 @@ abstract class JumpStmt extends Stmt {
  * break;
  * ```
  */
-abstract class BreakOrContinueStmt extends JumpStmt {
+class BreakOrContinueStmt extends TBreakOrContinueStmt, JumpStmt {
   /** Gets the label this statement refers to, if any. */
   string getTargetLabel() { result = getChildExpr(0).(Identifier).getName() }
 

--- a/javascript/ql/src/semmle/javascript/Variables.qll
+++ b/javascript/ql/src/semmle/javascript/Variables.qll
@@ -406,6 +406,8 @@ class BindingPattern extends @pattern, Expr {
   }
 }
 
+private class TDestructuringPattern = @arraypattern or @objectpattern;
+
 /**
  * A destructuring pattern, that is, either an array pattern or an object pattern.
  *
@@ -418,9 +420,9 @@ class BindingPattern extends @pattern, Expr {
  * }
  * ```
  */
-abstract class DestructuringPattern extends BindingPattern {
+class DestructuringPattern extends TDestructuringPattern, BindingPattern {
   /** Gets the rest pattern of this destructuring pattern, if any. */
-  abstract Expr getRest();
+  Expr getRest() { none() } // Overridden in subtypes.
 }
 
 /**


### PR DESCRIPTION
A number of `AST` classes were abstract but weren't meant to be extension points, such as `DestructuringPattern`.

This PR uses the new union-of-base-types feature to make the classes non-abstract without any dbscheme changes.