### PR TITLE
C#: Correctly propagate exit code in `autobuild.cmd`

### DIFF
--- a/csharp/tools/autobuild.cmd
+++ b/csharp/tools/autobuild.cmd
@@ -1,9 +1,7 @@
 @echo off
-SETLOCAL EnableDelayedExpansion
 
 rem The autobuilder is already being traced
 set CODEQL_AUTOBUILDER_CSHARP_NO_INDEXING=true
 
-type NUL && "%CODEQL_EXTRACTOR_CSHARP_ROOT%/tools/%CODEQL_PLATFORM%/Semmle.Autobuild.CSharp.exe" || exit /b %ERRORLEVEL%
-
-ENDLOCAL
+type NUL && "%CODEQL_EXTRACTOR_CSHARP_ROOT%/tools/%CODEQL_PLATFORM%/Semmle.Autobuild.CSharp.exe"
+IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%

--- a/csharp/tools/autobuild.cmd
+++ b/csharp/tools/autobuild.cmd
@@ -4,4 +4,4 @@ rem The autobuilder is already being traced
 set CODEQL_AUTOBUILDER_CSHARP_NO_INDEXING=true
 
 type NUL && "%CODEQL_EXTRACTOR_CSHARP_ROOT%/tools/%CODEQL_PLATFORM%/Semmle.Autobuild.CSharp.exe"
-IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
+exit /b %ERRORLEVEL%

--- a/csharp/tools/pre-finalize.cmd
+++ b/csharp/tools/pre-finalize.cmd
@@ -1,5 +1,4 @@
 @echo off
-SETLOCAL EnableDelayedExpansion
 
 type NUL && "%CODEQL_DIST%\codeql" database index-files ^
     --include-extension=.config ^
@@ -10,5 +9,4 @@ type NUL && "%CODEQL_DIST%\codeql" database index-files ^
     --language xml ^
     -- ^
     "%CODEQL_EXTRACTOR_CSHARP_WIP_DATABASE%"
-
-ENDLOCAL
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
Turns out that `autobuild.cmd` would always return exit code 0. Not sure why, but the fix below works.