### PR TITLE
JS: Bump extractor version string

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -43,7 +43,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2020-09-02";
+  public static final String EXTRACTOR_VERSION = "2020-09-12";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 


### PR DESCRIPTION
Forgot to bump in https://github.com/github/codeql/pull/4153, causing dist-compare runs to fail due to bad TRAP cache lookups.