### PR TITLE
C++: Allow .inc files to be included

### DIFF
--- a/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.ql
+++ b/cpp/ql/src/jsf/4.06 Pre-Processing Directives/AV Rule 32.ql
@@ -18,6 +18,7 @@ from Include i, File f, string extension
 where
   f = i.getIncludedFile() and
   extension = f.getExtension().toLowerCase() and
+  extension != "inc" and
   extension != "inl" and
   extension != "tcc" and
   extension != "tpp" and


### PR DESCRIPTION
JSF AV Rule 32 checks for non-header files being included. Per [Google's style guide](https://google.github.io/styleguide/cppguide.html#Self_contained_Headers), the `.inc` extension should be used if non-header files need to be included. This PR prevents CodeQL from flagging possibly legitimate inclusions of `.inc` files.