### PR TITLE
Python: Sync InlineExpectationsTest.qll between Python and C++

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -325,6 +325,10 @@
     "csharp/ql/src/experimental/ir/implementation/raw/gvn/internal/ValueNumberingImports.qll",
     "csharp/ql/src/experimental/ir/implementation/unaliased_ssa/gvn/internal/ValueNumberingImports.qll"
   ],
+  "Inline Test Expectations": [
+    "cpp/ql/test/TestUtilities/InlineExpectationsTest.qll",
+    "python/ql/test/TestUtilities/InlineExpectationsTest.qll"
+  ],
   "XML": [
     "cpp/ql/src/semmle/code/cpp/XML.qll",
     "csharp/ql/src/semmle/code/csharp/XML.qll",

--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -28,11 +28,11 @@
  *   }
  *
  *   override predicate hasActualResult(
- *     Location location, string element, string tag, string values
+ *     Location location, string element, string tag, string value
  *   ) {
  *     exists(Expr e |
  *       tag = "const" and // The tag for this test.
- *       values = e.getValue() and // The expected value. Will only hold for constant expressions.
+ *       value = e.getValue() and // The expected value. Will only hold for constant expressions.
  *       location = e.getLocation() and // The location of the result to be reported.
  *       element = e.toString() // The display text for the result.
  *     )

--- a/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/cpp/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -28,11 +28,11 @@
  *   }
  *
  *   override predicate hasActualResult(
- *     Location location, string element, string tag, string valuesasas
+ *     Location location, string element, string tag, string values
  *   ) {
  *     exists(Expr e |
  *       tag = "const" and // The tag for this test.
- *       valuesasas = e.getValue() and // The expected value. Will only hold for constant expressions.
+ *       values = e.getValue() and // The expected value. Will only hold for constant expressions.
  *       location = e.getLocation() and // The location of the result to be reported.
  *       element = e.toString() // The display text for the result.
  *     )

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -28,11 +28,11 @@
  *   }
  *
  *   override predicate hasActualResult(
- *     Location location, string element, string tag, string values
+ *     Location location, string element, string tag, string value
  *   ) {
  *     exists(Expr e |
  *       tag = "const" and // The tag for this test.
- *       values = e.getValue() and // The expected value. Will only hold for constant expressions.
+ *       value = e.getValue() and // The expected value. Will only hold for constant expressions.
  *       location = e.getLocation() and // The location of the result to be reported.
  *       element = e.toString() // The display text for the result.
  *     )

--- a/python/ql/test/TestUtilities/InlineExpectationsTest.qll
+++ b/python/ql/test/TestUtilities/InlineExpectationsTest.qll
@@ -28,11 +28,11 @@
  *   }
  *
  *   override predicate hasActualResult(
- *     Location location, string element, string tag, string valuesasas
+ *     Location location, string element, string tag, string values
  *   ) {
  *     exists(Expr e |
  *       tag = "const" and // The tag for this test.
- *       valuesasas = e.getValue() and // The expected value. Will only hold for constant expressions.
+ *       values = e.getValue() and // The expected value. Will only hold for constant expressions.
  *       location = e.getLocation() and // The location of the result to be reported.
  *       element = e.toString() // The display text for the result.
  *     )


### PR DESCRIPTION
Also changes `valuesasas` to `values` in the test example.