### PR TITLE
Java: Make XssSink extensible.

### DIFF
--- a/java/ql/src/Security/CWE/CWE-079/XSS.ql
+++ b/java/ql/src/Security/CWE/CWE-079/XSS.ql
@@ -12,11 +12,10 @@
 
 import java
 import semmle.code.java.dataflow.FlowSources
-import semmle.code.java.dataflow.TaintTracking2
 import semmle.code.java.security.XSS
-import DataFlow2::PathGraph
+import DataFlow::PathGraph
 
-class XSSConfig extends TaintTracking2::Configuration {
+class XSSConfig extends TaintTracking::Configuration {
   XSSConfig() { this = "XSSConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
@@ -28,7 +27,7 @@ class XSSConfig extends TaintTracking2::Configuration {
   }
 }
 
-from DataFlow2::PathNode source, DataFlow2::PathNode sink, XSSConfig conf
+from DataFlow::PathNode source, DataFlow::PathNode sink, XSSConfig conf
 where conf.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Cross-site scripting vulnerability due to $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-079/XSSLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-079/XSSLocal.ql
@@ -12,11 +12,10 @@
 
 import java
 import semmle.code.java.dataflow.FlowSources
-import semmle.code.java.dataflow.TaintTracking2
 import semmle.code.java.security.XSS
-import DataFlow2::PathGraph
+import DataFlow::PathGraph
 
-class XSSLocalConfig extends TaintTracking2::Configuration {
+class XSSLocalConfig extends TaintTracking::Configuration {
   XSSLocalConfig() { this = "XSSLocalConfig" }
 
   override predicate isSource(DataFlow::Node source) { source instanceof LocalUserInput }
@@ -24,7 +23,7 @@ class XSSLocalConfig extends TaintTracking2::Configuration {
   override predicate isSink(DataFlow::Node sink) { sink instanceof XssSink }
 }
 
-from DataFlow2::PathNode source, DataFlow2::PathNode sink, XSSLocalConfig conf
+from DataFlow::PathNode source, DataFlow::PathNode sink, XSSLocalConfig conf
 where conf.hasFlowPath(source, sink)
 select sink.getNode(), source, sink, "Cross-site scripting vulnerability due to $@.",
   source.getNode(), "user-provided value"

--- a/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.ql
+++ b/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.ql
@@ -14,7 +14,7 @@
 
 import java
 import semmle.code.java.dataflow.DataFlow
-import semmle.code.java.dataflow.TaintTracking2
+import semmle.code.java.dataflow.TaintTracking
 import semmle.code.java.security.XSS
 
 /**
@@ -84,7 +84,7 @@ predicate stackTraceExpr(Expr exception, MethodAccess stackTraceString) {
   )
 }
 
-class StackTraceStringToXssSinkFlowConfig extends TaintTracking2::Configuration {
+class StackTraceStringToXssSinkFlowConfig extends TaintTracking::Configuration {
   StackTraceStringToXssSinkFlowConfig() {
     this = "StackTraceExposure::StackTraceStringToXssSinkFlowConfig"
   }
@@ -124,7 +124,7 @@ class GetMessageFlowSource extends MethodAccess {
   }
 }
 
-class GetMessageFlowSourceToXssSinkFlowConfig extends TaintTracking2::Configuration {
+class GetMessageFlowSourceToXssSinkFlowConfig extends TaintTracking::Configuration {
   GetMessageFlowSourceToXssSinkFlowConfig() {
     this = "StackTraceExposure::GetMessageFlowSourceToXssSinkFlowConfig"
   }


### PR DESCRIPTION
This makes `XssSink` an abstract class such that it can be extended. I've also included some minor cleanup such that `XSS.qll` doesn't claim the canonical dataflow library.