### PR TITLE
C++: Fix two join orders in FlowVar.qll

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -427,7 +427,7 @@ module FlowVar_internal {
     /**
      * Gets a variable that is assigned in this loop and read outside the loop.
      */
-    private Variable getARelevantVariable() {
+    Variable getARelevantVariable() {
       result = this.getAVariableAssignedInLoop() and
       exists(VariableAccess va |
         va.getTarget() = result and
@@ -472,8 +472,14 @@ module FlowVar_internal {
         reachesWithoutAssignment(bb.getAPredecessor(), v) and
         this.bbInLoop(bb)
       ) and
-      not assignmentLikeOperation(bb.getANode(), v, _, _)
+      not assignsToVar(bb, v)
     }
+  }
+
+  pragma[noinline]
+  private predicate assignsToVar(BasicBlock bb, Variable v) {
+    assignmentLikeOperation(bb.getANode(), v, _, _) and
+    exists(AlwaysTrueUponEntryLoop loop | v = loop.getARelevantVariable())
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/FlowVar.qll
@@ -125,6 +125,11 @@ private module PartialDefinitions {
     deprecated predicate partiallyDefinesThis(ThisExpr e) { innerDefinedExpr = e }
 
     /**
+     * Gets the subBasicBlock where this `PartialDefinition` is defined.
+     */
+    ControlFlowNode getSubBasicBlockStart() { result = node }
+
+    /**
      * Holds if this `PartialDefinition` defines variable `v` at control-flow
      * node `cfn`.
      */


### PR DESCRIPTION
These two changes together fix a performance regression in queries that use the AST data-flow library. The regression is visible on kamailio/kamailio, but I haven't seen it on other projects.

https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1364/ compares `rc/1.24`, `rc/1.25` and `main` (in that order). While kamailio/kamailio speeds up overall because `rc/1.25` fixes an even worse performance problem on that project, the slowdown is clearly visible in [the Analysis Time view](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1364//artifact/analysis_time.html).

I've observed and tested these performance problems locally, where my QL compiler is from `main` rather than `rc/1.25`, so I'll have to confirm that these fixes apply to `rc/1.25`.