### PR TITLE
Add additional Hibernate SQL sinks

### DIFF
--- a/java/ql/src/semmle/code/java/frameworks/Hibernate.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Hibernate.qll
@@ -10,11 +10,11 @@ class HibernateSession extends RefType {
 }
 
 /**
- * Holds if `m` is a method on `HibernateSession` taking an SQL string as its
- * first argument.
+ * Holds if `m` is a method on `HibernateSession`, or a subclass, taking an SQL
+ * string as its first argument.
  */
 predicate hibernateSqlMethod(Method m) {
-  m.getDeclaringType() instanceof HibernateSession and
+  m.getDeclaringType().getASourceSupertype*() instanceof HibernateSession and
   m.getParameterType(0) instanceof TypeString and
   (
     m.hasName("createQuery") or

--- a/java/ql/src/semmle/code/java/frameworks/Hibernate.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Hibernate.qll
@@ -4,20 +4,36 @@
 
 import java
 
+/** The interface `org.hibernate.query.QueryProducer`. */
+class HibernateQueryProducer extends RefType {
+  HibernateQueryProducer() { this.hasQualifiedName("org.hibernate.query", "QueryProducer") }
+}
+
+/** The interface `org.hibernate.SharedSessionContract`. */
+class HibernateSharedSessionContract extends RefType {
+  HibernateSharedSessionContract() {
+    this.hasQualifiedName("org.hibernate", "SharedSessionContract")
+  }
+}
+
 /** The interface `org.hibernate.Session`. */
 class HibernateSession extends RefType {
   HibernateSession() { this.hasQualifiedName("org.hibernate", "Session") }
 }
 
 /**
- * Holds if `m` is a method on `HibernateSession`, or a subclass, taking an SQL
- * string as its first argument.
+ * Holds if `m` is a method on `HibernateQueryProducer`, or `HibernateSharedSessionContract`
+ * or `HibernateSession`, or a subclass, taking an SQL string as its first argument.
  */
 predicate hibernateSqlMethod(Method m) {
-  m.getDeclaringType().getASourceSupertype*() instanceof HibernateSession and
+  exists(RefType t |
+    t = m.getDeclaringType().getASourceSupertype*() and
+    (
+      t instanceof HibernateQueryProducer or
+      t instanceof HibernateSharedSessionContract or
+      t instanceof HibernateSession
+    )
+  ) and
   m.getParameterType(0) instanceof TypeString and
-  (
-    m.hasName("createQuery") or
-    m.hasName("createSQLQuery")
-  )
+  m.hasName(["createQuery", "createNativeQuery", "createSQLQuery"])
 }


### PR DESCRIPTION
The `createQuery` methods have been moved around a bit over time

* https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/Session.html
* https://docs.jboss.org/hibernate/orm/4.0/javadocs/org/hibernate/SharedSessionContract.html
* https://docs.jboss.org/hibernate/orm/6.0/javadocs/org/hibernate/query/QueryProducer.html
* https://docs.jboss.org/hibernate/orm/current/javadocs/org/hibernate/query/QueryProducer.html

This pull request will model the various `create(Native|SQL)?Query` method of the aforementioned interfaces and their implementations and their subclasses.