### PR TITLE
C#: Restrict `DataFlowType` to types belonging to `Node`s

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -222,10 +222,10 @@ class Content extends TContent {
   Location getLocation() { none() }
 
   /** Gets the type of the object containing this content. */
-  deprecated DataFlowType getContainerType() { none() }
+  deprecated Gvn::GvnType getContainerType() { none() }
 
   /** Gets the type of this content. */
-  deprecated DataFlowType getType() { none() }
+  deprecated Gvn::GvnType getType() { none() }
 }
 
 /** A reference to a field. */
@@ -241,11 +241,11 @@ class FieldContent extends Content, TFieldContent {
 
   override Location getLocation() { result = f.getLocation() }
 
-  deprecated override DataFlowType getContainerType() {
+  deprecated override Gvn::GvnType getContainerType() {
     result = Gvn::getGlobalValueNumber(f.getDeclaringType())
   }
 
-  deprecated override DataFlowType getType() { result = Gvn::getGlobalValueNumber(f.getType()) }
+  deprecated override Gvn::GvnType getType() { result = Gvn::getGlobalValueNumber(f.getType()) }
 }
 
 /** A reference to a property. */
@@ -261,11 +261,11 @@ class PropertyContent extends Content, TPropertyContent {
 
   override Location getLocation() { result = p.getLocation() }
 
-  deprecated override DataFlowType getContainerType() {
+  deprecated override Gvn::GvnType getContainerType() {
     result = Gvn::getGlobalValueNumber(p.getDeclaringType())
   }
 
-  deprecated override DataFlowType getType() { result = Gvn::getGlobalValueNumber(p.getType()) }
+  deprecated override Gvn::GvnType getType() { result = Gvn::getGlobalValueNumber(p.getType()) }
 }
 
 /** A reference to an element in a collection. */


### PR DESCRIPTION
This reduces the size of the `commonSubType` predicates as we only compute them for relevant `DataFlowType`s.