### PR TITLE
Python: Add example of strange DataFlow::jumpStep

### DIFF
--- a/python/ql/test/experimental/dataflow/strange-essaflow/test.py
+++ b/python/ql/test/experimental/dataflow/strange-essaflow/test.py
@@ -1,0 +1,11 @@
+
+import os
+
+from flask import Flask, request
+app = Flask(__name__)
+
+@app.route("/command1")
+def command_injection1():
+    files = request.args.get('files', '')
+    # Don't let files be `; rm -rf /`
+    os.system("ls " + files)

--- a/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.expected
+++ b/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.expected
@@ -1,0 +1,11 @@
+os_import
+| test.py:2:8:2:9 | GSSA Variable os |
+flowstep
+jumpStep
+| test.py:2:8:2:9 | GSSA Variable os | test.py:5:7:5:21 | ControlFlowNode for Flask() |
+| test.py:2:8:2:9 | GSSA Variable os | test.py:7:2:7:23 | ControlFlowNode for Attribute() |
+| test.py:2:8:2:9 | GSSA Variable os | test.py:7:2:7:23 | ControlFlowNode for Attribute()() |
+essaFlowStep
+| test.py:2:8:2:9 | GSSA Variable os | test.py:5:7:5:21 | ControlFlowNode for Flask() |
+| test.py:2:8:2:9 | GSSA Variable os | test.py:7:2:7:23 | ControlFlowNode for Attribute() |
+| test.py:2:8:2:9 | GSSA Variable os | test.py:7:2:7:23 | ControlFlowNode for Attribute()() |

--- a/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.ql
+++ b/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.ql
@@ -1,0 +1,36 @@
+import python
+import experimental.dataflow.DataFlow
+
+/** Gets the EssaNode that holds the module imported by the fully qualified module name `name` */
+DataFlow::EssaNode module_import(string name) {
+  exists(Variable var, Import imp, Alias alias |
+    alias = imp.getAName() and
+    alias.getAsname() = var.getAStore() and
+    (
+      name = alias.getValue().(ImportMember).getImportedModuleName()
+      or
+      name = alias.getValue().(ImportExpr).getImportedModuleName()
+    ) and
+    result.getVar().(AssignmentDefinition).getSourceVariable() = var
+  )
+}
+
+query predicate os_import(DataFlow::Node node) {
+  node = module_import("os") and
+  exists(node.getLocation().getFile().getRelativePath())
+}
+
+query predicate flowstep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  os_import(nodeFrom) and
+  DataFlow::localFlowStep(nodeFrom, nodeTo)
+}
+
+query predicate jumpStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  os_import(nodeFrom) and
+  DataFlow::jumpStep(nodeFrom, nodeTo)
+}
+
+query predicate essaFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
+  os_import(nodeFrom) and
+  DataFlow::EssaFlow::essaFlowStep(nodeFrom, nodeTo)
+}


### PR DESCRIPTION
The example code is just copied from command injection tests, that is not too important. The important part is that `jumpStep` says there is flow from the import of `os` to `app.route()` :O