### PR TITLE
C#: Skip `foreach` loop bodies in the CFG when the iteration expression is empty

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -318,7 +318,7 @@ module ControlFlow {
 
     class BooleanSplit = BooleanSplitting::BooleanSplitImpl;
 
-    class LoopUnrollingSplit = LoopUnrollingSplitting::LoopUnrollingSplitImpl;
+    class LoopSplit = LoopSplitting::LoopSplitImpl;
   }
 
   class BasicBlock = BBs::BasicBlock;

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -429,10 +429,7 @@
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | 1 |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | 5 |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | 7 |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 | 1 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | 4 |
+| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 | 9 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | 18 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | 1 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | 1 |
@@ -449,17 +446,9 @@
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:14:69:23 | call to method Any | 6 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 | 1 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; | 1 |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:29:72:32 | access to parameter args | 4 |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | 4 |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | 8 |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 1 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | 5 |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | 8 |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 1 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | 5 |
+| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | 5 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 10 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | 9 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | 1 |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | 6 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -419,39 +419,50 @@
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:9:13:9:28 | ... == ... | 7 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 | 1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; | 1 |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | 5 |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | 2 |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | 5 |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | 2 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | 11 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 | 1 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | 5 |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | 5 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:24:29:24:32 | access to parameter args | 3 |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 | 1 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | 1 |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | 5 |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:26:32:27 | access to local variable xs | 7 |
+| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | 7 |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 | 1 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | 4 |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | 4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | 18 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | 1 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | 3 |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | 7 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | 3 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | 7 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:49:9:52:9 | {...} | 13 |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:51:13:51:23 | goto ...; | 5 |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:51:13:51:23 | goto ...; | 5 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:60:17:60:17 | access to parameter b | 15 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 | 1 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | 4 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | 4 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | 4 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | 4 |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | 9 |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | 3 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:69:14:69:23 | call to method Any | 6 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 | 1 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; | 1 |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:28:72:31 | access to parameter args | 4 |
+| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:29:72:32 | access to parameter args | 4 |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | 1 |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | 4 |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | 4 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | 8 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 | 1 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | 1 |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | 5 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | 8 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 | 1 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | 1 |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | 5 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | 9 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | 1 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | 6 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | 1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 | 1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -424,39 +424,46 @@ conditionBlock
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 | true |
 | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x | false |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:10:13:10:19 | return ...; | true |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:21:11:23 | String arg | false |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:28:11:31 | access to parameter args | false |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:21:11:23 | String arg | false |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:22:11:24 | String arg | false |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args | false |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:22:11:24 | String arg | false |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 | false |
-| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:21:18:21 | String x | false |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 | true |
+| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:22:18:22 | String x | false |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 | true |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 | true |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | false |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | true |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:21:32:21 | String x | false |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:21:40:21 | String x | false |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:25:41:25 | String y | false |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:22:40:22 | String x | false |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:26:41:26 | String y | false |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 | true |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:41:25:41:25 | String y | false |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 | true |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | true |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | false |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | true |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:26:41:26 | String y | false |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 | true |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | true |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | true |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | true |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
-| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | false |
-| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | false |
+| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | false |
+| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; | true |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | true |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:21:72:23 | String arg | true |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:21:72:23 | String arg | false |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:22:72:24 | String arg | true |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg | false |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | true |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x | false |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | true |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x | false |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | false |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x | false |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 | true |
 | NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:28:3:28 | 0 | true |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:30:5:34 | false | true |
 | NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:39:5:39 | 0 | true |
@@ -1009,7 +1016,7 @@ conditionFlow
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
 | Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | false |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | true |
-| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:28:11:31 | access to parameter args | false |
+| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | false |
 | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
 | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | true |
 | LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -434,8 +434,6 @@ conditionBlock
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | false |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:26:25:29 | Char arg0 | false |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | true |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | false |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:22:40:22 | String x | false |
@@ -454,13 +452,6 @@ conditionBlock
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; | false |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; | true |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | true |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:22:72:24 | String arg | true |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg | false |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | true |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x | false |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | true |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x | false |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 | false |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x | false |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1937,12 +1937,8 @@ dominance
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:33 | ...; |
-| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
-| LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |
@@ -2033,11 +2029,7 @@ dominance
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; |
-| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
-| LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 |
@@ -2045,13 +2037,8 @@ dominance
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:80:9:82:9 | {...} |
-| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:81:13:81:33 | ...; |
-| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
-| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 |
@@ -2059,13 +2046,8 @@ dominance
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:89:9:91:9 | {...} |
-| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:90:13:90:33 | ...; |
-| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
-| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 |
@@ -5109,18 +5091,14 @@ postDominance
 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 |
 | LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:40 | ...; |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:30:5:34:5 | {...} |
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:29:31:29 | 0 |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:9:31:31 | ... ...; |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
-| LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
-| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:33 | ...; |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:37:5:43:5 | {...} |
@@ -5201,7 +5179,7 @@ postDominance
 | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b |
 | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:68:5:74:5 | {...} |
 | LoopUnrolling.cs:69:13:69:23 | !... | LoopUnrolling.cs:69:9:70:19 | if (...) ... |
@@ -5209,40 +5187,26 @@ postDominance
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine |
+| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
-| LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
-| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:72:22:72:24 | String arg |
-| LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:35 | ...; |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | enter M9 |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:77:5:83:5 | {...} |
 | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:32:78:32 | 0 |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:9:78:34 | ... ...; |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:29:78:29 | 2 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
-| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
-| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:80:9:82:9 | {...} |
-| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:33 | ...; |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | enter M10 |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:86:5:92:5 | {...} |
 | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:32:87:32 | 2 |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:9:87:34 | ... ...; |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:29:87:29 | 0 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
-| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
-| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:89:9:91:9 | {...} |
-| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:33 | ...; |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:95:5:101:5 | {...} |
@@ -7627,14 +7591,6 @@ blockDominance
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
@@ -7670,34 +7626,11 @@ blockDominance
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:22:72:24 | String arg |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x |
@@ -9736,14 +9669,6 @@ postBlockDominance
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:24:22:24:24 | Char arg |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:25:26:25:29 | Char arg0 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | enter M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
@@ -9779,32 +9704,10 @@ postBlockDominance
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | enter M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | enter M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1895,27 +1895,27 @@ dominance
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length |
 | LoopUnrolling.cs:9:13:9:23 | access to property Length | LoopUnrolling.cs:9:28:9:28 | 0 |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:28 | ... == ... |
-| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} |
-| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:47 | ... ...; |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:17:18:17:46 | array creation of type String[] |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:18:26:18:27 | access to local variable xs |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:17:32:17:34 | "a" |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:17:13:17:46 | String[] xs = ... |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:17:37:17:39 | "b" |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:17:42:17:44 | "c" |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:17:30:17:46 | { ..., ... } |
-| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:21:18:21 | String x |
+| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:33:17:35 | "a" |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:38:17:40 | "b" |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } |
+| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:19:13:19:33 | ...; |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine |
@@ -1934,77 +1934,77 @@ dominance
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 |
-| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:26:32:27 | access to local variable xs |
+| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:21:32:21 | String x |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:33:13:33:33 | ...; |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:33 | ...; |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} |
-| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:47 | ... ...; |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:38:18:38:46 | array creation of type String[] |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:39:9:39:47 | ... ...; |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:38:32:38:34 | "a" |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:38:13:38:46 | String[] xs = ... |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:38:37:38:39 | "b" |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:38:42:38:44 | "c" |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:38:30:38:46 | { ..., ... } |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:39:18:39:46 | array creation of type String[] |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:40:26:40:27 | access to local variable xs |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:39:32:39:34 | "0" |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:39:13:39:46 | String[] ys = ... |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:39:37:39:39 | "1" |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:39:42:39:44 | "2" |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:39:30:39:46 | { ..., ... } |
-| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:21:40:21 | String x |
+| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:33:38:35 | "a" |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:38:38:40 | "b" |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:43:38:45 | "c" |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:31:38:47 | { ..., ... } |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:33:39:35 | "0" |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:38:39:40 | "1" |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } |
+| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:41:30:41:31 | access to local variable ys |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:42:17:42:41 | ...; |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:42:17:42:41 | ...; |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:35:42:35 | access to local variable x |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:39:42:39 | access to local variable y |
 | LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine |
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:35:42:39 | ... + ... |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:46:5:53:5 | {...} |
-| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:47 | ... ...; |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:47:18:47:46 | array creation of type String[] |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:48:26:48:27 | access to local variable xs |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:47:32:47:34 | "a" |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:47:13:47:46 | String[] xs = ... |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:47:37:47:39 | "b" |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:47:42:47:44 | "c" |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:47:30:47:46 | { ..., ... } |
-| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:21:48:21 | String x |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:49:9:52:9 | {...} |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:13:50:17 | Label: |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:20:50:40 | ...; |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:50:38:50:38 | access to local variable x |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:50:20:50:39 | call to method WriteLine |
+| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:48 | ... ...; |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:33:47:35 | "a" |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:38:47:40 | "b" |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:43:47:45 | "c" |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:31:47:47 | { ..., ... } |
+| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:22:48:22 | String x |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:49:9:52:9 | {...} |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:9:50:13 | Label: |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:16:50:36 | ...; |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:34:50:34 | access to local variable x |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} |
-| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:47 | ... ...; |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:57:18:57:46 | array creation of type String[] |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:58:26:58:27 | access to local variable xs |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:57:32:57:34 | "a" |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:57:13:57:46 | String[] xs = ... |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:57:37:57:39 | "b" |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:57:42:57:44 | "c" |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:57:30:57:46 | { ..., ... } |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
-| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | String x |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:59:9:64:9 | {...} |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:33:57:35 | "a" |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:38:57:40 | "b" |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:43:57:45 | "c" |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:31:57:47 | { ..., ... } |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
+| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | String x |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:59:9:64:9 | {...} |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:60:13:61:37 | if (...) ... |
@@ -2031,13 +2031,56 @@ dominance
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
-| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:28:72:31 | access to parameter args |
+| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:21:72:23 | String arg |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:80:9:82:9 | {...} |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:81:13:81:33 | ...; |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:89:9:91:9 | {...} |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:90:13:90:33 | ...; |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] |
+| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:33 | ...; |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:31:99:31 | access to local variable x |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... |
@@ -5032,27 +5075,27 @@ postDominance
 | LoopUnrolling.cs:9:13:9:23 | access to property Length | LoopUnrolling.cs:9:13:9:16 | access to parameter args |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:9:28:9:28 | 0 |
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:23 | access to property Length |
-| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
-| LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:11:21:11:23 | String arg |
+| LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:11:22:11:24 | String arg |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:35 | ...; |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:15:10:15:11 | enter M2 |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:16:5:20:5 | {...} |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:17:30:17:46 | { ..., ... } |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:17:9:17:47 | ... ...; |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:17:42:17:44 | "c" |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:17:18:17:46 | array creation of type String[] |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:17:32:17:34 | "a" |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:17:37:17:39 | "b" |
-| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:26:18:27 | access to local variable xs |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:16:5:20:5 | {...} |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:17:31:17:47 | { ..., ... } |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:9:17:48 | ... ...; |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:43:17:45 | "c" |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:33:17:35 | "a" |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:38:17:40 | "b" |
+| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:17:13:17:46 | String[] xs = ... |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
-| LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:18:21:18:21 | String x |
+| LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:33 | ...; |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:22:10:22:11 | enter M3 |
@@ -5072,75 +5115,75 @@ postDominance
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:29:31:29 | 0 |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:9:31:31 | ... ...; |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:26:32:27 | access to local variable xs |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |
 | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
-| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:32:21:32:21 | String x |
+| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:33 | ...; |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:37:5:43:5 | {...} |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:38:30:38:46 | { ..., ... } |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:38:9:38:47 | ... ...; |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:38:42:38:44 | "c" |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:38:18:38:46 | array creation of type String[] |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:38:32:38:34 | "a" |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:38:37:38:39 | "b" |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:38:13:38:46 | String[] xs = ... |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:39:30:39:46 | { ..., ... } |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:39:9:39:47 | ... ...; |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:39:42:39:44 | "2" |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:39:18:39:46 | array creation of type String[] |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:39:32:39:34 | "0" |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:39:37:39:39 | "1" |
-| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:26:40:27 | access to local variable xs |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:37:5:43:5 | {...} |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:38:31:38:47 | { ..., ... } |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:9:38:48 | ... ...; |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:43:38:45 | "c" |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:33:38:35 | "a" |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:38:38:40 | "b" |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:39:31:39:47 | { ..., ... } |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:9:39:48 | ... ...; |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:43:39:45 | "2" |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:33:39:35 | "0" |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:38:39:40 | "1" |
+| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:39:13:39:46 | String[] ys = ... |
-| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:30:41:31 | access to local variable ys |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... |
+| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |
 | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:40:21:40:21 | String x |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:40:22:40:22 | String x |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:42:35:42:39 | ... + ... |
-| LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:17:42:41 | ...; |
 | LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:39:42:39 | access to local variable y |
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:35:42:35 | access to local variable x |
 | LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:45:10:45:11 | enter M6 |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:46:5:53:5 | {...} |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:47:30:47:46 | { ..., ... } |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:47:9:47:47 | ... ...; |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:47:42:47:44 | "c" |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:47:18:47:46 | array creation of type String[] |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:47:32:47:34 | "a" |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:47:37:47:39 | "b" |
-| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:26:48:27 | access to local variable xs |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:47:13:47:46 | String[] xs = ... |
-| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:48:21:48:21 | String x |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:50:38:50:38 | access to local variable x |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:50:13:50:17 | Label: |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:50:20:50:40 | ...; |
-| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:20:50:39 | call to method WriteLine |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:46:5:53:5 | {...} |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:47:31:47:47 | { ..., ... } |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:9:47:48 | ... ...; |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:43:47:45 | "c" |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:33:47:35 | "a" |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:38:47:40 | "b" |
+| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... |
+| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:48:22:48:22 | String x |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:50:34:50:34 | access to local variable x |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:9:50:13 | Label: |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:36 | ...; |
+| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:55:10:55:11 | enter M7 |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:56:5:65:5 | {...} |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:57:30:57:46 | { ..., ... } |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:57:9:57:47 | ... ...; |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:57:42:57:44 | "c" |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:57:18:57:46 | array creation of type String[] |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:57:32:57:34 | "a" |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:57:37:57:39 | "b" |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:56:5:65:5 | {...} |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:57:31:57:47 | { ..., ... } |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:9:57:48 | ... ...; |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:43:57:45 | "c" |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:33:57:35 | "a" |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:38:57:40 | "b" |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine |
-| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:26:58:27 | access to local variable xs |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:57:13:57:46 | String[] xs = ... |
-| LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
-| LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:58:21:58:21 | String x |
+| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... |
+| LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
+| LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:58:22:58:22 | String x |
 | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} |
 | LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} |
 | LoopUnrolling.cs:60:13:61:37 | if (...) ... | LoopUnrolling.cs:59:9:64:9 | {...} |
@@ -5166,12 +5209,55 @@ postDominance
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:69:14:69:17 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:28:72:31 | access to parameter args |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |
 | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
-| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:35 | ...; |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | enter M9 |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:77:5:83:5 | {...} |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:32:78:32 | 0 |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:9:78:34 | ... ...; |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:29:78:29 | 2 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:80:9:82:9 | {...} |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:33 | ...; |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | enter M10 |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:86:5:92:5 | {...} |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:32:87:32 | 2 |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:9:87:34 | ... ...; |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:29:87:29 | 0 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:89:9:91:9 | {...} |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:33 | ...; |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:95:5:101:5 | {...} |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:32:96:32 | 2 |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:9:96:34 | ... ...; |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:29:96:29 | 2 |
+| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:99:31:99:31 | access to local variable x |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:98:9:100:9 | {...} |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:33 | ...; |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | throw ... |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:28:6:31 | null |
@@ -7514,19 +7600,19 @@ blockDominance
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:21:18:21 | String x |
+| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:21:18:21 | String x |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | exit M2 |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |
@@ -7543,57 +7629,81 @@ blockDominance
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:21:32:21 | String x |
+| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:21:32:21 | String x |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:32:21:32:21 | String x |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:41:25:41:25 | String y |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:26:41:26 | String y |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | exit M5 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | enter M6 |
-| LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:50:13:50:17 | Label: |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:13:50:17 | Label: |
+| LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:50:9:50:13 | Label: |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
-| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
+| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
-| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
+| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | exit M8 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:21:72:23 | String arg |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
@@ -9600,18 +9710,18 @@ postBlockDominance
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | enter M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | exit M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | enter M2 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | exit M2 |
-| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:18:21:18:21 | String x |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:15:10:15:11 | enter M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:21:18:21 | String x |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:18:22:18:22 | String x |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | enter M2 |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | enter M3 |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | exit M3 |
@@ -9629,40 +9739,40 @@ postBlockDominance
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | exit M4 |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:21:32:21 | String x |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | enter M4 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:21:32:21 | String x |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:32:21:32:21 | String x |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | exit M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | enter M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:25:41:25 | String y |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:36:10:36:11 | enter M5 |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:25:41:25 | String y |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | enter M5 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | enter M5 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:26:41:26 | String y |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | enter M6 |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:13:50:17 | Label: |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | enter M7 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | exit M7 |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
-| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
+| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; |
-| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x |
+| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | enter M8 |
@@ -9670,13 +9780,37 @@ postBlockDominance
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:72:22:72:24 | String arg |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:70:13:70:19 | return ...; |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:71:9:71:21 | ...; |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:21:72:23 | String arg |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:72:21:72:23 | String arg |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | enter M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | exit M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | enter M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | enter M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | exit M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | enter M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | exit M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | enter M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | enter get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -2083,12 +2083,8 @@ nodeEnclosing
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | M5 |
@@ -2184,12 +2180,8 @@ nodeEnclosing
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | M9 |
@@ -2198,13 +2190,8 @@ nodeEnclosing
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | M10 |
@@ -2213,13 +2200,8 @@ nodeEnclosing
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | M11 |
@@ -4065,9 +4047,6 @@ blockEnclosing
 | LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
@@ -4085,16 +4064,8 @@ blockEnclosing
 | LoopUnrolling.cs:67:10:67:11 | exit M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | M9 |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:76:10:76:11 | M9 |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | M10 |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:85:10:85:12 | M10 |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
 | LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | M11 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -2041,25 +2041,25 @@ nodeEnclosing
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | M1 |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:7:10:7:11 | M1 |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:15:10:15:11 | M2 |
@@ -2084,36 +2084,36 @@ nodeEnclosing
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:29:10:29:11 | M4 |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:36:10:36:11 | M5 |
@@ -2121,39 +2121,39 @@ nodeEnclosing
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:55:10:55:11 | M7 |
@@ -2185,11 +2185,57 @@ nodeEnclosing
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:94:10:94:12 | M11 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
@@ -4008,11 +4054,11 @@ blockEnclosing
 | LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:7:10:7:11 | exit M1 | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | M1 |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:7:10:7:11 | M1 |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:7:10:7:11 | M1 |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:7:10:7:11 | M1 |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:15:10:15:11 | exit M2 | LoopUnrolling.cs:15:10:15:11 | M2 |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:15:10:15:11 | M2 |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:15:10:15:11 | M2 |
 | LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:22:10:22:11 | exit M3 | LoopUnrolling.cs:22:10:22:11 | M3 |
 | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | M3 |
@@ -4021,18 +4067,18 @@ blockEnclosing
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:29:10:29:11 | exit M4 | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | M4 |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:29:10:29:11 | M4 |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:36:10:36:11 | exit M5 | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:36:10:36:11 | M5 |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:36:10:36:11 | M5 |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:36:10:36:11 | M5 |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:45:10:45:11 | M6 |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:45:10:45:11 | M6 |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:45:10:45:11 | M6 |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:55:10:55:11 | exit M7 | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:55:10:55:11 | M7 |
 | LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:67:10:67:11 | M8 |
