### PR TITLE
JS: only flag unused-variable for array-destructs if it is the last variable

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -28,6 +28,7 @@
 |--------------------------------|------------------------------|---------------------------------------------------------------------------|
 | Incomplete URL substring sanitization (`js/incomplete-url-substring-sanitization`) | More results | This query now recognizes additional URLs when the substring check is an inclusion check. |
 | Ambiguous HTML id attribute (`js/duplicate-html-id`) | Results no longer shown | Precision tag reduced to "low". The query is no longer run by default. |
+| Unused loop iteration variable (`js/unused-loop-variable`) | Fewer results | This query no longer flags variables in a destructuring array assignment that are not the last variable in the destructed array. |
 
 
 ## Changes to libraries

--- a/javascript/ql/src/Statements/SuspiciousUnusedLoopIterationVariable.ql
+++ b/javascript/ql/src/Statements/SuspiciousUnusedLoopIterationVariable.ql
@@ -45,11 +45,28 @@ predicate countingLoop(EnhancedForLoop efl) {
   )
 }
 
+/**
+ * Holds if `iter` is the non-last variable of array-destructuring in a for-loop.
+ * E.g. `for(const [foo, iter, bar] of array) {..}`.
+ */
+predicate isNonLastDestructedArrayElement(PurelyLocalVariable iter) {
+  exists(ArrayPattern pattern | pattern = any(EnhancedForLoop loop).getLValue() |
+    iter = pattern.getAVariable() and
+    iter =
+      pattern
+          .getElement([0 .. pattern.getSize() - 2])
+          .(BindingPattern)
+          .getABindingVarRef()
+          .getVariable()
+  )
+}
+
 from EnhancedForLoop efl, PurelyLocalVariable iter
 where
   iter = efl.getAnIterationVariable() and
   not exists(SsaExplicitDefinition ssa | ssa.defines(efl.getIteratorExpr(), iter)) and
   exists(ReachableBasicBlock body | body.getANode() = efl.getBody() | body.getASuccessor+() = body) and
   not countingLoop(efl) and
+  not isNonLastDestructedArrayElement(iter) and
   not iter.getName().toLowerCase().regexpMatch("(_|dummy|unused).*")
 select efl.getIterator(), "For loop variable " + iter.getName() + " is not used in the loop body."

--- a/javascript/ql/src/Statements/SuspiciousUnusedLoopIterationVariable.ql
+++ b/javascript/ql/src/Statements/SuspiciousUnusedLoopIterationVariable.ql
@@ -46,8 +46,8 @@ predicate countingLoop(EnhancedForLoop efl) {
 }
 
 /**
- * Holds if `iter` is the non-last variable of array-destructuring in a for-loop.
- * E.g. `for(const [foo, iter, bar] of array) {..}`.
+ * Holds if `iter` is a non-last variable of array-destructuring in a for-loop.
+ * For example `foo` or `iter` in `for(const [foo, iter, bar] of array) {..}`.
  */
 predicate isNonLastDestructedArrayElement(PurelyLocalVariable iter) {
   exists(ArrayPattern pattern | pattern = any(EnhancedForLoop loop).getLValue() |

--- a/javascript/ql/test/query-tests/Statements/SuspiciousUnusedLoopIterationVariable/SuspiciousUnusedLoopIterationVariable.expected
+++ b/javascript/ql/test/query-tests/Statements/SuspiciousUnusedLoopIterationVariable/SuspiciousUnusedLoopIterationVariable.expected
@@ -1,1 +1,4 @@
 | tst.js:4:7:4:11 | let x | For loop variable x is not used in the loop body. |
+| tst.js:138:6:138:23 | const [key, value] | For loop variable value is not used in the loop body. |
+| tst.js:151:6:151:35 | const [ ...  value] | For loop variable value is not used in the loop body. |
+| tst.js:152:6:152:10 | let i | For loop variable i is not used in the loop body. |

--- a/javascript/ql/test/query-tests/Statements/SuspiciousUnusedLoopIterationVariable/tst.js
+++ b/javascript/ql/test/query-tests/Statements/SuspiciousUnusedLoopIterationVariable/tst.js
@@ -133,3 +133,20 @@ function countOccurrencesDead(xs, p) {
 		a;
 	}
 });
+
+// NOT OK
+for (const [key, value] of array) {}
+
+// OK: for array-destructurings we only flag the last element
+for (const [key, value] of array) {
+	console.log(value)
+}
+
+// OK: for array-destructurings we only flag the last element
+for (const [key, key2, key3, value] of array) {
+	console.log(value)
+}
+
+// NOT OK
+for (const [key, key2, key3, value] of array) {}
+for (let i of [1, 2]) {}


### PR DESCRIPTION
Inspired by an [anomalous query result](https://lgtm.com/projects/g/Azure/adl/alerts?id=js%2Funused-loop-variable&mode=list), and [the recent script I wrote](https://github.com/github/codeql/pull/4153) - which suffers this "issue".   
(Although in my recent script I use `array.map`, where we don't flag this kind of issue).  

It is somewhat common to type out the elements in an array-destructing, even if not all the elements are used. 

E.g. 
```JavaScript
for (const [key, value] of getEntries()) {
  use(value);
}
```

The above example is currently flagged by `js/unused-loop-variable`. 

Removing the unused variables (or naming them `_` or similar) does not produce more readable code. 
So I think `js/unused-loop-variable` should only flag array-destructing when its the last variable that is unused. 

Among [the alerts for `js/unused-loop-variable`](https://lgtm.com/rules/9980086/alerts/) there are plenty of examples this pattern. 

[An evaluation looks great](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1599057282701). (I was not able to reproduce the slowdown on `test262` locally). 