### PR TITLE
Python: Make import of python private in shared dataflow

### DIFF
--- a/python/ql/src/experimental/dataflow/DataFlow.qll
+++ b/python/ql/src/experimental/dataflow/DataFlow.qll
@@ -15,7 +15,7 @@
  * `DataFlow::localFlowStep` with arguments of type `DataFlow::Node`.
  */
 
-import python
+private import python
 
 /**
  * Provides classes for performing local (intra-procedural) and

--- a/python/ql/src/experimental/dataflow/DataFlow2.qll
+++ b/python/ql/src/experimental/dataflow/DataFlow2.qll
@@ -15,7 +15,7 @@
  * `DataFlow::localFlowStep` with arguments of type `DataFlow::Node`.
  */
 
-import python
+private import python
 
 /**
  * Provides classes for performing local (intra-procedural) and

--- a/python/ql/src/experimental/dataflow/TaintTracking.qll
+++ b/python/ql/src/experimental/dataflow/TaintTracking.qll
@@ -8,7 +8,7 @@
  * `TaintTracking::localTaintStep` with arguments of type `DataFlow::Node`.
  */
 
-import python
+private import python
 
 /**
  * Provides classes for performing local (intra-procedural) and

--- a/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
@@ -2,7 +2,7 @@
  * Provides Python-specific definitions for use in the data flow library.
  */
 
-import python
+private import python
 private import DataFlowPrivate
 
 /**

--- a/python/ql/test/experimental/dataflow/callGraphConfig.qll
+++ b/python/ql/test/experimental/dataflow/callGraphConfig.qll
@@ -1,3 +1,4 @@
+private import python
 import experimental.dataflow.DataFlow
 
 /**

--- a/python/ql/test/experimental/dataflow/coverage/argumentRouting1.ql
+++ b/python/ql/test/experimental/dataflow/coverage/argumentRouting1.ql
@@ -1,3 +1,4 @@
+import python
 import experimental.dataflow.DataFlow
 
 /**

--- a/python/ql/test/experimental/dataflow/coverage/argumentRouting2.ql
+++ b/python/ql/test/experimental/dataflow/coverage/argumentRouting2.ql
@@ -1,3 +1,4 @@
+import python
 import experimental.dataflow.DataFlow
 
 /**

--- a/python/ql/test/experimental/dataflow/coverage/argumentRouting3.ql
+++ b/python/ql/test/experimental/dataflow/coverage/argumentRouting3.ql
@@ -1,3 +1,4 @@
+import python
 import experimental.dataflow.DataFlow
 
 /**

--- a/python/ql/test/experimental/dataflow/coverage/argumentRouting4.ql
+++ b/python/ql/test/experimental/dataflow/coverage/argumentRouting4.ql
@@ -1,3 +1,4 @@
+import python
 import experimental.dataflow.DataFlow
 
 /**

--- a/python/ql/test/experimental/dataflow/coverage/dataflow.ql
+++ b/python/ql/test/experimental/dataflow/coverage/dataflow.ql
@@ -2,6 +2,7 @@
  * @kind path-problem
  */
 
+import python
 import experimental.dataflow.testConfig
 import DataFlow::PathGraph
 

--- a/python/ql/test/experimental/dataflow/regression/dataflow.ql
+++ b/python/ql/test/experimental/dataflow/regression/dataflow.ql
@@ -5,6 +5,7 @@
  * hope to remove the false positive.
  */
 
+import python
 import experimental.dataflow.testConfig
 
 from DataFlow::Node source, DataFlow::Node sink

--- a/python/ql/test/experimental/dataflow/testConfig.qll
+++ b/python/ql/test/experimental/dataflow/testConfig.qll
@@ -20,6 +20,7 @@
  * complex | `42j` (not supported yet)
  */
 
+private import python
 import experimental.dataflow.DataFlow
 
 class TestConfiguration extends DataFlow::Configuration {


### PR DESCRIPTION
So we don't export all the definitions from `python` into the DataFlow module :| this makes for much better autocompletion, as illustrated below

### without private import

![image](https://user-images.githubusercontent.com/1054041/91425530-89376b80-e85b-11ea-99a8-71293fb6fc30.png)


### with private import

![image](https://user-images.githubusercontent.com/1054041/91425453-73c24180-e85b-11ea-9c86-4468a6c56a09.png)
