### PR TITLE
JS: Fix Bad join orders in UnsafeJQueryPlugin

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeJQueryPluginCustomizations.qll
@@ -195,15 +195,25 @@ module UnsafeJQueryPlugin {
    */
   predicate isLikelyIntentionalHtmlSink(DataFlow::Node sink) {
     exists(
-      JQuery::JQueryPluginMethod plugin, DataFlow::PropWrite defaultDef, string default,
+      JQuery::JQueryPluginMethod plugin, DataFlow::PropWrite defaultDef,
       DataFlow::PropRead finalRead
     |
       hasDefaultOption(plugin, defaultDef) and
-      defaultDef.getPropertyName() = finalRead.getPropertyName() and
-      defaultDef.getRhs().mayHaveStringValue(default) and
-      default.regexpMatch("\\s*<.*") and
+      defaultDef = getALikelyHTMLWrite(finalRead.getPropertyName()) and
       finalRead.flowsTo(sink) and
       sink.getTopLevel() = plugin.getTopLevel()
+    )
+  }
+
+  /**
+   * Gets a property-write that writes a HTML-like constant string to `prop`.
+   */
+  pragma[noinline]
+  private DataFlow::PropWrite getALikelyHTMLWrite(string prop) {
+    exists(string default |
+      result.getRhs().mayHaveStringValue(default) and
+      default.regexpMatch("\\s*<.*") and
+      result.getPropertyName() = prop
     )
   }
 }


### PR DESCRIPTION
My [recent PR](https://github.com/github/codeql/pull/4206) caused a bad join order - in a seemingly unrelated location. 

Here are some tuple counts from the bad join-order: 

```
131770      ~1%     {2} r73 = SCAN AsyncPackage::AsyncPackage::getLastParameter#ff AS I OUTPUT I.<1>, I.<0>
69902       ~4%     {2} r74 = JOIN r73 WITH Sources::SourceNode::getACall_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r73.<1>
92999       ~4%     {3} r75 = JOIN r74 WITH Nodes::InvokeNode::getArgument_dispred#fff AS R ON FIRST 1 OUTPUT R.<1>, r74.<1>, R.<2>
10799433111 ~6%     {4} r76 = JOIN r75 WITH Nodes::FunctionNode::getParameter_dispred#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r75.<1>, r75.<2>, R.<2>
274380      ~0%     {5} r77 = JOIN r76 WITH AsyncPackage::AsyncPackage::IterationCall::getFinalCallback_dispred#fb_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, R.<1>, r76.<1>, r76.<2>, r76.<3>
```

Adding a `pragma[noinline]` fixes the join-order. 

I also did a drive-by change to `aliasPropertyPresenceStep` to improve the performance of that.   
(On `azure-sdk-for-node` the time taken goes from ~55s to ~10s for that predicate). 