### PR TITLE
Python: Remove symlink from experimental test

### DIFF
--- a/python/ql/test/experimental/library-tests/CallGraph-xfail/CallGraphTest.qll
+++ b/python/ql/test/experimental/library-tests/CallGraph-xfail/CallGraphTest.qll
@@ -1,1 +1,0 @@
-../CallGraph/CallGraphTest.qll

--- a/python/ql/test/experimental/library-tests/CallGraph-xfail/PointsTo.ql
+++ b/python/ql/test/experimental/library-tests/CallGraph-xfail/PointsTo.ql
@@ -1,1 +1,0 @@
-../CallGraph/PointsTo.ql

--- a/python/ql/test/experimental/library-tests/CallGraph-xfail/PointsTo.qlref
+++ b/python/ql/test/experimental/library-tests/CallGraph-xfail/PointsTo.qlref
@@ -1,0 +1,1 @@
+../CallGraph/PointsTo.ql


### PR DESCRIPTION
This caused some problems on windows apparently :grimacing: 