### PR TITLE
CWE-327 BrokenCryptoAlgorithm recommendation to AES instead of Blowfish

### DIFF
--- a/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
+++ b/python/ql/src/Security/CWE-327/BrokenCryptoAlgorithm.qhelp
@@ -33,7 +33,7 @@
                <code>pycrypto</code> you must specify the encryption
                algorithm to use. The first example uses DES, which is an
                older algorithm that is now considered weak. The second
-               example uses Blowfish, which is a stronger more modern algorithm.
+               example uses AES, which is a stronger modern algorithm.
           </p>
 
           <sample src="examples/broken_crypto.py" />

--- a/python/ql/src/Security/CWE-327/examples/broken_crypto.py
+++ b/python/ql/src/Security/CWE-327/examples/broken_crypto.py
@@ -1,4 +1,4 @@
-from Crypto.Cipher import DES, Blowfish
+from Crypto.Cipher import DES, AES
 
 cipher = DES.new(SECRET_KEY)
 

--- a/python/ql/src/Security/CWE-327/examples/broken_crypto.py
+++ b/python/ql/src/Security/CWE-327/examples/broken_crypto.py
@@ -6,7 +6,7 @@ def send_encrypted(channel, message):
     channel.send(cipher.encrypt(message)) # BAD: weak encryption
 
 
-cipher = Blowfish.new(SECRET_KEY)
+cipher = AES.new(SECRET_KEY)
 
 def send_encrypted(channel, message):
     channel.send(cipher.encrypt(message)) # GOOD: strong encryption


### PR DESCRIPTION
Changing the [BrokenCryptoAlgorithm](https://help.semmle.com/wiki/display/PYTHON/Use+of+a+broken+or+weak+cryptographic+algorithm) second example recommendation to AES instead of Blowfish for Python same as:
[JS](https://help.semmle.com/wiki/display/JS/Use+of+a+broken+or+weak+cryptographic+algorithm), [Java](https://help.semmle.com/wiki/display/JAVA/Use+of+a+broken+or+risky+cryptographic+algorithm) and [C++](https://help.semmle.com/wiki/display/CCPPOBJ/Use+of+a+broken+or+risky+cryptographic+algorithm) 
