### PR TITLE
C++: Exclude decrementing unsigned counters from inconsistentLoopDirection.ql

### DIFF
--- a/change-notes/1.26/analysis-cpp.md
+++ b/change-notes/1.26/analysis-cpp.md
@@ -13,6 +13,7 @@ The following changes in version 1.26 affect C/C++ analysis in all applications.
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
+| Inconsistent direction of for loop (`cpp/inconsistent-loop-direction`) | Fewer false positive results | The query now accounts for intentional wrapping of an unsigned loop counter. |
 
 ## Changes to libraries
 

--- a/change-notes/1.26/analysis-cpp.md
+++ b/change-notes/1.26/analysis-cpp.md
@@ -1,0 +1,18 @@
+# Improvements to C/C++ analysis
+
+The following changes in version 1.26 affect C/C++ analysis in all applications.
+
+## General improvements
+
+## New queries
+
+| **Query**                   | **Tags**  | **Purpose**                                                        |
+|-----------------------------|-----------|--------------------------------------------------------------------|
+
+## Changes to existing queries
+
+| **Query**                  | **Expected impact**    | **Change**                                                       |
+|----------------------------|------------------------|------------------------------------------------------------------|
+
+## Changes to libraries
+

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -54,7 +54,9 @@ predicate illDefinedDecrForStmt(
       or
       (forstmt.conditionAlwaysFalse() or forstmt.conditionAlwaysTrue())
     )
-  )
+  ) and
+  // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
+  not v.getUnspecifiedType().(IntegralType).isUnsigned()
 }
 
 pragma[noinline]

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -50,12 +50,11 @@ predicate illDefinedDecrForStmt(
     DataFlow::localFlowStep(DataFlow::exprNode(initialCondition), DataFlow::exprNode(lesserOperand)) and
     // `initialCondition` < `terminalCondition`
     (
+      upperBound(initialCondition) < lowerBound(terminalCondition) and
       (
-        upperBound(initialCondition) < lowerBound(terminalCondition) and (
-          // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
-          v.getUnspecifiedType().(IntegralType).isSigned() or
-          initialCondition.getValue().toInt() = 0
-        )
+        // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
+        v.getUnspecifiedType().(IntegralType).isSigned() or
+        initialCondition.getValue().toInt() = 0
       )
       or
       (forstmt.conditionAlwaysFalse() or forstmt.conditionAlwaysTrue())

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -54,9 +54,11 @@ predicate illDefinedDecrForStmt(
       or
       (forstmt.conditionAlwaysFalse() or forstmt.conditionAlwaysTrue())
     )
-  ) and
-  // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
-  not v.getUnspecifiedType().(IntegralType).isUnsigned()
+  ) and (
+    // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
+    v.getUnspecifiedType().(IntegralType).isSigned() or
+    initialCondition.getValue().toInt() = 0
+  )
 }
 
 pragma[noinline]

--- a/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/inconsistentLoopDirection.ql
@@ -50,14 +50,16 @@ predicate illDefinedDecrForStmt(
     DataFlow::localFlowStep(DataFlow::exprNode(initialCondition), DataFlow::exprNode(lesserOperand)) and
     // `initialCondition` < `terminalCondition`
     (
-      upperBound(initialCondition) < lowerBound(terminalCondition)
+      (
+        upperBound(initialCondition) < lowerBound(terminalCondition) and (
+          // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
+          v.getUnspecifiedType().(IntegralType).isSigned() or
+          initialCondition.getValue().toInt() = 0
+        )
+      )
       or
       (forstmt.conditionAlwaysFalse() or forstmt.conditionAlwaysTrue())
     )
-  ) and (
-    // exclude cases where the loop counter is `unsigned` (where wrapping behaviour can be used deliberately)
-    v.getUnspecifiedType().(IntegralType).isSigned() or
-    initialCondition.getValue().toInt() = 0
   )
 }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.c
