### PR TITLE
JavaScript: Make `PromiseFlow` module public.

### DIFF
--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -249,7 +249,7 @@ private class PromiseStep extends PreCallGraphStep {
  * This module defines how data-flow propagates into and out of a Promise.
  * The data-flow is based on pseudo-properties rather than tainting the Promise object (which is what `PromiseTaintStep` does).
  */
-private module PromiseFlow {
+module PromiseFlow {
   private predicate valueProp = Promises::valueProp/0;
 
   private predicate errorProp = Promises::errorProp/0;


### PR DESCRIPTION
In https://github.com/github/codeql/pull/4082, I'd like to use `PromiseFlow::storeStep` directly instead of going via `PromiseTypeTracking::promiseStep`, since that seems to require importing an internal module in order to be able to access `StoreStep`. (Or perhaps there is a better way of achieving the same thing?)