### PR TITLE
JS: correctly treat ES2015 modules as being in strict-mode in the JavaScript extractor

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ASTExtractor.java
@@ -669,7 +669,9 @@ public class ASTExtractor {
     public Label visit(Program nd, Context c) {
       contextManager.enterContainer(toplevelLabel);
 
-      isStrict = hasUseStrict(nd.getBody());
+      boolean prevIsStrict = isStrict;
+
+      isStrict = isStrict || hasUseStrict(nd.getBody());
 
       // Add platform-specific globals.
       scopeManager.addVariables(platform.getPredefinedGlobals());
@@ -714,6 +716,8 @@ public class ASTExtractor {
       contextManager.leaveContainer();
 
       emitNodeSymbol(nd, toplevelLabel);
+
+      isStrict = prevIsStrict;
 
       return toplevelLabel;
     }

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2020-04-01";
+  public static final String EXTRACTOR_VERSION = "2020-08-18";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/tests/ts/output/trap/decorators.ts.trap
+++ b/javascript/extractor/tests/ts/output/trap/decorators.ts.trap
@@ -311,10 +311,10 @@ scopenodes(#20001,#20112)
 scopenesting(#20112,#20000)
 isModule(#20001)
 isES2015Module(#20001)
-#20113=@"var;{fun};{#20112}"
-variables(#20113,"fun",#20112)
-#20114=@"var;{Class};{#20112}"
-variables(#20114,"Class",#20112)
+#20113=@"var;{Class};{#20112}"
+variables(#20113,"Class",#20112)
+#20114=@"var;{fun};{#20112}"
+variables(#20114,"fun",#20112)
 #20115=@"var;{Class2};{#20112}"
 variables(#20115,"Class2",#20112)
 #20116=@"local_type_name;{Class};{#20112}"
@@ -347,7 +347,7 @@ hasLocation(#20123,#20037)
 enclosingStmt(#20123,#20118)
 exprContainers(#20123,#20001)
 literals("Class","Class",#20123)
-decl(#20123,#20114)
+decl(#20123,#20113)
 typedecl(#20123,#20116)
 #20124=*
 scopes(#20124,10)
@@ -499,7 +499,7 @@ exprs(#20161,78,#20159,-1,"fun")
 hasLocation(#20161,#20086)
 exprContainers(#20161,#20159)
 literals("fun","fun",#20161)
-decl(#20161,#20113)
+decl(#20161,#20114)
 #20162=*
 scopes(#20162,1)
 scopenodes(#20159,#20162)

--- a/javascript/extractor/tests/ts/output/trap/export.ts.trap
+++ b/javascript/extractor/tests/ts/output/trap/export.ts.trap
@@ -155,12 +155,12 @@ scopenodes(#20001,#20055)
 scopenesting(#20055,#20000)
 isModule(#20001)
 isES2015Module(#20001)
-#20056=@"var;{f};{#20055}"
-variables(#20056,"f",#20055)
-#20057=@"var;{foo};{#20055}"
-variables(#20057,"foo",#20055)
-#20058=@"var;{C};{#20055}"
-variables(#20058,"C",#20055)
+#20056=@"var;{foo};{#20055}"
+variables(#20056,"foo",#20055)
+#20057=@"var;{C};{#20055}"
+variables(#20057,"C",#20055)
+#20058=@"var;{f};{#20055}"
+variables(#20058,"f",#20055)
 #20059=@"local_type_name;{C};{#20055}"
 local_type_names(#20059,"C",#20055)
 #20060=*
@@ -186,7 +186,7 @@ hasLocation(#20065,#20017)
 enclosingStmt(#20065,#20061)
 exprContainers(#20065,#20001)
 literals("foo","foo",#20065)
-decl(#20065,#20057)
+decl(#20065,#20056)
 #20066=*
 exprs(#20066,3,#20063,1,"42")
 hasLocation(#20066,#20021)
@@ -209,7 +209,7 @@ hasLocation(#20070,#20029)
 enclosingStmt(#20070,#20068)
 exprContainers(#20070,#20001)
 literals("C","C",#20070)
-decl(#20070,#20058)
+decl(#20070,#20057)
 typedecl(#20070,#20059)
 #20071=*
 scopes(#20071,10)
@@ -260,7 +260,7 @@ exprs(#20083,78,#20081,-1,"f")
 hasLocation(#20083,#20041)
 exprContainers(#20083,#20081)
 literals("f","f",#20083)
-decl(#20083,#20056)
+decl(#20083,#20058)
 #20084=*
 scopes(#20084,1)
 scopenodes(#20081,#20084)

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/non-strict.js
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/non-strict.js
@@ -1,0 +1,8 @@
+(function () {
+  if (true) {
+    function foo() {
+      return 3;
+    }
+  }
+  return foo(); // this resolves to `foo` above, because we have function-scope in non-strict mode.
+})();

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/strict.js
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/strict.js
@@ -1,0 +1,10 @@
+(function () {
+  if (true) {
+    function foo() {
+      return 3;
+    }
+  }
+  return foo(); // `foo` is not defined, because we are in strict-mode.
+})();
+
+export default 3; // strict-mode implied because ES2015 module.

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/strict2.js
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/strict2.js
@@ -1,0 +1,12 @@
+"use strict";
+(function () {
+  "use strict";
+  if (true) {
+    function foo() {
+      return 3;
+    }
+  }
+  return foo(); // `foo` is not defined, because we are in strict-mode.
+})();
+
+export default 3; // strict-mode implied because ES2015 module.

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -90,6 +90,11 @@ test_getAFunctionValue
 | m.js:3:1:3:16 | module.exports.f | m.js:1:13:1:25 | function() {} |
 | n.js:2:1:2:3 | m.f | m.js:1:13:1:25 | function() {} |
 | n.js:5:1:5:4 | m2.f | m2.js:2:6:2:18 | function() {} |
+| non-strict.js:1:1:8:2 | (functi ... ode.\\n}) | non-strict.js:1:2:8:1 | functio ... mode.\\n} |
+| non-strict.js:1:2:8:1 | functio ... mode.\\n} | non-strict.js:1:2:8:1 | functio ... mode.\\n} |
+| non-strict.js:3:5:5:5 | functio ... ;\\n    } | non-strict.js:3:5:5:5 | functio ... ;\\n    } |
+| non-strict.js:3:14:3:16 | foo | non-strict.js:3:5:5:5 | functio ... ;\\n    } |
+| non-strict.js:7:10:7:12 | foo | non-strict.js:3:5:5:5 | functio ... ;\\n    } |
 | protoclass.js:3:1:5:1 | functio ... it();\\n} | protoclass.js:3:1:5:1 | functio ... it();\\n} |
 | protoclass.js:3:10:3:10 | F | protoclass.js:3:1:5:1 | functio ... it();\\n} |
 | protoclass.js:4:3:4:11 | this.init | protoclass.js:7:20:11:1 | functio ...  m();\\n} |
@@ -110,6 +115,12 @@ test_getAFunctionValue
 | reflection.js:7:1:7:3 | add | reflection.js:1:1:3:1 | functio ...  x+y;\\n} |
 | reflection.js:8:1:8:3 | add | reflection.js:1:1:3:1 | functio ...  x+y;\\n} |
 | reflection.js:8:1:8:9 | add.apply | reflection.js:5:15:5:39 | functio ... n 56; } |
+| strict2.js:2:1:10:2 | (functi ... ode.\\n}) | strict2.js:2:2:10:1 | functio ... mode.\\n} |
+| strict2.js:2:2:10:1 | functio ... mode.\\n} | strict2.js:2:2:10:1 | functio ... mode.\\n} |
+| strict2.js:5:5:7:5 | functio ... ;\\n    } | strict2.js:5:5:7:5 | functio ... ;\\n    } |
+| strict.js:1:1:8:2 | (functi ... ode.\\n}) | strict.js:1:2:8:1 | functio ... mode.\\n} |
+| strict.js:1:2:8:1 | functio ... mode.\\n} | strict.js:1:2:8:1 | functio ... mode.\\n} |
+| strict.js:3:5:5:5 | functio ... ;\\n    } | strict.js:3:5:5:5 | functio ... ;\\n    } |
 | tst3.js:1:1:1:22 | functio ... fn() {} | tst3.js:1:1:1:22 | functio ... fn() {} |
 | tst3.js:2:1:2:23 | functio ... n2() {} | tst3.js:2:1:2:23 | functio ... n2() {} |
 | tst.js:1:1:1:15 | function f() {} | tst.js:1:1:1:15 | function f() {} |
@@ -225,6 +236,8 @@ test_getNumArgument
 | n.js:2:1:2:5 | m.f() | 0 |
 | n.js:4:10:4:24 | require('./m2') | 1 |
 | n.js:5:1:5:6 | m2.f() | 0 |
+| non-strict.js:1:1:8:4 | (functi ... e.\\n})() | 0 |
+| non-strict.js:7:10:7:14 | foo() | 0 |
 | protoclass.js:4:3:4:13 | this.init() | 0 |
 | protoclass.js:8:3:8:15 | this.method() | 0 |
 | protoclass.js:9:11:9:32 | this.me ... d(this) | 1 |
@@ -233,6 +246,10 @@ test_getNumArgument
 | reflection.js:7:1:7:22 | add.cal ... 23, 19) | 3 |
 | reflection.js:7:1:7:22 | reflective call | 2 |
 | reflection.js:8:1:8:25 | add.app ... 3, 19]) | 2 |
+| strict2.js:2:1:10:4 | (functi ... e.\\n})() | 0 |
+| strict2.js:9:10:9:14 | foo() | 0 |
+| strict.js:1:1:8:4 | (functi ... e.\\n})() | 0 |
+| strict.js:7:10:7:14 | foo() | 0 |
 | tst.js:6:1:6:3 | f() | 0 |
 | tst.js:7:1:7:3 | g() | 0 |
 | tst.js:8:1:8:3 | h() | 0 |
@@ -321,6 +338,8 @@ test_getCalleeNode
 | n.js:2:1:2:5 | m.f() | n.js:2:1:2:3 | m.f |
 | n.js:4:10:4:24 | require('./m2') | n.js:4:10:4:16 | require |
 | n.js:5:1:5:6 | m2.f() | n.js:5:1:5:4 | m2.f |
+| non-strict.js:1:1:8:4 | (functi ... e.\\n})() | non-strict.js:1:1:8:2 | (functi ... ode.\\n}) |
+| non-strict.js:7:10:7:14 | foo() | non-strict.js:7:10:7:12 | foo |
 | protoclass.js:4:3:4:13 | this.init() | protoclass.js:4:3:4:11 | this.init |
 | protoclass.js:8:3:8:15 | this.method() | protoclass.js:8:3:8:13 | this.method |
 | protoclass.js:9:11:9:32 | this.me ... d(this) | protoclass.js:9:11:9:26 | this.method.bind |
@@ -330,6 +349,10 @@ test_getCalleeNode
 | reflection.js:7:1:7:22 | reflective call | reflection.js:7:1:7:3 | add |
 | reflection.js:8:1:8:25 | add.app ... 3, 19]) | reflection.js:8:1:8:9 | add.apply |
 | reflection.js:8:1:8:25 | reflective call | reflection.js:8:1:8:3 | add |
+| strict2.js:2:1:10:4 | (functi ... e.\\n})() | strict2.js:2:1:10:2 | (functi ... ode.\\n}) |
+| strict2.js:9:10:9:14 | foo() | strict2.js:9:10:9:12 | foo |
+| strict.js:1:1:8:4 | (functi ... e.\\n})() | strict.js:1:1:8:2 | (functi ... ode.\\n}) |
+| strict.js:7:10:7:14 | foo() | strict.js:7:10:7:12 | foo |
 | tst.js:6:1:6:3 | f() | tst.js:6:1:6:1 | f |
 | tst.js:7:1:7:3 | g() | tst.js:7:1:7:1 | g |
 | tst.js:8:1:8:3 | h() | tst.js:8:1:8:1 | h |
@@ -408,11 +431,15 @@ test_getACallee
 | m.js:3:1:3:18 | module.exports.f() | m.js:1:13:1:25 | function() {} |
 | n.js:2:1:2:5 | m.f() | m.js:1:13:1:25 | function() {} |
 | n.js:5:1:5:6 | m2.f() | m2.js:2:6:2:18 | function() {} |
+| non-strict.js:1:1:8:4 | (functi ... e.\\n})() | non-strict.js:1:2:8:1 | functio ... mode.\\n} |
+| non-strict.js:7:10:7:14 | foo() | non-strict.js:3:5:5:5 | functio ... ;\\n    } |
 | protoclass.js:4:3:4:13 | this.init() | protoclass.js:7:20:11:1 | functio ...  m();\\n} |
 | protoclass.js:8:3:8:15 | this.method() | protoclass.js:13:22:13:34 | function() {} |
 | reflection.js:7:1:7:22 | reflective call | reflection.js:1:1:3:1 | functio ...  x+y;\\n} |
 | reflection.js:8:1:8:25 | add.app ... 3, 19]) | reflection.js:5:15:5:39 | functio ... n 56; } |
 | reflection.js:8:1:8:25 | reflective call | reflection.js:1:1:3:1 | functio ...  x+y;\\n} |
+| strict2.js:2:1:10:4 | (functi ... e.\\n})() | strict2.js:2:2:10:1 | functio ... mode.\\n} |
+| strict.js:1:1:8:4 | (functi ... e.\\n})() | strict.js:1:2:8:1 | functio ... mode.\\n} |
 | tst.js:6:1:6:3 | f() | tst.js:1:1:1:15 | function f() {} |
 | tst.js:7:1:7:3 | g() | tst.js:2:9:2:21 | function() {} |
 | tst.js:8:1:8:3 | h() | tst.js:3:5:3:17 | function() {} |
@@ -463,6 +490,7 @@ test_getCalleeName
 | n.js:2:1:2:5 | m.f() | f |
 | n.js:4:10:4:24 | require('./m2') | require |
 | n.js:5:1:5:6 | m2.f() | f |
+| non-strict.js:7:10:7:14 | foo() | foo |
 | protoclass.js:4:3:4:13 | this.init() | init |
 | protoclass.js:8:3:8:15 | this.method() | method |
 | protoclass.js:9:11:9:32 | this.me ... d(this) | bind |
@@ -470,6 +498,8 @@ test_getCalleeName
 | reflection.js:4:5:4:12 | sneaky() | sneaky |
 | reflection.js:7:1:7:22 | add.cal ... 23, 19) | call |
 | reflection.js:8:1:8:25 | add.app ... 3, 19]) | apply |
+| strict2.js:9:10:9:14 | foo() | foo |
+| strict.js:7:10:7:14 | foo() | foo |
 | tst.js:6:1:6:3 | f() | f |
 | tst.js:7:1:7:3 | g() | g |
 | tst.js:8:1:8:3 | h() | h |


### PR DESCRIPTION
I was trying to understand the QL/Java code for module detection, and I encountered this bug.

The extractor would always overwrite `isStrict` with the result from `hasUseStrict(nd.getBody())`.    
So whether the file was a ES2015 module would be ignored while extracting. 

The `prevIsStrict` variable should not be necessary (because `Program` is the top-most node visited), but I added it anyway because I feel it is good style. 

The only impact this has in the extractor is function/block scopes for functions, so I added a test for that.