### PR TITLE
JS: adjust error message when files have been found while extracting

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -210,6 +210,7 @@ public class AutoBuild {
   private final String defaultEncoding;
   private ExecutorService threadPool;
   private volatile boolean seenCode = false;
+  private volatile boolean seenFiles = false;
   private boolean installDependencies = false;
   private int installDependenciesTimeout;
   private final VirtualSourceRoot virtualSourceRoot;
@@ -472,7 +473,11 @@ public class AutoBuild {
       shutdownThreadPool();
     }
     if (!seenCode) {
-      warn("No JavaScript or TypeScript code found.");
+      if (seenFiles) {
+        warn("Only found JavaScript or TypeScript files that were empty or contained syntax errors.");
+      } else {
+        warn("No JavaScript or TypeScript code found.");
+      }
       return -1;
     }
     return 0;
@@ -1201,6 +1206,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
       long start = logBeginProcess("Extracting " + file);
       Integer loc = extractor.extract(f, state);
       if (!extractor.getConfig().isExterns() && (loc == null || loc != 0)) seenCode = true;
+      if (!extractor.getConfig().isExterns()) seenFiles = true;
       logEndProcess(start, "Done extracting " + file);
     } catch (Throwable t) {
       System.err.println("Exception while extracting " + file + ".");


### PR DESCRIPTION
The `No JavaScript or TypeScript code found.` error can sometimes be confusing if a repository contains files with a `js` or `ts` extension. 

With this change we instead report the following when `.js` or `.ts` files where found in the repository: `Only found JavaScript or TypeScript files that were empty or contained syntax errors.`. 

I think we should keep the existing behavior of returning an error (as opposed to creating a database that contains syntax errors), as having a database that only contains files with syntax errors is not that useful anyway.