### PR TITLE
C#: Download nuget.exe in auto-builder if it does not exist

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BuildScripts.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Build.Construction;
 using System.Xml;
+using System.IO;
 
 namespace Semmle.Autobuild.CSharp.Tests
 {
@@ -34,7 +35,7 @@ namespace Semmle.Autobuild.CSharp.Tests
             FileExistsIn.Add(file);
             if (FileExists.TryGetValue(file, out var ret))
                 return ret;
-            if (FileExists.TryGetValue(System.IO.Path.GetFileName(file), out ret))
+            if (FileExists.TryGetValue(Path.GetFileName(file), out ret))
                 return ret;
             throw new ArgumentException("Missing FileExists " + file);
         }
@@ -43,6 +44,8 @@ namespace Semmle.Autobuild.CSharp.Tests
         public readonly IDictionary<string, int> RunProcess = new Dictionary<string, int>();
         public readonly IDictionary<string, string> RunProcessOut = new Dictionary<string, string>();
         public readonly IDictionary<string, string> RunProcessWorkingDirectory = new Dictionary<string, string>();
+        public readonly HashSet<string> CreateDirectories = new HashSet<string>();
+        public readonly HashSet<(string, string)> DownloadFiles = new HashSet<(string, string)>();
 
         int IBuildActions.RunProcess(string cmd, string args, string? workingDirectory, IDictionary<string, string>? env, out IList<string> stdOut)
         {
@@ -109,7 +112,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         IEnumerable<string> IBuildActions.EnumerateFiles(string dir)
         {
             if (EnumerateFiles.TryGetValue(dir, out var str))
-                return str.Split("\n");
+                return str.Split("\n").Select(p => PathCombine(dir, p));
             throw new ArgumentException("Missing EnumerateFiles " + dir);
         }
 
@@ -118,7 +121,7 @@ namespace Semmle.Autobuild.CSharp.Tests
         IEnumerable<string> IBuildActions.EnumerateDirectories(string dir)
         {
             if (EnumerateDirectories.TryGetValue(dir, out var str))
-                return string.IsNullOrEmpty(str) ? Enumerable.Empty<string>() : str.Split("\n");
+                return string.IsNullOrEmpty(str) ? Enumerable.Empty<string>() : str.Split("\n").Select(p => PathCombine(dir, p));
             throw new ArgumentException("Missing EnumerateDirectories " + dir);
         }
 
@@ -126,12 +129,20 @@ namespace Semmle.Autobuild.CSharp.Tests
 
         bool IBuildActions.IsWindows() => IsWindows;
 
-        string IBuildActions.PathCombine(params string[] parts)
+        public string PathCombine(params string[] parts)
         {
             return string.Join(IsWindows ? '\\' : '/', parts.Where(p => !string.IsNullOrWhiteSpace(p)));
         }
 
         string IBuildActions.GetFullPath(string path) => path;
+
+        string? IBuildActions.GetFileName(string? path) => Path.GetFileName(path?.Replace('\\', '/'));
+
+        public string? GetDirectoryName(string? path)
+        {
+            var dir = Path.GetDirectoryName(path?.Replace('\\', '/'));
+            return dir is null ? path : path?.Substring(0, dir.Length);
+        }
 
         void IBuildActions.WriteAllText(string filename, string contents)
         {
@@ -151,6 +162,18 @@ namespace Semmle.Autobuild.CSharp.Tests
             foreach (var kvp in GetEnvironmentVariable)
                 s = s.Replace($"%{kvp.Key}%", kvp.Value);
             return s;
+        }
+
+        public void CreateDirectory(string path)
+        {
+            if (!CreateDirectories.Contains(path))
+                throw new ArgumentException($"Missing CreateDirectory, {path}");
+        }
+
+        public void DownloadFile(string address, string fileName)
+        {
+            if (!DownloadFiles.Contains((address, fileName)))
+                throw new ArgumentException($"Missing DownloadFile, {address}, {fileName}");
         }
     }
 
