### PR TITLE
JS: Fix 2 FPs in TargetBlank.ql

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -26,6 +26,7 @@
 
 | **Query**                      | **Expected impact**          | **Change**                                                                |
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
+| Potentially unsafe external link (`js/unsafe-external-link`) | Fewer results | This query no longer flags URLs constructed using a template system where only the hash or query part of the URL is dynamic. |
 | Incomplete URL substring sanitization (`js/incomplete-url-substring-sanitization`) | More results | This query now recognizes additional URLs when the substring check is an inclusion check. |
 | Ambiguous HTML id attribute (`js/duplicate-html-id`) | Results no longer shown | Precision tag reduced to "low". The query is no longer run by default. |
 

--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -29,7 +29,7 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
     or
     exists(string url | url = attr.getStringValue() |
       // fixed string with templating
-      url.regexpMatch(Templating::getDelimiterMatchingRegexp()) and
+      url.regexpMatch(Templating::getDelimiterMatchingRegexpWithPrefix("[^?#]*")) and
       // ... that does not start with a fixed host or a relative path (common formats)
       not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
       // ... that is not a mailto: link

--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -31,7 +31,9 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
       // fixed string with templating
       url.regexpMatch(Templating::getDelimiterMatchingRegexp()) and
       // ... that does not start with a fixed host or a relative path (common formats)
-      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*")
+      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
+      // ... that is not a mailto: link
+      not url.regexpMatch("mailto:.*")
     )
   )
 }

--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -31,9 +31,7 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
       // fixed string with templating
       url.regexpMatch(Templating::getDelimiterMatchingRegexpWithPrefix("[^?#]*")) and
       // ... that does not start with a fixed host or a relative path (common formats)
-      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
-      // ... that is not a mailto: link
-      not url.regexpMatch("mailto:.*")
+      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*")
     )
   )
 }

--- a/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
@@ -36,9 +36,7 @@ module Templating {
    * of the known template delimiters identified by `getADelimiter()`,
    * storing it in its first (and only) capture group.
    */
-  string getDelimiterMatchingRegexp() {
-    result = "(?s).*(" + concat("\\Q" + getADelimiter() + "\\E", "|") + ").*"
-  }
+  string getDelimiterMatchingRegexp() { result = getDelimiterMatchingRegexpWithPrefix(".*") }
 
   /**
    * Gets a regular expression that matches a string containing one

--- a/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Templating.qll
@@ -39,4 +39,15 @@ module Templating {
   string getDelimiterMatchingRegexp() {
     result = "(?s).*(" + concat("\\Q" + getADelimiter() + "\\E", "|") + ").*"
   }
+
+  /**
+   * Gets a regular expression that matches a string containing one
+   * of the known template delimiters identified by `getADelimiter()`,
+   * storing it in its first (and only) capture group.
+   * Where the string prior to the template delimiter matches the regexp `prefix`.
+   */
+  bindingset[prefix]
+  string getDelimiterMatchingRegexpWithPrefix(string prefix) {
+    result = "(?s)" + prefix + "(" + concat("\\Q" + getADelimiter() + "\\E", "|") + ").*"
+  }
 }

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/TargetBlank.expected
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/TargetBlank.expected
@@ -1,6 +1,7 @@
 | tst.html:23:1:23:61 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
 | tst.html:24:1:24:48 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
 | tst.html:25:1:25:36 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
+| tst.html:30:1:30:61 | <a>...</> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:18:1:18:43 | <a href ... ple</a> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:19:1:19:58 | <a href ... ple</a> | External links without noopener/noreferrer are a potential security risk. |
 | tst.js:20:1:20:51 | <a data ... ple</a> | External links without noopener/noreferrer are a potential security risk. |

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
@@ -26,5 +26,8 @@
   Example
 </a>
 
+<h1>OK: mailto is fine.</h1>
+<a target="_blank" href="mailto:{{var:mail}}">mail somone</a>
+
 </body>
 </html>

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
@@ -29,5 +29,10 @@
 <h1>OK: mailto is fine.</h1>
 <a target="_blank" href="mailto:{{var:mail}}">mail somone</a>
 
+<h1>OK: template elements after # or ? are fine.</h1>
+<a href="file.extension?#[% row.href %]" target="_blank">Example</a>
+<a href="file.extension?[% row.href %]" target="_blank">Example</a>
+<a href="file.extension#[% row.href %]" target="_blank">Example</a>
+
 </body>
 </html>

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.html
@@ -26,7 +26,7 @@
   Example
 </a>
 
-<h1>OK: mailto is fine.</h1>
+<h1>NOT OK: mailto is not fine.</h1>
 <a target="_blank" href="mailto:{{var:mail}}">mail somone</a>
 
 <h1>OK: template elements after # or ? are fine.</h1>


### PR DESCRIPTION
1) `mailto:` links (found in an anomalous query result)

`mailto` links are safe, they open in a email-program / webmail (which should be safe). 

2) links constructed using template system with safe prefix (reported here: https://github.com/github/codeql/issues/4169)

Something like `<a href="http://google.com/{{payload}}>safe</a>` was already considered safe, but something like `<a href="foo.bar#{{payload}}">safe</a>` was not.  
With this PR we use `#` and `?` as marker chars to determine if the `payload` is actually part of the query/hash part of the URL.  
This [does remove some additional FPs in our usual benchmarks](https://lgtm.com/query/4994963496395627155/).   
But it is not perfect, as some template expressions might contain `?` or `#` without those chars ending up as a prefix in the URL. 