@@ -24,7 +24,7 @@ void Unsigned()
 {
     unsigned long i;
 
-    for (i = 0; i < 100; i--)   //BUG
+    for (i = 0; i < 100; i--)   //BUG [NOT DETECTED]
     {
     }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.c
@@ -24,7 +24,7 @@ void Unsigned()
 {
     unsigned long i;
 
-    for (i = 0; i < 100; i--)   //BUG [NOT DETECTED]
+    for (i = 0; i < 100; i--)   //BUG
     {
     }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -190,8 +190,9 @@ void IntendedOverflow()
     for (i = 63; i < 255; i--) {} // GOOD
 
     for (i = m - 1; i < m; i--) {} // GOOD
-    for (i = m - 1; i < m; i--) {} // DUBIOUS
-    for (i = m - 1; i < m; i--) {} // GOOD
+    for (i = m - 2; i < m; i--) {} // DUBIOUS
+    for (i = m; i < m + 1; i--) {} // GOOD
 
     for (s = 63; s < 64; s--) {} // BAD (signed numbers don't wrap at 0 / at all)
+    for (s = m + 1; s < m; s--) {} // BAD (never runs)
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -179,7 +179,7 @@ void FalseNegativeTestCases()
     for (int i = 100; i > 0; i ++ ) {}  // BUG
 }
 
-void IntendedOverflow()
+void IntendedOverflow(unsigned char p)
 {
     const unsigned char m = 10;
     unsigned char i;
@@ -195,4 +195,7 @@ void IntendedOverflow()
 
     for (s = 63; s < 64; s--) {} // BAD (signed numbers don't wrap at 0 / at all)
     for (s = m + 1; s < m; s--) {} // BAD (never runs)
+
+    for (i = p - 1; i < p; i--) {} // GOOD
+    for (s = p - 1; s < p; s--) {} // BAD [NOT DETECTED]
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -198,4 +198,22 @@ void IntendedOverflow(unsigned char p)
 
     for (i = p - 1; i < p; i--) {} // GOOD
     for (s = p - 1; s < p; s--) {} // BAD [NOT DETECTED]
+
+	{
+		int n;
+		
+		n = 64;
+		for (i = n - 1; i < n; i--) {} // GOOD
+		n = 64;
+		for (i = n - 1; i < 64; i--) {} // GOOD
+		n = 64;
+		for (i = 63; i < n; i--) {} // GOOD
+
+		n = 64;
+		for (s = n - 1; s < n; s--) {} // BAD [NOT DETECTED]
+		n = 64;
+		for (s = n - 1; s < 64; s--) {} // BAD
+		n = 64;
+		for (s = 63; s < n; s--) {} // BAD [NOT DETECTED]
+	}
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -130,7 +130,7 @@ void InvalidConditionUnsignedCornerCase()
     unsigned char min = 0;
     unsigned char max = 100;
 
-    for (i = 100; i < 0; i--)   //BUG [NOT DETECTED]
+    for (i = 100; i < 0; i--)   //BUG
     {
     }
 

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -178,3 +178,20 @@ void FalseNegativeTestCases()
     // For comparison
     for (int i = 100; i > 0; i ++ ) {}  // BUG
 }
+
+void IntendedOverflow()
+{
+    const unsigned char m = 10;
+    unsigned char i;
+    signed char s;
+
+    for (i = 63; i < 64; i--) {} // GOOD (legitimate way to count down with an unsigned) [FALSE POSITIVE]
+    for (i = 63; i < 128; i--) {} // DUBIOUS (could still be a typo?)
+    for (i = 63; i < 255; i--) {} // GOOD [FALSE POSITIVE]
+
+    for (i = m - 1; i < m; i--) {} // GOOD [FALSE POSITIVE]
+    for (i = m - 1; i < m; i--) {} // DUBIOUS
+    for (i = m - 1; i < m; i--) {} // GOOD [FALSE POSITIVE]
+
+    for (s = 63; s < 64; s--) {} // BAD (signed numbers don't wrap at 0 / at all)
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.cpp
@@ -130,7 +130,7 @@ void InvalidConditionUnsignedCornerCase()
     unsigned char min = 0;
     unsigned char max = 100;
 
-    for (i = 100; i < 0; i--)   //BUG
+    for (i = 100; i < 0; i--)   //BUG [NOT DETECTED]
     {
     }
 
@@ -185,13 +185,13 @@ void IntendedOverflow()
     unsigned char i;
     signed char s;
 
-    for (i = 63; i < 64; i--) {} // GOOD (legitimate way to count down with an unsigned) [FALSE POSITIVE]
+    for (i = 63; i < 64; i--) {} // GOOD (legitimate way to count down with an unsigned)
     for (i = 63; i < 128; i--) {} // DUBIOUS (could still be a typo?)
-    for (i = 63; i < 255; i--) {} // GOOD [FALSE POSITIVE]
+    for (i = 63; i < 255; i--) {} // GOOD
 
-    for (i = m - 1; i < m; i--) {} // GOOD [FALSE POSITIVE]
+    for (i = m - 1; i < m; i--) {} // GOOD
     for (i = m - 1; i < m; i--) {} // DUBIOUS
-    for (i = m - 1; i < m; i--) {} // GOOD [FALSE POSITIVE]
+    for (i = m - 1; i < m; i--) {} // GOOD
 
     for (s = 63; s < 64; s--) {} // BAD (signed numbers don't wrap at 0 / at all)
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -1,10 +1,12 @@
 | inconsistentLoopDirection.c:5:5:7:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:13:5:15:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
+| inconsistentLoopDirection.c:27:5:29:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:35:5:37:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.c:48:5:50:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:58:5:60:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:5:5:7:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:13:5:15:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
+| inconsistentLoopDirection.cpp:27:5:29:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:35:5:37:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:46:5:48:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:54:5:56:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -21,3 +21,4 @@
 | inconsistentLoopDirection.cpp:175:5:175:36 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (10). |
 | inconsistentLoopDirection.cpp:179:5:179:38 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:196:5:196:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (63), but the terminal condition is higher (64). |
+| inconsistentLoopDirection.cpp:197:5:197:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (... + ...), but the terminal condition is always false. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -1,12 +1,10 @@
 | inconsistentLoopDirection.c:5:5:7:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:13:5:15:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
-| inconsistentLoopDirection.c:27:5:29:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:35:5:37:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.c:48:5:50:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.c:58:5:60:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:5:5:7:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:13:5:15:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
-| inconsistentLoopDirection.cpp:27:5:29:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:35:5:37:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:46:5:48:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (100). |
 | inconsistentLoopDirection.cpp:54:5:56:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
@@ -16,14 +14,7 @@
 | inconsistentLoopDirection.cpp:101:5:103:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:118:5:120:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (max), but the terminal condition is always false. |
 | inconsistentLoopDirection.cpp:122:5:124:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (min), but the terminal condition is always false. |
-| inconsistentLoopDirection.cpp:133:5:135:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (100), but the terminal condition is always false. |
 | inconsistentLoopDirection.cpp:140:5:142:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (200), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:175:5:175:36 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (10). |
 | inconsistentLoopDirection.cpp:179:5:179:38 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
-| inconsistentLoopDirection.cpp:188:5:188:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (64). |
-| inconsistentLoopDirection.cpp:189:5:189:33 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (128). |
-| inconsistentLoopDirection.cpp:190:5:190:33 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (255). |
-| inconsistentLoopDirection.cpp:192:5:192:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
-| inconsistentLoopDirection.cpp:193:5:193:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
-| inconsistentLoopDirection.cpp:194:5:194:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
 | inconsistentLoopDirection.cpp:196:5:196:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (63), but the terminal condition is higher (64). |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -22,3 +22,4 @@
 | inconsistentLoopDirection.cpp:179:5:179:38 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:196:5:196:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (63), but the terminal condition is higher (64). |
 | inconsistentLoopDirection.cpp:197:5:197:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (... + ...), but the terminal condition is always false. |
+| inconsistentLoopDirection.cpp:215:3:215:33 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (... - ...), but the terminal condition is higher (64). |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -20,3 +20,10 @@
 | inconsistentLoopDirection.cpp:140:5:142:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (200), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:175:5:175:36 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (10). |
 | inconsistentLoopDirection.cpp:179:5:179:38 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
+| inconsistentLoopDirection.cpp:188:5:188:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (64). |
+| inconsistentLoopDirection.cpp:189:5:189:33 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (128). |
+| inconsistentLoopDirection.cpp:190:5:190:33 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (63), but the terminal condition is higher (255). |
+| inconsistentLoopDirection.cpp:192:5:192:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
+| inconsistentLoopDirection.cpp:193:5:193:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
+| inconsistentLoopDirection.cpp:194:5:194:34 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (... - ...), but the terminal condition is higher (m). |
+| inconsistentLoopDirection.cpp:196:5:196:32 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "s" counts downward from a value (63), but the terminal condition is higher (64). |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/inconsistentLoopDirection/inconsistentLoopDirection.expected
@@ -16,6 +16,7 @@
 | inconsistentLoopDirection.cpp:101:5:103:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:118:5:120:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (max), but the terminal condition is always false. |
 | inconsistentLoopDirection.cpp:122:5:124:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (min), but the terminal condition is always false. |
+| inconsistentLoopDirection.cpp:133:5:135:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (100), but the terminal condition is always false. |
 | inconsistentLoopDirection.cpp:140:5:142:5 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (200), but the terminal condition is lower (0). |
 | inconsistentLoopDirection.cpp:175:5:175:36 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts downward from a value (0), but the terminal condition is higher (10). |
 | inconsistentLoopDirection.cpp:179:5:179:38 | for(...;...;...) ... | Ill-defined for-loop: a loop using variable "i" counts upward from a value (100), but the terminal condition is lower (0). |


### PR DESCRIPTION
There's a pattern where a loop with an `unsigned` loop counter that counts down is deliberately allowed to wrap at zero, because this is arguably cleaner than the alternative ways of making a loop like this:
```
for (i = 63; i < 64; i--) {}
```
After some discussion we decided that these loops should be permitted.

See https://github.com/github/codeql/issues/4018.