@@ -4040,7 +4086,18 @@ blockEnclosing
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:67:10:67:11 | M8 |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | M8 |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:67:10:67:11 | M8 |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:76:10:76:11 | M9 |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:85:10:85:12 | M10 |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 | LoopUnrolling.cs:94:10:94:12 | M11 |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:94:10:94:12 | M11 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | get_P1 |
 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | MultiImplementationA.cs:6:22:6:31 | get_P1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1418,24 +1418,24 @@
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args |
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:28:9:28 | 0 |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; |
-| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:21:11:23 | String arg |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:28:11:31 | access to parameter args |
+| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:13:12:35 | ...; |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:16:5:20:5 | {...} |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:17:9:17:47 | ... ...; |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:17:18:17:46 | array creation of type String[] |
-| LoopUnrolling.cs:17:18:17:46 | 3 | LoopUnrolling.cs:17:18:17:46 | 3 |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:17:18:17:46 | array creation of type String[] |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:17:32:17:34 | "a" |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:17:32:17:34 | "a" |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:17:37:17:39 | "b" |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:17:42:17:44 | "c" |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:26:18:27 | access to local variable xs |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:21:18:21 | String x |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:18:26:18:27 | access to local variable xs |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:9:17:48 | ... ...; |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] |
+| LoopUnrolling.cs:17:18:17:47 | 3 | LoopUnrolling.cs:17:18:17:47 | 3 |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:33:17:35 | "a" |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:33:17:35 | "a" |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:38:17:40 | "b" |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:43:17:45 | "c" |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:13:19:33 | ...; |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:31:19:31 | access to local variable x |
@@ -1454,70 +1454,70 @@
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:31:29:31:29 | 0 |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:29:31:29 | 0 |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:29:31:29 | 0 |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:26:32:27 | access to local variable xs |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:32:21:32:21 | String x |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:32:26:32:27 | access to local variable xs |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |
 | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
 | LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:13:33:33 | ...; |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:31:33:31 | access to local variable x |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:37:5:43:5 | {...} |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:38:9:38:47 | ... ...; |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:38:18:38:46 | array creation of type String[] |
-| LoopUnrolling.cs:38:18:38:46 | 3 | LoopUnrolling.cs:38:18:38:46 | 3 |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:38:18:38:46 | array creation of type String[] |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:38:32:38:34 | "a" |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:38:32:38:34 | "a" |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:38:37:38:39 | "b" |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:38:42:38:44 | "c" |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:39:9:39:47 | ... ...; |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:39:18:39:46 | array creation of type String[] |
-| LoopUnrolling.cs:39:18:39:46 | 3 | LoopUnrolling.cs:39:18:39:46 | 3 |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:39:18:39:46 | array creation of type String[] |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:39:32:39:34 | "0" |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:39:32:39:34 | "0" |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:39:37:39:39 | "1" |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:39:42:39:44 | "2" |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:26:40:27 | access to local variable xs |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:21:40:21 | String x |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:40:26:40:27 | access to local variable xs |
-| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:30:41:31 | access to local variable ys |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:25:41:25 | String y |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:41:30:41:31 | access to local variable ys |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:9:38:48 | ... ...; |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |
+| LoopUnrolling.cs:38:18:38:47 | 3 | LoopUnrolling.cs:38:18:38:47 | 3 |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:33:38:35 | "a" |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:33:38:35 | "a" |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:38:38:40 | "b" |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:43:38:45 | "c" |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:9:39:48 | ... ...; |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] |
+| LoopUnrolling.cs:39:18:39:47 | 3 | LoopUnrolling.cs:39:18:39:47 | 3 |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:33:39:35 | "0" |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:33:39:35 | "0" |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:38:39:40 | "1" |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:43:39:45 | "2" |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:22:40:22 | String x |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:27:40:28 | access to local variable xs |
+| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:26:41:26 | String y |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:42:35:42:35 | access to local variable x |
 | LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:17:42:41 | ...; |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:35:42:35 | access to local variable x |
 | LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:35:42:35 | access to local variable x |
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:39:42:39 | access to local variable y |
 | LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:46:5:53:5 | {...} |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:47:9:47:47 | ... ...; |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:47:18:47:46 | array creation of type String[] |
-| LoopUnrolling.cs:47:18:47:46 | 3 | LoopUnrolling.cs:47:18:47:46 | 3 |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:47:18:47:46 | array creation of type String[] |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:47:32:47:34 | "a" |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:47:32:47:34 | "a" |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:47:37:47:39 | "b" |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:47:42:47:44 | "c" |
-| LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:48:26:48:27 | access to local variable xs |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:48:21:48:21 | String x |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:48:26:48:27 | access to local variable xs |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:9:47:48 | ... ...; |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] |
+| LoopUnrolling.cs:47:18:47:47 | 3 | LoopUnrolling.cs:47:18:47:47 | 3 |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:33:47:35 | "a" |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:33:47:35 | "a" |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:38:47:40 | "b" |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:43:47:45 | "c" |
+| LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:48:22:48:22 | String x |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:27:48:28 | access to local variable xs |
 | LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:49:9:52:9 | {...} |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:13:50:17 | Label: |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:50:38:50:38 | access to local variable x |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:50:20:50:40 | ...; |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:50:38:50:38 | access to local variable x |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:50:34:50:34 | access to local variable x |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:16:50:36 | ...; |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:34:50:34 | access to local variable x |
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:51:13:51:23 | goto ...; |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:56:5:65:5 | {...} |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:57:9:57:47 | ... ...; |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:57:18:57:46 | array creation of type String[] |
-| LoopUnrolling.cs:57:18:57:46 | 3 | LoopUnrolling.cs:57:18:57:46 | 3 |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:57:18:57:46 | array creation of type String[] |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:57:32:57:34 | "a" |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:57:32:57:34 | "a" |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:57:37:57:39 | "b" |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:57:42:57:44 | "c" |
-| LoopUnrolling.cs:58:9:64:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:58:26:58:27 | access to local variable xs |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:58:21:58:21 | String x |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:58:26:58:27 | access to local variable xs |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:9:57:48 | ... ...; |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] |
+| LoopUnrolling.cs:57:18:57:47 | 3 | LoopUnrolling.cs:57:18:57:47 | 3 |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:33:57:35 | "a" |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:33:57:35 | "a" |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:38:57:40 | "b" |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:43:57:45 | "c" |
+| LoopUnrolling.cs:58:9:64:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:58:22:58:22 | String x |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:59:9:64:9 | {...} |
 | LoopUnrolling.cs:60:13:61:37 | if (...) ... | LoopUnrolling.cs:60:13:61:37 | if (...) ... |
 | LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:60:17:60:17 | access to parameter b |
