### PR TITLE
Increase insufficient key size value from 1024 to 2048

### DIFF
--- a/change-notes/1.26/analysis-csharp.md
+++ b/change-notes/1.26/analysis-csharp.md
@@ -12,7 +12,7 @@ The following changes in version 1.26 affect C# analysis in all applications.
 
 | **Query**                    | **Expected impact**    | **Change**                        |
 |------------------------------|------------------------|-----------------------------------|
-
+| Weak encryption: Insufficient key size (`cs/insufficient-key-size`) | More results | The required key size has been increased from 1024 to 2048. |
 
 ## Removal of old queries
 

--- a/csharp/ql/src/Security Features/InsufficientKeySize.cs
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.cs
@@ -11,7 +11,7 @@ namespace InsufficientKeySize
         {
             try
             {
-                RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(512); // BAD
+                RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(1024); // BAD
                 rsa.ImportParameters(key);
                 return rsa.Encrypt(plaintext, true);
             }
@@ -27,7 +27,7 @@ namespace InsufficientKeySize
             try
             {
                 RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(); // BAD
-                rsa = new RSACryptoServiceProvider(1024); // GOOD
+                rsa = new RSACryptoServiceProvider(2048); // GOOD
                 rsa.ImportParameters(key);
                 return rsa.Encrypt(plaintext, true);
             }
@@ -58,7 +58,7 @@ namespace InsufficientKeySize
             try
             {
                 DSACryptoServiceProvider dsa = new DSACryptoServiceProvider(); // BAD
-                dsa = new DSACryptoServiceProvider(1024); // GOOD
+                dsa = new DSACryptoServiceProvider(2048); // GOOD
                 dsa.ImportParameters(key);
                 return dsa.SignData(plaintext);
             }
@@ -121,7 +121,7 @@ namespace InsufficientKeySize
             try
             {
                 // Create a new instance of DSACryptoServiceProvider.
-                using (DSACryptoServiceProvider DSA = new DSACryptoServiceProvider(1024)) // GOOD
+                using (DSACryptoServiceProvider DSA = new DSACryptoServiceProvider(2048)) // GOOD
                 {
                     // Import the key information.
                     DSA.ImportParameters(DSAKeyInfo);

--- a/csharp/ql/src/Security Features/InsufficientKeySize.qhelp
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.qhelp
@@ -8,7 +8,7 @@ are vulnerable to brute force attack when too small a key size is used.</p>
 
 </overview>
 <recommendation>
-<p>The key should be at least 1024-bit long when using RSA encryption, and 128-bit long when using 
+<p>The key should be at least 2048-bit long when using RSA encryption, and 128-bit long when using 
 symmetric encryption.</p>
 
 </recommendation>

--- a/csharp/ql/src/Security Features/InsufficientKeySize.ql
+++ b/csharp/ql/src/Security Features/InsufficientKeySize.ql
@@ -29,8 +29,8 @@ predicate incorrectUseOfDSA(ObjectCreation e, string msg) {
       .getTarget()
       .getDeclaringType()
       .hasQualifiedName("System.Security.Cryptography", "DSACryptoServiceProvider") and
-  exists(Expr i | e.getArgument(0) = i and i.getValue().toInt() < 1024) and
-  msg = "Key size should be at least 1024 bits for DSA encryption."
+  exists(Expr i | e.getArgument(0) = i and i.getValue().toInt() < 2048) and
+  msg = "Key size should be at least 2048 bits for DSA encryption."
 }
 
 predicate incorrectUseOfRSA(ObjectCreation e, string msg) {
@@ -38,8 +38,8 @@ predicate incorrectUseOfRSA(ObjectCreation e, string msg) {
       .getTarget()
       .getDeclaringType()
       .hasQualifiedName("System.Security.Cryptography", "RSACryptoServiceProvider") and
-  exists(Expr i | e.getArgument(0) = i and i.getValue().toInt() < 1024) and
-  msg = "Key size should be at least 1024 bits for RSA encryption."
+  exists(Expr i | e.getArgument(0) = i and i.getValue().toInt() < 2048) and
+  msg = "Key size should be at least 2048 bits for RSA encryption."
 }
 
 from Expr e, string msg

--- a/csharp/ql/test/query-tests/Security Features/CWE-327/InsufficientKeySize/InsufficientKeySize.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-327/InsufficientKeySize/InsufficientKeySize.cs
@@ -13,18 +13,18 @@ public class InsufficientKeySize
         // GOOD: Key size is greater than 128
         new RC2CryptoServiceProvider().EffectiveKeySize = 256;
 
-        // BAD: Key size is less than 1024.
+        // BAD: Key size is less than 2048.
         DSACryptoServiceProvider dsaBad = new DSACryptoServiceProvider(512);
-        // GOOD: Key size defaults to 1024.
+        // GOOD: Key size defaults to 2048.
         DSACryptoServiceProvider dsaGood1 = new DSACryptoServiceProvider();
-        // GOOD: Key size is greater than 1024.
+        // GOOD: Key size is greater than 2048.
         DSACryptoServiceProvider dsaGood2 = new DSACryptoServiceProvider(2048);
 
-        // BAD: Key size is less than 1024.
+        // BAD: Key size is less than 2048.
         RSACryptoServiceProvider rsaBad = new RSACryptoServiceProvider(512);
-        // GOOD: Key size defaults to 1024.
+        // GOOD: Key size defaults to 2048.
         RSACryptoServiceProvider rsaGood1 = new RSACryptoServiceProvider();
-        // GOOD: Key size is greater than 1024.
+        // GOOD: Key size is greater than 2048.
         RSACryptoServiceProvider rsaGood2 = new RSACryptoServiceProvider(2048);
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-327/InsufficientKeySize/InsufficientKeySize.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-327/InsufficientKeySize/InsufficientKeySize.expected
@@ -1,3 +1,3 @@
 | InsufficientKeySize.cs:10:9:10:60 | ... = ... | Key size should be at least 128 bits for RC2 encryption. |
-| InsufficientKeySize.cs:17:43:17:75 | object creation of type DSACryptoServiceProvider | Key size should be at least 1024 bits for DSA encryption. |
-| InsufficientKeySize.cs:24:43:24:75 | object creation of type RSACryptoServiceProvider | Key size should be at least 1024 bits for RSA encryption. |
+| InsufficientKeySize.cs:17:43:17:75 | object creation of type DSACryptoServiceProvider | Key size should be at least 2048 bits for DSA encryption. |
+| InsufficientKeySize.cs:24:43:24:75 | object creation of type RSACryptoServiceProvider | Key size should be at least 2048 bits for RSA encryption. |


### PR DESCRIPTION
 this PR will change [this](https://help.semmle.com/wiki/display/CSHARP/Weak+encryption%3A+Insufficient+key+size) by increasing the key size from 1024-bit to 2048-bit to align with the same recommendation we are giving [here](https://help.semmle.com/wiki/display/PYTHON/Use+of+weak+cryptographic+key).
