### PR TITLE
C++: fix compilation errors in ssa.cpp

### DIFF
--- a/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
+++ b/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
@@ -291,7 +291,7 @@ struct A {
 Point *NewAliasing(int x) {
   Point* p = new Point;
   Point* q = new Point;
-  int j = new A(new A(x))->i;
+  int j = (new A(new A(x)))->i;
   A* a = new A;
   return p;
 }


### PR DESCRIPTION
The file did not previously compile with clang:
```
» clang -c ssa.cpp
ssa.cpp:294:7: error: cannot initialize a variable of type 'int' with an rvalue of type 'A *'
  int j = new A(new A(x))->i;
      ^   ~~~~~~~~~~~~~~~
ssa.cpp:294:26: error: expected ';' at end of declaration
  int j = new A(new A(x))->i;
                         ^
                         ;
2 errors generated.
```
or gcc:
```
» gcc -c ssa.cpp
ssa.cpp: In function ‘Point* NewAliasing(int)’:
ssa.cpp:294:25: error: invalid conversion from ‘A*’ to ‘int’ [-fpermissive]
  294 |   int j = new A(new A(x))->i;
      |                         ^
      |                         |
      |                         A*
ssa.cpp:294:26: error: expected ‘,’ or ‘;’ before ‘->’ token
  294 |   int j = new A(new A(x))->i;
      |                          ^~
```

And the same line causes an error with the upcoming extractor frontend upgrade:
```
".../ql/cpp/ql/test/library-tests/ir/ssa/ssa.cpp", line 294: error: this operator is not allowed at this point; parenthesize the preceding new-expression
    int j = new A(new A(x))->i;
                           ^
```

I've applied the suggested parentheses, and all three are now happy.