### PR TITLE
Python: Add missing 1.25 change notes

### DIFF
--- a/change-notes/1.25/analysis-python.md
+++ b/change-notes/1.25/analysis-python.md
@@ -5,5 +5,5 @@
 * Added taint modeling of routed parameters in Flask.
 * Improved modeling of built-in methods on strings for taint tracking.
 * Improved classification of test files.
-* New class `BoundMethodValue` exposing information about a bound method.
+* New class `BoundMethodValue` represents a bound method during runtime.
 * The query `py/command-line-injection` now recognizes command execution with the `fabric` and `invoke` Python libraries.

--- a/change-notes/1.25/analysis-python.md
+++ b/change-notes/1.25/analysis-python.md
@@ -2,8 +2,8 @@
 
 * Importing `semmle.python.web.HttpRequest` will no longer import `UntrustedStringKind` transitively. `UntrustedStringKind` is the most commonly used non-abstract subclass of `ExternalStringKind`. If not imported (by one mean or another), taint-tracking queries that concern `ExternalStringKind` will not produce any results. Please ensure such queries contain an explicit import (`import semmle.python.security.strings.Untrusted`).
 * Added model of taint sources for HTTP servers using `http.server`.
-* Added taint modeling of routed parameters in flask.
-* Improved modeling of builtin methods on strings for taint tracking.
+* Added taint modeling of routed parameters in Flask.
+* Improved modeling of built-in methods on strings for taint tracking.
 * Improved classification of test files.
 * New class `BoundMethodValue` exposing information about a bound method.
 * The query `py/command-line-injection` now recognizes command execution with the `fabric` and `invoke` Python libraries.

--- a/change-notes/1.25/analysis-python.md
+++ b/change-notes/1.25/analysis-python.md
@@ -1,22 +1,9 @@
 # Improvements to Python analysis
 
-The following changes in version 1.25 affect Python analysis in all applications.
-
-## General improvements
-
-
-## New queries
-
-| **Query**                   | **Tags**  | **Purpose**                                                        |
-|-----------------------------|-----------|--------------------------------------------------------------------|
-
-
-## Changes to existing queries
-
-| **Query**                  | **Expected impact**    | **Change**                                                       |
-|----------------------------|------------------------|------------------------------------------------------------------|
-
-
-## Changes to libraries
-
 * Importing `semmle.python.web.HttpRequest` will no longer import `UntrustedStringKind` transitively. `UntrustedStringKind` is the most commonly used non-abstract subclass of `ExternalStringKind`. If not imported (by one mean or another), taint-tracking queries that concern `ExternalStringKind` will not produce any results. Please ensure such queries contain an explicit import (`import semmle.python.security.strings.Untrusted`).
+* Added model of taint sources for HTTP servers using `http.server`.
+* Added taint modeling of routed parameters in flask.
+* Improved modeling of builtin methods on strings for taint tracking.
+* Improved classification of test files.
+* New class `BoundMethodValue` exposing information about a bound method.
+* The query `py/command-line-injection` now recognizes command execution with the `fabric` and `invoke` Python libraries.


### PR DESCRIPTION
I looked through PRs between rc/1.24 and rc/1.25 and added missing change notes for:

- https://github.com/github/codeql/pull/3314
- https://github.com/github/codeql/pull/3302
- https://github.com/github/codeql/pull/3212
- https://github.com/github/codeql/pull/3453
- https://github.com/github/codeql/pull/3407
- https://github.com/github/codeql/pull/3563

```
git log --grep="Merge pull request" --format=oneline rc/1.24..rc/1.25 -- python/
```

I'm guessing this should be against rc/1.25 branch, so it will have correct information. Once we do a mergeback from rc/1.25 to main, all should be good again.