### PR TITLE
JS: support module.createRequire

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -163,7 +163,16 @@ private predicate isRequire(DataFlow::Node nd) {
   or
   isRequire(nd.getAPredecessor())
   or
-  nd = DataFlow::moduleMember("module", "createRequire").getACall()
+  // `import { createRequire } from 'module';` support.
+  // specialized to ES2015 modules to avoid recursion in the `DataFlow::moduleImport()` predicate.
+  exists(ImportDeclaration imp | imp.getImportedPath().getValue() = "module" |
+    nd =
+      imp
+          .getImportedModuleNode()
+          .(DataFlow::SourceNode)
+          .getAPropertyRead("createRequire")
+          .getACall()
+  )
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -162,6 +162,8 @@ private predicate isRequire(DataFlow::Node nd) {
   not nd.getFile().getExtension() = "mjs"
   or
   isRequire(nd.getAPredecessor())
+  or
+  nd = DataFlow::moduleMember("module", "createRequire").getACall()
 }
 
 /**

--- a/javascript/ql/test/library-tests/NodeJS/Require.expected
+++ b/javascript/ql/test/library-tests/NodeJS/Require.expected
@@ -15,6 +15,7 @@
 | g.js:1:43:1:61 | require("electron") |
 | index.js:1:12:1:26 | require('path') |
 | index.js:2:1:2:41 | require ... b.js")) |
+| mjs-files/createRequire.mjs:4:26:4:49 | require ... erver') |
 | mjs-files/require-from-js.js:1:12:1:36 | require ... on-me') |
 | mjs-files/require-from-js.js:2:12:2:39 | require ... me.js') |
 | mjs-files/require-from-js.js:3:12:3:40 | require ... e.mjs') |

--- a/javascript/ql/test/library-tests/NodeJS/mjs-files/createRequire.mjs
+++ b/javascript/ql/test/library-tests/NodeJS/mjs-files/createRequire.mjs
@@ -1,0 +1,4 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { ApolloServer } = require('apollo-server');


### PR DESCRIPTION
Documentation: https://nodejs.org/api/modules.html#modules_module_createrequire_filename

Files that use the ES2015 module system does not have access to the `require()` function.   
However, you can create an instance of `require` in the following way: 

```JavaScript
import {createRequire} from "module";
let require = createRequire(import.meta.url)
```

With this PR we support that pattern.   
[Here is a file that use the pattern.](https://github.com/conermurphy/covid-19-graphql-api/blob/master/index.js). 

`createRequire(path)` does take a path as argument, and this path determines from where future imports happen.  
However, that path is often either very difficult to determine, or the path is `import.meta.url` (a path to self).   
So in the vast majority of cases we can safely ignore that path.  
(And even if we get it wrong, it is unlikely that we import the wrong file, we will likely just be unable to resolve the import). 

I encountered this while looking at how the module systems work. 