### PR TITLE
C++: Detect GoogleTest tests cases in FNumberOfTests.ql

### DIFF
--- a/cpp/ql/src/Metrics/Files/FNumberOfTests.ql
+++ b/cpp/ql/src/Metrics/Files/FNumberOfTests.ql
@@ -18,6 +18,9 @@ Expr getTest() {
   or
   // boost tests; http://www.boost.org/
   result.(FunctionCall).getTarget().hasQualifiedName("boost::unit_test", "make_test_case")
+  or
+  // googletest tests; https://github.com/google/googletest/
+  result.(FunctionCall).getTarget().hasQualifiedName("testing::internal", "MakeAndRegisterTestInfo")
 }
 
 from File f, int n


### PR DESCRIPTION
Implementation is based off of the contents of the GTEST_TEST_ macro implementation.
See: https://github.com/google/googletest/blob/master/googletest/include/gtest/internal/gtest-internal.h#L1487