### PR TITLE
C++: SAL.qll QLDoc and cleanup

### DIFF
--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -27,7 +27,7 @@ class SALMacro extends Macro {
   }
 }
 
-pragma[noinline]
+private pragma[noinline]
 predicate isTopLevelMacroAccess(MacroAccess ma) { not exists(ma.getParentInvocation()) }
 
 /**
@@ -107,7 +107,7 @@ class SALMaybeNull extends SALAnnotation {
  * Holds if `a` annotates the declaration entry `d` and
  * its start position is the `idx`th position in `file` that holds a SAL element.
  */
-predicate annotatesAt(SALAnnotation a, DeclarationEntry d, File file, int idx) {
+private predicate annotatesAt(SALAnnotation a, DeclarationEntry d, File file, int idx) {
   annotatesAtPosition(a.(SALElement).getStartPosition(), d, file, idx)
 }
 

--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -101,6 +101,22 @@ class SALMaybeNull extends SALAnnotation {
   }
 }
 
+/**
+ * A parameter annotated by one or more SAL annotations.
+ */
+class SALParameter extends Parameter {
+  /** One of this parameter's annotations. */
+  SALAnnotation a;
+
+  SALParameter() { annotatesAt(a, this.getADeclarationEntry(), _, _) }
+
+  predicate isIn() { a.getMacroName().toLowerCase().matches("%\\_in%") }
+
+  predicate isOut() { a.getMacroName().toLowerCase().matches("%\\_out%") }
+
+  predicate isInOut() { a.getMacroName().toLowerCase().matches("%\\_inout%") }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Implementation details
 /**
@@ -129,22 +145,6 @@ private predicate annotatesAtPosition(SALPosition pos, DeclarationEntry d, File 
     // Recursive case: `pos` right before some annotation on `d`
     annotatesAtPosition(_, d, file, idx + 1)
   )
-}
-
-/**
- * A parameter annotated by one or more SAL annotations.
- */
-class SALParameter extends Parameter {
-  /** One of this parameter's annotations. */
-  SALAnnotation a;
-
-  SALParameter() { annotatesAt(a, this.getADeclarationEntry(), _, _) }
-
-  predicate isIn() { a.getMacroName().toLowerCase().matches("%\\_in%") }
-
-  predicate isOut() { a.getMacroName().toLowerCase().matches("%\\_out%") }
-
-  predicate isInOut() { a.getMacroName().toLowerCase().matches("%\\_inout%") }
 }
 
 /**

--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -1,5 +1,13 @@
+/**
+ * Provides classes for identifying and reasoning about Microsoft source code
+ * annoatation language (SAL) macros.
+ */
+
 import cpp
 
+/**
+ * A SAL macro defined in `sal.h` or a similar header file.
+ */
 class SALMacro extends Macro {
   SALMacro() {
     exists(string filename | filename = this.getFile().getBaseName() |
@@ -22,25 +30,32 @@ class SALMacro extends Macro {
 pragma[noinline]
 predicate isTopLevelMacroAccess(MacroAccess ma) { not exists(ma.getParentInvocation()) }
 
+/**
+ * An invocation of a SAL macro (excluding invocations inside other macros).
+ */
 class SALAnnotation extends MacroInvocation {
   SALAnnotation() {
     this.getMacro() instanceof SALMacro and
     isTopLevelMacroAccess(this)
   }
 
-  /** Returns the `Declaration` annotated by `this`. */
+  /** Gets the `Declaration` annotated by `this`. */
   Declaration getDeclaration() {
     annotatesAt(this, result.getADeclarationEntry(), _, _) and
     not result instanceof Type // exclude typedefs
   }
 
-  /** Returns the `DeclarationEntry` annotated by `this`. */
+  /** Gets the `DeclarationEntry` annotated by `this`. */
   DeclarationEntry getDeclarationEntry() {
     annotatesAt(this, result, _, _) and
     not result instanceof TypeDeclarationEntry // exclude typedefs
   }
 }
 
+/**
+ * A SAL macro indicating that the return value of a function should always be
+ * checked.
+ */
 class SALCheckReturn extends SALAnnotation {
   SALCheckReturn() {
     exists(SALMacro m | m = this.getMacro() |
@@ -50,6 +65,10 @@ class SALCheckReturn extends SALAnnotation {
   }
 }
 
+/**
+ * A SAL macro indicating that a pointer variable or return value should not be
+ * `NULL`.
+ */
 class SALNotNull extends SALAnnotation {
   SALNotNull() {
     exists(SALMacro m | m = this.getMacro() |
@@ -69,6 +88,9 @@ class SALNotNull extends SALAnnotation {
   }
 }
 
+/**
+ * A SAL macro indicating that a value may be `NULL`.
+ */
 class SALMaybeNull extends SALAnnotation {
   SALMaybeNull() {
     exists(SALMacro m | m = this.getMacro() |

--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -1,6 +1,6 @@
 /**
  * Provides classes for identifying and reasoning about Microsoft source code
- * annoatation language (SAL) macros.
+ * annotation language (SAL) macros.
  */
 
 import cpp

--- a/cpp/ql/src/Microsoft/SAL.qll
+++ b/cpp/ql/src/Microsoft/SAL.qll
@@ -27,8 +27,8 @@ class SALMacro extends Macro {
   }
 }
 
-private pragma[noinline]
-predicate isTopLevelMacroAccess(MacroAccess ma) { not exists(ma.getParentInvocation()) }
+pragma[noinline]
+private predicate isTopLevelMacroAccess(MacroAccess ma) { not exists(ma.getParentInvocation()) }
 
 /**
  * An invocation of a SAL macro (excluding invocations inside other macros).


### PR DESCRIPTION
We accepted some new contributions to `Microsoft/SAL.qll` a while back and hadn't got around to cleaning them up.  It's pretty good, just lacking a few pieces of QLDoc and rigorous use of `private`.

@rdmarsh2 can you review this?