@@ -374,13 +397,13 @@ namespace Semmle.Autobuild.CSharp.Tests
         public void TestDefaultCSharpAutoBuilder()
         {
             Actions.RunProcess["cmd.exe /C dotnet --info"] = 0;
-            Actions.RunProcess["cmd.exe /C dotnet clean test.csproj"] = 0;
-            Actions.RunProcess["cmd.exe /C dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto dotnet build --no-incremental test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C dotnet clean C:\Project\test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C dotnet restore C:\Project\test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto dotnet build --no-incremental C:\Project\test.csproj"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists["test.csproj"] = true;
+            Actions.FileExists[@"C:\Project\test.csproj"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "foo.cs\nbar.cs\ntest.csproj";
@@ -393,7 +416,7 @@ namespace Semmle.Autobuild.CSharp.Tests
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project\test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(true);
             TestAutobuilderScript(autobuilder, 0, 6);
@@ -406,13 +429,13 @@ namespace Semmle.Autobuild.CSharp.Tests
             Actions.RunProcessOut["dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             Actions.RunProcess["dotnet --info"] = 0;
-            Actions.RunProcess["dotnet clean test.csproj"] = 0;
-            Actions.RunProcess["dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto dotnet build --no-incremental /p:UseSharedCompilation=false test.csproj"] = 0;
+            Actions.RunProcess[@"dotnet clean C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"dotnet restore C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto dotnet build --no-incremental /p:UseSharedCompilation=false C:\Project/test.csproj"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists["test.csproj"] = true;
+            Actions.FileExists[@"C:\Project/test.csproj"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.cs\ntest.csproj";
@@ -425,7 +448,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project/test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(false);
             TestAutobuilderScript(autobuilder, 0, 7);
@@ -596,11 +619,11 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.EnumerateDirectories[@"C:\Project"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
-            Actions.RunProcess["/bin/chmod u+x build/build.sh"] = 0;
+            Actions.RunProcess[@"/bin/chmod u+x C:\Project/build/build.sh"] = 0;
             Actions.RunProcess["dotnet --list-runtimes"] = 1;
             Actions.RunProcessOut["dotnet --list-runtimes"] = "";
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto build/build.sh"] = 0;
-            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto build/build.sh"] = "build";
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build/build.sh"] = 0;
+            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build/build.sh"] = @"C:\Project/build";
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -617,11 +640,11 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
 
-            Actions.RunProcess["/bin/chmod u+x build.sh"] = 0;
+            Actions.RunProcess[@"/bin/chmod u+x C:\Project/build.sh"] = 0;
             Actions.RunProcess["dotnet --list-runtimes"] = 1;
             Actions.RunProcessOut["dotnet --list-runtimes"] = "";
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto build.sh"] = 0;
-            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto build.sh"] = "";
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = 0;
+            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = @"C:\Project";
             Actions.FileExists["csharp.log"] = false;
 
             var autobuilder = CreateAutoBuilder(false);
@@ -636,11 +659,11 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
 
-            Actions.RunProcess["/bin/chmod u+x build.sh"] = 0;
+            Actions.RunProcess[@"/bin/chmod u+x C:\Project/build.sh"] = 0;
             Actions.RunProcess["dotnet --list-runtimes"] = 1;
             Actions.RunProcessOut["dotnet --list-runtimes"] = "";
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto build.sh"] = 5;
-            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto build.sh"] = "";
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = 5;
+            Actions.RunProcessWorkingDirectory[@"C:\odasa/tools/odasa index --auto C:\Project/build.sh"] = @"C:\Project";
             Actions.FileExists["csharp.log"] = true;
 
             var autobuilder = CreateAutoBuilder(false);
@@ -654,8 +677,8 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.EnumerateDirectories[@"C:\Project"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto build.bat"] = 0;
-            Actions.RunProcessWorkingDirectory[@"cmd.exe /C C:\odasa\tools\odasa index --auto build.bat"] = "";
+            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\build.bat"] = 0;
+            Actions.RunProcessWorkingDirectory[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\build.bat"] = "";
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -671,8 +694,8 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.EnumerateDirectories[@"C:\Project"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto build.bat"] = 1;
-            Actions.RunProcessWorkingDirectory[@"cmd.exe /C C:\odasa\tools\odasa index --auto build.bat"] = "";
+            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\build.bat"] = 1;
+            Actions.RunProcessWorkingDirectory[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\build.bat"] = "";
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -702,9 +725,9 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestWindowCSharpMsBuild()
         {
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore C:\Project\test1.sln"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\Project\.nuget\nuget.exe restore C:\Project\test1.sln"] = 0;
             Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\test1.sln /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore C:\Project\test2.sln"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\Project\.nuget\nuget.exe restore C:\Project\test2.sln"] = 0;
             Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\test2.sln /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
@@ -718,7 +741,9 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest1.cs\ntest2.cs";
-            Actions.EnumerateDirectories[@"C:\Project"] = "";
+            Actions.EnumerateFiles[@"C:\Project\.nuget"] = "nuget.exe";
+            Actions.EnumerateDirectories[@"C:\Project"] = @".nuget";
+            Actions.EnumerateDirectories[@"C:\Project\.nuget"] = "";
 
             var autobuilder = CreateAutoBuilder(true, msBuildArguments: "/P:Fu=Bar", msBuildTarget: "Windows", msBuildPlatform: "x86", msBuildConfiguration: "Debug",
                 vsToolsVersion: "12", allSolutions: "true");
@@ -733,15 +758,15 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestWindowCSharpMsBuildMultipleSolutions()
         {
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore test1.csproj"] = 0;
-            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild test1.csproj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore test2.csproj"] = 0;
-            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild test2.csproj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
+            Actions.RunProcess[@"cmd.exe /C nuget restore C:\Project\test1.csproj"] = 0;
+            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\test1.csproj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
+            Actions.RunProcess[@"cmd.exe /C nuget restore C:\Project\test2.csproj"] = 0;
+            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\test2.csproj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists[@"test1.csproj"] = true;
-            Actions.FileExists[@"test2.csproj"] = true;
+            Actions.FileExists[@"C:\Project\test1.csproj"] = true;
+            Actions.FileExists[@"C:\Project\test2.csproj"] = true;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"] = false;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"] = false;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"] = true;
@@ -760,7 +785,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
       <Compile Include=""test1.cs"" />
     </ItemGroup>
   </Project>");
-            Actions.LoadXml["test1.csproj"] = csproj1;
+            Actions.LoadXml[@"C:\Project\test1.csproj"] = csproj1;
 
             var csproj2 = new XmlDocument();
             csproj2.LoadXml(@"<?xml version=""1.0"" encoding=""utf - 8""?>
@@ -769,7 +794,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
       <Compile Include=""test1.cs"" />
     </ItemGroup>
   </Project>");
-            Actions.LoadXml["test2.csproj"] = csproj2;
+            Actions.LoadXml[@"C:\Project\test2.csproj"] = csproj2;
 
             var autobuilder = CreateAutoBuilder(true, msBuildArguments: "/P:Fu=Bar", msBuildTarget: "Windows", msBuildPlatform: "x86", msBuildConfiguration: "Debug",
                 vsToolsVersion: "12");
@@ -780,7 +805,7 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestWindowCSharpMsBuildFailed()
         {
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore C:\Project\test1.sln"] = 0;
+            Actions.RunProcess[@"cmd.exe /C nuget restore C:\Project\test1.sln"] = 0;
             Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\test1.sln /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 1;
             Actions.FileExists["csharp.log"] = true;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"] = false;
@@ -857,13 +882,13 @@ Microsoft.NETCore.App 2.2.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.RunProcessOut["dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             Actions.RunProcess["dotnet --info"] = 0;
-            Actions.RunProcess["dotnet clean test.csproj"] = 0;
-            Actions.RunProcess["dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto dotnet build --no-incremental /p:UseSharedCompilation=false --no-restore test.csproj"] = 0;
+            Actions.RunProcess[@"dotnet clean C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"dotnet restore C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto dotnet build --no-incremental /p:UseSharedCompilation=false --no-restore C:\Project/test.csproj"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists["test.csproj"] = true;
+            Actions.FileExists[@"C:\Project/test.csproj"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "foo.cs\ntest.cs\ntest.csproj";
@@ -876,7 +901,7 @@ Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project/test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(false, dotnetArguments: "--no-restore");  // nugetRestore=false does not work for now.
             TestAutobuilderScript(autobuilder, 0, 7);
@@ -887,7 +912,6 @@ Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         {
             Actions.RunProcess["dotnet --list-sdks"] = 0;
             Actions.RunProcessOut["dotnet --list-sdks"] = "2.1.2 [C:\\Program Files\\dotnet\\sdks]\n2.1.4 [C:\\Program Files\\dotnet\\sdks]";
-            Actions.RunProcess[@"curl -L -sO https://dot.net/v1/dotnet-install.sh"] = 0;
             Actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             Actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             Actions.RunProcess[@"rm dotnet-install.sh"] = 0;
@@ -895,9 +919,9 @@ Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.RunProcessOut[@"C:\Project/.dotnet/dotnet --list-runtimes"] = @"Microsoft.AspNetCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
 Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             Actions.RunProcess[@"C:\Project/.dotnet/dotnet --info"] = 0;
-            Actions.RunProcess[@"C:\Project/.dotnet/dotnet clean test.csproj"] = 0;
-            Actions.RunProcess[@"C:\Project/.dotnet/dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental test.csproj"] = 0;
+            Actions.RunProcess[@"C:\Project/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\Project/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental C:\Project/test.csproj"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -915,10 +939,11 @@ Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project/test.csproj"] = xml;
+            Actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 12);
+            TestAutobuilderScript(autobuilder, 0, 11);
         }
 
         [Fact]
@@ -927,7 +952,6 @@ Microsoft.NETCore.App 3.0.0 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.RunProcess["dotnet --list-sdks"] = 0;
             Actions.RunProcessOut["dotnet --list-sdks"] = @"2.1.3 [C:\Program Files\dotnet\sdks]
 2.1.4 [C:\Program Files\dotnet\sdks]";
-            Actions.RunProcess[@"curl -L -sO https://dot.net/v1/dotnet-install.sh"] = 0;
             Actions.RunProcess[@"chmod u+x dotnet-install.sh"] = 0;
             Actions.RunProcess[@"./dotnet-install.sh --channel release --version 2.1.3 --install-dir C:\Project/.dotnet"] = 0;
             Actions.RunProcess[@"rm dotnet-install.sh"] = 0;
@@ -937,9 +961,9 @@ Microsoft.AspNetCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.AspNetC
 Microsoft.NETCore.App 2.1.3 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
 Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]";
             Actions.RunProcess[@"C:\Project/.dotnet/dotnet --info"] = 0;
-            Actions.RunProcess[@"C:\Project/.dotnet/dotnet clean test.csproj"] = 0;
-            Actions.RunProcess[@"C:\Project/.dotnet/dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental /p:UseSharedCompilation=false test.csproj"] = 0;
+            Actions.RunProcess[@"C:\Project/.dotnet/dotnet clean C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\Project/.dotnet/dotnet restore C:\Project/test.csproj"] = 0;
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto C:\Project/.dotnet/dotnet build --no-incremental /p:UseSharedCompilation=false C:\Project/test.csproj"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
@@ -957,10 +981,11 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project/test.csproj"] = xml;
+            Actions.DownloadFiles.Add(("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh"));
 
             var autobuilder = CreateAutoBuilder(false, dotnetVersion: "2.1.3");
-            TestAutobuilderScript(autobuilder, 0, 12);
+            TestAutobuilderScript(autobuilder, 0, 11);
         }
 
         [Fact]
@@ -971,13 +996,13 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.RunProcess[@"cmd.exe /C powershell -NoProfile -ExecutionPolicy unrestricted -file C:\Project\install-dotnet.ps1 -Version 2.1.3 -InstallDir C:\Project\.dotnet"] = 0;
             Actions.RunProcess[@"cmd.exe /C del C:\Project\install-dotnet.ps1"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet --info"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean test.csproj"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore test.csproj"] = 0;
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet clean C:\Project\test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\Project\.dotnet\dotnet restore C:\Project\test.csproj"] = 0;
+            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --auto C:\Project\.dotnet\dotnet build --no-incremental C:\Project\test.csproj"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists["test.csproj"] = true;
+            Actions.FileExists[@"C:\Project\test.csproj"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.GetEnvironmentVariable["PATH"] = "/bin:/usr/bin";
@@ -991,7 +1016,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
   </PropertyGroup>
 
 </Project>");
-            Actions.LoadXml["test.csproj"] = xml;
+            Actions.LoadXml[@"C:\Project\test.csproj"] = xml;
 
             var autobuilder = CreateAutoBuilder(true, dotnetVersion: "2.1.3");
             TestAutobuilderScript(autobuilder, 0, 9);
@@ -1000,13 +1025,14 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
         [Fact]
         public void TestDirsProjWindows()
         {
-            Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\csharp\nuget\nuget.exe restore dirs.proj"] = 1;
-            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild dirs.proj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
+            Actions.RunProcess[@"cmd.exe /C nuget restore C:\Project\dirs.proj"] = 1;
+            Actions.RunProcess[@"cmd.exe /C C:\Project\.nuget\nuget.exe restore C:\Project\dirs.proj"] = 0;
+            Actions.RunProcess["cmd.exe /C CALL ^\"C:\\Program Files ^(x86^)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat^\" && set Platform=&& type NUL && C:\\odasa\\tools\\odasa index --auto msbuild C:\\Project\\dirs.proj /p:UseSharedCompilation=false /t:Windows /p:Platform=\"x86\" /p:Configuration=\"Debug\" /p:MvcBuildViews=true /P:Fu=Bar"] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\codeql\tools\java\bin\java -jar C:\codeql\csharp\tools\extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"cmd.exe /C C:\odasa\tools\odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
             Actions.FileExists[@"a\test.csproj"] = true;
-            Actions.FileExists["dirs.proj"] = true;
+            Actions.FileExists[@"C:\Project\dirs.proj"] = true;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"] = false;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"] = false;
             Actions.FileExists[@"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"] = true;
@@ -1017,6 +1043,8 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "a\\test.cs\na\\test.csproj\ndirs.proj";
             Actions.EnumerateDirectories[@"C:\Project"] = "";
+            Actions.CreateDirectories.Add(@"C:\Project\.nuget");
+            Actions.DownloadFiles.Add(("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", @"C:\Project\.nuget\nuget.exe"));
 
             var csproj = new XmlDocument();
             csproj.LoadXml(@"<?xml version=""1.0"" encoding=""utf - 8""?>
@@ -1025,7 +1053,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
       <Compile Include=""test.cs"" />
     </ItemGroup>
   </Project>");
-            Actions.LoadXml["a\\test.csproj"] = csproj;
+            Actions.LoadXml[@"a\test.csproj"] = csproj;
 
             var dirsproj = new XmlDocument();
             dirsproj.LoadXml(@"<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""3.5"">
@@ -1033,27 +1061,30 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
     <ProjectFiles Include=""a\test.csproj"" />
   </ItemGroup>
 </Project>");
-            Actions.LoadXml["dirs.proj"] = dirsproj;
+            Actions.LoadXml[@"C:\Project\dirs.proj"] = dirsproj;
 
             var autobuilder = CreateAutoBuilder(true, msBuildArguments: "/P:Fu=Bar", msBuildTarget: "Windows", msBuildPlatform: "x86", msBuildConfiguration: "Debug",
                 vsToolsVersion: "12", allSolutions: "true");
-            TestAutobuilderScript(autobuilder, 0, 4);
+            TestAutobuilderScript(autobuilder, 0, 5);
         }
 
         [Fact]
         public void TestDirsProjLinux()
         {
-            Actions.RunProcess[@"mono C:\odasa\tools/csharp/nuget/nuget.exe restore dirs.proj"] = 1;
-            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto msbuild dirs.proj /p:UseSharedCompilation=false /t:rebuild /p:MvcBuildViews=true"] = 0;
+            Actions.RunProcess[@"nuget restore C:\Project/dirs.proj"] = 1;
+            Actions.RunProcess[@"mono C:\Project/.nuget/nuget.exe restore C:\Project/dirs.proj"] = 0;
+            Actions.RunProcess[@"C:\odasa/tools/odasa index --auto msbuild C:\Project/dirs.proj /p:UseSharedCompilation=false /t:rebuild /p:MvcBuildViews=true"] = 0;
             Actions.RunProcess[@"C:\codeql\tools\java/bin/java -jar C:\codeql\csharp/tools/extractor-asp.jar ."] = 0;
             Actions.RunProcess[@"C:\odasa/tools/odasa index --xml --extensions config csproj props xml"] = 0;
             Actions.FileExists["csharp.log"] = true;
-            Actions.FileExists["a/test.csproj"] = true;
-            Actions.FileExists["dirs.proj"] = true;
+            Actions.FileExists[@"C:\Project/a/test.csproj"] = true;
+            Actions.FileExists[@"C:\Project/dirs.proj"] = true;
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_TRAP_DIR"] = "";
             Actions.GetEnvironmentVariable["CODEQL_EXTRACTOR_CSHARP_SOURCE_ARCHIVE_DIR"] = "";
             Actions.EnumerateFiles[@"C:\Project"] = "a/test.cs\na/test.csproj\ndirs.proj";
             Actions.EnumerateDirectories[@"C:\Project"] = "";
+            Actions.CreateDirectories.Add(@"C:\Project/.nuget");
+            Actions.DownloadFiles.Add(("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", @"C:\Project/.nuget/nuget.exe"));
 
             var csproj = new XmlDocument();
             csproj.LoadXml(@"<?xml version=""1.0"" encoding=""utf - 8""?>
@@ -1062,7 +1093,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
       <Compile Include=""test.cs"" />
     </ItemGroup>
   </Project>");
-            Actions.LoadXml["a/test.csproj"] = csproj;
+            Actions.LoadXml[@"C:\Project/a/test.csproj"] = csproj;
 
             var dirsproj = new XmlDocument();
             dirsproj.LoadXml(@"<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""3.5"">
@@ -1070,10 +1101,10 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
     <ProjectFiles Include=""a\test.csproj"" />
   </ItemGroup>
 </Project>");
-            Actions.LoadXml["dirs.proj"] = dirsproj;
+            Actions.LoadXml[@"C:\Project/dirs.proj"] = dirsproj;
 
             var autobuilder = CreateAutoBuilder(false);
-            TestAutobuilderScript(autobuilder, 0, 4);
+            TestAutobuilderScript(autobuilder, 0, 5);
         }
 
         [Fact]
@@ -1092,7 +1123,7 @@ Microsoft.NETCore.App 2.1.4 [/usr/local/share/dotnet/shared/Microsoft.NETCore.Ap
     <ProjectFiles Include=""dirs.proj"" />
   </ItemGroup>
 </Project>");
-            Actions.LoadXml["dirs.proj"] = dirsproj1;
+            Actions.LoadXml[@"C:\Project/dirs.proj"] = dirsproj1;
 
             var autobuilder = CreateAutoBuilder(false);
             TestAutobuilderScript(autobuilder, 1, 0);

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Semmle.Util;
 using System.Text.RegularExpressions;
 using Semmle.Autobuild.Shared;
+using System.Net;
 
 namespace Semmle.Autobuild.CSharp
 {
@@ -229,11 +230,7 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                     }
                     else
                     {
-                        var curl = new CommandBuilder(builder.Actions).
-                            RunCommand("curl").
-                            Argument("-L").
-                            Argument("-sO").
-                            Argument("https://dot.net/v1/dotnet-install.sh");
+                        var downloadDotNetInstallSh = BuildScript.DownloadFile("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh");
 
                         var chmod = new CommandBuilder(builder.Actions).
                             RunCommand("chmod").
@@ -253,7 +250,7 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                             RunCommand("rm").
                             Argument("dotnet-install.sh");
 
-                        return curl.Script & chmod.Script & install.Script & BuildScript.Try(removeScript.Script);
+                        return downloadDotNetInstallSh & chmod.Script & install.Script & BuildScript.Try(removeScript.Script);
                     }
                 });
         }

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -7,7 +7,6 @@ using System.IO;
 using Semmle.Util;
 using System.Text.RegularExpressions;
 using Semmle.Autobuild.Shared;
-using System.Net;
 
 namespace Semmle.Autobuild.CSharp
 {
@@ -230,7 +229,10 @@ Invoke-Command -ScriptBlock $ScriptBlock";
                     }
                     else
                     {
-                        var downloadDotNetInstallSh = BuildScript.DownloadFile("https://dot.net/v1/dotnet-install.sh", "dotnet-install.sh");
+                        var downloadDotNetInstallSh = BuildScript.DownloadFile(
+                            "https://dot.net/v1/dotnet-install.sh",
+                            "dotnet-install.sh",
+                            e => builder.Log(Severity.Warning, $"Failed to download 'dotnet-install.sh': {e.Message}"));
 
                         var chmod = new CommandBuilder(builder.Actions).
                             RunCommand("chmod").

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/Autobuilder.cs
@@ -68,7 +68,7 @@ namespace Semmle.Autobuild.Shared
         /// <param name="name">The filename to find.</param>
         /// <returns>Possibly empty sequence of paths with the given filename.</returns>
         public IEnumerable<(string, int)> GetFilename(string name) =>
-            Paths.Where(p => Path.GetFileName(p.Item1) == name);
+            Paths.Where(p => Actions.GetFileName(p.Item1) == name);
 
         /// <summary>
         /// Holds if a given path, relative to the root of the source directory

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildActions.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Xml;
+using System.Net;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -59,6 +61,11 @@ namespace Semmle.Autobuild.Shared
         void DirectoryDelete(string dir, bool recursive);
 
         /// <summary>
+        /// Creates all directories and subdirectories in the specified path unless they already exist.
+        /// </summary>
+        void CreateDirectory(string path);
+
+        /// <summary>
         /// Gets an environment variable, Environment.GetEnvironmentVariable().
         /// </summary>
         /// <param name="name">The name of the variable.</param>
@@ -103,6 +110,17 @@ namespace Semmle.Autobuild.Shared
         string GetFullPath(string path);
 
         /// <summary>
+        /// Returns the file name and extension of the specified path string.
+        /// </summary>
+        [return: NotNullIfNotNull("path")]
+        string? GetFileName(string? path);
+
+        /// <summary>
+        /// Returns the directory information for the specified path string.
+        /// </summary>
+        string? GetDirectoryName(string? path);
+
+        /// <summary>
         /// Writes contents to file, File.WriteAllText().
         /// </summary>
         /// <param name="filename">The filename.</param>
@@ -114,11 +132,12 @@ namespace Semmle.Autobuild.Shared
         /// </summary>
         XmlDocument LoadXml(string filename);
 
-        /// <summary>
-        /// Expand all Windows-style environment variables in <paramref name="s"/>,
-        /// Environment.ExpandEnvironmentVariables()
-        /// </summary>
         string EnvironmentExpandEnvironmentVariables(string s);
+
+        /// <summary>
+        /// Downloads the resource with the specified URI to a local file.
+        /// </summary>
+        void DownloadFile(string address, string fileName);
     }
 
     /// <summary>
@@ -166,6 +185,8 @@ namespace Semmle.Autobuild.Shared
 
         bool IBuildActions.DirectoryExists(string dir) => Directory.Exists(dir);
 
+        void IBuildActions.CreateDirectory(string path) => Directory.CreateDirectory(path);
+
         string? IBuildActions.GetEnvironmentVariable(string name) => Environment.GetEnvironmentVariable(name);
 
         string IBuildActions.GetCurrentDirectory() => Directory.GetCurrentDirectory();
@@ -189,7 +210,17 @@ namespace Semmle.Autobuild.Shared
 
         string IBuildActions.GetFullPath(string path) => Path.GetFullPath(path);
 
+        string? IBuildActions.GetFileName(string? path) => Path.GetFileName(path);
+
+        string? IBuildActions.GetDirectoryName(string? path) => Path.GetDirectoryName(path);
+
         public string EnvironmentExpandEnvironmentVariables(string s) => Environment.ExpandEnvironmentVariables(s);
+
+        public void DownloadFile(string address, string fileName)
+        {
+            using var webClient = new WebClient();
+            webClient.DownloadFile(address, fileName);
+        }
 
         public static readonly IBuildActions Instance = new SystemBuildActions();
     }

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildScript.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildScript.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -191,6 +192,25 @@ namespace Semmle.Autobuild.Shared
         /// </summary>
         public static BuildScript Create(Func<IBuildActions, int> func) =>
             new ReturnBuildCommand(func);
+
+        /// <summary>
+        /// Creates a build script that downloads the specified file.
+        /// </summary>
+        public static BuildScript DownloadFile(string address, string fileName) =>
+            Create(actions =>
+            {
+                if (actions.GetDirectoryName(fileName) is string dir && !string.IsNullOrWhiteSpace(dir))
+                    actions.CreateDirectory(dir);
+                try
+                {
+                    actions.DownloadFile(address, fileName);
+                    return 0;
+                }
+                catch (WebException)
+                {
+                    return 1;
+                }
+            });
 
         /// <summary>
         /// Creates a build script that runs <paramref name="s1"/>, followed by running the script

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/BuildScript.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/BuildScript.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -196,7 +195,7 @@ namespace Semmle.Autobuild.Shared
         /// <summary>
         /// Creates a build script that downloads the specified file.
         /// </summary>
-        public static BuildScript DownloadFile(string address, string fileName) =>
+        public static BuildScript DownloadFile(string address, string fileName, Action<Exception> exceptionCallback) =>
             Create(actions =>
             {
                 if (actions.GetDirectoryName(fileName) is string dir && !string.IsNullOrWhiteSpace(dir))
@@ -206,8 +205,9 @@ namespace Semmle.Autobuild.Shared
                     actions.DownloadFile(address, fileName);
                     return 0;
                 }
-                catch (WebException)
+                catch (Exception e)
                 {
+                    exceptionCallback(e);
                     return 1;
                 }
             });

--- a/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.Shared/MsBuildRule.cs
@@ -1,6 +1,5 @@
 using Semmle.Util.Logging;
 using System.Linq;
-using System.Net;
 
 namespace Semmle.Autobuild.Shared
 {
@@ -168,7 +167,10 @@ namespace Semmle.Autobuild.Shared
                 return 0;
             })
             &
-            BuildScript.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", path)
+            BuildScript.DownloadFile(
+                "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe",
+                path,
+                e => builder.Log(Severity.Warning, $"Failed to download 'nuget.exe': {e.Message}"))
             &
             BuildScript.Create(_ =>
             {


### PR DESCRIPTION
We used to bundle `nuget.exe` with the old ODASA distribution, but that is not the case with the C# CodeQL extractor pack. It therefore makes sense for the C# auto-builder to fetch `nuget.exe` from nuget.org, if it is not already present. This also has the benefit that we always get the latest stable version, as opposed to a potentially out-of-date bundled copy.