### PR TITLE
C++: Taint through RangeBasedForStmt (AST only)

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -65,6 +65,15 @@ predicate localAdditionalTaintStep(DataFlow::Node nodeFrom, DataFlow::Node nodeT
     // tracking. The flow from expression `x` into `x++` etc. is handled in the
     // case above.
     exprTo = DataFlow::getAnAccessToAssignedVariable(exprFrom.(PostfixCrementOperation))
+    or
+    // In `for (char c : s) { ... c ... }`, this rule propagates taint from `s`
+    // to `c`.
+    exists(RangeBasedForStmt rbf |
+      exprFrom = rbf.getRange() and
+      // It's guaranteed up to at least C++20 that the range-based for loop
+      // desugars to a variable with an initializer.
+      exprTo = rbf.getVariable().getInitializer().getExpr()
+    )
   )
   or
   // Taint can flow through modeled functions

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -417,6 +417,7 @@
 | stl.cpp:239:15:239:15 | ref arg (__range) | stl.cpp:239:15:239:15 | (__range) |  |
 | stl.cpp:239:15:239:15 | s | stl.cpp:239:15:239:15 | (__range) |  |
 | stl.cpp:239:15:239:15 | s | stl.cpp:239:15:239:15 | (__range) |  |
+| stl.cpp:239:15:239:15 | s | stl.cpp:239:15:239:15 | call to operator* | TAINT |
 | stl.cpp:243:33:243:33 | ref arg s | stl.cpp:243:50:243:50 | s |  |
 | stl.cpp:243:33:243:33 | ref arg s | stl.cpp:247:16:247:16 | s |  |
 | stl.cpp:243:35:243:39 | call to begin | stl.cpp:243:44:243:45 | it |  |
@@ -438,6 +439,7 @@
 | stl.cpp:247:16:247:16 | ref arg (__range) | stl.cpp:247:16:247:16 | (__range) |  |
 | stl.cpp:247:16:247:16 | s | stl.cpp:247:16:247:16 | (__range) |  |
 | stl.cpp:247:16:247:16 | s | stl.cpp:247:16:247:16 | (__range) |  |
+| stl.cpp:247:16:247:16 | s | stl.cpp:247:16:247:16 | call to operator* | TAINT |
 | stl.cpp:251:28:251:33 | call to source | stl.cpp:251:28:251:36 | call to basic_string | TAINT |
 | stl.cpp:251:28:251:36 | call to basic_string | stl.cpp:252:22:252:28 | const_s |  |
 | stl.cpp:252:22:252:22 | call to begin | stl.cpp:252:22:252:22 | (__begin) |  |
@@ -450,6 +452,7 @@
 | stl.cpp:252:22:252:22 | ref arg (__begin) | stl.cpp:252:22:252:22 | (__begin) |  |
 | stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | (__range) |  |
 | stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | (__range) |  |
+| stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | call to operator* | TAINT |
 | structlikeclass.cpp:5:7:5:7 | Unknown literal | structlikeclass.cpp:5:7:5:7 | constructor init of field v | TAINT |
 | structlikeclass.cpp:5:7:5:7 | Unknown literal | structlikeclass.cpp:5:7:5:7 | constructor init of field v | TAINT |
 | structlikeclass.cpp:5:7:5:7 | this | structlikeclass.cpp:5:7:5:7 | constructor init of field v [pre-this] |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -453,6 +453,60 @@
 | stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | (__range) |  |
 | stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | (__range) |  |
 | stl.cpp:252:22:252:28 | const_s | stl.cpp:252:22:252:22 | call to operator* | TAINT |
