### PR TITLE
Python: Taint tracking setup alá Go

### DIFF
--- a/python/ql/src/experimental/Customizations.qll
+++ b/python/ql/src/experimental/Customizations.qll
@@ -1,0 +1,20 @@
+/**
+ * Contains customizations to the standard library.
+ *
+ * This module is imported by `python.qll`, so any customizations defined here automatically
+ * apply to all queries.
+ *
+ * Typical examples of customizations include adding new subclasses of abstract classes such as
+ * the `RemoteFlowSource::Range` and `AdditionalTaintStep` classes associated with the security
+ * queries to model frameworks that are not covered by the standard library.
+ */
+
+import python
+/* General import that is useful */
+// import experimental.dataflow.DataFlow
+//
+/* for extending `TaintTracking::AdditionalTaintStep` */
+// import experimental.dataflow.TaintTracking
+//
+/* for extending `RemoteFlowSource::Range` */
+// import experimental.dataflow.RemoteFlowSources

--- a/python/ql/src/experimental/dataflow/RemoteFlowSources.qll
+++ b/python/ql/src/experimental/dataflow/RemoteFlowSources.qll
@@ -1,0 +1,33 @@
+private import python
+private import experimental.dataflow.DataFlow
+// Need to import since frameworks can extend `RemoteFlowSource::Range`
+private import experimental.semmle.python.Frameworks
+
+/**
+ * A data flow source of remote user input.
+ *
+ * Extend this class to refine existing API models. If you want to model new APIs,
+ * extend `RemoteFlowSource::Range` instead.
+ */
+class RemoteFlowSource extends DataFlow::Node {
+  RemoteFlowSource::Range self;
+
+  RemoteFlowSource() { this = self }
+
+  /** Gets a string that describes the type of this remote flow source. */
+  string getSourceType() { result = self.getSourceType() }
+}
+
+/** Provides a class for modeling new sources of remote user input. */
+module RemoteFlowSource {
+  /**
+   * A data flow source of remote user input.
+   *
+   * Extend this class to model new APIs. If you want to refine existing API models,
+   * extend `RemoteFlowSource` instead.
+   */
+  abstract class Range extends DataFlow::Node {
+    /** Gets a string that describes the type of this remote flow source. */
+    abstract string getSourceType();
+  }
+}

--- a/python/ql/src/experimental/dataflow/internal/TaintTrackingPublic.qll
+++ b/python/ql/src/experimental/dataflow/internal/TaintTrackingPublic.qll
@@ -6,6 +6,8 @@
 private import python
 private import TaintTrackingPrivate
 private import experimental.dataflow.DataFlow
+// Need to import since frameworks can extend `AdditionalTaintStep`
+private import experimental.semmle.python.Frameworks
 
 // Local taint flow and helpers
 /**

--- a/python/ql/src/experimental/semmle/python/Concepts.qll
+++ b/python/ql/src/experimental/semmle/python/Concepts.qll
@@ -1,0 +1,40 @@
+/**
+ * Provides abstract classes representing generic concepts such as file system
+ * access or system command execution, for which individual framework libraries
+ * provide concrete subclasses.
+ */
+
+import python
+private import experimental.dataflow.DataFlow
+private import experimental.semmle.python.Frameworks
+
+/**
+ * A data-flow node that executes an operating system command,
+ * for instance by spawning a new process.
+ *
+ * Extend this class to refine existing API models. If you want to model new APIs,
+ * extend `SystemCommandExecution::Range` instead.
+ */
+class SystemCommandExecution extends DataFlow::Node {
+  SystemCommandExecution::Range self;
+
+  SystemCommandExecution() { this = self }
+
+  /** Gets the argument that specifies the command to be executed. */
+  DataFlow::Node getCommand() { result = self.getCommand() }
+}
+
+/** Provides a class for modeling new system-command execution APIs. */
+module SystemCommandExecution {
+  /**
+   * A data-flow node that executes an operating system command,
+   * for instance by spawning a new process.
+   *
+   * Extend this class to model new APIs. If you want to refine existing API models,
+   * extend `SystemCommandExecution` instead.
+   */
+  abstract class Range extends DataFlow::Node {
+    /** Gets the argument that specifies the command to be executed. */
+    abstract DataFlow::Node getCommand();
+  }
+}

--- a/python/ql/src/experimental/semmle/python/Frameworks.qll
+++ b/python/ql/src/experimental/semmle/python/Frameworks.qll
@@ -1,6 +1,7 @@
 /**
  * Helper file that imports all framework modeling.
  */
+
 private import experimental.semmle.python.frameworks.Flask
 private import experimental.semmle.python.frameworks.Django
 private import experimental.semmle.python.frameworks.Stdlib

--- a/python/ql/src/experimental/semmle/python/Frameworks.qll
+++ b/python/ql/src/experimental/semmle/python/Frameworks.qll
@@ -1,0 +1,6 @@
+/**
+ * Helper file that imports all framework modeling.
+ */
+private import experimental.semmle.python.frameworks.Flask
+private import experimental.semmle.python.frameworks.Django
+private import experimental.semmle.python.frameworks.Stdlib

--- a/python/ql/src/experimental/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Django.qll
@@ -1,0 +1,12 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `django` package.
+ */
+
+private import python
+private import experimental.dataflow.DataFlow
+private import experimental.dataflow.RemoteFlowSources
+private import experimental.semmle.python.Concepts
+
+private module Django {
+
+}

