### PR TITLE
Java: remove security tag from java/integer-multiplication-cast-to-long

### DIFF
--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -7,7 +7,6 @@
  * @precision very-high
  * @id java/integer-multiplication-cast-to-long
  * @tags reliability
- *       security
  *       correctness
  *       types
  *       external/cwe/cwe-190


### PR DESCRIPTION
Most of the results of this query are not security related.