@@ -1538,12 +1538,51 @@
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:12 | access to parameter args |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:21 | ...; |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:28:72:31 | access to parameter args |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:72:21:72:23 | String arg |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:72:28:72:31 | access to parameter args |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:29:72:32 | access to parameter args |
 | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
 | LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:13:73:35 | ...; |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:31:73:33 | access to local variable arg |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:77:5:83:5 | {...} |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:9:78:34 | ... ...; |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:78:29:78:29 | 2 |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:29:78:29 | 2 |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:29:78:29 | 2 |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:32:78:32 | 0 |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:80:9:82:9 | {...} |
+| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:13:81:33 | ...; |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:31:81:31 | access to local variable x |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:86:5:92:5 | {...} |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:9:87:34 | ... ...; |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:87:29:87:29 | 0 |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:29:87:29 | 0 |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:29:87:29 | 0 |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:32:87:32 | 2 |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:89:9:91:9 | {...} |
+| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:13:90:33 | ...; |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:31:90:31 | access to local variable x |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:95:5:101:5 | {...} |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:9:96:34 | ... ...; |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:96:29:96:29 | 2 |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:29:96:29 | 2 |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:29:96:29 | 2 |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:98:9:100:9 | {...} |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:99:31:99:31 | access to local variable x |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:13:99:33 | ...; |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:31:99:31 | access to local variable x |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:25:7:39 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1920,23 +1920,23 @@
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:28:9:28 | 0 | normal |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:10:13:10:19 | return ...; | return |
 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:11:21:11:23 | String arg | normal |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:28:11:31 | access to parameter args | normal |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:11:22:11:24 | String arg | normal |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:29:11:32 | access to parameter args | normal |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | normal |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | normal |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | normal |
 | LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:17:18:17:46 | 3 | LoopUnrolling.cs:17:18:17:46 | 3 | normal |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:17:30:17:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:17:30:17:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:17:32:17:34 | "a" | normal |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:17:37:17:39 | "b" | normal |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:17:42:17:44 | "c" | normal |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:17:18:17:47 | 3 | LoopUnrolling.cs:17:18:17:47 | 3 | normal |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:31:17:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:31:17:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:33:17:35 | "a" | normal |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:38:17:40 | "b" | normal |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:43:17:45 | "c" | normal |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:18:21:18:21 | String x | normal |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:18:26:18:27 | access to local variable xs | normal |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:18:22:18:22 | String x | normal |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | normal |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | normal |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | normal |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:31:19:31 | access to local variable x | normal |
@@ -1956,34 +1956,34 @@
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | normal |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:29:31:29 | 0 | normal |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:32:21:32:21 | String x | normal |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:32:26:32:27 | access to local variable xs | normal |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:32:22:32:22 | String x | normal |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | normal |
 | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | normal |
 | LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | normal |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:31:33:31 | access to local variable x | normal |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:38:18:38:46 | 3 | LoopUnrolling.cs:38:18:38:46 | 3 | normal |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:38:30:38:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:38:30:38:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:38:32:38:34 | "a" | normal |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:38:37:38:39 | "b" | normal |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:38:42:38:44 | "c" | normal |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | normal |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | normal |
-| LoopUnrolling.cs:39:18:39:46 | 3 | LoopUnrolling.cs:39:18:39:46 | 3 | normal |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:39:30:39:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:39:30:39:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:39:32:39:34 | "0" | normal |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:39:37:39:39 | "1" | normal |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:39:42:39:44 | "2" | normal |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:38:18:38:47 | 3 | LoopUnrolling.cs:38:18:38:47 | 3 | normal |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:31:38:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:31:38:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:33:38:35 | "a" | normal |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:38:38:40 | "b" | normal |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:43:38:45 | "c" | normal |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | normal |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | normal |
+| LoopUnrolling.cs:39:18:39:47 | 3 | LoopUnrolling.cs:39:18:39:47 | 3 | normal |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:31:39:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:31:39:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:33:39:35 | "0" | normal |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:38:39:40 | "1" | normal |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:43:39:45 | "2" | normal |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:40:21:40:21 | String x | normal |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:40:26:40:27 | access to local variable xs | normal |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:40:22:40:22 | String x | normal |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:27:40:28 | access to local variable xs | normal |
 | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:41:25:41:25 | String y | normal |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:41:30:41:31 | access to local variable ys | normal |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:41:26:41:26 | String y | normal |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:31:41:32 | access to local variable ys | normal |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | normal |
 | LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | normal |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:35:42:35 | access to local variable x | normal |
@@ -1991,36 +1991,36 @@
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:39:42:39 | access to local variable y | normal |
 | LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | empty |
 | LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:51:13:51:23 | goto ...; | goto(Label) |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:47:18:47:46 | 3 | LoopUnrolling.cs:47:18:47:46 | 3 | normal |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:47:30:47:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:47:30:47:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:47:32:47:34 | "a" | normal |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:47:37:47:39 | "b" | normal |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:47:42:47:44 | "c" | normal |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:47:18:47:47 | 3 | LoopUnrolling.cs:47:18:47:47 | 3 | normal |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:31:47:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:31:47:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:33:47:35 | "a" | normal |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:38:47:40 | "b" | normal |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:43:47:45 | "c" | normal |
 | LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | empty |
 | LoopUnrolling.cs:48:9:52:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:51:13:51:23 | goto ...; | goto(Label) |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:48:21:48:21 | String x | normal |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:48:26:48:27 | access to local variable xs | normal |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:48:22:48:22 | String x | normal |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:27:48:28 | access to local variable xs | normal |
 | LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:51:13:51:23 | goto ...; | goto(Label) |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:13:50:17 | Label: | normal |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | normal |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | normal |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:50:38:50:38 | access to local variable x | normal |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:9:50:13 | Label: | normal |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | normal |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | normal |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:34:50:34 | access to local variable x | normal |
 | LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:51:13:51:23 | goto ...; | goto(Label) |
 | LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:58:9:64:9 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | normal |
-| LoopUnrolling.cs:57:18:57:46 | 3 | LoopUnrolling.cs:57:18:57:46 | 3 | normal |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:57:30:57:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:57:30:57:46 | { ..., ... } | normal |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:57:32:57:34 | "a" | normal |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:57:37:57:39 | "b" | normal |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:57:42:57:44 | "c" | normal |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | normal |
+| LoopUnrolling.cs:57:18:57:47 | 3 | LoopUnrolling.cs:57:18:57:47 | 3 | normal |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:31:57:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:31:57:47 | { ..., ... } | normal |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:33:57:35 | "a" | normal |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:38:57:40 | "b" | normal |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:43:57:45 | "c" | normal |
 | LoopUnrolling.cs:58:9:64:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:58:9:64:9 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:58:21:58:21 | String x | normal |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:58:26:58:27 | access to local variable xs | normal |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:58:22:58:22 | String x | normal |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:27:58:28 | access to local variable xs | normal |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:62:17:62:17 | access to parameter b | false |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:63:17:63:36 | call to method WriteLine | normal |
 | LoopUnrolling.cs:60:13:61:37 | if (...) ... | LoopUnrolling.cs:60:17:60:17 | access to parameter b | false |
