### PR TITLE
Python: fstring taint change note should be for 1.26

### DIFF
--- a/change-notes/1.26/analysis-python.md
+++ b/change-notes/1.26/analysis-python.md
@@ -1,6 +1,6 @@
 # Improvements to Python analysis
 
-The following changes in version 1.25 affect Python analysis in all applications.
+The following changes in version 1.26 affect Python analysis in all applications.
 
 ## General improvements
 
@@ -19,4 +19,4 @@ The following changes in version 1.25 affect Python analysis in all applications
 
 ## Changes to libraries
 
-* Importing `semmle.python.web.HttpRequest` will no longer import `UntrustedStringKind` transitively. `UntrustedStringKind` is the most commonly used non-abstract subclass of `ExternalStringKind`. If not imported (by one mean or another), taint-tracking queries that concern `ExternalStringKind` will not produce any results. Please ensure such queries contain an explicit import (`import semmle.python.security.strings.Untrusted`).
+* Added taint tracking support for string formatting through f-strings.


### PR DESCRIPTION
This fixes problem introduced in https://github.com/github/codeql/pull/4127

~Draft since I'm still looking into if there is a new procedure for writing change notes for 1.26~