### PR TITLE
C++: Support customizable ranges for RangeSsaDefinitions.

### DIFF
--- a/cpp/ql/src/experimental/semmle/code/cpp/models/interfaces/SimpleRangeAnalysisDef.qll
+++ b/cpp/ql/src/experimental/semmle/code/cpp/models/interfaces/SimpleRangeAnalysisDef.qll
@@ -1,0 +1,34 @@
+/**
+ * EXPERIMENTAL: The API of this module may change without notice.
+ *
+ * Provides a class for modeling `RangeSsaDefinition`s with a restricted range.
+ */
+
+import cpp
+import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
+
+/**
+ * EXPERIMENTAL: The API of this class may change without notice.
+ *
+ * An SSA definition for which a range can be deduced. Extend this class to add
+ * functionality to the range analysis library.
+ */
+abstract class SimpleRangeAnalysisDefinition extends RangeSsaDefinition {
+    /**
+   * Gets the lower bound of the defomotopn.
+   *
+   * Implementations of this predicate should use
+   * `getFullyConvertedLowerBounds` and `getFullyConvertedUpperBounds` for
+   * recursive calls to get the bounds of their children.
+   */
+  abstract float getLowerBounds();
+
+  /**
+   * Gets the upper bound of the definition.
+   *
+   * Implementations of this predicate should use
+   * `getFullyConvertedLowerBounds` and `getFullyConvertedUpperBounds` for
+   * recursive calls to get the bounds of their children.
+   */
+  abstract float getUpperBounds();
+}

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -45,6 +45,7 @@
 import cpp
 private import RangeAnalysisUtils
 private import experimental.semmle.code.cpp.models.interfaces.SimpleRangeAnalysisExpr
+private import experimental.semmle.code.cpp.models.interfaces.SimpleRangeAnalysisDef
 import RangeSSA
 import SimpleRangeAnalysisCached
 private import NanAnalysis
@@ -492,6 +493,9 @@ private predicate analyzableDef(RangeSsaDefinition def, StackVariable v) {
   v = def.getAVariable()
   or
   phiDependsOnDef(def, v, _, _)
+  or
+  // A modeled def for range analysis
+  def.(SimpleRangeAnalysisDefinition).getAVariable() =v
 }
 
 /**
@@ -1211,6 +1215,9 @@ private float getDefLowerBoundsImpl(RangeSsaDefinition def, StackVariable v) {
   // Phi nodes.
   result = getPhiLowerBounds(v, def)
   or
+  // A modeled def for range analysis
+  result = def.(SimpleRangeAnalysisDefinition).getLowerBounds()
+  or
   // Unanalyzable definitions.
   unanalyzableDefBounds(def, v, result, _)
 }
@@ -1243,6 +1250,9 @@ private float getDefUpperBoundsImpl(RangeSsaDefinition def, StackVariable v) {
   or
   // Phi nodes.
   result = getPhiUpperBounds(v, def)
+  or
+  // A modeled def for range analysis
+  result = def.(SimpleRangeAnalysisDefinition).getUpperBounds()
   or
   // Unanalyzable definitions.
   unanalyzableDefBounds(def, v, _, result)


### PR DESCRIPTION
Similarly to the `SimpleRangeAnalysisExpr` class, this provides a `SimpleRangeAnalysisDefinition` class that allows you to override the default range for a `RangeSsaDefinition`.