### PR TITLE
C#: Add flag to Standalone extractor to use the self contained .Net framework

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/BuildAnalysis.cs
@@ -88,7 +88,7 @@ namespace Semmle.BuildAnalyser
                     nuget = new NugetPackages(sourceDir.FullName, PackageDirectory);
                     ReadNugetFiles();
                 }
-                catch(FileNotFoundException)
+                catch (FileNotFoundException)
                 {
                     progressMonitor.MissingNuGet();
                 }
@@ -97,7 +97,9 @@ namespace Semmle.BuildAnalyser
             // Find DLLs in the .Net Framework
             if (options.ScanNetFrameworkDlls)
             {
-                dllDirNames.Add(Runtime.Runtimes.First());
+                var runtimeLocation = Runtime.GetRuntime(options.UseSelfContainedDotnet);
+                progressMonitor.Log(Util.Logging.Severity.Debug, $"Runtime location selected: {runtimeLocation}");
+                dllDirNames.Add(runtimeLocation);
             }
 
             // These files can sometimes prevent `dotnet restore` from working correctly.
@@ -279,7 +281,7 @@ namespace Semmle.BuildAnalyser
 
         void AnalyseProject(FileInfo project)
         {
-            if(!project.Exists)
+            if (!project.Exists)
             {
                 progressMonitor.MissingProject(project.FullName);
                 return;
@@ -323,7 +325,7 @@ namespace Semmle.BuildAnalyser
         void Restore(string projectOrSolution)
         {
             int exit = DotNet.RestoreToDirectory(projectOrSolution, PackageDirectory.DirInfo.FullName);
-            switch(exit)
+            switch (exit)
             {
                 case 0:
                 case 1:
@@ -342,7 +344,7 @@ namespace Semmle.BuildAnalyser
 
         public void AnalyseSolutions(IEnumerable<string> solutions)
         {
-            Parallel.ForEach(solutions, new ParallelOptions { MaxDegreeOfParallelism = 4 } , solutionFile =>
+            Parallel.ForEach(solutions, new ParallelOptions { MaxDegreeOfParallelism = 4 }, solutionFile =>
             {
                 try
                 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
@@ -13,7 +13,7 @@ namespace Semmle.Extraction.CSharp.Standalone
     {
         public override bool handleFlag(string key, bool value)
         {
-            switch(key)
+            switch (key)
             {
                 case "silent":
                     Verbosity = value ? Verbosity.Off : Verbosity.Info;
@@ -36,6 +36,9 @@ namespace Semmle.Extraction.CSharp.Standalone
                 case "skip-dotnet":
                     ScanNetFrameworkDlls = !value;
                     return true;
+                case "self-contained-dotnet":
+                    UseSelfContainedDotnet = value;
+                    return true;
                 default:
                     return base.handleFlag(key, value);
             }
@@ -43,7 +46,7 @@ namespace Semmle.Extraction.CSharp.Standalone
 
         public override bool handleOption(string key, string value)
         {
-            switch(key)
+            switch (key)
             {
                 case "exclude":
                     Excludes.Add(value);
@@ -135,6 +138,11 @@ namespace Semmle.Extraction.CSharp.Standalone
         public bool Help = false;
 
         /// <summary>
+        /// Whether to use the packaged dotnet runtime.
+        /// </summary>
+        public bool UseSelfContainedDotnet = false;
+
+        /// <summary>
         /// Determine whether the given path should be excluded.
         /// </summary>
         /// <param name="path">The path to query.</param>
@@ -162,6 +170,7 @@ namespace Semmle.Extraction.CSharp.Standalone
             output.WriteLine("    --threads:nnn    Specify number of threads (default=CPU cores)");
             output.WriteLine("    --verbose        Produce more output");
             output.WriteLine("    --pdb            Cross-reference information from PDBs where available");
+            output.WriteLine("    --self-contained-dotnet    Use the .Net Framework packaged with the extractor");
         }
 
         private Options()

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/ProgressMonitor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/ProgressMonitor.cs
@@ -16,7 +16,7 @@ namespace Semmle.BuildAnalyser
         void NugetInstall(string package);
         void ResolvedReference(string filename);
         void Summary(int existingSources, int usedSources, int missingSources, int references, int unresolvedReferences, int resolvedConflicts, int totalProjects, int failedProjects, TimeSpan analysisTime);
-        void Warning(string message);
+        void Log(Severity severity, string message);
         void ResolvedConflict(string asm1, string asm2);
         void MissingProject(string projectFile);
         void CommandFailed(string exe, string arguments, int exitCode);
@@ -93,9 +93,9 @@ namespace Semmle.BuildAnalyser
             logger.Log(Severity.Info, "Build analysis completed in {0}", analysisTime);
         }
 
-        public void Warning(string message)
+        public void Log(Severity severity, string message)
         {
-            logger.Log(Severity.Warning, message);
+            logger.Log(severity, message);
         }
 
         public void ResolvedConflict(string asm1, string asm2)

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         /// <summary>
         /// Locates .NET Core Runtimes.
         /// </summary>
-        public static IEnumerable<string> CoreRuntimes
+        private static IEnumerable<string> CoreRuntimes
         {
             get
             {
@@ -37,7 +37,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         /// Locates .NET Desktop Runtimes.
         /// This includes Mono and Microsoft.NET.
         /// </summary>
-        public static IEnumerable<string> DesktopRuntimes
+        private static IEnumerable<string> DesktopRuntimes
         {
             get
             {
@@ -63,7 +63,20 @@ namespace Semmle.Extraction.CSharp.Standalone
             }
         }
 
-        public static IEnumerable<string> Runtimes
+        /// <summary>
+        /// Gets the .NET runtime location to use for extraction
+        /// </summary>
+        public static string GetRuntime(bool useSelfContained)
+        {
+            if (useSelfContained)
+            {
+                return ExecutingRuntime;
+            }
+
+            return Runtimes.First();
+        }
+
+        private static IEnumerable<string> Runtimes
         {
             get
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Runtime.cs
@@ -66,15 +66,7 @@ namespace Semmle.Extraction.CSharp.Standalone
         /// <summary>
         /// Gets the .NET runtime location to use for extraction
         /// </summary>
-        public static string GetRuntime(bool useSelfContained)
-        {
-            if (useSelfContained)
-            {
-                return ExecutingRuntime;
-            }
-
-            return Runtimes.First();
-        }
+        public static string GetRuntime(bool useSelfContained) => useSelfContained ? ExecutingRuntime : Runtimes.First();
 
         private static IEnumerable<string> Runtimes
         {


### PR DESCRIPTION
When running the standalone extractor from tests, we should make sure that the bundled (self-contained) .NET runtime is used during extraction. This way the output of the standalone test would only depend on the version of dotnet that was used to build the codeql CLI.

This PR is not changing the default behaviour of the Standalone Extractor. A new flag is added with default value `false`.