### PR TITLE
JS: make sanitization a "common" technique rather than "important"

### DIFF
--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -41,7 +41,7 @@
 		<p>
 
 			An even safer alternative is to design the application
-			such that sanitization isn't needed at all, for instance by using HTML
+			so that sanitization is not needed, for instance by using HTML
 			templates that are explicit about the values they treat as HTML.
 
 		</p>

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -6,7 +6,7 @@
 	<overview>
 		<p>
 
-			Sanitizing untrusted input for HTML meta-characters is an important
+			Sanitizing untrusted input for HTML meta-characters is a common
 			technique for preventing cross-site scripting attacks. Usually, this
 			is done by escaping <code>&lt;</code>, <code>&gt;</code>,
 			<code>&amp;</code> and <code>&quot;</code>. However, the context in which
@@ -35,6 +35,14 @@
 			Sanitize all relevant HTML meta-characters when
 			constructing HTML dynamically, and pay special attention to where the
 			sanitized value is used.
+
+		</p>
+
+		<p>
+
+			An even safer alternative is to design the application
+			such that sanitization isn't needed at all, for instance by using HTML
+			templates that are explicit about the values they treat as HTML.
 
 		</p>
 

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.qhelp
@@ -5,7 +5,7 @@
 
 <overview>
 <p>
-Sanitizing untrusted input is an important technique for preventing injection attacks such as
+Sanitizing untrusted input is a common technique for preventing injection attacks such as
 SQL injection or cross-site scripting. Usually, this is done by escaping meta-characters such
 as quotes in a domain-specific way so that they are treated as normal characters.
 </p>
@@ -31,6 +31,14 @@ still have undesirable effects, such as badly rendered or confusing output.
 Use a (well-tested) sanitization library if at all possible. These libraries are much more
 likely to handle corner cases correctly than a custom implementation.
 </p>
+
+<p>
+
+An even safer alternative is to design the application such that sanitization isn't
+needed at all, for instance by using prepared statements for SQL queries.
+
+</p>
+
 <p>
 Otherwise, make sure to use a regular expression with the <code>g</code> flag to ensure that
 all occurrences are replaced, and remember to escape backslashes if applicable.

--- a/javascript/ql/src/Security/CWE-116/IncompleteSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteSanitization.qhelp
@@ -34,8 +34,8 @@ likely to handle corner cases correctly than a custom implementation.
 
 <p>
 
-An even safer alternative is to design the application such that sanitization isn't
-needed at all, for instance by using prepared statements for SQL queries.
+An even safer alternative is to design the application so that sanitization is not
+needed, for instance by using prepared statements for SQL queries.
 
 </p>
 

--- a/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
+++ b/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
@@ -6,8 +6,8 @@
 	<overview>
 		<p>
 
-			Sanitizing untrusted input for HTML meta-characters is an
-			important technique for preventing cross-site scripting attacks. But
+			Sanitizing untrusted input for HTML meta-characters is a
+			common technique for preventing cross-site scripting attacks. But
 			even a sanitized input can be dangerous to use if it is modified
 			further before a browser treats it as HTML.
 
@@ -28,6 +28,15 @@
 			them as HTML.
 
 		</p>
+
+		<p>
+
+			An even safer alternative is to design the application
+			such that sanitization isn't needed at all, for instance by using HTML
+			templates that are explicit about the values they treat as HTML.
+
+		</p>
+
 	</recommendation>
 
 	<example>

--- a/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
+++ b/javascript/ql/src/Security/CWE-116/UnsafeHtmlExpansion.qhelp
@@ -32,7 +32,7 @@
 		<p>
 
 			An even safer alternative is to design the application
-			such that sanitization isn't needed at all, for instance by using HTML
+			so that sanitization is not needed, for instance by using HTML
 			templates that are explicit about the values they treat as HTML.
 
 		</p>

--- a/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
+++ b/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
@@ -38,8 +38,8 @@
 
 		<p>
 
-			An even safer alternative is to design the application such that sanitization isn't
-			needed at all, for instance by using prepared statements for SQL queries.
+			An even safer alternative is to design the application so that sanitization is not
+			needed, for instance by using prepared statements for SQL queries.
 
 		</p>
 

--- a/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
+++ b/javascript/ql/src/Security/CWE-843/TypeConfusionThroughParameterTampering.qhelp
@@ -4,7 +4,7 @@
 	<overview>
 		<p>
 
-			Sanitizing untrusted HTTP request parameters is an important
+			Sanitizing untrusted HTTP request parameters is a common
 			technique for preventing injection attacks such as SQL injection or
 			path traversal. This is sometimes done by checking if the request
 			parameters contain blacklisted substrings.
@@ -35,6 +35,15 @@
 			is user-controlled.
 
 		</p>
+
+		<p>
+
+			An even safer alternative is to design the application such that sanitization isn't
+			needed at all, for instance by using prepared statements for SQL queries.
+
+		</p>
+
+
 	</recommendation>
 
 	<example>

--- a/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
+++ b/python/ql/src/Security/CWE-020/IncompleteHostnameRegExp.qhelp
@@ -6,7 +6,7 @@
     <overview>
         <p>
 
-            Sanitizing untrusted URLs is an important technique for
+            Sanitizing untrusted URLs is a common technique for
             preventing attacks such as request forgeries and malicious
             redirections. Often, this is done by checking that the host of a URL
             is in a set of allowed hosts.

--- a/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
+++ b/python/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qhelp
@@ -6,7 +6,7 @@
     <overview>
         <p>
 
-            Sanitizing untrusted URLs is an important technique for
+            Sanitizing untrusted URLs is a common technique for
             preventing attacks such as request forgeries and malicious
             redirections. Usually, this is done by checking that the host of a URL
             is in a set of allowed hosts.


### PR DESCRIPTION
It was pointed out that sanitization is bordering on being an anti-pattern, and that we should make it clearer in our documentation that better alternatives exist.
I have therefore changed the "sanitization is important" formulations to "sanitization is common", and added an example of an alternative where appropriate.