@@ -2051,11 +2051,50 @@
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:71:9:71:20 | call to method Clear | normal |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:20 | call to method Clear | normal |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | empty |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:72:21:72:23 | String arg | normal |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:72:28:72:31 | access to parameter args | normal |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:72:22:72:24 | String arg | normal |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:29:72:32 | access to parameter args | normal |
 | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | normal |
 | LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | normal |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | normal |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | normal |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:29:78:29 | 2 | normal |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:32:78:32 | 0 | normal |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:79:22:79:22 | String x | normal |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | normal |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:31:81:31 | access to local variable x | normal |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | normal |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:29:87:29 | 0 | normal |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:32:87:32 | 2 | normal |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:88:22:88:22 | String x | normal |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | normal |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:31:90:31 | access to local variable x | normal |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | normal |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | normal |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:29:96:29 | 2 | normal |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 | normal |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:97:22:97:22 | String x | normal |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | normal |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | normal |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:31:99:31 | access to local variable x | normal |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | throw ... | throw(NullReferenceException) |
 | MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:28:6:31 | null | normal |
 | MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:27:7:37 | throw ...; | throw(NullReferenceException) |

--- a/csharp/ql/test/library-tests/controlflow/graph/LoopUnrolling.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/LoopUnrolling.cs
@@ -29,7 +29,7 @@ class LoopUnrolling
     void M4()
     {
         var xs = new string[0];
-        foreach (var x in xs) // skip [MISSING]
+        foreach (var x in xs) // skip
             Console.WriteLine(x);
     }
 
@@ -69,14 +69,14 @@ class LoopUnrolling
         if (!args.Any())
             return;
         args.Clear();