+| stl.cpp:288:43:288:49 | source1 | stl.cpp:292:21:292:27 | source1 |  |
+| stl.cpp:288:43:288:49 | source1 | stl.cpp:306:33:306:39 | source1 |  |
+| stl.cpp:292:21:292:27 | source1 | stl.cpp:292:21:292:28 | call to vector | TAINT |
+| stl.cpp:292:21:292:28 | call to vector | stl.cpp:294:14:294:14 | v |  |
+| stl.cpp:292:21:292:28 | call to vector | stl.cpp:298:38:298:38 | v |  |
+| stl.cpp:292:21:292:28 | call to vector | stl.cpp:298:55:298:55 | v |  |
+| stl.cpp:292:21:292:28 | call to vector | stl.cpp:302:15:302:15 | v |  |
+| stl.cpp:294:14:294:14 | call to begin | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | call to begin | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | call to begin | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | call to end | stl.cpp:294:14:294:14 | (__end) |  |
+| stl.cpp:294:14:294:14 | call to operator* | stl.cpp:295:8:295:8 | x |  |
+| stl.cpp:294:14:294:14 | ref arg (__begin) | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | ref arg (__begin) | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | ref arg (__begin) | stl.cpp:294:14:294:14 | (__begin) |  |
+| stl.cpp:294:14:294:14 | ref arg (__range) | stl.cpp:294:14:294:14 | (__range) |  |
+| stl.cpp:294:14:294:14 | v | stl.cpp:294:14:294:14 | (__range) |  |
+| stl.cpp:294:14:294:14 | v | stl.cpp:294:14:294:14 | (__range) |  |
+| stl.cpp:294:14:294:14 | v | stl.cpp:294:14:294:14 | call to operator* | TAINT |
+| stl.cpp:298:38:298:38 | ref arg v | stl.cpp:298:55:298:55 | v |  |
+| stl.cpp:298:38:298:38 | ref arg v | stl.cpp:302:15:302:15 | v |  |
+| stl.cpp:298:40:298:44 | call to begin | stl.cpp:298:49:298:50 | it |  |
+| stl.cpp:298:40:298:44 | call to begin | stl.cpp:298:66:298:67 | it |  |
+| stl.cpp:298:40:298:44 | call to begin | stl.cpp:299:9:299:10 | it |  |
+| stl.cpp:298:55:298:55 | ref arg v | stl.cpp:298:55:298:55 | v |  |
+| stl.cpp:298:55:298:55 | ref arg v | stl.cpp:302:15:302:15 | v |  |
+| stl.cpp:298:66:298:67 | ref arg it | stl.cpp:298:49:298:50 | it |  |
+| stl.cpp:298:66:298:67 | ref arg it | stl.cpp:298:66:298:67 | it |  |
+| stl.cpp:298:66:298:67 | ref arg it | stl.cpp:299:9:299:10 | it |  |
+| stl.cpp:302:15:302:15 | call to begin | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | call to begin | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | call to begin | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | call to end | stl.cpp:302:15:302:15 | (__end) |  |
+| stl.cpp:302:15:302:15 | call to operator* | stl.cpp:303:8:303:8 | x |  |
+| stl.cpp:302:15:302:15 | ref arg (__begin) | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | ref arg (__begin) | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | ref arg (__begin) | stl.cpp:302:15:302:15 | (__begin) |  |
+| stl.cpp:302:15:302:15 | ref arg (__range) | stl.cpp:302:15:302:15 | (__range) |  |
+| stl.cpp:302:15:302:15 | v | stl.cpp:302:15:302:15 | (__range) |  |
+| stl.cpp:302:15:302:15 | v | stl.cpp:302:15:302:15 | (__range) |  |
+| stl.cpp:302:15:302:15 | v | stl.cpp:302:15:302:15 | call to operator* | TAINT |
+| stl.cpp:306:33:306:39 | source1 | stl.cpp:306:33:306:40 | call to vector | TAINT |
+| stl.cpp:306:33:306:40 | call to vector | stl.cpp:307:21:307:27 | const_v |  |
+| stl.cpp:307:21:307:21 | call to begin | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:21 | call to begin | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:21 | call to begin | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:21 | call to end | stl.cpp:307:21:307:21 | (__end) |  |
+| stl.cpp:307:21:307:21 | call to operator* | stl.cpp:308:8:308:8 | x |  |
+| stl.cpp:307:21:307:21 | ref arg (__begin) | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:21 | ref arg (__begin) | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:21 | ref arg (__begin) | stl.cpp:307:21:307:21 | (__begin) |  |
+| stl.cpp:307:21:307:27 | const_v | stl.cpp:307:21:307:21 | (__range) |  |
+| stl.cpp:307:21:307:27 | const_v | stl.cpp:307:21:307:21 | (__range) |  |
+| stl.cpp:307:21:307:27 | const_v | stl.cpp:307:21:307:21 | call to operator* | TAINT |
 | structlikeclass.cpp:5:7:5:7 | Unknown literal | structlikeclass.cpp:5:7:5:7 | constructor init of field v | TAINT |
 | structlikeclass.cpp:5:7:5:7 | Unknown literal | structlikeclass.cpp:5:7:5:7 | constructor init of field v | TAINT |
 | structlikeclass.cpp:5:7:5:7 | this | structlikeclass.cpp:5:7:5:7 | constructor init of field v [pre-this] |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
@@ -234,7 +234,7 @@ void test_string_constructors_assignments()
 
 void sink(char) {}
 
