### PR TITLE
Java: Adjust a few qltests.

### DIFF
--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/controlledString.ql
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/controlledString.ql
@@ -5,5 +5,6 @@ where
   controlledString(controlled) and
   method = controlled.getEnclosingCallable() and
   line = controlled.getLocation().getStartLine() - method.getLocation().getStartLine() and
-  controlled.getCompilationUnit().fromSource()
+  controlled.getCompilationUnit().fromSource() and
+  controlled.getFile().getStem() = ["Test", "Validation"]
 select method.getName(), line, controlled

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/endsInQuote.ql
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/endsInQuote.ql
@@ -1,6 +1,9 @@
 import semmle.code.java.security.ControlledString
 
 from Expr precedes, Method method
-where endsInQuote(precedes) and precedes.getEnclosingCallable() = method
+where
+  endsInQuote(precedes) and
+  precedes.getEnclosingCallable() = method and
+  precedes.getFile().getStem() = "Test"
 select method.getName(),
   precedes.getLocation().getStartLine() - method.getLocation().getStartLine(), precedes

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/taintedString.ql
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/taintedString.ql
@@ -9,5 +9,8 @@ class Conf extends TaintTracking::Configuration {
 }
 
 from Conf conf, Expr tainted, Method method
-where conf.hasFlowToExpr(tainted) and tainted.getEnclosingCallable() = method
+where
+  conf.hasFlowToExpr(tainted) and
+  tainted.getEnclosingCallable() = method and
+  tainted.getFile().getStem() = ["Test", "Validation"]
 select method, tainted.getLocation().getStartLine() - method.getLocation().getStartLine(), tainted


### PR DESCRIPTION
Adjust a few tests to avoid accidentally applying to new `.java` files added targeting the main query qltests in the directory.