### PR TITLE
Java: Minor fixup for SSA AdjacentUsesImpl::varBlockReaches

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SSA.qll
@@ -779,7 +779,9 @@ private module SsaImpl {
      * between `b1` and `b2`.
      */
     private predicate varBlockReaches(TrackedVar v, BasicBlock b1, BasicBlock b2) {
-      varOccursInBlock(v, b1) and b2 = b1.getABBSuccessor()
+      varOccursInBlock(v, b1) and
+      b2 = b1.getABBSuccessor() and
+      blockPrecedesVar(v, b2)
       or
       exists(BasicBlock mid |
         varBlockReaches(v, b1, mid) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
@@ -330,7 +330,9 @@ private module SsaImpl {
      * between `b1` and `b2`.
      */
     private predicate varBlockReaches(BaseSsaSourceVariable v, BasicBlock b1, BasicBlock b2) {
-      varOccursInBlock(v, b1) and b2 = b1.getABBSuccessor()
+      varOccursInBlock(v, b1) and
+      b2 = b1.getABBSuccessor() and
+      blockPrecedesVar(v, b2)
       or
       exists(BasicBlock mid |
         varBlockReaches(v, b1, mid) and


### PR DESCRIPTION
This should not change anything in regards to correctness overall -- what we really care about is `varBlockStep`, and that checks `varOccursInBlock(v, b2)`. However, the comment is a bit easier to read together with the code now (and probably also gives slightly smaller predicate result size).