-void test_range_based_for_loop() {
+void test_range_based_for_loop_string() {
 	std::string s(source());
 	for(char c : s) {
 		sink(c); // tainted [NOT DETECTED by IR]
@@ -251,5 +251,60 @@ void test_range_based_for_loop() {
 	const std::string const_s(source());
 	for(const char& c : const_s) {
 		sink(c); // tainted [NOT DETECTED by IR]
+	}
+}
+
+
+
+
+
+
+
+
+namespace std {
+	template <class T>
+	class vector {
+	private:
+		void *data_;
+	public:
+		vector(int size);
+
+		T& operator[](int idx);
+		const T& operator[](int idx) const;
+
+		typedef std::iterator<random_access_iterator_tag, T> iterator;
+		typedef std::iterator<random_access_iterator_tag, const T> const_iterator;
+
+		iterator begin() noexcept;
+		iterator end() noexcept;
+
+		const_iterator begin() const noexcept;
+		const_iterator end() const noexcept;
+	};
+}
+
+void sink(int);
+
+void test_range_based_for_loop_vector(int source1) {
+	// Tainting the vector by allocating a tainted length. This doesn't represent
+	// how a vector would typically get tainted, but it allows this test to avoid
+	// being concerned with std::vector modeling.
+	std::vector<int> v(source1);
+
+	for(int x : v) {
+		sink(x); // tainted [NOT DETECTED by IR]
+	}
+
+	for(std::vector<int>::iterator it = v.begin(); it != v.end(); ++it) {
+		sink(*it); // tainted [NOT DETECTED]
+	}
+
+	for(int& x : v) {
+		sink(x); // tainted [NOT DETECTED by IR]
+	}
+
+	const std::vector<int> const_v(source1);
+	for(const int& x : const_v) {
+		sink(x); // tainted [NOT DETECTED by IR]
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
@@ -237,7 +237,7 @@ void sink(char) {}
 void test_range_based_for_loop() {
 	std::string s(source());
 	for(char c : s) {
-		sink(c); // tainted [NOT DETECTED]
+		sink(c); // tainted [NOT DETECTED by IR]
 	}
 
 	for(std::string::iterator it = s.begin(); it != s.end(); ++it) {
@@ -245,11 +245,11 @@ void test_range_based_for_loop() {
 	}
 
 	for(char& c : s) {
-		sink(c); // tainted [NOT DETECTED]
+		sink(c); // tainted [NOT DETECTED by IR]
 	}
 
 	const std::string const_s(source());
 	for(const char& c : const_s) {
-		sink(c); // tainted [NOT DETECTED]
+		sink(c); // tainted [NOT DETECTED by IR]
 	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -47,6 +47,9 @@
 | stl.cpp:211:8:211:9 | s3 | stl.cpp:207:8:207:13 | call to source |
 | stl.cpp:230:8:230:9 | s1 | stl.cpp:226:32:226:37 | call to source |
 | stl.cpp:231:8:231:9 | s2 | stl.cpp:228:20:228:25 | call to source |
+| stl.cpp:240:8:240:8 | c | stl.cpp:238:16:238:21 | call to source |
+| stl.cpp:248:8:248:8 | c | stl.cpp:238:16:238:21 | call to source |
+| stl.cpp:253:8:253:8 | c | stl.cpp:251:28:251:33 | call to source |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |
 | structlikeclass.cpp:37:8:37:9 | s3 | structlikeclass.cpp:29:22:29:27 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -50,6 +50,9 @@
 | stl.cpp:240:8:240:8 | c | stl.cpp:238:16:238:21 | call to source |
 | stl.cpp:248:8:248:8 | c | stl.cpp:238:16:238:21 | call to source |
 | stl.cpp:253:8:253:8 | c | stl.cpp:251:28:251:33 | call to source |
+| stl.cpp:295:8:295:8 | x | stl.cpp:288:43:288:49 | source1 |
+| stl.cpp:303:8:303:8 | x | stl.cpp:288:43:288:49 | source1 |
+| stl.cpp:308:8:308:8 | x | stl.cpp:288:43:288:49 | source1 |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |
 | structlikeclass.cpp:37:8:37:9 | s3 | structlikeclass.cpp:29:22:29:27 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -47,6 +47,9 @@
 | stl.cpp:240:8:240:8 | stl.cpp:238:16:238:21 | AST only |
 | stl.cpp:248:8:248:8 | stl.cpp:238:16:238:21 | AST only |
 | stl.cpp:253:8:253:8 | stl.cpp:251:28:251:33 | AST only |
+| stl.cpp:295:8:295:8 | stl.cpp:288:43:288:49 | AST only |
+| stl.cpp:303:8:303:8 | stl.cpp:288:43:288:49 | AST only |
+| stl.cpp:308:8:308:8 | stl.cpp:288:43:288:49 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |
 | structlikeclass.cpp:37:8:37:9 | structlikeclass.cpp:29:22:29:27 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -44,6 +44,9 @@
 | stl.cpp:211:8:211:9 | stl.cpp:207:8:207:13 | AST only |
 | stl.cpp:230:8:230:9 | stl.cpp:226:32:226:37 | AST only |
 | stl.cpp:231:8:231:9 | stl.cpp:228:20:228:25 | AST only |
+| stl.cpp:240:8:240:8 | stl.cpp:238:16:238:21 | AST only |
+| stl.cpp:248:8:248:8 | stl.cpp:238:16:238:21 | AST only |
+| stl.cpp:253:8:253:8 | stl.cpp:251:28:251:33 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |
 | structlikeclass.cpp:37:8:37:9 | structlikeclass.cpp:29:22:29:27 | AST only |


### PR DESCRIPTION
Fixes #117. This PR doesn't implement the corresponding feature for IR taint tracking because it appears [we can't track taint through `std::string` properly with the IR yet](https://github.com/github/codeql/blob/205dd1aeadd6b2647aeab3fac700b13f560338e7/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected#L33), and the test case we have uses `std::string`. That's a separate issue, and I think it's outside the scope of #117.