### PR TITLE
C#: Increase `accessPathLimit` from 3 to 5

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -2354,7 +2354,7 @@ private predicate viableConstantBooleanParamArg(
   )
 }
 
-int accessPathLimit() { result = 3 }
+int accessPathLimit() { result = 5 }
 
 /**
  * Holds if `n` does not require a `PostUpdateNode` as it either cannot be


### PR DESCRIPTION
This change was made possible by https://github.com/github/codeql/pull/3838 and https://github.com/github/codeql/pull/3610.

CSharp-Differences job: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/360/.