--- a/python/ql/src/experimental/semmle/python/frameworks/Django.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Django.qll
@@ -7,6 +7,4 @@ private import experimental.dataflow.DataFlow
 private import experimental.dataflow.RemoteFlowSources
 private import experimental.semmle.python.Concepts
 
-private module Django {
-
-}
+private module Django { }

--- a/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
@@ -7,6 +7,4 @@ private import experimental.dataflow.DataFlow
 private import experimental.dataflow.RemoteFlowSources
 private import experimental.semmle.python.Concepts
 
-private module Flask {
-
-}
+private module Flask { }

--- a/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Flask.qll
@@ -1,0 +1,12 @@
+/**
+ * Provides classes modeling security-relevant aspects of the `flask` package.
+ */
+
+private import python
+private import experimental.dataflow.DataFlow
+private import experimental.dataflow.RemoteFlowSources
+private import experimental.semmle.python.Concepts
+
+private module Flask {
+
+}

--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -1,0 +1,9 @@
+/**
+ * Provides classes modeling security-relevant aspects of the standard libraries.
+ * Note: some modeling is done internally in the dataflow/taint tracking implementation.
+ */
+
+private import python
+private import experimental.dataflow.DataFlow
+private import experimental.dataflow.RemoteFlowSources
+private import experimental.semmle.python.Concepts


### PR DESCRIPTION
## TaintFlow sources

The class `RemoteFlowSource` is very similarly defined as the other languages [C++](https://github.com/github/codeql/blob/ac22e7950c126a9407e02d4b468a4b690a9868e2/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll), [Java](https://github.com/github/codeql/blob/6de612a56605eea2a2262f33e86d891f38033667/java/ql/src/semmle/code/java/dataflow/FlowSources.qll), [C#](https://github.com/github/codeql/blob/fddbce0b7bb8dc7e97971a0af7b01902954d1d49/csharp/ql/src/semmle/code/csharp/security/dataflow/flowsources/Remote.qll), [JS](https://github.com/github/codeql/blob/78334af3540dfd776ba4fdb561692161c515ca66/javascript/ql/src/semmle/javascript/security/dataflow/RemoteFlowSources.qll), and [Go](https://github.com/github/codeql-go/blob/24b3133e0cce6a36e5727fdb393efa2cc4379de4/ql/src/semmle/go/security/FlowSources.qll). There are some minor differences:

- Java/C++ defines the class in `FlowSources.qll`
- C# uses `csharp/ql/src/semmle/code/csharp/security/dataflow/flowsources/Remote.qll`, and provide `StoredFlowSource` and `LocalFlowSource` in separate classes.
- JS uses `RemoteFlowSources.qll`.
- JS defines additional predicate `RemoteFlowSource.isUserControlledObject`
- Go uses the class name `UntrustedFlowSource`, but still defined in `ql/src/semmle/go/security/FlowSources.qll`
- Go uses the `::Range` pattern to allow both extensibility and refinement

The big difference is how a RemoteFlowSource is specified:

- Java and C# have all subclasses of `RemoteFlowSource` defined in the same file
- Go and JS defines subclasses for frameworks in the actual framework `.qll` file, and all frameworks are transitively imported by `import go` or `import javascript` (so subclasses are always in scope).
- C++ uses class `RemoteFlowFunction` to do all the heavy lifting (and its subclasses are transitively imported).

### What we will do

Use file `RemoteFlowSource.qll`, define subclasses in framework library classes.

_Why? Personally I really like it, Go/JS is already doing it, and Tom expressed a preference for doing the same for C# (although that is not what they are doing today)._

Jonas gave this advice:
> Whether you split the definitions between multiple files or keep them all in one file, the property you want is that all definitions are included when the abstract class is included. Otherwise you can get unexpected results via transitive includes.

We will make imports of all frameworks in the same file that defines `RemoteFlowSource`, as it seems to be the least intrusive change. If that turns out to be a problem, we can also move them to `python.qll` (the other way is not so easy).

## TaintFlow sinks

[JS](https://github.com/github/codeql/blob/473787a4268a5e90b4a653ee8bcdb3681f7867ff/javascript/ql/src/semmle/javascript/Concepts.qll) and [Go](https://github.com/github/codeql-go/blob/ecff1e6a164b18da20daa9611933df4aace20915/ql/src/semmle/go/Concepts.qll) defines abstract base classes for interesting sinks in `Concepts.qll` (and all uses the `::Range` pattern in Go).

I really like this idea, since it allows multiple queries to reuse the same sink definitions, and it makes it _easy_ to discover what default sinks are available.

Personally I'm not 100% on board with the naming, but I don't have any good reason to change the naming convention.

## Framework modeling

Following the model from Go ([example](https://github.com/github/codeql-go/blob/main/ql/src/semmle/go/frameworks/Gin.qll)), I propose that we make every definition in a framework modeling `private`. This allows some greater flexibility in changing our modeling, since we don't need to think about keeping deprecated versions around for a whole year.

It _does_ have the downside that someone writing a query can't reuse the classes/predicates for a framework, but it didn't seem to be too big of a concern. If we need to provide access, we can always make the definitions non-private (the other way is not so easy).

## Customizations

Also introduced `Customizations.qll` like in JS/Java/Go (to replace `site.qll`)