### PR TITLE
Enable labeler action again

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This time using `pull_request_target`, so it will work properly with forks. See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

This reverts commit d5d6093e751d252897d266faf61d5a2923c9df2a.

~Since the configuration file is already present on main, I _think_ we should be able to tests this out before merging the PR. I'll at least give it a try :blush:~

I couldn't figure out how to test this without merging to main, but it should just work :crossed_fingers: