### PR TITLE
Update devcontainer memory settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,6 @@
     "slevesque.vscode-zipexplorer"
   ],
   "settings": {
-    "codeQL.experimentalBqrsParsing": true
+    "codeQL.runningQueries.memory": 2048
   }
 }


### PR DESCRIPTION
CodeQL CLI needs a minimum of 2G of memory. By default, the memory used is slightly less than that, leading to poor performance.

This change also removes an old, unused setting.