### PR TITLE
Python: port dataflow tests

### DIFF
--- a/python/ql/test/experimental/dataflow/coverage/classes.py
+++ b/python/ql/test/experimental/dataflow/coverage/classes.py
@@ -5,7 +5,7 @@
 # These tests should cover all the class calls that we hope to support.
 # It is based on https://docs.python.org/3/reference/datamodel.html, and headings refer there.
 #
-# All functions starting with "test_" should run and print `"OK"`.
+# All functions starting with "test_" should run and execute `print("OK")` one or more times.
 # This can be checked by running validTest.py.
 
 import asyncio

--- a/python/ql/test/experimental/dataflow/coverage/dataflow.expected
+++ b/python/ql/test/experimental/dataflow/coverage/dataflow.expected
@@ -131,6 +131,8 @@ edges
 | test.py:276:28:276:33 | ControlFlowNode for SOURCE | test.py:276:10:276:34 | ControlFlowNode for second() |
 | test.py:335:12:335:17 | ControlFlowNode for SOURCE | test.py:335:10:335:18 | ControlFlowNode for f() |
 | test.py:339:28:339:33 | ControlFlowNode for SOURCE | test.py:339:10:339:34 | ControlFlowNode for second() |
+| test.py:372:9:372:14 | ControlFlowNode for SOURCE | test.py:374:10:374:10 | ControlFlowNode for a |
+| test.py:372:9:372:14 | ControlFlowNode for SOURCE | test.py:379:10:379:10 | ControlFlowNode for b |
 nodes
 | datamodel.py:13:1:13:6 | GSSA Variable SOURCE | semmle.label | GSSA Variable SOURCE |
 | datamodel.py:13:10:13:17 | ControlFlowNode for Str | semmle.label | ControlFlowNode for Str |
@@ -260,6 +262,9 @@ nodes
 | test.py:335:12:335:17 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
 | test.py:339:10:339:34 | ControlFlowNode for second() | semmle.label | ControlFlowNode for second() |
 | test.py:339:28:339:33 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
+| test.py:372:9:372:14 | ControlFlowNode for SOURCE | semmle.label | ControlFlowNode for SOURCE |
+| test.py:374:10:374:10 | ControlFlowNode for a | semmle.label | ControlFlowNode for a |
+| test.py:379:10:379:10 | ControlFlowNode for b | semmle.label | ControlFlowNode for b |
 #select
 | datamodel.py:38:6:38:17 | ControlFlowNode for f() | datamodel.py:13:10:13:17 | ControlFlowNode for Str | datamodel.py:38:6:38:17 | ControlFlowNode for f() | <message> |
 | datamodel.py:38:6:38:17 | ControlFlowNode for f() | datamodel.py:38:8:38:13 | ControlFlowNode for SOURCE | datamodel.py:38:6:38:17 | ControlFlowNode for f() | <message> |
@@ -301,3 +306,5 @@ nodes
 | test.py:276:10:276:34 | ControlFlowNode for second() | test.py:276:28:276:33 | ControlFlowNode for SOURCE | test.py:276:10:276:34 | ControlFlowNode for second() | <message> |
 | test.py:335:10:335:18 | ControlFlowNode for f() | test.py:335:12:335:17 | ControlFlowNode for SOURCE | test.py:335:10:335:18 | ControlFlowNode for f() | <message> |
 | test.py:339:10:339:34 | ControlFlowNode for second() | test.py:339:28:339:33 | ControlFlowNode for SOURCE | test.py:339:10:339:34 | ControlFlowNode for second() | <message> |
+| test.py:374:10:374:10 | ControlFlowNode for a | test.py:372:9:372:14 | ControlFlowNode for SOURCE | test.py:374:10:374:10 | ControlFlowNode for a | <message> |
+| test.py:379:10:379:10 | ControlFlowNode for b | test.py:372:9:372:14 | ControlFlowNode for SOURCE | test.py:379:10:379:10 | ControlFlowNode for b | <message> |

--- a/python/ql/test/experimental/dataflow/coverage/test.py
+++ b/python/ql/test/experimental/dataflow/coverage/test.py
@@ -377,3 +377,28 @@ def test_swap():
     a, b = b, a
     SINK_F(a)
     SINK(b)
+
+
+def test_deep_callgraph():
+    # port of python/ql/test/library-tests/taint/general/deep.py
+
+    def f1(arg):
+        return arg
+
+    def f2(arg):
+        return f1(arg)
+
+    def f3(arg):
+        return f2(arg)
+
+    def f4(arg):
+        return f3(arg)
+
+    def f5(arg):
+        return f4(arg)
+
+    def f6(arg):
+        return f5(arg)
+
+    x = f6(SOURCE)
+    SINK(x) # Flow missing

--- a/python/ql/test/experimental/dataflow/coverage/test.py
+++ b/python/ql/test/experimental/dataflow/coverage/test.py
@@ -366,3 +366,14 @@ def test_lambda_extra_keyword():
 def test_lambda_extra_keyword_flow():
     f_extra_keyword_flow = lambda **a : [*a][0] # return the name of the first extra keyword argument
     SINK(f_extra_keyword_flow(**{SOURCE: None})) # Flow missing
+
+
+def test_swap():
+    a = SOURCE
+    b = NONSOURCE
+    SINK(a)
+    SINK_F(b)
+
+    a, b = b, a
+    SINK_F(a)
+    SINK(b)

--- a/python/ql/test/experimental/dataflow/coverage/test.py
+++ b/python/ql/test/experimental/dataflow/coverage/test.py
@@ -6,7 +6,7 @@
 #
 # Functions whose name ends with "_with_local_flow" will also be tested for local flow.
 #
-# All functions starting with "test_" should run and print `"OK"`.
+# All functions starting with "test_" should run and execute `print("OK")` one or more times.
 # This can be checked by running validTest.py.
 
 # These are defined so that we can evaluate the test code.

--- a/python/ql/test/experimental/dataflow/coverage/validTest.py
+++ b/python/ql/test/experimental/dataflow/coverage/validTest.py
@@ -1,5 +1,5 @@
 def check_output(outtext, f):
-    if all(s == "OK" for s in outtext.splitlines()):
+    if outtext and all(s == "OK" for s in outtext.splitlines()):
         pass
     else:
         raise RuntimeError("Function failed", outtext, f)

--- a/python/ql/test/experimental/dataflow/coverage/validTest.py
+++ b/python/ql/test/experimental/dataflow/coverage/validTest.py
@@ -1,8 +1,8 @@
-def check_output(s, f):
-    if s == "OK\n":
+def check_output(outtext, f):
+    if all(s == "OK" for s in outtext.splitlines()):
         pass
     else:
-        raise RuntimeError("Function failed", s, f)
+        raise RuntimeError("Function failed", outtext, f)
 
 def check_test_function(f):
     from io import StringIO


### PR DESCRIPTION
This ports the interesting dataflow tests from `python/ql/test/library-tests/taint` that were not already ported.

Although we discussed moving more interaction/integration tests into a separate file, I couldn't figure out a good naming, and ended up slapping them straight at the end of `test.py` (that is, `test_deep_callgraph`). Maybe we should split it up into `unittest.py` and `integrationtest.py`?