-        foreach (var arg in args) // skip [MISSING]
+        foreach (var arg in args) // skip
             Console.WriteLine(arg);
     }
 
     void M9()
     {
         var xs = new string[2, 0];
-        foreach (var x in xs) //skip [MISSING]
+        foreach (var x in xs) //skip
         {
             Console.WriteLine(x);
         }
@@ -85,7 +85,7 @@ class LoopUnrolling
     void M10()
     {
         var xs = new string[0, 2];
-        foreach (var x in xs) // skip [MISSING]
+        foreach (var x in xs) // skip
         {
             Console.WriteLine(x);
         }

--- a/csharp/ql/test/library-tests/controlflow/graph/LoopUnrolling.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/LoopUnrolling.cs
@@ -8,14 +8,14 @@ class LoopUnrolling
     {
         if (args.Length == 0)
             return;
-        foreach(var arg in args) // unroll
+        foreach (var arg in args) // unroll
             Console.WriteLine(arg);
     }
 
     void M2()
     {
-        var xs = new string[]{ "a", "b", "c" };
-        foreach(var x in xs) // unroll
+        var xs = new string[] { "a", "b", "c" };
+        foreach (var x in xs) // unroll
             Console.WriteLine(x);
     }
 
@@ -29,33 +29,33 @@ class LoopUnrolling
     void M4()
     {
         var xs = new string[0];
-        foreach(var x in xs) // no unroll
+        foreach (var x in xs) // skip [MISSING]
             Console.WriteLine(x);
     }
 
     void M5()
     {
-        var xs = new string[]{ "a", "b", "c" };
-        var ys = new string[]{ "0", "1", "2" };
-        foreach(var x in xs) // unroll
-            foreach(var y in ys) // unroll
+        var xs = new string[] { "a", "b", "c" };
+        var ys = new string[] { "0", "1", "2" };
+        foreach (var x in xs) // unroll
+            foreach (var y in ys) // unroll
                 Console.WriteLine(x + y);
     }
 
     void M6()
     {
-        var xs = new string[]{ "a", "b", "c" };
-        foreach(var x in xs) // unroll
+        var xs = new string[] { "a", "b", "c" };
+        foreach (var x in xs) // unroll
         {
-            Label: Console.WriteLine(x);
+        Label: Console.WriteLine(x);
             goto Label;
         }
     }
 
     void M7(bool b)
     {
-        var xs = new string[]{ "a", "b", "c" };
-        foreach(var x in xs) // unroll
+        var xs = new string[] { "a", "b", "c" };
+        foreach (var x in xs) // unroll
         {
             if (b)
                 Console.WriteLine(x);
@@ -69,7 +69,34 @@ class LoopUnrolling
         if (!args.Any())
             return;
         args.Clear();
-        foreach(var arg in args) // no unroll
+        foreach (var arg in args) // skip [MISSING]
             Console.WriteLine(arg);
+    }
+
+    void M9()
+    {
+        var xs = new string[2, 0];
+        foreach (var x in xs) //skip [MISSING]
+        {
+            Console.WriteLine(x);
+        }
+    }
+
+    void M10()
+    {
+        var xs = new string[0, 2];
+        foreach (var x in xs) // skip [MISSING]
+        {
+            Console.WriteLine(x);
+        }
+    }
+
+    void M11()
+    {
+        var xs = new string[2, 2];
+        foreach (var x in xs) // unroll
+        {
+            Console.WriteLine(x);
+        }
     }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2153,13 +2153,8 @@
 | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | semmle.label | successor |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | empty |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:31:33:31 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | empty |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | semmle.label | successor |
@@ -2258,13 +2253,8 @@
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args | semmle.label | successor |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | empty |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | semmle.label | successor |
-| LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | empty |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 | semmle.label | successor |
@@ -2272,14 +2262,8 @@
 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 | semmle.label | successor |
 | LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | empty |
-| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:80:9:82:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:81:13:81:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:31:81:31 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | empty |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 | semmle.label | successor |
@@ -2287,14 +2271,8 @@
 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 | semmle.label | successor |
 | LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | semmle.label | successor |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | empty |
-| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:89:9:91:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:90:13:90:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:31:90:31 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | empty |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -2105,31 +2105,31 @@
 | LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length | semmle.label | successor |
 | LoopUnrolling.cs:9:13:9:23 | access to property Length | LoopUnrolling.cs:9:28:9:28 | 0 | semmle.label | successor |
 | LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | semmle.label | true |
-| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:28:11:31 | access to parameter args | semmle.label | false |
+| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | semmle.label | false |
 | LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:28 | ... == ... | semmle.label | successor |
 | LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | return |
-| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:21:11:23 | String arg | semmle.label | non-empty |
+| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
 | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | exit M1 | semmle.label | empty |
-| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:21:11:23 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:11:21:11:23 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:11:28:11:31 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | semmle.label | non-empty |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | semmle.label | successor |
 | LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:47 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:17:9:17:47 | ... ...; | LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | LoopUnrolling.cs:18:26:18:27 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:17:18:17:46 | array creation of type String[] | LoopUnrolling.cs:17:32:17:34 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:17:30:17:46 | { ..., ... } | LoopUnrolling.cs:17:13:17:46 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:17:32:17:34 | "a" | LoopUnrolling.cs:17:37:17:39 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:17:37:17:39 | "b" | LoopUnrolling.cs:17:42:17:44 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:17:42:17:44 | "c" | LoopUnrolling.cs:17:30:17:46 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:21:18:21 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | semmle.label | successor |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:33:17:35 | "a" | semmle.label | successor |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:38:17:40 | "b" | semmle.label | successor |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" | semmle.label | successor |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } | semmle.label | successor |
+| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 | semmle.label | empty |
-| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:21:18:21 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:18:21:18:21 | String x | LoopUnrolling.cs:19:13:19:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:18:26:18:27 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x | semmle.label | successor |
 | LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | semmle.label | successor |
@@ -2150,83 +2150,83 @@
 | LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} | semmle.label | successor |
 | LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; | semmle.label | successor |
 | LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 | semmle.label | successor |
-| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:26:32:27 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs | semmle.label | successor |
 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | semmle.label | successor |
 | LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | semmle.label | successor |
 | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 | semmle.label | empty |
-| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:21:32:21 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:32:21:32:21 | String x | LoopUnrolling.cs:33:13:33:33 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:32:26:32:27 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:32:22:32:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:32:22:32:22 | String x | LoopUnrolling.cs:33:13:33:33 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | LoopUnrolling.cs:32:9:33:33 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:33:13:33:33 | ...; | LoopUnrolling.cs:33:31:33:31 | access to local variable x | semmle.label | successor |
 | LoopUnrolling.cs:33:31:33:31 | access to local variable x | LoopUnrolling.cs:33:13:33:32 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:47 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:38:9:38:47 | ... ...; | LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | LoopUnrolling.cs:39:9:39:47 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:38:18:38:46 | array creation of type String[] | LoopUnrolling.cs:38:32:38:34 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:38:30:38:46 | { ..., ... } | LoopUnrolling.cs:38:13:38:46 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:38:32:38:34 | "a" | LoopUnrolling.cs:38:37:38:39 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:38:37:38:39 | "b" | LoopUnrolling.cs:38:42:38:44 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:38:42:38:44 | "c" | LoopUnrolling.cs:38:30:38:46 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:39:9:39:47 | ... ...; | LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | LoopUnrolling.cs:40:26:40:27 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:39:18:39:46 | array creation of type String[] | LoopUnrolling.cs:39:32:39:34 | "0" | semmle.label | successor |
-| LoopUnrolling.cs:39:30:39:46 | { ..., ... } | LoopUnrolling.cs:39:13:39:46 | String[] ys = ... | semmle.label | successor |
-| LoopUnrolling.cs:39:32:39:34 | "0" | LoopUnrolling.cs:39:37:39:39 | "1" | semmle.label | successor |
-| LoopUnrolling.cs:39:37:39:39 | "1" | LoopUnrolling.cs:39:42:39:44 | "2" | semmle.label | successor |
-| LoopUnrolling.cs:39:42:39:44 | "2" | LoopUnrolling.cs:39:30:39:46 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:21:40:21 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | semmle.label | successor |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:33:38:35 | "a" | semmle.label | successor |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:38:38:40 | "b" | semmle.label | successor |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:43:38:45 | "c" | semmle.label | successor |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:31:38:47 | { ..., ... } | semmle.label | successor |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | semmle.label | successor |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:33:39:35 | "0" | semmle.label | successor |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | semmle.label | successor |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:38:39:40 | "1" | semmle.label | successor |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" | semmle.label | successor |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } | semmle.label | successor |
+| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
 | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 | semmle.label | empty |
-| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:21:40:21 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:40:21:40:21 | String x | LoopUnrolling.cs:41:30:41:31 | access to local variable ys | semmle.label | successor |
-| LoopUnrolling.cs:40:26:40:27 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:25:41:25 | String y | semmle.label | non-empty |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys | semmle.label | successor |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | semmle.label | non-empty |
 | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | semmle.label | empty |
-| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:25:41:25 | String y | semmle.label | non-empty |
-| LoopUnrolling.cs:41:25:41:25 | String y | LoopUnrolling.cs:42:17:42:41 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:41:30:41:31 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | semmle.label | non-empty |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:42:17:42:41 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:35:42:35 | access to local variable x | semmle.label | successor |
 | LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:39:42:39 | access to local variable y | semmle.label | successor |
 | LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | semmle.label | successor |
 | LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:35:42:39 | ... + ... | semmle.label | successor |
 | LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:46:5:53:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:47 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:47:9:47:47 | ... ...; | LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | LoopUnrolling.cs:48:26:48:27 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:47:18:47:46 | array creation of type String[] | LoopUnrolling.cs:47:32:47:34 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:47:30:47:46 | { ..., ... } | LoopUnrolling.cs:47:13:47:46 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:47:32:47:34 | "a" | LoopUnrolling.cs:47:37:47:39 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:47:37:47:39 | "b" | LoopUnrolling.cs:47:42:47:44 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:47:42:47:44 | "c" | LoopUnrolling.cs:47:30:47:46 | { ..., ... } | semmle.label | successor |
-| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:21:48:21 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:48:21:48:21 | String x | LoopUnrolling.cs:49:9:52:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:48:26:48:27 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | semmle.label | successor |
-| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:13:50:17 | Label: | semmle.label | successor |
-| LoopUnrolling.cs:50:13:50:17 | Label: | LoopUnrolling.cs:50:20:50:40 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; | semmle.label | successor |
-| LoopUnrolling.cs:50:20:50:40 | ...; | LoopUnrolling.cs:50:38:50:38 | access to local variable x | semmle.label | successor |
-| LoopUnrolling.cs:50:38:50:38 | access to local variable x | LoopUnrolling.cs:50:20:50:39 | call to method WriteLine | semmle.label | successor |
-| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:13:50:17 | Label: | semmle.label | goto(Label) |
+| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:48 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | semmle.label | successor |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:33:47:35 | "a" | semmle.label | successor |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:38:47:40 | "b" | semmle.label | successor |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:43:47:45 | "c" | semmle.label | successor |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:31:47:47 | { ..., ... } | semmle.label | successor |
+| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:22:48:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:49:9:52:9 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:9:50:13 | Label: | semmle.label | successor |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:16:50:36 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; | semmle.label | successor |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:34:50:34 | access to local variable x | semmle.label | successor |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:9:50:13 | Label: | semmle.label | goto(Label) |
 | LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:47 | ... ...; | semmle.label | successor |
-| LoopUnrolling.cs:57:9:57:47 | ... ...; | LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | semmle.label | successor |
-| LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | LoopUnrolling.cs:58:26:58:27 | access to local variable xs | semmle.label | successor |
-| LoopUnrolling.cs:57:18:57:46 | array creation of type String[] | LoopUnrolling.cs:57:32:57:34 | "a" | semmle.label | successor |
-| LoopUnrolling.cs:57:30:57:46 | { ..., ... } | LoopUnrolling.cs:57:13:57:46 | String[] xs = ... | semmle.label | successor |
-| LoopUnrolling.cs:57:32:57:34 | "a" | LoopUnrolling.cs:57:37:57:39 | "b" | semmle.label | successor |
-| LoopUnrolling.cs:57:37:57:39 | "b" | LoopUnrolling.cs:57:42:57:44 | "c" | semmle.label | successor |
-| LoopUnrolling.cs:57:42:57:44 | "c" | LoopUnrolling.cs:57:30:57:46 | { ..., ... } | semmle.label | successor |
+| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | semmle.label | successor |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:33:57:35 | "a" | semmle.label | successor |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:38:57:40 | "b" | semmle.label | successor |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:43:57:45 | "c" | semmle.label | successor |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:31:57:47 | { ..., ... } | semmle.label | successor |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | semmle.label | non-empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | semmle.label | non-empty |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 | semmle.label | empty |
-| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:21:58:21 | String x | semmle.label | non-empty |
-| LoopUnrolling.cs:58:21:58:21 | String x | LoopUnrolling.cs:59:9:64:9 | {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | semmle.label | successor |
-| LoopUnrolling.cs:58:26:58:27 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | semmle.label | non-empty |
+| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:59:9:64:9 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | semmle.label | successor |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | semmle.label | successor |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | semmle.label | successor |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... | semmle.label | successor |
 | LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:60:13:61:37 | if (...) ... | semmle.label | successor |
@@ -2256,15 +2256,61 @@
 | LoopUnrolling.cs:69:14:69:23 | call to method Any | LoopUnrolling.cs:71:9:71:21 | ...; | semmle.label | true |
 | LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | return |
 | LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear | semmle.label | successor |
-| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:28:72:31 | access to parameter args | semmle.label | successor |
+| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args | semmle.label | successor |
 | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 | semmle.label | empty |
-| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:21:72:23 | String arg | semmle.label | non-empty |
-| LoopUnrolling.cs:72:21:72:23 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; | semmle.label | successor |
-| LoopUnrolling.cs:72:28:72:31 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:72:22:72:24 | String arg | semmle.label | non-empty |
+| LoopUnrolling.cs:72:22:72:24 | String arg | LoopUnrolling.cs:73:13:73:35 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | LoopUnrolling.cs:72:9:73:35 | foreach (... ... in ...) ... | semmle.label | successor |
 | LoopUnrolling.cs:73:13:73:35 | ...; | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | semmle.label | successor |
 | LoopUnrolling.cs:73:31:73:33 | access to local variable arg | LoopUnrolling.cs:73:13:73:34 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 | semmle.label | successor |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 | semmle.label | successor |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | semmle.label | successor |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 | semmle.label | empty |
+| LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:79:22:79:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:79:22:79:22 | String x | LoopUnrolling.cs:80:9:82:9 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:80:9:82:9 | {...} | LoopUnrolling.cs:81:13:81:33 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | LoopUnrolling.cs:79:9:82:9 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:81:13:81:33 | ...; | LoopUnrolling.cs:81:31:81:31 | access to local variable x | semmle.label | successor |
+| LoopUnrolling.cs:81:31:81:31 | access to local variable x | LoopUnrolling.cs:81:13:81:32 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 | semmle.label | successor |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 | semmle.label | successor |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | semmle.label | successor |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 | semmle.label | empty |
+| LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:88:22:88:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:88:22:88:22 | String x | LoopUnrolling.cs:89:9:91:9 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:89:9:91:9 | {...} | LoopUnrolling.cs:90:13:90:33 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | LoopUnrolling.cs:88:9:91:9 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:90:13:90:33 | ...; | LoopUnrolling.cs:90:31:90:31 | access to local variable x | semmle.label | successor |
+| LoopUnrolling.cs:90:31:90:31 | access to local variable x | LoopUnrolling.cs:90:13:90:32 | call to method WriteLine | semmle.label | successor |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; | semmle.label | successor |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 | semmle.label | successor |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs | semmle.label | successor |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | semmle.label | successor |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 | semmle.label | successor |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | semmle.label | successor |
+| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 | semmle.label | empty |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | semmle.label | non-empty |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} | semmle.label | successor |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:33 | ...; | semmle.label | successor |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | semmle.label | successor |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:31:99:31 | access to local variable x | semmle.label | successor |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | semmle.label | successor |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null | semmle.label | successor |
 | MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 | semmle.label | successor |
 | MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 | semmle.label | exception(NullReferenceException) |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -224,8 +224,8 @@ booleanNode
 | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | b1 (line 176): true |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | b (line 55): false |
 | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | b (line 55): true |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): false] String x | b (line 55): false |
-| LoopUnrolling.cs:58:21:58:21 | [b (line 55): true] String x | b (line 55): true |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | b (line 55): false |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | b (line 55): true |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | b (line 55): false |
 | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | b (line 55): true |
 | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | b (line 55): false |
@@ -736,6 +736,9 @@ entryPoint
 | LoopUnrolling.cs:45:10:45:11 | M6 | LoopUnrolling.cs:46:5:53:5 | {...} |
 | LoopUnrolling.cs:55:10:55:11 | M7 | LoopUnrolling.cs:56:5:65:5 | {...} |
 | LoopUnrolling.cs:67:10:67:11 | M8 | LoopUnrolling.cs:68:5:74:5 | {...} |
+| LoopUnrolling.cs:76:10:76:11 | M9 | LoopUnrolling.cs:77:5:83:5 | {...} |
+| LoopUnrolling.cs:85:10:85:12 | M10 | LoopUnrolling.cs:86:5:92:5 | {...} |
+| LoopUnrolling.cs:94:10:94:12 | M11 | LoopUnrolling.cs:95:5:101:5 | {...} |
 | MultiImplementationA.cs:6:22:6:31 | get_P1 | MultiImplementationA.cs:6:28:6:31 | null |
 | MultiImplementationA.cs:6:22:6:31 | get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |
 | MultiImplementationA.cs:7:21:7:23 | get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |


### PR DESCRIPTION
It turned out to be very easy to generalize the existing logic for unfolding `foreach` loops where the iterator expression is guaranteed non-empty to also include skipping the loop body when the iterator expression is guaranteed empty. This is probably not likely to happen often in practice (the [CSharp-Differences](https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/405/) job shows no changes in results), but again the change was so small that I thought it was still worthwhile.