### PR TITLE
C++: Model iterator versions of string and vector methods

### DIFF
--- a/change-notes/1.26/analysis-cpp.md
+++ b/change-notes/1.26/analysis-cpp.md
@@ -19,7 +19,7 @@ The following changes in version 1.26 affect C/C++ analysis in all applications.
 
 ## Changes to libraries
 
-* The models library now models some taint flows through `std::array`, `std::vector`, `std::deque`, `std::list` and `std::forward_list`.
+* The models library now models many taint flows through `std::array`, `std::vector`, `std::deque`, `std::list` and `std::forward_list`.
 * The models library now models many more taint flows through `std::string`.
 * The `SimpleRangeAnalysis` library now supports multiplications of the form
   `e1 * e2` and `x *= e2` when `e1` and `e2` are unsigned or constant.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -90,6 +90,42 @@ class StdSequenceContainerFrontBack extends TaintFunction {
 }
 
 /**
+ * The standard container function `insert`.
+ */
+class StdSequenceContainerInsert extends TaintFunction {
+  StdSequenceContainerInsert() {
+    this.hasQualifiedName("std", ["vector", "deque", "list"], "insert")
+  }
+
+  /**
+   * Gets the index of a parameter to this function that is a reference to the
+   * value type of the container.
+   */
+  int getAValueTypeParameterIndex() {
+    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
+  }
+
+  /**
+   * Gets the index of a parameter to this function that is an iterator.
+   */
+  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // flow from parameter to container itself (qualifier) and return value
+    (
+      input.isQualifierObject() or
+      input.isParameterDeref(getAValueTypeParameterIndex()) or
+      input.isParameter(getAnIteratorParameterIndex())
+    ) and
+    (
+      output.isQualifierObject() or
+      output.isReturnValueDeref()
+    )
+  }
+}
+
+/**
  * The standard container function `assign`.
  */
 class StdSequenceContainerAssign extends TaintFunction {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -106,9 +106,17 @@ class StdSequenceContainerAssign extends TaintFunction {
       getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
   }
 
+  /**
+   * Gets the index of a parameter to this function that is an iterator.
+   */
+  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    // flow from parameter to string itself (qualifier) and return value
-    input.isParameterDeref(getAValueTypeParameterIndex()) and
+    // flow from parameter to container itself (qualifier)
+    (
+      input.isParameterDeref(getAValueTypeParameterIndex()) or
+      input.isParameter(getAnIteratorParameterIndex())
+    ) and
     output.isQualifierObject()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -3,6 +3,7 @@
  */
 
 import semmle.code.cpp.models.interfaces.Taint
+import semmle.code.cpp.models.implementations.Iterator
 
 /**
  * Additional model for standard container constructors that reference the
@@ -109,6 +110,26 @@ class StdSequenceContainerAssign extends TaintFunction {
     // flow from parameter to string itself (qualifier) and return value
     input.isParameterDeref(getAValueTypeParameterIndex()) and
     output.isQualifierObject()
+  }
+}
+
+/**
+ * The standard container `begin` and `end` functions and their
+ * variants.
+ */
+class StdSequenceContainerBeginEnd extends TaintFunction {
+  StdSequenceContainerBeginEnd() {
+    this
+        .hasQualifiedName("std", ["array", "vector", "deque", "list"],
+          ["begin", "cbegin", "rbegin", "crbegin", "end", "cend", "rend", "crend"]) or
+    this
+        .hasQualifiedName("std", "forward_list",
+          ["before_begin", "begin", "end", "cbefore_begin", "cbegin", "cend"])
+  }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isQualifierObject() and
+    output.isReturnValue()
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -90,11 +90,12 @@ class StdSequenceContainerFrontBack extends TaintFunction {
 }
 
 /**
- * The standard container function `insert`.
+ * The standard container functions `insert` and `insert_after`.
  */
 class StdSequenceContainerInsert extends TaintFunction {
   StdSequenceContainerInsert() {
-    this.hasQualifiedName("std", ["vector", "deque", "list"], "insert")
+    this.hasQualifiedName("std", ["vector", "deque", "list"], "insert") or
+    this.hasQualifiedName("std", ["forward_list"], "insert_after")
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -27,9 +27,17 @@ class StdSequenceContainerConstructor extends Constructor, TaintFunction {
       getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. the `T` of this `std::vector<T>`
   }
 
+  /**
+   * Gets the index of a parameter to this function that is an iterator.
+   */
+  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // taint flow from any parameter of the value type to the returned object
-    input.isParameterDeref(getAValueTypeParameterIndex()) and
+    (
+      input.isParameterDeref(getAValueTypeParameterIndex()) or
+      input.isParameter(getAnIteratorParameterIndex())
+    ) and
     output.isReturnValue() // TODO: this should be `isQualifierObject` by our current definitions, but that flow is not yet supported.
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
@@ -145,14 +145,9 @@ class StdStringAssign extends TaintFunction {
  */
 class StdStringBeginEnd extends TaintFunction {
   StdStringBeginEnd() {
-    this.hasQualifiedName("std", "basic_string", "begin") or
-    this.hasQualifiedName("std", "basic_string", "cbegin") or
-    this.hasQualifiedName("std", "basic_string", "rbegin") or
-    this.hasQualifiedName("std", "basic_string", "crbegin") or
-    this.hasQualifiedName("std", "basic_string", "end") or
-    this.hasQualifiedName("std", "basic_string", "cend") or
-    this.hasQualifiedName("std", "basic_string", "rend") or
-    this.hasQualifiedName("std", "basic_string", "crend")
+    this
+        .hasQualifiedName("std", "basic_string",
+          ["begin", "cbegin", "rbegin", "crbegin", "end", "cend", "rend", "crend"])
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
@@ -15,6 +15,43 @@ class StdBasicString extends TemplateClass {
 }
 
 /**
+ * Additional model for `std::string` constructors that reference the character
+ * type of the container, or an iterator.  For example construction from
+ * iterators:
+ * ```
+ * std::string b(a.begin(), a.end());
+ * ```
+ */
+class StdStringConstructor extends Constructor, TaintFunction {
+  StdStringConstructor() { this.getDeclaringType().hasQualifiedName("std", "basic_string") }
+
+  /**
+   * Gets the index of a parameter to this function that is a string (or
+   * character).
+   */
+  int getAStringParameterIndex() {
+    getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
+    getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
+    getParameter(result).getUnspecifiedType() =
+      getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
+  }
+
+  /**
+   * Gets the index of a parameter to this function that is an iterator.
+   */
+  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // taint flow from any parameter of the value type to the returned object
+    (
+      input.isParameterDeref(getAStringParameterIndex()) or
+      input.isParameter(getAnIteratorParameterIndex())
+    ) and
+    output.isReturnValue() // TODO: this should be `isQualifierObject` by our current definitions, but that flow is not yet supported.
+  }
+}
+
+/**
  * The `std::string` function `c_str`.
  */
 class StdStringCStr extends TaintFunction {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
@@ -79,8 +79,8 @@ class StdStringAppend extends TaintFunction {
    * character).
    */
   int getAStringParameterIndex() {
-    getParameter(result).getType() instanceof PointerType or
-    getParameter(result).getType() instanceof ReferenceType or
+    getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
+    getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
     getParameter(result).getUnspecifiedType() =
       getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
   }
@@ -115,15 +115,23 @@ class StdStringAssign extends TaintFunction {
    * character).
    */
   int getAStringParameterIndex() {
-    getParameter(result).getType() instanceof PointerType or
-    getParameter(result).getType() instanceof ReferenceType or
+    getParameter(result).getType() instanceof PointerType or // e.g. `std::basic_string::CharT *`
+    getParameter(result).getType() instanceof ReferenceType or // e.g. `std::basic_string &`
     getParameter(result).getUnspecifiedType() =
       getDeclaringType().getTemplateArgument(0).(Type).getUnspecifiedType() // i.e. `std::basic_string::CharT`
   }
 
+  /**
+   * Gets the index of a parameter to this function that is an iterator.
+   */
+  int getAnIteratorParameterIndex() { getParameter(result).getType() instanceof Iterator }
+
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     // flow from parameter to string itself (qualifier) and return value
-    input.isParameterDeref(getAStringParameterIndex()) and
+    (
+      input.isParameterDeref(getAStringParameterIndex()) or
+      input.isParameter(getAnIteratorParameterIndex())
+    ) and
     (
       output.isQualifierObject() or
       output.isReturnValueDeref()

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -461,12 +461,12 @@
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:53:12:53:18 | source1 |  |
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
 | standalone_iterators.cpp:53:12:53:18 | ref arg source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
-| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
-| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
-| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
-| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
-| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
-| stl.h:168:53:168:63 | 0 | stl.h:168:46:168:64 | (no string representation) | TAINT |
+| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
+| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
+| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
+| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
+| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
+| stl.h:171:53:171:63 | 0 | stl.h:171:46:171:64 | (no string representation) | TAINT |
 | string.cpp:24:12:24:17 | call to source | string.cpp:28:7:28:7 | a |  |
 | string.cpp:25:16:25:20 | 123 | string.cpp:25:16:25:21 | call to basic_string | TAINT |
 | string.cpp:25:16:25:21 | call to basic_string | string.cpp:29:7:29:7 | b |  |
@@ -1015,6 +1015,190 @@
 | string.cpp:412:5:412:6 | i9 | string.cpp:412:3:412:3 | call to operator-- | TAINT |
 | string.cpp:412:5:412:6 | ref arg i9 | string.cpp:413:9:413:10 | i9 |  |
 | string.cpp:413:9:413:10 | i9 | string.cpp:413:8:413:8 | call to operator* | TAINT |
+| string.cpp:419:17:419:20 | aa | string.cpp:419:17:419:21 | call to basic_string | TAINT |
+| string.cpp:419:17:419:21 | call to basic_string | string.cpp:424:7:424:8 | s1 |  |
+| string.cpp:419:17:419:21 | call to basic_string | string.cpp:425:7:425:8 | s1 |  |
+| string.cpp:420:17:420:20 | bb | string.cpp:420:17:420:21 | call to basic_string | TAINT |
+| string.cpp:420:17:420:21 | call to basic_string | string.cpp:427:7:427:8 | s2 |  |
+| string.cpp:420:17:420:21 | call to basic_string | string.cpp:428:7:428:8 | s2 |  |
+| string.cpp:421:14:421:17 | cc | string.cpp:424:20:424:22 | cs1 |  |
+| string.cpp:422:14:422:19 | call to source | string.cpp:427:20:427:22 | cs2 |  |
+| string.cpp:424:7:424:8 | ref arg s1 | string.cpp:425:7:425:8 | s1 |  |
+| string.cpp:424:7:424:8 | s1 | string.cpp:424:10:424:15 | call to insert | TAINT |
+| string.cpp:424:20:424:22 | cs1 | string.cpp:424:7:424:8 | ref arg s1 | TAINT |
+| string.cpp:424:20:424:22 | cs1 | string.cpp:424:10:424:15 | call to insert | TAINT |
+| string.cpp:427:7:427:8 | ref arg s2 | string.cpp:428:7:428:8 | s2 |  |
+| string.cpp:427:7:427:8 | s2 | string.cpp:427:10:427:15 | call to insert | TAINT |
+| string.cpp:427:20:427:22 | cs2 | string.cpp:427:7:427:8 | ref arg s2 | TAINT |
+| string.cpp:427:20:427:22 | cs2 | string.cpp:427:10:427:15 | call to insert | TAINT |
+| string.cpp:436:17:436:20 | aa | string.cpp:436:17:436:21 | call to basic_string | TAINT |
+| string.cpp:436:17:436:21 | call to basic_string | string.cpp:439:8:439:8 | a |  |
+| string.cpp:436:17:436:21 | call to basic_string | string.cpp:439:17:439:17 | a |  |
+| string.cpp:436:17:436:21 | call to basic_string | string.cpp:440:8:440:8 | a |  |
+| string.cpp:437:17:437:20 | bb | string.cpp:437:17:437:21 | call to basic_string | TAINT |
+| string.cpp:437:17:437:21 | call to basic_string | string.cpp:442:8:442:8 | b |  |
+| string.cpp:437:17:437:21 | call to basic_string | string.cpp:442:17:442:17 | b |  |
+| string.cpp:437:17:437:21 | call to basic_string | string.cpp:443:8:443:8 | b |  |
+| string.cpp:439:8:439:8 | a | string.cpp:439:10:439:15 | call to insert | TAINT |
+| string.cpp:439:8:439:8 | ref arg a | string.cpp:440:8:440:8 | a |  |
+| string.cpp:439:17:439:17 | a | string.cpp:439:19:439:23 | call to begin | TAINT |
+| string.cpp:439:17:439:17 | ref arg a | string.cpp:439:8:439:8 | a |  |
+| string.cpp:439:17:439:17 | ref arg a | string.cpp:440:8:440:8 | a |  |
+| string.cpp:439:19:439:23 | call to begin | string.cpp:439:17:439:25 | call to iterator | TAINT |
+| string.cpp:439:32:439:34 | 120 | string.cpp:439:8:439:8 | ref arg a | TAINT |
+| string.cpp:439:32:439:34 | 120 | string.cpp:439:10:439:15 | call to insert | TAINT |
+| string.cpp:442:8:442:8 | b | string.cpp:442:10:442:15 | call to insert | TAINT |
+| string.cpp:442:8:442:8 | ref arg b | string.cpp:443:8:443:8 | b |  |
+| string.cpp:442:17:442:17 | b | string.cpp:442:19:442:23 | call to begin | TAINT |
+| string.cpp:442:17:442:17 | ref arg b | string.cpp:442:8:442:8 | b |  |
+| string.cpp:442:17:442:17 | ref arg b | string.cpp:443:8:443:8 | b |  |
+| string.cpp:442:19:442:23 | call to begin | string.cpp:442:17:442:25 | call to iterator | TAINT |
+| string.cpp:442:32:442:46 | call to source | string.cpp:442:8:442:8 | ref arg b | TAINT |
+| string.cpp:442:32:442:46 | call to source | string.cpp:442:10:442:15 | call to insert | TAINT |
+| string.cpp:447:17:447:20 | cc | string.cpp:447:17:447:21 | call to basic_string | TAINT |
+| string.cpp:447:17:447:21 | call to basic_string | string.cpp:452:8:452:8 | c |  |
+| string.cpp:447:17:447:21 | call to basic_string | string.cpp:452:17:452:17 | c |  |
+| string.cpp:447:17:447:21 | call to basic_string | string.cpp:453:8:453:8 | c |  |
+| string.cpp:448:17:448:20 | dd | string.cpp:448:17:448:21 | call to basic_string | TAINT |
+| string.cpp:448:17:448:21 | call to basic_string | string.cpp:455:8:455:8 | d |  |
+| string.cpp:448:17:448:21 | call to basic_string | string.cpp:455:17:455:17 | d |  |
+| string.cpp:448:17:448:21 | call to basic_string | string.cpp:456:8:456:8 | d |  |
+| string.cpp:449:18:449:21 | 11 | string.cpp:449:18:449:22 | call to basic_string | TAINT |
+| string.cpp:449:18:449:22 | call to basic_string | string.cpp:452:26:452:27 | s1 |  |
+| string.cpp:449:18:449:22 | call to basic_string | string.cpp:452:38:452:39 | s1 |  |
+| string.cpp:449:18:449:22 | call to basic_string | string.cpp:458:28:458:29 | s1 |  |
+| string.cpp:449:18:449:22 | call to basic_string | string.cpp:458:40:458:41 | s1 |  |
+| string.cpp:450:18:450:23 | call to source | string.cpp:450:18:450:26 | call to basic_string | TAINT |
+| string.cpp:450:18:450:26 | call to basic_string | string.cpp:455:26:455:27 | s2 |  |
+| string.cpp:450:18:450:26 | call to basic_string | string.cpp:455:38:455:39 | s2 |  |
+| string.cpp:450:18:450:26 | call to basic_string | string.cpp:458:8:458:9 | s2 |  |
+| string.cpp:450:18:450:26 | call to basic_string | string.cpp:458:18:458:19 | s2 |  |
+| string.cpp:450:18:450:26 | call to basic_string | string.cpp:459:8:459:9 | s2 |  |
+| string.cpp:452:8:452:8 | c | string.cpp:452:10:452:15 | call to insert | TAINT |
+| string.cpp:452:8:452:8 | ref arg c | string.cpp:453:8:453:8 | c |  |
+| string.cpp:452:17:452:17 | c | string.cpp:452:19:452:21 | call to end | TAINT |
+| string.cpp:452:17:452:17 | ref arg c | string.cpp:452:8:452:8 | c |  |
+| string.cpp:452:17:452:17 | ref arg c | string.cpp:453:8:453:8 | c |  |
+| string.cpp:452:19:452:21 | call to end | string.cpp:452:17:452:23 | call to iterator | TAINT |
+| string.cpp:452:26:452:27 | ref arg s1 | string.cpp:452:38:452:39 | s1 |  |
+| string.cpp:452:26:452:27 | ref arg s1 | string.cpp:458:28:458:29 | s1 |  |
+| string.cpp:452:26:452:27 | ref arg s1 | string.cpp:458:40:458:41 | s1 |  |
+| string.cpp:452:26:452:27 | s1 | string.cpp:452:29:452:33 | call to begin | TAINT |
+| string.cpp:452:29:452:33 | call to begin | string.cpp:452:8:452:8 | ref arg c | TAINT |
+| string.cpp:452:29:452:33 | call to begin | string.cpp:452:10:452:15 | call to insert | TAINT |
+| string.cpp:452:38:452:39 | ref arg s1 | string.cpp:458:28:458:29 | s1 |  |
+| string.cpp:452:38:452:39 | ref arg s1 | string.cpp:458:40:458:41 | s1 |  |
+| string.cpp:452:38:452:39 | s1 | string.cpp:452:41:452:43 | call to end | TAINT |
+| string.cpp:452:41:452:43 | call to end | string.cpp:452:8:452:8 | ref arg c | TAINT |
+| string.cpp:452:41:452:43 | call to end | string.cpp:452:10:452:15 | call to insert | TAINT |
+| string.cpp:455:8:455:8 | d | string.cpp:455:10:455:15 | call to insert | TAINT |
+| string.cpp:455:8:455:8 | ref arg d | string.cpp:456:8:456:8 | d |  |
+| string.cpp:455:17:455:17 | d | string.cpp:455:19:455:21 | call to end | TAINT |
+| string.cpp:455:17:455:17 | ref arg d | string.cpp:455:8:455:8 | d |  |
+| string.cpp:455:17:455:17 | ref arg d | string.cpp:456:8:456:8 | d |  |
+| string.cpp:455:19:455:21 | call to end | string.cpp:455:17:455:23 | call to iterator | TAINT |
+| string.cpp:455:26:455:27 | ref arg s2 | string.cpp:455:38:455:39 | s2 |  |
+| string.cpp:455:26:455:27 | ref arg s2 | string.cpp:458:8:458:9 | s2 |  |
+| string.cpp:455:26:455:27 | ref arg s2 | string.cpp:458:18:458:19 | s2 |  |
+| string.cpp:455:26:455:27 | ref arg s2 | string.cpp:459:8:459:9 | s2 |  |
+| string.cpp:455:26:455:27 | s2 | string.cpp:455:29:455:33 | call to begin | TAINT |
+| string.cpp:455:29:455:33 | call to begin | string.cpp:455:8:455:8 | ref arg d | TAINT |
+| string.cpp:455:29:455:33 | call to begin | string.cpp:455:10:455:15 | call to insert | TAINT |
+| string.cpp:455:38:455:39 | ref arg s2 | string.cpp:458:8:458:9 | s2 |  |
+| string.cpp:455:38:455:39 | ref arg s2 | string.cpp:458:18:458:19 | s2 |  |
+| string.cpp:455:38:455:39 | ref arg s2 | string.cpp:459:8:459:9 | s2 |  |
+| string.cpp:455:38:455:39 | s2 | string.cpp:455:41:455:43 | call to end | TAINT |
+| string.cpp:455:41:455:43 | call to end | string.cpp:455:8:455:8 | ref arg d | TAINT |
+| string.cpp:455:41:455:43 | call to end | string.cpp:455:10:455:15 | call to insert | TAINT |
+| string.cpp:458:8:458:9 | ref arg s2 | string.cpp:459:8:459:9 | s2 |  |
+| string.cpp:458:8:458:9 | s2 | string.cpp:458:11:458:16 | call to insert | TAINT |
+| string.cpp:458:18:458:19 | ref arg s2 | string.cpp:458:8:458:9 | s2 |  |
+| string.cpp:458:18:458:19 | ref arg s2 | string.cpp:459:8:459:9 | s2 |  |
+| string.cpp:458:18:458:19 | s2 | string.cpp:458:21:458:23 | call to end | TAINT |
+| string.cpp:458:21:458:23 | call to end | string.cpp:458:18:458:25 | call to iterator | TAINT |
+| string.cpp:458:28:458:29 | ref arg s1 | string.cpp:458:40:458:41 | s1 |  |
+| string.cpp:458:28:458:29 | s1 | string.cpp:458:31:458:35 | call to begin | TAINT |
+| string.cpp:458:31:458:35 | call to begin | string.cpp:458:8:458:9 | ref arg s2 | TAINT |
+| string.cpp:458:31:458:35 | call to begin | string.cpp:458:11:458:16 | call to insert | TAINT |
+| string.cpp:458:40:458:41 | s1 | string.cpp:458:43:458:45 | call to end | TAINT |
+| string.cpp:458:43:458:45 | call to end | string.cpp:458:8:458:9 | ref arg s2 | TAINT |
+| string.cpp:458:43:458:45 | call to end | string.cpp:458:11:458:16 | call to insert | TAINT |
+| string.cpp:463:17:463:20 | ee | string.cpp:463:17:463:21 | call to basic_string | TAINT |
+| string.cpp:463:17:463:21 | call to basic_string | string.cpp:468:8:468:8 | e |  |
+| string.cpp:463:17:463:21 | call to basic_string | string.cpp:469:8:469:8 | e |  |
+| string.cpp:464:17:464:20 | ff | string.cpp:464:17:464:21 | call to basic_string | TAINT |
+| string.cpp:464:17:464:21 | call to basic_string | string.cpp:471:8:471:8 | f |  |
+| string.cpp:464:17:464:21 | call to basic_string | string.cpp:472:8:472:8 | f |  |
+| string.cpp:465:18:465:21 | 33 | string.cpp:465:18:465:22 | call to basic_string | TAINT |
+| string.cpp:465:18:465:22 | call to basic_string | string.cpp:468:17:468:18 | s3 |  |
+| string.cpp:465:18:465:22 | call to basic_string | string.cpp:468:29:468:30 | s3 |  |
+| string.cpp:465:18:465:22 | call to basic_string | string.cpp:474:18:474:19 | s3 |  |
+| string.cpp:465:18:465:22 | call to basic_string | string.cpp:474:30:474:31 | s3 |  |
+| string.cpp:466:18:466:23 | call to source | string.cpp:466:18:466:26 | call to basic_string | TAINT |
+| string.cpp:466:18:466:26 | call to basic_string | string.cpp:471:17:471:18 | s4 |  |
+| string.cpp:466:18:466:26 | call to basic_string | string.cpp:471:29:471:30 | s4 |  |
+| string.cpp:466:18:466:26 | call to basic_string | string.cpp:474:8:474:9 | s4 |  |
+| string.cpp:466:18:466:26 | call to basic_string | string.cpp:475:8:475:9 | s4 |  |
+| string.cpp:468:8:468:8 | e | string.cpp:468:10:468:15 | call to append | TAINT |
+| string.cpp:468:8:468:8 | ref arg e | string.cpp:469:8:469:8 | e |  |
+| string.cpp:468:17:468:18 | ref arg s3 | string.cpp:468:29:468:30 | s3 |  |
+| string.cpp:468:17:468:18 | ref arg s3 | string.cpp:474:18:474:19 | s3 |  |
+| string.cpp:468:17:468:18 | ref arg s3 | string.cpp:474:30:474:31 | s3 |  |
+| string.cpp:468:17:468:18 | s3 | string.cpp:468:20:468:24 | call to begin | TAINT |
+| string.cpp:468:20:468:24 | call to begin | string.cpp:468:8:468:8 | ref arg e | TAINT |
+| string.cpp:468:20:468:24 | call to begin | string.cpp:468:10:468:15 | call to append | TAINT |
+| string.cpp:468:29:468:30 | ref arg s3 | string.cpp:474:18:474:19 | s3 |  |
+| string.cpp:468:29:468:30 | ref arg s3 | string.cpp:474:30:474:31 | s3 |  |
+| string.cpp:468:29:468:30 | s3 | string.cpp:468:32:468:34 | call to end | TAINT |
+| string.cpp:468:32:468:34 | call to end | string.cpp:468:8:468:8 | ref arg e | TAINT |
+| string.cpp:468:32:468:34 | call to end | string.cpp:468:10:468:15 | call to append | TAINT |
+| string.cpp:471:8:471:8 | f | string.cpp:471:10:471:15 | call to append | TAINT |
+| string.cpp:471:8:471:8 | ref arg f | string.cpp:472:8:472:8 | f |  |
+| string.cpp:471:17:471:18 | ref arg s4 | string.cpp:471:29:471:30 | s4 |  |
+| string.cpp:471:17:471:18 | ref arg s4 | string.cpp:474:8:474:9 | s4 |  |
+| string.cpp:471:17:471:18 | ref arg s4 | string.cpp:475:8:475:9 | s4 |  |
+| string.cpp:471:17:471:18 | s4 | string.cpp:471:20:471:24 | call to begin | TAINT |
+| string.cpp:471:20:471:24 | call to begin | string.cpp:471:8:471:8 | ref arg f | TAINT |
+| string.cpp:471:20:471:24 | call to begin | string.cpp:471:10:471:15 | call to append | TAINT |
+| string.cpp:471:29:471:30 | ref arg s4 | string.cpp:474:8:474:9 | s4 |  |
+| string.cpp:471:29:471:30 | ref arg s4 | string.cpp:475:8:475:9 | s4 |  |
+| string.cpp:471:29:471:30 | s4 | string.cpp:471:32:471:34 | call to end | TAINT |
+| string.cpp:471:32:471:34 | call to end | string.cpp:471:8:471:8 | ref arg f | TAINT |
+| string.cpp:471:32:471:34 | call to end | string.cpp:471:10:471:15 | call to append | TAINT |
+| string.cpp:474:8:474:9 | ref arg s4 | string.cpp:475:8:475:9 | s4 |  |
+| string.cpp:474:8:474:9 | s4 | string.cpp:474:11:474:16 | call to append | TAINT |
+| string.cpp:474:18:474:19 | ref arg s3 | string.cpp:474:30:474:31 | s3 |  |
+| string.cpp:474:18:474:19 | s3 | string.cpp:474:21:474:25 | call to begin | TAINT |
+| string.cpp:474:21:474:25 | call to begin | string.cpp:474:8:474:9 | ref arg s4 | TAINT |
+| string.cpp:474:21:474:25 | call to begin | string.cpp:474:11:474:16 | call to append | TAINT |
+| string.cpp:474:30:474:31 | s3 | string.cpp:474:33:474:35 | call to end | TAINT |
+| string.cpp:474:33:474:35 | call to end | string.cpp:474:8:474:9 | ref arg s4 | TAINT |
+| string.cpp:474:33:474:35 | call to end | string.cpp:474:11:474:16 | call to append | TAINT |
+| string.cpp:479:17:479:20 | gg | string.cpp:479:17:479:21 | call to basic_string | TAINT |
+| string.cpp:479:17:479:21 | call to basic_string | string.cpp:484:8:484:8 | g |  |
+| string.cpp:479:17:479:21 | call to basic_string | string.cpp:485:8:485:8 | g |  |
+| string.cpp:480:17:480:20 | hh | string.cpp:480:17:480:21 | call to basic_string | TAINT |
+| string.cpp:480:17:480:21 | call to basic_string | string.cpp:487:8:487:8 | h |  |
+| string.cpp:480:17:480:21 | call to basic_string | string.cpp:488:8:488:8 | h |  |
+| string.cpp:481:18:481:21 | 55 | string.cpp:481:18:481:22 | call to basic_string | TAINT |
+| string.cpp:481:18:481:22 | call to basic_string | string.cpp:484:17:484:18 | s5 |  |
+| string.cpp:481:18:481:22 | call to basic_string | string.cpp:484:30:484:31 | s5 |  |
+| string.cpp:481:18:481:22 | call to basic_string | string.cpp:490:18:490:19 | s5 |  |
+| string.cpp:481:18:481:22 | call to basic_string | string.cpp:490:31:490:32 | s5 |  |
+| string.cpp:482:18:482:23 | call to source | string.cpp:482:18:482:26 | call to basic_string | TAINT |
+| string.cpp:482:18:482:26 | call to basic_string | string.cpp:487:17:487:18 | s6 |  |
+| string.cpp:482:18:482:26 | call to basic_string | string.cpp:487:30:487:31 | s6 |  |
+| string.cpp:482:18:482:26 | call to basic_string | string.cpp:490:8:490:9 | s6 |  |
+| string.cpp:482:18:482:26 | call to basic_string | string.cpp:491:8:491:9 | s6 |  |
+| string.cpp:484:8:484:8 | ref arg g | string.cpp:485:8:485:8 | g |  |
+| string.cpp:484:17:484:18 | s5 | string.cpp:484:20:484:25 | call to cbegin | TAINT |
+| string.cpp:484:30:484:31 | s5 | string.cpp:484:33:484:36 | call to cend | TAINT |
+| string.cpp:487:8:487:8 | ref arg h | string.cpp:488:8:488:8 | h |  |
+| string.cpp:487:17:487:18 | s6 | string.cpp:487:20:487:25 | call to cbegin | TAINT |
+| string.cpp:487:30:487:31 | s6 | string.cpp:487:33:487:36 | call to cend | TAINT |
+| string.cpp:490:8:490:9 | ref arg s6 | string.cpp:491:8:491:9 | s6 |  |
+| string.cpp:490:18:490:19 | s5 | string.cpp:490:21:490:26 | call to cbegin | TAINT |
+| string.cpp:490:31:490:32 | s5 | string.cpp:490:34:490:37 | call to cend | TAINT |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:16:2:16:4 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:22:7:22:9 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:27:7:27:9 | ss1 |  |
@@ -2674,3 +2858,72 @@
 | vector.cpp:292:7:292:8 | v2 | vector.cpp:292:10:292:13 | call to data | TAINT |
 | vector.cpp:292:10:292:13 | call to data | vector.cpp:292:7:292:18 | access to array | TAINT |
 | vector.cpp:292:17:292:17 | 2 | vector.cpp:292:7:292:18 | access to array | TAINT |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:305:7:305:7 | a |  |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:305:16:305:16 | a |  |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:306:7:306:7 | a |  |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:311:25:311:25 | a |  |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:311:36:311:36 | a |  |
+| vector.cpp:298:19:298:19 | call to vector | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:299:19:299:19 | call to vector | vector.cpp:305:25:305:25 | b |  |
+| vector.cpp:299:19:299:19 | call to vector | vector.cpp:305:36:305:36 | b |  |
+| vector.cpp:299:19:299:19 | call to vector | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:300:19:300:19 | call to vector | vector.cpp:308:7:308:7 | c |  |
+| vector.cpp:300:19:300:19 | call to vector | vector.cpp:308:16:308:16 | c |  |
+| vector.cpp:300:19:300:19 | call to vector | vector.cpp:309:7:309:7 | c |  |
+| vector.cpp:300:19:300:19 | call to vector | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:303:2:303:2 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:308:25:308:25 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:308:36:308:36 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:311:7:311:7 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:311:16:311:16 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:301:19:301:19 | call to vector | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:308:25:308:25 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:308:36:308:36 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:311:7:311:7 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:311:16:311:16 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:303:2:303:2 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:303:14:303:19 | call to source | vector.cpp:303:2:303:2 | ref arg d | TAINT |
+| vector.cpp:305:7:305:7 | ref arg a | vector.cpp:306:7:306:7 | a |  |
+| vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
+| vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
+| vector.cpp:305:7:305:7 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:305:16:305:16 | ref arg a | vector.cpp:305:7:305:7 | a |  |
+| vector.cpp:305:16:305:16 | ref arg a | vector.cpp:306:7:306:7 | a |  |
+| vector.cpp:305:16:305:16 | ref arg a | vector.cpp:311:25:311:25 | a |  |
+| vector.cpp:305:16:305:16 | ref arg a | vector.cpp:311:36:311:36 | a |  |
+| vector.cpp:305:16:305:16 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:305:18:305:20 | call to end | vector.cpp:305:16:305:22 | call to iterator | TAINT |
+| vector.cpp:305:25:305:25 | ref arg b | vector.cpp:305:36:305:36 | b |  |
+| vector.cpp:305:25:305:25 | ref arg b | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:305:36:305:36 | ref arg b | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
+| vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
+| vector.cpp:306:7:306:7 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:308:7:308:7 | ref arg c | vector.cpp:309:7:309:7 | c |  |
+| vector.cpp:308:7:308:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:308:16:308:16 | ref arg c | vector.cpp:308:7:308:7 | c |  |
+| vector.cpp:308:16:308:16 | ref arg c | vector.cpp:309:7:309:7 | c |  |
+| vector.cpp:308:16:308:16 | ref arg c | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:308:18:308:20 | call to end | vector.cpp:308:16:308:22 | call to iterator | TAINT |
+| vector.cpp:308:25:308:25 | ref arg d | vector.cpp:308:36:308:36 | d |  |
+| vector.cpp:308:25:308:25 | ref arg d | vector.cpp:311:7:311:7 | d |  |
+| vector.cpp:308:25:308:25 | ref arg d | vector.cpp:311:16:311:16 | d |  |
+| vector.cpp:308:25:308:25 | ref arg d | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:308:25:308:25 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:7:311:7 | d |  |
+| vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:16:311:16 | d |  |
+| vector.cpp:308:36:308:36 | ref arg d | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:308:36:308:36 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:309:7:309:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:311:7:311:7 | ref arg d | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:311:7:311:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:311:16:311:16 | ref arg d | vector.cpp:311:7:311:7 | d |  |
+| vector.cpp:311:16:311:16 | ref arg d | vector.cpp:312:7:312:7 | d |  |
+| vector.cpp:311:16:311:16 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:311:18:311:20 | call to end | vector.cpp:311:16:311:22 | call to iterator | TAINT |
+| vector.cpp:311:25:311:25 | ref arg a | vector.cpp:311:36:311:36 | a |  |
+| vector.cpp:311:25:311:25 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:311:36:311:36 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:312:7:312:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2388,6 +2388,9 @@
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:85:7:85:8 | v7 |  |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:101:1:101:1 | v7 |  |
+| vector.cpp:81:3:81:4 | v7 | vector.cpp:81:6:81:11 | call to insert | TAINT |
+| vector.cpp:81:17:81:22 | call to source | vector.cpp:81:3:81:4 | ref arg v7 | TAINT |
+| vector.cpp:81:17:81:22 | call to source | vector.cpp:81:6:81:11 | call to insert | TAINT |
 | vector.cpp:83:7:83:8 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
 | vector.cpp:83:7:83:8 | ref arg v7 | vector.cpp:85:7:85:8 | v7 |  |
 | vector.cpp:83:7:83:8 | ref arg v7 | vector.cpp:101:1:101:1 | v7 |  |
@@ -2403,6 +2406,7 @@
 | vector.cpp:90:3:90:4 | ref arg v8 | vector.cpp:93:7:93:8 | v8 |  |
 | vector.cpp:90:3:90:4 | ref arg v8 | vector.cpp:94:7:94:8 | v8 |  |
 | vector.cpp:90:3:90:4 | ref arg v8 | vector.cpp:101:1:101:1 | v8 |  |
+| vector.cpp:90:3:90:4 | v8 | vector.cpp:90:6:90:11 | call to insert | TAINT |
 | vector.cpp:92:7:92:8 | ref arg v8 | vector.cpp:93:7:93:8 | v8 |  |
 | vector.cpp:92:7:92:8 | ref arg v8 | vector.cpp:94:7:94:8 | v8 |  |
 | vector.cpp:92:7:92:8 | ref arg v8 | vector.cpp:101:1:101:1 | v8 |  |
@@ -2918,6 +2922,7 @@
 | vector.cpp:303:2:303:2 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:303:2:303:2 | ref arg d | vector.cpp:313:1:313:1 | d |  |
 | vector.cpp:303:14:303:19 | call to source | vector.cpp:303:2:303:2 | ref arg d | TAINT |
+| vector.cpp:305:7:305:7 | a | vector.cpp:305:9:305:14 | call to insert | TAINT |
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:306:7:306:7 | a |  |
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
@@ -2932,11 +2937,16 @@
 | vector.cpp:305:25:305:25 | b | vector.cpp:305:27:305:31 | call to begin | TAINT |
 | vector.cpp:305:25:305:25 | ref arg b | vector.cpp:305:36:305:36 | b |  |
 | vector.cpp:305:25:305:25 | ref arg b | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:305:27:305:31 | call to begin | vector.cpp:305:7:305:7 | ref arg a | TAINT |
+| vector.cpp:305:27:305:31 | call to begin | vector.cpp:305:9:305:14 | call to insert | TAINT |
 | vector.cpp:305:36:305:36 | b | vector.cpp:305:38:305:40 | call to end | TAINT |
 | vector.cpp:305:36:305:36 | ref arg b | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:305:38:305:40 | call to end | vector.cpp:305:7:305:7 | ref arg a | TAINT |
+| vector.cpp:305:38:305:40 | call to end | vector.cpp:305:9:305:14 | call to insert | TAINT |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:308:7:308:7 | c | vector.cpp:308:9:308:14 | call to insert | TAINT |
 | vector.cpp:308:7:308:7 | ref arg c | vector.cpp:309:7:309:7 | c |  |
 | vector.cpp:308:7:308:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
 | vector.cpp:308:16:308:16 | c | vector.cpp:308:18:308:20 | call to end | TAINT |
@@ -2950,12 +2960,17 @@
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:311:16:311:16 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:308:27:308:31 | call to begin | vector.cpp:308:7:308:7 | ref arg c | TAINT |
+| vector.cpp:308:27:308:31 | call to begin | vector.cpp:308:9:308:14 | call to insert | TAINT |
 | vector.cpp:308:36:308:36 | d | vector.cpp:308:38:308:40 | call to end | TAINT |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:7:311:7 | d |  |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:16:311:16 | d |  |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:308:38:308:40 | call to end | vector.cpp:308:7:308:7 | ref arg c | TAINT |
+| vector.cpp:308:38:308:40 | call to end | vector.cpp:308:9:308:14 | call to insert | TAINT |
 | vector.cpp:309:7:309:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:311:7:311:7 | d | vector.cpp:311:9:311:14 | call to insert | TAINT |
 | vector.cpp:311:7:311:7 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:311:7:311:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |
 | vector.cpp:311:16:311:16 | d | vector.cpp:311:18:311:20 | call to end | TAINT |
@@ -2966,6 +2981,10 @@
 | vector.cpp:311:25:311:25 | a | vector.cpp:311:27:311:31 | call to begin | TAINT |
 | vector.cpp:311:25:311:25 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:311:25:311:25 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:311:27:311:31 | call to begin | vector.cpp:311:7:311:7 | ref arg d | TAINT |
+| vector.cpp:311:27:311:31 | call to begin | vector.cpp:311:9:311:14 | call to insert | TAINT |
 | vector.cpp:311:36:311:36 | a | vector.cpp:311:38:311:40 | call to end | TAINT |
 | vector.cpp:311:36:311:36 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:311:38:311:40 | call to end | vector.cpp:311:7:311:7 | ref arg d | TAINT |
+| vector.cpp:311:38:311:40 | call to end | vector.cpp:311:9:311:14 | call to insert | TAINT |
 | vector.cpp:312:7:312:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -461,12 +461,12 @@
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:53:12:53:18 | source1 |  |
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
 | standalone_iterators.cpp:53:12:53:18 | ref arg source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
-| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
-| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
-| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
-| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
-| stl.h:171:30:171:40 | call to allocator | stl.h:171:21:171:41 | noexcept(...) | TAINT |
-| stl.h:171:53:171:63 | 0 | stl.h:171:46:171:64 | (no string representation) | TAINT |
+| stl.h:172:30:172:40 | call to allocator | stl.h:172:21:172:41 | noexcept(...) | TAINT |
+| stl.h:172:30:172:40 | call to allocator | stl.h:172:21:172:41 | noexcept(...) | TAINT |
+| stl.h:172:30:172:40 | call to allocator | stl.h:172:21:172:41 | noexcept(...) | TAINT |
+| stl.h:172:30:172:40 | call to allocator | stl.h:172:21:172:41 | noexcept(...) | TAINT |
+| stl.h:172:30:172:40 | call to allocator | stl.h:172:21:172:41 | noexcept(...) | TAINT |
+| stl.h:172:53:172:63 | 0 | stl.h:172:46:172:64 | (no string representation) | TAINT |
 | string.cpp:24:12:24:17 | call to source | string.cpp:28:7:28:7 | a |  |
 | string.cpp:25:16:25:20 | 123 | string.cpp:25:16:25:21 | call to basic_string | TAINT |
 | string.cpp:25:16:25:21 | call to basic_string | string.cpp:29:7:29:7 | b |  |
@@ -1211,6 +1211,28 @@
 | string.cpp:490:31:490:32 | s5 | string.cpp:490:34:490:37 | call to cend | TAINT |
 | string.cpp:490:34:490:37 | call to cend | string.cpp:490:8:490:9 | ref arg s6 | TAINT |
 | string.cpp:490:34:490:37 | call to cend | string.cpp:490:11:490:16 | call to assign | TAINT |
+| string.cpp:496:14:496:18 | abc | string.cpp:498:17:498:19 | cs1 |  |
+| string.cpp:497:14:497:19 | call to source | string.cpp:499:17:499:19 | cs2 |  |
+| string.cpp:498:17:498:19 | cs1 | string.cpp:498:17:498:20 | call to basic_string | TAINT |
+| string.cpp:498:17:498:20 | call to basic_string | string.cpp:500:17:500:18 | s1 |  |
+| string.cpp:498:17:498:20 | call to basic_string | string.cpp:500:29:500:30 | s1 |  |
+| string.cpp:498:17:498:20 | call to basic_string | string.cpp:503:7:503:8 | s1 |  |
+| string.cpp:499:17:499:19 | cs2 | string.cpp:499:17:499:20 | call to basic_string | TAINT |
+| string.cpp:499:17:499:20 | call to basic_string | string.cpp:501:17:501:18 | s2 |  |
+| string.cpp:499:17:499:20 | call to basic_string | string.cpp:501:29:501:30 | s2 |  |
+| string.cpp:499:17:499:20 | call to basic_string | string.cpp:504:7:504:8 | s2 |  |
+| string.cpp:500:17:500:18 | ref arg s1 | string.cpp:500:29:500:30 | s1 |  |
+| string.cpp:500:17:500:18 | ref arg s1 | string.cpp:503:7:503:8 | s1 |  |
+| string.cpp:500:17:500:18 | s1 | string.cpp:500:20:500:24 | call to begin | TAINT |
+| string.cpp:500:17:500:37 | call to basic_string | string.cpp:505:7:505:8 | s3 |  |
+| string.cpp:500:29:500:30 | ref arg s1 | string.cpp:503:7:503:8 | s1 |  |
+| string.cpp:500:29:500:30 | s1 | string.cpp:500:32:500:34 | call to end | TAINT |
+| string.cpp:501:17:501:18 | ref arg s2 | string.cpp:501:29:501:30 | s2 |  |
+| string.cpp:501:17:501:18 | ref arg s2 | string.cpp:504:7:504:8 | s2 |  |
+| string.cpp:501:17:501:18 | s2 | string.cpp:501:20:501:24 | call to begin | TAINT |
+| string.cpp:501:17:501:37 | call to basic_string | string.cpp:506:7:506:8 | s4 |  |
+| string.cpp:501:29:501:30 | ref arg s2 | string.cpp:504:7:504:8 | s2 |  |
+| string.cpp:501:29:501:30 | s2 | string.cpp:501:32:501:34 | call to end | TAINT |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:16:2:16:4 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:22:7:22:9 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:27:7:27:9 | ss1 |  |
@@ -2988,3 +3010,39 @@
 | vector.cpp:311:38:311:40 | call to end | vector.cpp:311:7:311:7 | ref arg d | TAINT |
 | vector.cpp:311:38:311:40 | call to end | vector.cpp:311:9:311:14 | call to insert | TAINT |
 | vector.cpp:312:7:312:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:316:19:316:20 | call to vector | vector.cpp:320:22:320:23 | v1 |  |
+| vector.cpp:316:19:316:20 | call to vector | vector.cpp:320:34:320:35 | v1 |  |
+| vector.cpp:316:19:316:20 | call to vector | vector.cpp:323:7:323:8 | v1 |  |
+| vector.cpp:316:19:316:20 | call to vector | vector.cpp:327:1:327:1 | v1 |  |
+| vector.cpp:317:19:317:20 | call to vector | vector.cpp:318:2:318:3 | v2 |  |
+| vector.cpp:317:19:317:20 | call to vector | vector.cpp:321:22:321:23 | v2 |  |
+| vector.cpp:317:19:317:20 | call to vector | vector.cpp:321:34:321:35 | v2 |  |
+| vector.cpp:317:19:317:20 | call to vector | vector.cpp:324:7:324:8 | v2 |  |
+| vector.cpp:317:19:317:20 | call to vector | vector.cpp:327:1:327:1 | v2 |  |
+| vector.cpp:318:2:318:3 | ref arg v2 | vector.cpp:321:22:321:23 | v2 |  |
+| vector.cpp:318:2:318:3 | ref arg v2 | vector.cpp:321:34:321:35 | v2 |  |
+| vector.cpp:318:2:318:3 | ref arg v2 | vector.cpp:324:7:324:8 | v2 |  |
+| vector.cpp:318:2:318:3 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
+| vector.cpp:318:15:318:20 | call to source | vector.cpp:318:2:318:3 | ref arg v2 | TAINT |
+| vector.cpp:320:22:320:23 | ref arg v1 | vector.cpp:320:34:320:35 | v1 |  |
+| vector.cpp:320:22:320:23 | ref arg v1 | vector.cpp:323:7:323:8 | v1 |  |
+| vector.cpp:320:22:320:23 | ref arg v1 | vector.cpp:327:1:327:1 | v1 |  |
+| vector.cpp:320:22:320:23 | v1 | vector.cpp:320:25:320:29 | call to begin | TAINT |
+| vector.cpp:320:22:320:42 | call to vector | vector.cpp:325:7:325:8 | v3 |  |
+| vector.cpp:320:22:320:42 | call to vector | vector.cpp:327:1:327:1 | v3 |  |
+| vector.cpp:320:34:320:35 | ref arg v1 | vector.cpp:323:7:323:8 | v1 |  |
+| vector.cpp:320:34:320:35 | ref arg v1 | vector.cpp:327:1:327:1 | v1 |  |
+| vector.cpp:320:34:320:35 | v1 | vector.cpp:320:37:320:39 | call to end | TAINT |
+| vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:321:34:321:35 | v2 |  |
+| vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:324:7:324:8 | v2 |  |
+| vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
+| vector.cpp:321:22:321:23 | v2 | vector.cpp:321:25:321:29 | call to begin | TAINT |
+| vector.cpp:321:22:321:42 | call to vector | vector.cpp:326:7:326:8 | v4 |  |
+| vector.cpp:321:22:321:42 | call to vector | vector.cpp:327:1:327:1 | v4 |  |
+| vector.cpp:321:34:321:35 | ref arg v2 | vector.cpp:324:7:324:8 | v2 |  |
+| vector.cpp:321:34:321:35 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
+| vector.cpp:321:34:321:35 | v2 | vector.cpp:321:37:321:39 | call to end | TAINT |
+| vector.cpp:323:7:323:8 | ref arg v1 | vector.cpp:327:1:327:1 | v1 |  |
+| vector.cpp:324:7:324:8 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
+| vector.cpp:325:7:325:8 | ref arg v3 | vector.cpp:327:1:327:1 | v3 |  |
+| vector.cpp:326:7:326:8 | ref arg v4 | vector.cpp:327:1:327:1 | v4 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -245,6 +245,8 @@
 | file://:0:0:0:0 | p#0 | file://:0:0:0:0 | p#0 |  |
 | file://:0:0:0:0 | p#0 | file://:0:0:0:0 | p#0 |  |
 | file://:0:0:0:0 | p#0 | file://:0:0:0:0 | p#0 |  |
+| file://:0:0:0:0 | p#0 | file://:0:0:0:0 | p#0 |  |
+| file://:0:0:0:0 | p#0 | file://:0:0:0:0 | p#0 |  |
 | format.cpp:16:21:16:21 | s | format.cpp:22:22:22:22 | s |  |
 | format.cpp:16:31:16:31 | n | format.cpp:22:25:22:25 | n |  |
 | format.cpp:16:46:16:51 | format | format.cpp:22:28:22:33 | format |  |
@@ -459,12 +461,12 @@
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:53:12:53:18 | source1 |  |
 | standalone_iterators.cpp:51:37:51:43 | source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
 | standalone_iterators.cpp:53:12:53:18 | ref arg source1 | standalone_iterators.cpp:54:14:54:20 | source1 |  |
-| stl.h:156:30:156:40 | call to allocator | stl.h:156:21:156:41 | noexcept(...) | TAINT |
-| stl.h:156:30:156:40 | call to allocator | stl.h:156:21:156:41 | noexcept(...) | TAINT |
-| stl.h:156:30:156:40 | call to allocator | stl.h:156:21:156:41 | noexcept(...) | TAINT |
-| stl.h:156:30:156:40 | call to allocator | stl.h:156:21:156:41 | noexcept(...) | TAINT |
-| stl.h:156:30:156:40 | call to allocator | stl.h:156:21:156:41 | noexcept(...) | TAINT |
-| stl.h:156:53:156:63 | 0 | stl.h:156:46:156:64 | (no string representation) | TAINT |
+| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
+| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
+| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
+| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
+| stl.h:168:30:168:40 | call to allocator | stl.h:168:21:168:41 | noexcept(...) | TAINT |
+| stl.h:168:53:168:63 | 0 | stl.h:168:46:168:64 | (no string representation) | TAINT |
 | string.cpp:24:12:24:17 | call to source | string.cpp:28:7:28:7 | a |  |
 | string.cpp:25:16:25:20 | 123 | string.cpp:25:16:25:21 | call to basic_string | TAINT |
 | string.cpp:25:16:25:21 | call to basic_string | string.cpp:29:7:29:7 | b |  |
@@ -527,6 +529,7 @@
 | string.cpp:119:16:119:24 | call to basic_string | string.cpp:128:16:128:16 | s |  |
 | string.cpp:120:15:120:15 | (__begin) | string.cpp:120:15:120:15 | call to operator* | TAINT |
 | string.cpp:120:15:120:15 | (__begin) | string.cpp:120:15:120:15 | call to operator++ | TAINT |
+| string.cpp:120:15:120:15 | (__end) | string.cpp:120:15:120:15 | call to iterator |  |
 | string.cpp:120:15:120:15 | (__range) | string.cpp:120:15:120:15 | call to begin | TAINT |
 | string.cpp:120:15:120:15 | (__range) | string.cpp:120:15:120:15 | call to end | TAINT |
 | string.cpp:120:15:120:15 | call to begin | string.cpp:120:15:120:15 | (__begin) |  |
@@ -557,6 +560,7 @@
 | string.cpp:125:9:125:10 | it | string.cpp:125:8:125:8 | call to operator* | TAINT |
 | string.cpp:128:16:128:16 | (__begin) | string.cpp:128:16:128:16 | call to operator* | TAINT |
 | string.cpp:128:16:128:16 | (__begin) | string.cpp:128:16:128:16 | call to operator++ | TAINT |
+| string.cpp:128:16:128:16 | (__end) | string.cpp:128:16:128:16 | call to iterator |  |
 | string.cpp:128:16:128:16 | (__range) | string.cpp:128:16:128:16 | call to begin | TAINT |
 | string.cpp:128:16:128:16 | (__range) | string.cpp:128:16:128:16 | call to end | TAINT |
 | string.cpp:128:16:128:16 | call to begin | string.cpp:128:16:128:16 | (__begin) |  |
@@ -1874,6 +1878,7 @@
 | vector.cpp:17:26:17:32 | source1 | vector.cpp:17:21:17:33 | call to vector | TAINT |
 | vector.cpp:19:14:19:14 | (__begin) | vector.cpp:19:14:19:14 | call to operator* | TAINT |
 | vector.cpp:19:14:19:14 | (__begin) | vector.cpp:19:14:19:14 | call to operator++ | TAINT |
+| vector.cpp:19:14:19:14 | (__end) | vector.cpp:19:14:19:14 | call to iterator |  |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
@@ -1902,6 +1907,7 @@
 | vector.cpp:24:9:24:10 | it | vector.cpp:24:8:24:8 | call to operator* | TAINT |
 | vector.cpp:27:15:27:15 | (__begin) | vector.cpp:27:15:27:15 | call to operator* | TAINT |
 | vector.cpp:27:15:27:15 | (__begin) | vector.cpp:27:15:27:15 | call to operator++ | TAINT |
+| vector.cpp:27:15:27:15 | (__end) | vector.cpp:27:15:27:15 | call to iterator |  |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
@@ -1977,7 +1983,7 @@
 | vector.cpp:38:62:38:64 | call to vector | vector.cpp:75:7:75:8 | v6 |  |
 | vector.cpp:38:62:38:64 | call to vector | vector.cpp:76:7:76:8 | v6 |  |
 | vector.cpp:38:62:38:64 | call to vector | vector.cpp:101:1:101:1 | v6 |  |
-| vector.cpp:38:70:38:72 | call to vector | vector.cpp:79:33:79:34 | v7 |  |
+| vector.cpp:38:70:38:72 | call to vector | vector.cpp:80:41:80:42 | v7 |  |
 | vector.cpp:38:70:38:72 | call to vector | vector.cpp:81:3:81:4 | v7 |  |
 | vector.cpp:38:70:38:72 | call to vector | vector.cpp:83:7:83:8 | v7 |  |
 | vector.cpp:38:70:38:72 | call to vector | vector.cpp:84:7:84:8 | v7 |  |
@@ -2166,8 +2172,13 @@
 | vector.cpp:76:7:76:8 | v6 | vector.cpp:76:10:76:13 | call to data | TAINT |
 | vector.cpp:76:10:76:13 | call to data | vector.cpp:76:7:76:18 | access to array | TAINT |
 | vector.cpp:76:17:76:17 | 2 | vector.cpp:76:7:76:18 | access to array | TAINT |
-| vector.cpp:79:33:79:34 | v7 | vector.cpp:80:41:80:43 | v7c |  |
-| vector.cpp:80:45:80:49 | call to begin | vector.cpp:81:13:81:14 | it |  |
+| vector.cpp:80:40:80:50 | call to iterator | vector.cpp:81:13:81:14 | it |  |
+| vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:81:3:81:4 | v7 |  |
+| vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:83:7:83:8 | v7 |  |
+| vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
+| vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:85:7:85:8 | v7 |  |
+| vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:101:1:101:1 | v7 |  |
+| vector.cpp:80:44:80:48 | call to begin | vector.cpp:80:40:80:50 | call to iterator | TAINT |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:83:7:83:8 | v7 |  |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:85:7:85:8 | v7 |  |
@@ -2590,6 +2601,8 @@
 | vector.cpp:254:3:254:4 | ref arg i2 | vector.cpp:260:8:260:9 | i2 |  |
 | vector.cpp:255:3:255:4 | ref arg v6 | vector.cpp:261:8:261:9 | v6 |  |
 | vector.cpp:255:3:255:4 | ref arg v6 | vector.cpp:262:2:262:2 | v6 |  |
+| vector.cpp:255:13:255:14 | i1 | vector.cpp:255:13:255:14 | call to iterator |  |
+| vector.cpp:255:17:255:18 | i2 | vector.cpp:255:17:255:18 | call to iterator |  |
 | vector.cpp:257:8:257:9 | ref arg v4 | vector.cpp:262:2:262:2 | v4 |  |
 | vector.cpp:258:8:258:9 | ref arg v5 | vector.cpp:262:2:262:2 | v5 |  |
 | vector.cpp:261:8:261:9 | ref arg v6 | vector.cpp:262:2:262:2 | v6 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2075,6 +2075,8 @@
 | vector.cpp:19:14:19:14 | (__begin) | vector.cpp:19:14:19:14 | call to operator* | TAINT |
 | vector.cpp:19:14:19:14 | (__begin) | vector.cpp:19:14:19:14 | call to operator++ | TAINT |
 | vector.cpp:19:14:19:14 | (__end) | vector.cpp:19:14:19:14 | call to iterator |  |
+| vector.cpp:19:14:19:14 | (__range) | vector.cpp:19:14:19:14 | call to begin | TAINT |
+| vector.cpp:19:14:19:14 | (__range) | vector.cpp:19:14:19:14 | call to end | TAINT |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
 | vector.cpp:19:14:19:14 | call to begin | vector.cpp:19:14:19:14 | (__begin) |  |
@@ -2090,12 +2092,14 @@
 | vector.cpp:23:38:23:38 | ref arg v | vector.cpp:23:55:23:55 | v |  |
 | vector.cpp:23:38:23:38 | ref arg v | vector.cpp:27:15:27:15 | v |  |
 | vector.cpp:23:38:23:38 | ref arg v | vector.cpp:35:1:35:1 | v |  |
+| vector.cpp:23:38:23:38 | v | vector.cpp:23:40:23:44 | call to begin | TAINT |
 | vector.cpp:23:40:23:44 | call to begin | vector.cpp:23:49:23:50 | it |  |
 | vector.cpp:23:40:23:44 | call to begin | vector.cpp:23:66:23:67 | it |  |
 | vector.cpp:23:40:23:44 | call to begin | vector.cpp:24:9:24:10 | it |  |
 | vector.cpp:23:55:23:55 | ref arg v | vector.cpp:23:55:23:55 | v |  |
 | vector.cpp:23:55:23:55 | ref arg v | vector.cpp:27:15:27:15 | v |  |
 | vector.cpp:23:55:23:55 | ref arg v | vector.cpp:35:1:35:1 | v |  |
+| vector.cpp:23:55:23:55 | v | vector.cpp:23:57:23:59 | call to end | TAINT |
 | vector.cpp:23:66:23:67 | it | vector.cpp:23:64:23:64 | call to operator++ | TAINT |
 | vector.cpp:23:66:23:67 | ref arg it | vector.cpp:23:49:23:50 | it |  |
 | vector.cpp:23:66:23:67 | ref arg it | vector.cpp:23:66:23:67 | it |  |
@@ -2104,6 +2108,8 @@
 | vector.cpp:27:15:27:15 | (__begin) | vector.cpp:27:15:27:15 | call to operator* | TAINT |
 | vector.cpp:27:15:27:15 | (__begin) | vector.cpp:27:15:27:15 | call to operator++ | TAINT |
 | vector.cpp:27:15:27:15 | (__end) | vector.cpp:27:15:27:15 | call to iterator |  |
+| vector.cpp:27:15:27:15 | (__range) | vector.cpp:27:15:27:15 | call to begin | TAINT |
+| vector.cpp:27:15:27:15 | (__range) | vector.cpp:27:15:27:15 | call to end | TAINT |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
 | vector.cpp:27:15:27:15 | call to begin | vector.cpp:27:15:27:15 | (__begin) |  |
@@ -2121,6 +2127,8 @@
 | vector.cpp:31:38:31:44 | source1 | vector.cpp:31:33:31:45 | call to vector | TAINT |
 | vector.cpp:32:21:32:21 | (__begin) | vector.cpp:32:21:32:21 | call to operator* | TAINT |
 | vector.cpp:32:21:32:21 | (__begin) | vector.cpp:32:21:32:21 | call to operator++ | TAINT |
+| vector.cpp:32:21:32:21 | (__range) | vector.cpp:32:21:32:21 | call to begin | TAINT |
+| vector.cpp:32:21:32:21 | (__range) | vector.cpp:32:21:32:21 | call to end | TAINT |
 | vector.cpp:32:21:32:21 | call to begin | vector.cpp:32:21:32:21 | (__begin) |  |
 | vector.cpp:32:21:32:21 | call to begin | vector.cpp:32:21:32:21 | (__begin) |  |
 | vector.cpp:32:21:32:21 | call to begin | vector.cpp:32:21:32:21 | (__begin) |  |
@@ -2374,6 +2382,7 @@
 | vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
 | vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:85:7:85:8 | v7 |  |
 | vector.cpp:80:41:80:42 | ref arg v7 | vector.cpp:101:1:101:1 | v7 |  |
+| vector.cpp:80:41:80:42 | v7 | vector.cpp:80:44:80:48 | call to begin | TAINT |
 | vector.cpp:80:44:80:48 | call to begin | vector.cpp:80:40:80:50 | call to iterator | TAINT |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:83:7:83:8 | v7 |  |
 | vector.cpp:81:3:81:4 | ref arg v7 | vector.cpp:84:7:84:8 | v7 |  |
@@ -2388,6 +2397,7 @@
 | vector.cpp:85:7:85:8 | ref arg v7 | vector.cpp:101:1:101:1 | v7 |  |
 | vector.cpp:85:7:85:8 | v7 | vector.cpp:85:10:85:13 | call to back | TAINT |
 | vector.cpp:88:33:88:34 | v8 | vector.cpp:89:41:89:43 | v8c |  |
+| vector.cpp:89:41:89:43 | v8c | vector.cpp:89:45:89:49 | call to begin | TAINT |
 | vector.cpp:89:45:89:49 | call to begin | vector.cpp:90:13:90:14 | it |  |
 | vector.cpp:90:3:90:4 | ref arg v8 | vector.cpp:92:7:92:8 | v8 |  |
 | vector.cpp:90:3:90:4 | ref arg v8 | vector.cpp:93:7:93:8 | v8 |  |
@@ -2770,15 +2780,20 @@
 | vector.cpp:249:3:249:4 | ref arg v4 | vector.cpp:262:2:262:2 | v4 |  |
 | vector.cpp:249:13:249:14 | ref arg v1 | vector.cpp:249:25:249:26 | v1 |  |
 | vector.cpp:249:13:249:14 | ref arg v1 | vector.cpp:277:1:277:1 | v1 |  |
+| vector.cpp:249:13:249:14 | v1 | vector.cpp:249:16:249:20 | call to begin | TAINT |
 | vector.cpp:249:25:249:26 | ref arg v1 | vector.cpp:277:1:277:1 | v1 |  |
+| vector.cpp:249:25:249:26 | v1 | vector.cpp:249:28:249:30 | call to end | TAINT |
 | vector.cpp:250:3:250:4 | ref arg v5 | vector.cpp:258:8:258:9 | v5 |  |
 | vector.cpp:250:3:250:4 | ref arg v5 | vector.cpp:262:2:262:2 | v5 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:250:25:250:26 | v3 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:251:8:251:9 | v3 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
+| vector.cpp:250:13:250:14 | v3 | vector.cpp:250:16:250:20 | call to begin | TAINT |
 | vector.cpp:250:25:250:26 | ref arg v3 | vector.cpp:251:8:251:9 | v3 |  |
 | vector.cpp:250:25:250:26 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
+| vector.cpp:250:25:250:26 | v3 | vector.cpp:250:28:250:30 | call to end | TAINT |
 | vector.cpp:251:8:251:9 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
+| vector.cpp:251:8:251:9 | v3 | vector.cpp:251:11:251:15 | call to begin | TAINT |
 | vector.cpp:251:11:251:15 | call to begin | vector.cpp:251:3:251:17 | ... = ... |  |
 | vector.cpp:251:11:251:15 | call to begin | vector.cpp:252:3:252:4 | i1 |  |
 | vector.cpp:251:11:251:15 | call to begin | vector.cpp:253:8:253:9 | i1 |  |
@@ -2901,29 +2916,35 @@
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:305:7:305:7 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:305:16:305:16 | a | vector.cpp:305:18:305:20 | call to end | TAINT |
 | vector.cpp:305:16:305:16 | ref arg a | vector.cpp:305:7:305:7 | a |  |
 | vector.cpp:305:16:305:16 | ref arg a | vector.cpp:306:7:306:7 | a |  |
 | vector.cpp:305:16:305:16 | ref arg a | vector.cpp:311:25:311:25 | a |  |
 | vector.cpp:305:16:305:16 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:305:16:305:16 | ref arg a | vector.cpp:313:1:313:1 | a |  |
 | vector.cpp:305:18:305:20 | call to end | vector.cpp:305:16:305:22 | call to iterator | TAINT |
+| vector.cpp:305:25:305:25 | b | vector.cpp:305:27:305:31 | call to begin | TAINT |
 | vector.cpp:305:25:305:25 | ref arg b | vector.cpp:305:36:305:36 | b |  |
 | vector.cpp:305:25:305:25 | ref arg b | vector.cpp:313:1:313:1 | b |  |
+| vector.cpp:305:36:305:36 | b | vector.cpp:305:38:305:40 | call to end | TAINT |
 | vector.cpp:305:36:305:36 | ref arg b | vector.cpp:313:1:313:1 | b |  |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:25:311:25 | a |  |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:306:7:306:7 | ref arg a | vector.cpp:313:1:313:1 | a |  |
 | vector.cpp:308:7:308:7 | ref arg c | vector.cpp:309:7:309:7 | c |  |
 | vector.cpp:308:7:308:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
+| vector.cpp:308:16:308:16 | c | vector.cpp:308:18:308:20 | call to end | TAINT |
 | vector.cpp:308:16:308:16 | ref arg c | vector.cpp:308:7:308:7 | c |  |
 | vector.cpp:308:16:308:16 | ref arg c | vector.cpp:309:7:309:7 | c |  |
 | vector.cpp:308:16:308:16 | ref arg c | vector.cpp:313:1:313:1 | c |  |
 | vector.cpp:308:18:308:20 | call to end | vector.cpp:308:16:308:22 | call to iterator | TAINT |
+| vector.cpp:308:25:308:25 | d | vector.cpp:308:27:308:31 | call to begin | TAINT |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:308:36:308:36 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:311:7:311:7 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:311:16:311:16 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:308:25:308:25 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:308:36:308:36 | d | vector.cpp:308:38:308:40 | call to end | TAINT |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:7:311:7 | d |  |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:311:16:311:16 | d |  |
 | vector.cpp:308:36:308:36 | ref arg d | vector.cpp:312:7:312:7 | d |  |
@@ -2931,11 +2952,14 @@
 | vector.cpp:309:7:309:7 | ref arg c | vector.cpp:313:1:313:1 | c |  |
 | vector.cpp:311:7:311:7 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:311:7:311:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |
+| vector.cpp:311:16:311:16 | d | vector.cpp:311:18:311:20 | call to end | TAINT |
 | vector.cpp:311:16:311:16 | ref arg d | vector.cpp:311:7:311:7 | d |  |
 | vector.cpp:311:16:311:16 | ref arg d | vector.cpp:312:7:312:7 | d |  |
 | vector.cpp:311:16:311:16 | ref arg d | vector.cpp:313:1:313:1 | d |  |
 | vector.cpp:311:18:311:20 | call to end | vector.cpp:311:16:311:22 | call to iterator | TAINT |
+| vector.cpp:311:25:311:25 | a | vector.cpp:311:27:311:31 | call to begin | TAINT |
 | vector.cpp:311:25:311:25 | ref arg a | vector.cpp:311:36:311:36 | a |  |
 | vector.cpp:311:25:311:25 | ref arg a | vector.cpp:313:1:313:1 | a |  |
+| vector.cpp:311:36:311:36 | a | vector.cpp:311:38:311:40 | call to end | TAINT |
 | vector.cpp:311:36:311:36 | ref arg a | vector.cpp:313:1:313:1 | a |  |
 | vector.cpp:312:7:312:7 | ref arg d | vector.cpp:313:1:313:1 | d |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2781,17 +2781,21 @@
 | vector.cpp:249:13:249:14 | ref arg v1 | vector.cpp:249:25:249:26 | v1 |  |
 | vector.cpp:249:13:249:14 | ref arg v1 | vector.cpp:277:1:277:1 | v1 |  |
 | vector.cpp:249:13:249:14 | v1 | vector.cpp:249:16:249:20 | call to begin | TAINT |
+| vector.cpp:249:16:249:20 | call to begin | vector.cpp:249:3:249:4 | ref arg v4 | TAINT |
 | vector.cpp:249:25:249:26 | ref arg v1 | vector.cpp:277:1:277:1 | v1 |  |
 | vector.cpp:249:25:249:26 | v1 | vector.cpp:249:28:249:30 | call to end | TAINT |
+| vector.cpp:249:28:249:30 | call to end | vector.cpp:249:3:249:4 | ref arg v4 | TAINT |
 | vector.cpp:250:3:250:4 | ref arg v5 | vector.cpp:258:8:258:9 | v5 |  |
 | vector.cpp:250:3:250:4 | ref arg v5 | vector.cpp:262:2:262:2 | v5 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:250:25:250:26 | v3 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:251:8:251:9 | v3 |  |
 | vector.cpp:250:13:250:14 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
 | vector.cpp:250:13:250:14 | v3 | vector.cpp:250:16:250:20 | call to begin | TAINT |
+| vector.cpp:250:16:250:20 | call to begin | vector.cpp:250:3:250:4 | ref arg v5 | TAINT |
 | vector.cpp:250:25:250:26 | ref arg v3 | vector.cpp:251:8:251:9 | v3 |  |
 | vector.cpp:250:25:250:26 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
 | vector.cpp:250:25:250:26 | v3 | vector.cpp:250:28:250:30 | call to end | TAINT |
+| vector.cpp:250:28:250:30 | call to end | vector.cpp:250:3:250:4 | ref arg v5 | TAINT |
 | vector.cpp:251:8:251:9 | ref arg v3 | vector.cpp:277:1:277:1 | v3 |  |
 | vector.cpp:251:8:251:9 | v3 | vector.cpp:251:11:251:15 | call to begin | TAINT |
 | vector.cpp:251:11:251:15 | call to begin | vector.cpp:251:3:251:17 | ... = ... |  |
@@ -2812,7 +2816,9 @@
 | vector.cpp:254:3:254:4 | ref arg i2 | vector.cpp:260:8:260:9 | i2 |  |
 | vector.cpp:255:3:255:4 | ref arg v6 | vector.cpp:261:8:261:9 | v6 |  |
 | vector.cpp:255:3:255:4 | ref arg v6 | vector.cpp:262:2:262:2 | v6 |  |
+| vector.cpp:255:13:255:14 | call to iterator | vector.cpp:255:3:255:4 | ref arg v6 | TAINT |
 | vector.cpp:255:13:255:14 | i1 | vector.cpp:255:13:255:14 | call to iterator |  |
+| vector.cpp:255:17:255:18 | call to iterator | vector.cpp:255:3:255:4 | ref arg v6 | TAINT |
 | vector.cpp:255:17:255:18 | i2 | vector.cpp:255:17:255:18 | call to iterator |  |
 | vector.cpp:257:8:257:9 | ref arg v4 | vector.cpp:262:2:262:2 | v4 |  |
 | vector.cpp:258:8:258:9 | ref arg v5 | vector.cpp:262:2:262:2 | v5 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -1225,14 +1225,18 @@
 | string.cpp:500:17:500:18 | ref arg s1 | string.cpp:503:7:503:8 | s1 |  |
 | string.cpp:500:17:500:18 | s1 | string.cpp:500:20:500:24 | call to begin | TAINT |
 | string.cpp:500:17:500:37 | call to basic_string | string.cpp:505:7:505:8 | s3 |  |
+| string.cpp:500:20:500:24 | call to begin | string.cpp:500:17:500:37 | call to basic_string | TAINT |
 | string.cpp:500:29:500:30 | ref arg s1 | string.cpp:503:7:503:8 | s1 |  |
 | string.cpp:500:29:500:30 | s1 | string.cpp:500:32:500:34 | call to end | TAINT |
+| string.cpp:500:32:500:34 | call to end | string.cpp:500:17:500:37 | call to basic_string | TAINT |
 | string.cpp:501:17:501:18 | ref arg s2 | string.cpp:501:29:501:30 | s2 |  |
 | string.cpp:501:17:501:18 | ref arg s2 | string.cpp:504:7:504:8 | s2 |  |
 | string.cpp:501:17:501:18 | s2 | string.cpp:501:20:501:24 | call to begin | TAINT |
 | string.cpp:501:17:501:37 | call to basic_string | string.cpp:506:7:506:8 | s4 |  |
+| string.cpp:501:20:501:24 | call to begin | string.cpp:501:17:501:37 | call to basic_string | TAINT |
 | string.cpp:501:29:501:30 | ref arg s2 | string.cpp:504:7:504:8 | s2 |  |
 | string.cpp:501:29:501:30 | s2 | string.cpp:501:32:501:34 | call to end | TAINT |
+| string.cpp:501:32:501:34 | call to end | string.cpp:501:17:501:37 | call to basic_string | TAINT |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:16:2:16:4 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:22:7:22:9 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:27:7:27:9 | ss1 |  |
@@ -3030,18 +3034,22 @@
 | vector.cpp:320:22:320:23 | v1 | vector.cpp:320:25:320:29 | call to begin | TAINT |
 | vector.cpp:320:22:320:42 | call to vector | vector.cpp:325:7:325:8 | v3 |  |
 | vector.cpp:320:22:320:42 | call to vector | vector.cpp:327:1:327:1 | v3 |  |
+| vector.cpp:320:25:320:29 | call to begin | vector.cpp:320:22:320:42 | call to vector | TAINT |
 | vector.cpp:320:34:320:35 | ref arg v1 | vector.cpp:323:7:323:8 | v1 |  |
 | vector.cpp:320:34:320:35 | ref arg v1 | vector.cpp:327:1:327:1 | v1 |  |
 | vector.cpp:320:34:320:35 | v1 | vector.cpp:320:37:320:39 | call to end | TAINT |
+| vector.cpp:320:37:320:39 | call to end | vector.cpp:320:22:320:42 | call to vector | TAINT |
 | vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:321:34:321:35 | v2 |  |
 | vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:324:7:324:8 | v2 |  |
 | vector.cpp:321:22:321:23 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
 | vector.cpp:321:22:321:23 | v2 | vector.cpp:321:25:321:29 | call to begin | TAINT |
 | vector.cpp:321:22:321:42 | call to vector | vector.cpp:326:7:326:8 | v4 |  |
 | vector.cpp:321:22:321:42 | call to vector | vector.cpp:327:1:327:1 | v4 |  |
+| vector.cpp:321:25:321:29 | call to begin | vector.cpp:321:22:321:42 | call to vector | TAINT |
 | vector.cpp:321:34:321:35 | ref arg v2 | vector.cpp:324:7:324:8 | v2 |  |
 | vector.cpp:321:34:321:35 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
 | vector.cpp:321:34:321:35 | v2 | vector.cpp:321:37:321:39 | call to end | TAINT |
+| vector.cpp:321:37:321:39 | call to end | vector.cpp:321:22:321:42 | call to vector | TAINT |
 | vector.cpp:323:7:323:8 | ref arg v1 | vector.cpp:327:1:327:1 | v1 |  |
 | vector.cpp:324:7:324:8 | ref arg v2 | vector.cpp:327:1:327:1 | v2 |  |
 | vector.cpp:325:7:325:8 | ref arg v3 | vector.cpp:327:1:327:1 | v3 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -1192,13 +1192,25 @@
 | string.cpp:482:18:482:26 | call to basic_string | string.cpp:491:8:491:9 | s6 |  |
 | string.cpp:484:8:484:8 | ref arg g | string.cpp:485:8:485:8 | g |  |
 | string.cpp:484:17:484:18 | s5 | string.cpp:484:20:484:25 | call to cbegin | TAINT |
+| string.cpp:484:20:484:25 | call to cbegin | string.cpp:484:8:484:8 | ref arg g | TAINT |
+| string.cpp:484:20:484:25 | call to cbegin | string.cpp:484:10:484:15 | call to assign | TAINT |
 | string.cpp:484:30:484:31 | s5 | string.cpp:484:33:484:36 | call to cend | TAINT |
+| string.cpp:484:33:484:36 | call to cend | string.cpp:484:8:484:8 | ref arg g | TAINT |
+| string.cpp:484:33:484:36 | call to cend | string.cpp:484:10:484:15 | call to assign | TAINT |
 | string.cpp:487:8:487:8 | ref arg h | string.cpp:488:8:488:8 | h |  |
 | string.cpp:487:17:487:18 | s6 | string.cpp:487:20:487:25 | call to cbegin | TAINT |
+| string.cpp:487:20:487:25 | call to cbegin | string.cpp:487:8:487:8 | ref arg h | TAINT |
+| string.cpp:487:20:487:25 | call to cbegin | string.cpp:487:10:487:15 | call to assign | TAINT |
 | string.cpp:487:30:487:31 | s6 | string.cpp:487:33:487:36 | call to cend | TAINT |
+| string.cpp:487:33:487:36 | call to cend | string.cpp:487:8:487:8 | ref arg h | TAINT |
+| string.cpp:487:33:487:36 | call to cend | string.cpp:487:10:487:15 | call to assign | TAINT |
 | string.cpp:490:8:490:9 | ref arg s6 | string.cpp:491:8:491:9 | s6 |  |
 | string.cpp:490:18:490:19 | s5 | string.cpp:490:21:490:26 | call to cbegin | TAINT |
+| string.cpp:490:21:490:26 | call to cbegin | string.cpp:490:8:490:9 | ref arg s6 | TAINT |
+| string.cpp:490:21:490:26 | call to cbegin | string.cpp:490:11:490:16 | call to assign | TAINT |
 | string.cpp:490:31:490:32 | s5 | string.cpp:490:34:490:37 | call to cend | TAINT |
+| string.cpp:490:34:490:37 | call to cend | string.cpp:490:8:490:9 | ref arg s6 | TAINT |
+| string.cpp:490:34:490:37 | call to cend | string.cpp:490:11:490:16 | call to assign | TAINT |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:16:2:16:4 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:22:7:22:9 | ss1 |  |
 | stringstream.cpp:13:20:13:22 | call to basic_stringstream | stringstream.cpp:27:7:27:9 | ss1 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -99,12 +99,15 @@ namespace std
 		basic_string& append(const basic_string& str);
 		basic_string& append(const charT* s);
 		basic_string& append(size_type n, charT c);
-		template<class InputIterator>
-		/* constexpr */ basic_string& append(InputIterator first, InputIterator last);
+		template<class InputIterator> basic_string& append(InputIterator first, InputIterator last); 
 		basic_string& assign(const basic_string& str);
 		basic_string& assign(size_type n, charT c);
+		template<class InputIterator> basic_string& assign(InputIterator first, InputIterator last);
 		basic_string& insert(size_type pos, const basic_string& str);
 		basic_string& insert(size_type pos, size_type n, charT c);
+		basic_string& insert(size_type pos, const charT* s);
+		iterator insert(const_iterator p, size_type n, charT c);
+		template<class InputIterator> iterator insert(const_iterator p, InputIterator first, InputIterator last); 
 		basic_string& replace(size_type pos1, size_type n1, const basic_string& str);
 		basic_string& replace(size_type pos1, size_type n1, size_type n2, charT c);
 		size_type copy(charT* s, size_type n, size_type pos = 0) const;
@@ -203,6 +206,7 @@ namespace std {
 		iterator insert(const_iterator position, const T& x);
 		iterator insert(const_iterator position, T&& x);
 		iterator insert(const_iterator position, size_type n, const T& x);
+		template<class InputIterator> iterator insert(const_iterator position, InputIterator first, InputIterator last);
 
 		void swap(vector&) noexcept/*(allocator_traits<Allocator>::propagate_on_container_swap::value || allocator_traits<Allocator>::is_always_equal::value)*/;
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -75,6 +75,7 @@ namespace std
 
 		explicit basic_string(const Allocator& a = Allocator());
 		basic_string(const charT* s, const Allocator& a = Allocator());
+		template<class InputIterator> basic_string(InputIterator begin, InputIterator end, const Allocator& a = Allocator());
 
 		const charT* c_str() const;
 		charT* data() noexcept;
@@ -171,7 +172,10 @@ namespace std {
 		vector() noexcept(noexcept(Allocator())) : vector(Allocator()) { }
 		explicit vector(const Allocator&) noexcept;
 		explicit vector(size_type n, const Allocator& = Allocator());
-		vector(size_type n, const T& value, const Allocator& = Allocator()); 
+		vector(size_type n, const T& value, const Allocator& = Allocator());
+		template<class InputIterator, class IteratorCategory = typename InputIterator::iterator_category> vector(InputIterator first, InputIterator last, const Allocator& = Allocator());
+			// use of `iterator_category` makes sure InputIterator is (probably) an iterator, and not an `int` or
+			// similar that should match a different overload (SFINAE).
 		~vector();
 
 		vector& operator=(const vector& x);

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -1,6 +1,16 @@
 
 typedef unsigned long size_t;
 
+template<class T>
+struct remove_const { typedef T type; };
+
+template<class T>
+struct remove_const<const T> { typedef T type; };
+
+// `remove_const_t<T>` removes any `const` specifier from `T`
+template<class T>
+using remove_const_t = typename remove_const<T>::type;
+
 // --- iterator ---
 
 namespace std {
@@ -15,6 +25,9 @@ namespace std {
 			  class reference_type = value_type&>
 	struct iterator {
 		typedef Category iterator_category;
+
+		iterator();
+		iterator(iterator<Category, remove_const_t<value_type> > const &other); // non-const -> const conversion constructor
 
 		iterator &operator++();
 		iterator operator++(int);
@@ -45,13 +58,12 @@ namespace std
 
 	typedef size_t streamsize;
 
-
 	template <class T> class allocator {
 	public:
 		allocator() throw();
 		typedef size_t size_type;
 	};
-	
+
 	template<class charT, class traits = char_traits<charT>, class Allocator = allocator<charT> >
 	class basic_string {
 	public:

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -491,3 +491,17 @@ void test_string_iterator_methods()
 		sink(s6); // [FALSE POSITIVE]
 	}
 }
+
+void test_constructors_more() {
+	char *cs1 = "abc";
+	char *cs2 = source();
+	std::string s1(cs1);
+	std::string s2(cs2);
+	std::string s3(s1.begin(), s1.end());
+	std::string s4(s2.begin(), s2.end());
+
+	sink(s1);
+	sink(s2); // tainted
+	sink(s3);
+	sink(s4); // tainted [NOT DETECTED]
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -484,8 +484,8 @@ void test_string_iterator_methods()
 		sink(g.assign(s5.cbegin(), s5.cend()));
 		sink(g);
 
-		sink(h.assign(s6.cbegin(), s6.cend())); // tainted [NOT DETECTED]
-		sink(h); // tainted [NOT DETECTED]
+		sink(h.assign(s6.cbegin(), s6.cend())); // tainted
+		sink(h); // tainted
 
 		sink(s6.assign(s5.cbegin(), s5.cend()));
 		sink(s6); // [FALSE POSITIVE]

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -413,3 +413,81 @@ void test_string_iterators() {
 		sink(*i9); // tainted
 	}
 }
+
+void test_string_insert_more()
+{
+	std::string s1("aa");
+	std::string s2("bb");
+	char *cs1 = "cc";
+	char *cs2 = source();
+
+	sink(s1.insert(0, cs1));
+	sink(s1);
+
+	sink(s2.insert(0, cs2)); // tainted
+	sink(s2); // tainted
+}
+
+void sink(std::string::iterator);
+
+void test_string_iterator_methods()
+{
+	{
+		std::string a("aa");
+		std::string b("bb");
+
+		sink(a.insert(a.begin(), 10, 'x'));
+		sink(a);
+
+		sink(b.insert(b.begin(), 10, ns_char::source())); // tainted
+		sink(b); // tainted
+	}
+
+	{
+		std::string c("cc");
+		std::string d("dd");
+		std::string s1("11");
+		std::string s2(source());
+
+		sink(c.insert(c.end(), s1.begin(), s1.end()));
+		sink(c);
+
+		sink(d.insert(d.end(), s2.begin(), s2.end())); // tainted [NOT DETECTED]
+		sink(d); // tainted [NOT DETECTED]
+
+		sink(s2.insert(s2.end(), s1.begin(), s1.end())); // tainted
+		sink(s2); // tainted
+	}
+
+	{
+		std::string e("ee");
+		std::string f("ff");
+		std::string s3("33");
+		std::string s4(source());
+
+		sink(e.append(s3.begin(), s3.end()));
+		sink(e);
+
+		sink(f.append(s4.begin(), s4.end())); // tainted [NOT DETECTED]
+		sink(f); // tainted [NOT DETECTED]
+
+		sink(s4.append(s3.begin(), s3.end())); // tainted
+		sink(s4); // tainted
+	}
+
+	{
+		std::string g("gg");
+		std::string h("hh");
+		std::string s5("55");
+		std::string s6(source());
+
+		sink(g.assign(s5.cbegin(), s5.cend()));
+		sink(g);
+
+		sink(h.assign(s6.cbegin(), s6.cend())); // tainted [NOT DETECTED]
+		sink(h); // tainted [NOT DETECTED]
+
+		sink(s6.assign(s5.cbegin(), s5.cend()));
+		sink(s6); // [FALSE POSITIVE]
+	}
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -503,5 +503,5 @@ void test_constructors_more() {
 	sink(s1);
 	sink(s2); // tainted
 	sink(s3);
-	sink(s4); // tainted [NOT DETECTED]
+	sink(s4); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/string.cpp
@@ -452,8 +452,8 @@ void test_string_iterator_methods()
 		sink(c.insert(c.end(), s1.begin(), s1.end()));
 		sink(c);
 
-		sink(d.insert(d.end(), s2.begin(), s2.end())); // tainted [NOT DETECTED]
-		sink(d); // tainted [NOT DETECTED]
+		sink(d.insert(d.end(), s2.begin(), s2.end())); // tainted
+		sink(d); // tainted
 
 		sink(s2.insert(s2.end(), s1.begin(), s1.end())); // tainted
 		sink(s2); // tainted
@@ -468,8 +468,8 @@ void test_string_iterator_methods()
 		sink(e.append(s3.begin(), s3.end()));
 		sink(e);
 
-		sink(f.append(s4.begin(), s4.end())); // tainted [NOT DETECTED]
-		sink(f); // tainted [NOT DETECTED]
+		sink(f.append(s4.begin(), s4.end())); // tainted
+		sink(f); // tainted
 
 		sink(s4.append(s3.begin(), s3.end())); // tainted
 		sink(s4); // tainted

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -136,6 +136,7 @@
 | string.cpp:487:10:487:15 | call to assign | string.cpp:482:18:482:23 | call to source |
 | string.cpp:488:8:488:8 | h | string.cpp:482:18:482:23 | call to source |
 | string.cpp:491:8:491:9 | s6 | string.cpp:482:18:482:23 | call to source |
+| string.cpp:504:7:504:8 | s2 | string.cpp:497:14:497:19 | call to source |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |
 | structlikeclass.cpp:37:8:37:9 | s3 | structlikeclass.cpp:29:22:29:27 | call to source |
@@ -304,3 +305,4 @@
 | vector.cpp:309:7:309:7 | c | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:311:9:311:14 | call to insert | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:312:7:312:7 | d | vector.cpp:303:14:303:19 | call to source |
+| vector.cpp:324:7:324:8 | v2 | vector.cpp:318:15:318:20 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -284,8 +284,10 @@
 | vector.cpp:201:13:201:13 | call to operator[] | vector.cpp:200:14:200:19 | call to source |
 | vector.cpp:242:7:242:8 | v2 | vector.cpp:238:17:238:30 | call to source |
 | vector.cpp:243:7:243:8 | v3 | vector.cpp:239:15:239:20 | call to source |
+| vector.cpp:258:8:258:9 | v5 | vector.cpp:239:15:239:20 | call to source |
 | vector.cpp:259:8:259:9 | i1 | vector.cpp:239:15:239:20 | call to source |
 | vector.cpp:260:8:260:9 | i2 | vector.cpp:239:15:239:20 | call to source |
+| vector.cpp:261:8:261:9 | v6 | vector.cpp:239:15:239:20 | call to source |
 | vector.cpp:273:8:273:9 | v7 | vector.cpp:269:18:269:31 | call to source |
 | vector.cpp:274:8:274:9 | v8 | vector.cpp:270:18:270:35 | call to source |
 | vector.cpp:275:8:275:9 | v9 | vector.cpp:271:18:271:34 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -137,6 +137,7 @@
 | string.cpp:488:8:488:8 | h | string.cpp:482:18:482:23 | call to source |
 | string.cpp:491:8:491:9 | s6 | string.cpp:482:18:482:23 | call to source |
 | string.cpp:504:7:504:8 | s2 | string.cpp:497:14:497:19 | call to source |
+| string.cpp:506:7:506:8 | s4 | string.cpp:497:14:497:19 | call to source |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |
 | structlikeclass.cpp:37:8:37:9 | s3 | structlikeclass.cpp:29:22:29:27 | call to source |
@@ -306,3 +307,4 @@
 | vector.cpp:311:9:311:14 | call to insert | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:312:7:312:7 | d | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:324:7:324:8 | v2 | vector.cpp:318:15:318:20 | call to source |
+| vector.cpp:326:7:326:8 | v4 | vector.cpp:318:15:318:20 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -243,6 +243,7 @@
 | taint.cpp:471:7:471:7 | y | taint.cpp:462:6:462:11 | call to source |
 | taint.cpp:485:7:485:10 | line | taint.cpp:480:26:480:32 | source1 |
 | vector.cpp:20:8:20:8 | x | vector.cpp:16:43:16:49 | source1 |
+| vector.cpp:24:8:24:8 | call to operator* | vector.cpp:16:43:16:49 | source1 |
 | vector.cpp:28:8:28:8 | x | vector.cpp:16:43:16:49 | source1 |
 | vector.cpp:33:8:33:8 | x | vector.cpp:16:43:16:49 | source1 |
 | vector.cpp:52:7:52:8 | v2 | vector.cpp:51:10:51:15 | call to source |
@@ -283,6 +284,8 @@
 | vector.cpp:201:13:201:13 | call to operator[] | vector.cpp:200:14:200:19 | call to source |
 | vector.cpp:242:7:242:8 | v2 | vector.cpp:238:17:238:30 | call to source |
 | vector.cpp:243:7:243:8 | v3 | vector.cpp:239:15:239:20 | call to source |
+| vector.cpp:259:8:259:9 | i1 | vector.cpp:239:15:239:20 | call to source |
+| vector.cpp:260:8:260:9 | i2 | vector.cpp:239:15:239:20 | call to source |
 | vector.cpp:273:8:273:9 | v7 | vector.cpp:269:18:269:31 | call to source |
 | vector.cpp:274:8:274:9 | v8 | vector.cpp:270:18:270:35 | call to source |
 | vector.cpp:275:8:275:9 | v9 | vector.cpp:271:18:271:34 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -263,6 +263,9 @@
 | vector.cpp:72:10:72:13 | call to back | vector.cpp:69:15:69:20 | call to source |
 | vector.cpp:75:7:75:8 | v6 | vector.cpp:74:17:74:22 | call to source |
 | vector.cpp:76:7:76:18 | access to array | vector.cpp:74:17:74:22 | call to source |
+| vector.cpp:83:7:83:8 | v7 | vector.cpp:81:17:81:22 | call to source |
+| vector.cpp:84:10:84:14 | call to front | vector.cpp:81:17:81:22 | call to source |
+| vector.cpp:85:10:85:13 | call to back | vector.cpp:81:17:81:22 | call to source |
 | vector.cpp:97:7:97:8 | v9 | vector.cpp:96:13:96:18 | call to source |
 | vector.cpp:98:10:98:11 | call to at | vector.cpp:96:13:96:18 | call to source |
 | vector.cpp:99:10:99:11 | call to at | vector.cpp:96:13:96:18 | call to source |
@@ -297,4 +300,7 @@
 | vector.cpp:290:7:290:8 | v2 | vector.cpp:289:17:289:30 | call to source |
 | vector.cpp:291:10:291:13 | call to data | vector.cpp:289:17:289:30 | call to source |
 | vector.cpp:292:7:292:18 | access to array | vector.cpp:289:17:289:30 | call to source |
+| vector.cpp:308:9:308:14 | call to insert | vector.cpp:303:14:303:19 | call to source |
+| vector.cpp:309:7:309:7 | c | vector.cpp:303:14:303:19 | call to source |
+| vector.cpp:311:9:311:14 | call to insert | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:312:7:312:7 | d | vector.cpp:303:14:303:19 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -133,6 +133,8 @@
 | string.cpp:472:8:472:8 | f | string.cpp:466:18:466:23 | call to source |
 | string.cpp:474:11:474:16 | call to append | string.cpp:466:18:466:23 | call to source |
 | string.cpp:475:8:475:9 | s4 | string.cpp:466:18:466:23 | call to source |
+| string.cpp:487:10:487:15 | call to assign | string.cpp:482:18:482:23 | call to source |
+| string.cpp:488:8:488:8 | h | string.cpp:482:18:482:23 | call to source |
 | string.cpp:491:8:491:9 | s6 | string.cpp:482:18:482:23 | call to source |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -121,6 +121,19 @@
 | string.cpp:407:8:407:8 | call to operator* | string.cpp:387:18:387:23 | call to source |
 | string.cpp:409:8:409:8 | call to operator* | string.cpp:387:18:387:23 | call to source |
 | string.cpp:413:8:413:8 | call to operator* | string.cpp:387:18:387:23 | call to source |
+| string.cpp:427:10:427:15 | call to insert | string.cpp:422:14:422:19 | call to source |
+| string.cpp:428:7:428:8 | s2 | string.cpp:422:14:422:19 | call to source |
+| string.cpp:442:10:442:15 | call to insert | string.cpp:442:32:442:46 | call to source |
+| string.cpp:443:8:443:8 | b | string.cpp:442:32:442:46 | call to source |
+| string.cpp:455:10:455:15 | call to insert | string.cpp:450:18:450:23 | call to source |
+| string.cpp:456:8:456:8 | d | string.cpp:450:18:450:23 | call to source |
+| string.cpp:458:11:458:16 | call to insert | string.cpp:450:18:450:23 | call to source |
+| string.cpp:459:8:459:9 | s2 | string.cpp:450:18:450:23 | call to source |
+| string.cpp:471:10:471:15 | call to append | string.cpp:466:18:466:23 | call to source |
+| string.cpp:472:8:472:8 | f | string.cpp:466:18:466:23 | call to source |
+| string.cpp:474:11:474:16 | call to append | string.cpp:466:18:466:23 | call to source |
+| string.cpp:475:8:475:9 | s4 | string.cpp:466:18:466:23 | call to source |
+| string.cpp:491:8:491:9 | s6 | string.cpp:482:18:482:23 | call to source |
 | structlikeclass.cpp:35:8:35:9 | s1 | structlikeclass.cpp:29:22:29:27 | call to source |
 | structlikeclass.cpp:36:8:36:9 | s2 | structlikeclass.cpp:30:24:30:29 | call to source |
 | structlikeclass.cpp:37:8:37:9 | s3 | structlikeclass.cpp:29:22:29:27 | call to source |
@@ -277,3 +290,4 @@
 | vector.cpp:290:7:290:8 | v2 | vector.cpp:289:17:289:30 | call to source |
 | vector.cpp:291:10:291:13 | call to data | vector.cpp:289:17:289:30 | call to source |
 | vector.cpp:292:7:292:18 | access to array | vector.cpp:289:17:289:30 | call to source |
+| vector.cpp:312:7:312:7 | d | vector.cpp:303:14:303:19 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -131,6 +131,19 @@
 | string.cpp:407:8:407:8 | string.cpp:387:18:387:23 | AST only |
 | string.cpp:409:8:409:8 | string.cpp:387:18:387:23 | AST only |
 | string.cpp:413:8:413:8 | string.cpp:387:18:387:23 | AST only |
+| string.cpp:427:10:427:15 | string.cpp:422:14:422:19 | AST only |
+| string.cpp:428:7:428:8 | string.cpp:422:14:422:19 | AST only |
+| string.cpp:442:10:442:15 | string.cpp:442:32:442:46 | AST only |
+| string.cpp:443:8:443:8 | string.cpp:442:32:442:46 | AST only |
+| string.cpp:455:10:455:15 | string.cpp:450:18:450:23 | AST only |
+| string.cpp:456:8:456:8 | string.cpp:450:18:450:23 | AST only |
+| string.cpp:458:11:458:16 | string.cpp:450:18:450:23 | AST only |
+| string.cpp:459:8:459:9 | string.cpp:450:18:450:23 | AST only |
+| string.cpp:471:10:471:15 | string.cpp:466:18:466:23 | AST only |
+| string.cpp:472:8:472:8 | string.cpp:466:18:466:23 | AST only |
+| string.cpp:474:11:474:16 | string.cpp:466:18:466:23 | AST only |
+| string.cpp:475:8:475:9 | string.cpp:466:18:466:23 | AST only |
+| string.cpp:491:8:491:9 | string.cpp:482:18:482:23 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |
 | structlikeclass.cpp:37:8:37:9 | structlikeclass.cpp:29:22:29:27 | AST only |
@@ -226,3 +239,4 @@
 | vector.cpp:290:7:290:8 | vector.cpp:289:17:289:30 | AST only |
 | vector.cpp:291:10:291:13 | vector.cpp:289:17:289:30 | AST only |
 | vector.cpp:292:7:292:18 | vector.cpp:289:17:289:30 | AST only |
+| vector.cpp:312:7:312:7 | vector.cpp:303:14:303:19 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -191,6 +191,7 @@
 | taint.cpp:447:9:447:17 | taint.cpp:445:14:445:28 | AST only |
 | taint.cpp:471:7:471:7 | taint.cpp:462:6:462:11 | AST only |
 | vector.cpp:20:8:20:8 | vector.cpp:16:43:16:49 | AST only |
+| vector.cpp:24:8:24:8 | vector.cpp:16:43:16:49 | AST only |
 | vector.cpp:28:8:28:8 | vector.cpp:16:43:16:49 | AST only |
 | vector.cpp:33:8:33:8 | vector.cpp:16:43:16:49 | AST only |
 | vector.cpp:52:7:52:8 | vector.cpp:51:10:51:15 | AST only |
@@ -232,6 +233,8 @@
 | vector.cpp:201:13:201:13 | vector.cpp:200:14:200:19 | AST only |
 | vector.cpp:242:7:242:8 | vector.cpp:238:17:238:30 | AST only |
 | vector.cpp:243:7:243:8 | vector.cpp:239:15:239:20 | AST only |
+| vector.cpp:259:8:259:9 | vector.cpp:239:15:239:20 | AST only |
+| vector.cpp:260:8:260:9 | vector.cpp:239:15:239:20 | AST only |
 | vector.cpp:273:8:273:9 | vector.cpp:269:18:269:31 | AST only |
 | vector.cpp:274:8:274:9 | vector.cpp:270:18:270:35 | AST only |
 | vector.cpp:275:8:275:9 | vector.cpp:271:18:271:34 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -143,6 +143,8 @@
 | string.cpp:472:8:472:8 | string.cpp:466:18:466:23 | AST only |
 | string.cpp:474:11:474:16 | string.cpp:466:18:466:23 | AST only |
 | string.cpp:475:8:475:9 | string.cpp:466:18:466:23 | AST only |
+| string.cpp:487:10:487:15 | string.cpp:482:18:482:23 | AST only |
+| string.cpp:488:8:488:8 | string.cpp:482:18:482:23 | AST only |
 | string.cpp:491:8:491:9 | string.cpp:482:18:482:23 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -233,8 +233,10 @@
 | vector.cpp:201:13:201:13 | vector.cpp:200:14:200:19 | AST only |
 | vector.cpp:242:7:242:8 | vector.cpp:238:17:238:30 | AST only |
 | vector.cpp:243:7:243:8 | vector.cpp:239:15:239:20 | AST only |
+| vector.cpp:258:8:258:9 | vector.cpp:239:15:239:20 | AST only |
 | vector.cpp:259:8:259:9 | vector.cpp:239:15:239:20 | AST only |
 | vector.cpp:260:8:260:9 | vector.cpp:239:15:239:20 | AST only |
+| vector.cpp:261:8:261:9 | vector.cpp:239:15:239:20 | AST only |
 | vector.cpp:273:8:273:9 | vector.cpp:269:18:269:31 | AST only |
 | vector.cpp:274:8:274:9 | vector.cpp:270:18:270:35 | AST only |
 | vector.cpp:275:8:275:9 | vector.cpp:271:18:271:34 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -211,6 +211,9 @@
 | vector.cpp:72:10:72:13 | vector.cpp:69:15:69:20 | AST only |
 | vector.cpp:75:7:75:8 | vector.cpp:74:17:74:22 | AST only |
 | vector.cpp:76:7:76:18 | vector.cpp:74:17:74:22 | AST only |
+| vector.cpp:83:7:83:8 | vector.cpp:81:17:81:22 | AST only |
+| vector.cpp:84:10:84:14 | vector.cpp:81:17:81:22 | AST only |
+| vector.cpp:85:10:85:13 | vector.cpp:81:17:81:22 | AST only |
 | vector.cpp:97:7:97:8 | vector.cpp:96:13:96:18 | AST only |
 | vector.cpp:98:10:98:11 | vector.cpp:96:13:96:18 | AST only |
 | vector.cpp:99:10:99:11 | vector.cpp:96:13:96:18 | AST only |
@@ -246,4 +249,7 @@
 | vector.cpp:290:7:290:8 | vector.cpp:289:17:289:30 | AST only |
 | vector.cpp:291:10:291:13 | vector.cpp:289:17:289:30 | AST only |
 | vector.cpp:292:7:292:18 | vector.cpp:289:17:289:30 | AST only |
+| vector.cpp:308:9:308:14 | vector.cpp:303:14:303:19 | AST only |
+| vector.cpp:309:7:309:7 | vector.cpp:303:14:303:19 | AST only |
+| vector.cpp:311:9:311:14 | vector.cpp:303:14:303:19 | AST only |
 | vector.cpp:312:7:312:7 | vector.cpp:303:14:303:19 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -147,6 +147,7 @@
 | string.cpp:488:8:488:8 | string.cpp:482:18:482:23 | AST only |
 | string.cpp:491:8:491:9 | string.cpp:482:18:482:23 | AST only |
 | string.cpp:504:7:504:8 | string.cpp:497:14:497:19 | AST only |
+| string.cpp:506:7:506:8 | string.cpp:497:14:497:19 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |
 | structlikeclass.cpp:37:8:37:9 | structlikeclass.cpp:29:22:29:27 | AST only |
@@ -255,3 +256,4 @@
 | vector.cpp:311:9:311:14 | vector.cpp:303:14:303:19 | AST only |
 | vector.cpp:312:7:312:7 | vector.cpp:303:14:303:19 | AST only |
 | vector.cpp:324:7:324:8 | vector.cpp:318:15:318:20 | AST only |
+| vector.cpp:326:7:326:8 | vector.cpp:318:15:318:20 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -146,6 +146,7 @@
 | string.cpp:487:10:487:15 | string.cpp:482:18:482:23 | AST only |
 | string.cpp:488:8:488:8 | string.cpp:482:18:482:23 | AST only |
 | string.cpp:491:8:491:9 | string.cpp:482:18:482:23 | AST only |
+| string.cpp:504:7:504:8 | string.cpp:497:14:497:19 | AST only |
 | structlikeclass.cpp:35:8:35:9 | structlikeclass.cpp:29:22:29:27 | AST only |
 | structlikeclass.cpp:36:8:36:9 | structlikeclass.cpp:30:24:30:29 | AST only |
 | structlikeclass.cpp:37:8:37:9 | structlikeclass.cpp:29:22:29:27 | AST only |
@@ -253,3 +254,4 @@
 | vector.cpp:309:7:309:7 | vector.cpp:303:14:303:19 | AST only |
 | vector.cpp:311:9:311:14 | vector.cpp:303:14:303:19 | AST only |
 | vector.cpp:312:7:312:7 | vector.cpp:303:14:303:19 | AST only |
+| vector.cpp:324:7:324:8 | vector.cpp:318:15:318:20 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -75,9 +75,9 @@ void test_element_taint(int x) {
 	sink(v6); // tainted
 	sink(v6.data()[2]); // tainted
 
+
 	{
-		const std::vector<int> &v7c = v7; // (workaround because our iterators don't convert to const_iterator)
-		std::vector<int>::const_iterator it = v7c.begin();
+		std::vector<int>::const_iterator it = v7.begin();
 		v7.insert(it, source());
 	}
 	sink(v7); // tainted [NOT DETECTED]

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -80,9 +80,9 @@ void test_element_taint(int x) {
 		std::vector<int>::const_iterator it = v7.begin();
 		v7.insert(it, source());
 	}
-	sink(v7); // tainted [NOT DETECTED]
-	sink(v7.front()); // tainted [NOT DETECTED]
-	sink(v7.back());
+	sink(v7); // tainted
+	sink(v7.front()); // tainted
+	sink(v7.back()); // [FALSE POSITIVE]
 
 	{
 		const std::vector<int> &v8c = v8;
@@ -305,9 +305,9 @@ void test_vector_insert() {
 	sink(a.insert(a.end(), b.begin(), b.end()));
 	sink(a);
 
-	sink(c.insert(c.end(), d.begin(), d.end())); // tainted [NOT DETECTED]
-	sink(c); // tainted [NOT DETECTED]
+	sink(c.insert(c.end(), d.begin(), d.end())); // tainted
+	sink(c); // tainted
 
-	sink(d.insert(d.end(), a.begin(), a.end())); // tainted [NOT DETECTED]
+	sink(d.insert(d.end(), a.begin(), a.end())); // tainted
 	sink(d); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -323,5 +323,5 @@ void test_constructors_more() {
 	sink(v1);
 	sink(v2); // tainted
 	sink(v3);
-	sink(v4); // tainted [NOT DETECTED]
+	sink(v4); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -311,3 +311,17 @@ void test_vector_insert() {
 	sink(d.insert(d.end(), a.begin(), a.end())); // tainted
 	sink(d); // tainted
 }
+
+void test_constructors_more() {
+	std::vector<int> v1;
+	std::vector<int> v2;
+	v2.push_back(source());
+
+	std::vector<int> v3(v1.begin(), v1.end());
+	std::vector<int> v4(v2.begin(), v2.end());
+
+	sink(v1);
+	sink(v2); // tainted
+	sink(v3);
+	sink(v4); // tainted [NOT DETECTED]
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -255,10 +255,10 @@ void test_vector_assign() {
 		v6.assign(i1, i2);
 
 		sink(v4);
-		sink(v5); // tainted [NOT DETECTED]
+		sink(v5); // tainted
 		sink(i1); // tainted
 		sink(i2); // tainted
-		sink(v6); // tainted [NOT DETECTED]
+		sink(v6); // tainted
 	}
 
 	{

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -21,7 +21,7 @@ void test_range_based_for_loop_vector(int source1) {
 	}
 
 	for(std::vector<int>::iterator it = v.begin(); it != v.end(); ++it) {
-		sink(*it); // tainted [NOT DETECTED]
+		sink(*it); // tainted
 	}
 
 	for(int& x : v) {
@@ -256,8 +256,8 @@ void test_vector_assign() {
 
 		sink(v4);
 		sink(v5); // tainted [NOT DETECTED]
-		sink(i1); // tainted [NOT DETECTED]
-		sink(i2); // tainted [NOT DETECTED]
+		sink(i1); // tainted
+		sink(i2); // tainted
 		sink(v6); // tainted [NOT DETECTED]
 	}
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -291,3 +291,23 @@ void test_data_more() {
 	sink(v2.data()); // tainted
 	sink(v2.data()[2]); // tainted
 }
+
+void sink(std::vector<int>::iterator);
+
+void test_vector_insert() {
+	std::vector<int> a;
+	std::vector<int> b;
+	std::vector<int> c;
+	std::vector<int> d;
+
+	d.push_back(source());
+
+	sink(a.insert(a.end(), b.begin(), b.end()));
+	sink(a);
+
+	sink(c.insert(c.end(), d.begin(), d.end())); // tainted [NOT DETECTED]
+	sink(c); // tainted [NOT DETECTED]
+
+	sink(d.insert(d.end(), a.begin(), a.end())); // tainted [NOT DETECTED]
+	sink(d); // tainted
+}


### PR DESCRIPTION
Model iterator versions of `string` and `vector` methods:
 - `std::string` `assign` and fill/iterator constructors (`begin`, `end`, `append` and `insert` were already supported in @rdmarsh2 's initial iterators PR, but are more thoroughly tested here)
 - `std::vector` `begin`, `end`, `assign`, `insert`, `insert_after` and iterator constructors