### PR TITLE
C#: Use `DataFlow3` instead of `DataFlow2` in `Xml.qll` to avoid overlap

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/Xml.qll
@@ -2,7 +2,7 @@
 
 import csharp
 private import semmle.code.csharp.frameworks.System
-private import semmle.code.csharp.dataflow.DataFlow2
+private import semmle.code.csharp.dataflow.DataFlow3
 
 /** The `System.Xml` namespace. */
 class SystemXmlNamespace extends Namespace {
@@ -163,7 +163,7 @@ class XmlReaderSettingsCreation extends ObjectCreation {
   }
 }
 
-private class SettingsDataFlowConfig extends DataFlow2::Configuration {
+private class SettingsDataFlowConfig extends DataFlow3::Configuration {
   SettingsDataFlowConfig() { this = "SettingsDataFlowConfig" }
 
   override predicate isSource(DataFlow::Node source) {


### PR DESCRIPTION
`semmle.code.csharp.frameworks.system.Xml` is imported in `LibraryTypeDataFlow.qll`,
and therefore part of the default namespace. This means that the use of `DataFlow2`
inside `Xml.qll` overlaps with some queries. Bumping to `DataFlow3` resolves the issue.

CSharp-Differences job: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/351/.