### PR TITLE
C#: autobuild: fix buildless mode for CodeQL

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -345,6 +345,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_SOURCE_ARCHIVE_DIR"] = "";
             Actions.GetEnvironmentVariable[$"CODEQL_EXTRACTOR_{codeqlUpperLanguage}_ROOT"] = $@"C:\codeql\{codeqlUpperLanguage.ToLowerInvariant()}";
             Actions.GetEnvironmentVariable["CODEQL_JAVA_HOME"] = @"C:\codeql\tools\java";
+            Actions.GetEnvironmentVariable["CODEQL_PLATFORM"] = isWindows ? "win64" : "linux64";
             Actions.GetEnvironmentVariable["SEMMLE_DIST"] = @"C:\odasa";
             Actions.GetEnvironmentVariable["SEMMLE_JAVA_HOME"] = @"C:\odasa\tools\java";
             Actions.GetEnvironmentVariable["SEMMLE_PLATFORM_TOOLS"] = @"C:\odasa\tools";
@@ -497,7 +498,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestLinuxBuildlessExtractionSuccess()
         {
-            Actions.RunProcess[@"C:\odasa\tools/csharp/Semmle.Extraction.CSharp.Standalone --references:."] = 0;
+            Actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone --references:."] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -513,7 +514,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestLinuxBuildlessExtractionFailed()
         {
-            Actions.RunProcess[@"C:\odasa\tools/csharp/Semmle.Extraction.CSharp.Standalone --references:."] = 10;
+            Actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone --references:."] = 10;
             Actions.FileExists["csharp.log"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
@@ -527,7 +528,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestLinuxBuildlessExtractionSolution()
         {
-            Actions.RunProcess[@"C:\odasa\tools/csharp/Semmle.Extraction.CSharp.Standalone foo.sln --references:."] = 0;
+            Actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone foo.sln --references:."] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -835,7 +836,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestSkipNugetBuildless()
         {
-            Actions.RunProcess[@"C:\odasa\tools/csharp/Semmle.Extraction.CSharp.Standalone foo.sln --references:. --skip-nuget"] = 0;
+            Actions.RunProcess[@"C:\codeql\csharp/tools/linux64/Semmle.Extraction.CSharp.Standalone foo.sln --references:. --skip-nuget"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
@@ -11,10 +11,15 @@ namespace Semmle.Autobuild.CSharp
         {
             BuildScript GetCommand(string? solution)
             {
-                if (builder.SemmlePlatformTools is null)
+                string standalone;
+                if (!(builder.CodeQLExtractorLangRoot is null) && !(builder.CodeQlPlatform is null)) {
+                    standalone = builder.Actions.PathCombine(builder.CodeQLExtractorLangRoot, "tools", builder.CodeQlPlatform, "Semmle.Extraction.CSharp.Standalone");
+                } else if (!(builder.SemmlePlatformTools is null)) {
+                    standalone = builder.Actions.PathCombine(builder.SemmlePlatformTools, "csharp", "Semmle.Extraction.CSharp.Standalone");
+                } else {
                     return BuildScript.Failure;
+                }
 
-                var standalone = builder.Actions.PathCombine(builder.SemmlePlatformTools, "csharp", "Semmle.Extraction.CSharp.Standalone");
                 var cmd = new CommandBuilder(builder.Actions);
                 cmd.RunCommand(standalone);
 

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/StandaloneBuildRule.cs
@@ -12,9 +12,9 @@ namespace Semmle.Autobuild.CSharp
             BuildScript GetCommand(string? solution)
             {
                 string standalone;
-                if (!(builder.CodeQLExtractorLangRoot is null) && !(builder.CodeQlPlatform is null)) {
+                if (builder.CodeQLExtractorLangRoot is object && builder.CodeQlPlatform is object) {
                     standalone = builder.Actions.PathCombine(builder.CodeQLExtractorLangRoot, "tools", builder.CodeQlPlatform, "Semmle.Extraction.CSharp.Standalone");
-                } else if (!(builder.SemmlePlatformTools is null)) {
+                } else if (builder.SemmlePlatformTools is object) {
                     standalone = builder.Actions.PathCombine(builder.SemmlePlatformTools, "csharp", "Semmle.Extraction.CSharp.Standalone");
                 } else {
                     return BuildScript.Failure;

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
@@ -193,6 +193,8 @@ namespace Semmle.Autobuild.Shared
             SemmleDist = Actions.GetEnvironmentVariable("SEMMLE_DIST");
             SemmlePlatformTools = Actions.GetEnvironmentVariable("SEMMLE_PLATFORM_TOOLS");
 
+            CodeQlPlatform = Actions.GetEnvironmentVariable("CODEQL_PLATFORM");
+
             JavaHome =
                 Actions.GetEnvironmentVariable("CODEQL_JAVA_HOME") ??
                 Actions.GetEnvironmentVariable("SEMMLE_JAVA_HOME") ??
@@ -271,7 +273,7 @@ namespace Semmle.Autobuild.Shared
         /// <summary>
         /// Value of CODEQL_EXTRACTOR_<LANG>_ROOT environment variable.
         /// </summary>
-        private string? CodeQLExtractorLangRoot { get; }
+        public string? CodeQLExtractorLangRoot { get; }
 
         /// <summary>
         /// Value of SEMMLE_DIST environment variable.
@@ -286,6 +288,11 @@ namespace Semmle.Autobuild.Shared
         /// Value of SEMMLE_PLATFORM_TOOLS environment variable.
         /// </summary>
         public string? SemmlePlatformTools { get; }
+
+        /// <summary>
+        /// Value of CODEQL_PLATFORM environment variable.
+        /// </summary>
+        public string? CodeQlPlatform { get; }
 
         /// <summary>
         /// The absolute path of the odasa executable.


### PR DESCRIPTION
This pull request makes the "buildless" analyzer work with CodeQL. Before it relied on the old `SEMMLE_PLATFORM_TOOLS` environment variable.

@hvitved 