### PR TITLE
C++: Give fewer types to global variables

### DIFF
--- a/cpp/ql/test/library-tests/variables/global/vardecl.expected
+++ b/cpp/ql/test/library-tests/variables/global/vardecl.expected
@@ -1,0 +1,6 @@
+| a.c:4:5:4:6 | definition of is | array of {int} | 1 |
+| a.h:2:12:2:13 | declaration of is | array of 4 {int} | 1 |
+| file://:0:0:0:0 | definition of fp_offset | unsigned int | 1 |
+| file://:0:0:0:0 | definition of gp_offset | unsigned int | 1 |
+| file://:0:0:0:0 | definition of overflow_arg_area | pointer to {void} | 1 |
+| file://:0:0:0:0 | definition of reg_save_area | pointer to {void} | 1 |

--- a/cpp/ql/test/library-tests/variables/global/vardecl.ql
+++ b/cpp/ql/test/library-tests/variables/global/vardecl.ql
@@ -1,0 +1,5 @@
+import cpp
+
+from VariableDeclarationEntry vd, Type t
+where t = vd.getType()
+select vd, t.explain(), count(Type u | u = vd.getType())

--- a/cpp/ql/test/library-tests/variables/global/variables.expected
+++ b/cpp/ql/test/library-tests/variables/global/variables.expected
@@ -1,5 +1,4 @@
-| a.c:4:5:4:6 | is | array of 4 {int} | 2 |
-| a.c:4:5:4:6 | is | array of {int} | 2 |
+| a.c:4:5:4:6 | is | array of {int} | 1 |
 | file://:0:0:0:0 | fp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | gp_offset | unsigned int | 1 |
 | file://:0:0:0:0 | overflow_arg_area | pointer to {void} | 1 |


### PR DESCRIPTION
Follows change in the extractor.