### PR TITLE
JS: adjust comment about inconsistency for XSS in typeahead

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-079/typeahead.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/typeahead.js
@@ -7,7 +7,7 @@
     source: autocompleter.ttAdapter(),
     templates: {
       suggestion: function(loc) {
-        return loc; // NOT OK! - but not flagged due to not connecting the Bloodhound source with this sink [INCONSISTENCY]
+        return loc; // NOT OK - but only flagged when `AdditionalSources` are imported [INCONSISTENCY].
       }
     }
   })


### PR DESCRIPTION
The comment in the `typeahead` test suggested that we didn't find a result.  
We do actually find the result - but only when `AdditionalSources` are imported. 

I decided to keep the `[INCONSISTENCY]` flag, as else I would have to import `AdditionalSources` into the consistency test, which I'm not a fan of. 