### PR TITLE
Python: Fix false positive in `py/unintentional-import`.

### DIFF
--- a/python/ql/src/Imports/UnintentionalImport.ql
+++ b/python/ql/src/Imports/UnintentionalImport.ql
@@ -26,7 +26,7 @@ predicate all_defined(ModuleValue exporter) {
 }
 
 from ImportStar imp, ModuleValue exporter
-where import_star(imp, exporter) and not all_defined(exporter)
+where import_star(imp, exporter) and not all_defined(exporter) and not exporter.isAbsent()
 select imp,
   "Import pollutes the enclosing namespace, as the imported module $@ does not define '__all__'.",
   exporter, exporter.getName()

--- a/python/ql/test/query-tests/Imports/general/ImportStarUsed.expected
+++ b/python/ql/test/query-tests/Imports/general/ImportStarUsed.expected
@@ -1,2 +1,3 @@
 | imports_test.py:21:1:21:20 | from module import * | Using 'from ... import *' pollutes the namespace |
 | imports_test.py:22:1:22:32 | from module_without_all import * | Using 'from ... import *' pollutes the namespace |
+| imports_test.py:65:1:65:40 | from module_that_does_not_exist import * | Using 'from ... import *' pollutes the namespace |

--- a/python/ql/test/query-tests/Imports/general/UnintentionalImport.expected
+++ b/python/ql/test/query-tests/Imports/general/UnintentionalImport.expected
@@ -1,2 +1,1 @@
 | imports_test.py:22:1:22:32 | from module_without_all import * | Import pollutes the enclosing namespace, as the imported module $@ does not define '__all__'. | module_without_all.py:0:0:0:0 | Module module_without_all | module_without_all |
-| imports_test.py:65:1:65:40 | from module_that_does_not_exist import * | Import pollutes the enclosing namespace, as the imported module $@ does not define '__all__'. | file://:0:0:0:0 | Missing module module_that_does_not_exist | module_that_does_not_exist |

--- a/python/ql/test/query-tests/Imports/general/UnintentionalImport.expected
+++ b/python/ql/test/query-tests/Imports/general/UnintentionalImport.expected
@@ -1,1 +1,2 @@
 | imports_test.py:22:1:22:32 | from module_without_all import * | Import pollutes the enclosing namespace, as the imported module $@ does not define '__all__'. | module_without_all.py:0:0:0:0 | Module module_without_all | module_without_all |
+| imports_test.py:65:1:65:40 | from module_that_does_not_exist import * | Import pollutes the enclosing namespace, as the imported module $@ does not define '__all__'. | file://:0:0:0:0 | Missing module module_that_does_not_exist | module_that_does_not_exist |

--- a/python/ql/test/query-tests/Imports/general/imports_test.py
+++ b/python/ql/test/query-tests/Imports/general/imports_test.py
@@ -61,3 +61,5 @@ import module1 as different
 #Use it
 different
 
+# FP reported in https://github.com/github/codeql/issues/4003
+from module_that_does_not_exist import *


### PR DESCRIPTION
Fixes #4003. 

The problem here is that by default we make no assumptions about what attributes an absent module may have, and in particular we assume nothing about the existence and value of `__all__`. This of course means that if we test for its absence, this will always be true for absent modules.

In this case, the fix is simple -- we just disregard any results for which the exporting module is absent (which seems fair to me, since we really can't know in this case).