### PR TITLE
Don't trace through pkill or pgrep on macOS.

### DIFF
--- a/csharp/tools/osx64/compiler-tracing.spec
+++ b/csharp/tools/osx64/compiler-tracing.spec
@@ -12,3 +12,13 @@
   invoke /usr/bin/env
   prepend /usr/bin/codesign
   trace no
+/usr/bin/pkill:
+  replace yes
+  invoke /usr/bin/env
+  prepend /usr/bin/pkill
+  trace no
+/usr/bin/pgrep:
+  replace yes
+  invoke /usr/bin/env
+  prepend /usr/bin/pgrep
+  trace no


### PR DESCRIPTION
This fixes issues with pkill and pgrep hanging under trace.