### PR TITLE
JS: Add some support for indirect route handlers

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -4,8 +4,10 @@
 
 * Support for the following frameworks and libraries has been improved:
   - [bluebird](https://www.npmjs.com/package/bluebird)
+  - [express](https://www.npmjs.com/package/express)
   - [fast-json-stable-stringify](https://www.npmjs.com/package/fast-json-stable-stringify)
   - [fast-safe-stringify](https://www.npmjs.com/package/fast-safe-stringify)
+  - [http](https://nodejs.org/api/http.html)
   - [javascript-stringify](https://www.npmjs.com/package/javascript-stringify)
   - [js-stringify](https://www.npmjs.com/package/js-stringify)
   - [json-stable-stringify](https://www.npmjs.com/package/json-stable-stringify)

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -46,7 +46,12 @@ private DataFlow::SourceNode getARouteUsingCookies(DataFlow::TypeTracker t) {
   t.start() and
   isRouteHandlerUsingCookies(result)
   or
-  exists(DataFlow::TypeTracker t2 | result = getARouteUsingCookies(t2).track(t2, t))
+  exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred | pred = getARouteUsingCookies(t2) |
+    result = pred.track(t2, t)
+    or
+    t = t2 and
+    Express::routeHandlerStep(pred, result)
+  )
 }
 
 /** Gets a data flow node referring to a route handler that uses cookies. */

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -50,7 +50,7 @@ private DataFlow::SourceNode getARouteUsingCookies(DataFlow::TypeTracker t) {
     result = pred.track(t2, t)
     or
     t = t2 and
-    Express::routeHandlerStep(pred, result)
+    HTTP::routeHandlerStep(pred, result)
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -76,10 +76,10 @@ module Express {
    * Holds if `call` decorates the function `pred`.
    * This means that `call` returns a function that forwards its arguments to `pred`.
    */
-  predicate decoratedRouteHandler(DataFlow::SourceNode pred, DataFlow::CallNode call) {
+  predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
     // indirect route-handler `result` is given to function `outer`, which returns function `inner` which calls the function `pred`.
     exists(int i, Function outer, Function inner |
-      pred = call.getArgument(i).getALocalSource() and
+      decoratee = call.getArgument(i).getALocalSource() and
       outer = call.getACallee() and
       inner = outer.getAReturnedExpr() and
       forwardingCall(DataFlow::parameterNode(outer.getParameter(i)), inner.flow())
@@ -103,7 +103,7 @@ module Express {
    * Holds if there exists a step from `pred` to `succ` for a RouteHandler - beyond the usual steps defined by TypeTracking.
    */
   predicate routeHandlerStep(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
-    decoratedRouteHandler(pred, succ)
+    isDecoratedCall(succ, pred)
     or
     // A forwarding call
     forwardingCall(pred, succ)

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -111,11 +111,8 @@ module Express {
     exists(HTTP::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))
     or
     // (function (req, res) {}).bind(this);
-    exists(DataFlow::MethodCallNode call |
-      call.getMethodName() = "bind" and call.getNumArgument() = 1
-    |
-      succ = call and
-      pred = call.getReceiver().getALocalSource()
+    exists(DataFlow::PartialInvokeNode call |
+      succ = call.getBoundFunction(pred, 0)
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -91,7 +91,6 @@ module Express {
    */
   private predicate forwardingCall(DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f) {
     exists(DataFlow::CallNode call | call = callee.getACall() |
-      f.getNumParameter() >= 2 and
       forall(int arg | arg = [0 .. f.getNumParameter() - 1] |
         f.getParameter(arg).flowsTo(call.getArgument(arg))
       ) and

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -89,7 +89,7 @@ module Express {
   /**
    * Holds if a call to `callee` inside `f` forwards all of the parameters from `f` to that call.
    */
-  private predicate forwardingCall(DataFlow::SourceNode callee, DataFlow::FunctionNode f) {
+  private predicate forwardingCall(DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f) {
     exists(DataFlow::CallNode call | call = callee.getACall() |
       f.getNumParameter() >= 2 and
       forall(int arg | arg = [0 .. f.getNumParameter() - 1] |

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -82,14 +82,14 @@ module Express {
       decoratee = call.getArgument(i).getALocalSource() and
       outer = call.getACallee() and
       inner = outer.getAReturnedExpr() and
-      forwardingCall(DataFlow::parameterNode(outer.getParameter(i)), inner.flow())
+      isAForwardingRouteHandlerCall(DataFlow::parameterNode(outer.getParameter(i)), inner.flow())
     )
   }
 
   /**
-   * Holds if a call to `callee` inside `f` forwards all of the parameters from `f` to that call.
+   * Holds if `f` looks like a route-handler and a call to `callee` inside `f` forwards all of the parameters from `f` to that call, 
    */
-  private predicate forwardingCall(DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f) {
+  private predicate isAForwardingRouteHandlerCall(DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f) {
     exists(DataFlow::CallNode call | call = callee.getACall() |
       forall(int arg | arg = [0 .. f.getNumParameter() - 1] |
         f.getParameter(arg).flowsTo(call.getArgument(arg))
@@ -105,7 +105,7 @@ module Express {
     isDecoratedCall(succ, pred)
     or
     // A forwarding call
-    forwardingCall(pred, succ)
+    isAForwardingRouteHandlerCall(pred, succ)
     or
     // a container containing route-handlers.
     exists(HTTP::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -661,7 +661,8 @@ module HTTP {
         )
       }
 
-      override RouteHandlerCandidate getRouteHandler(DataFlow::SourceNode access) {
+      override DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
+        result instanceof RouteHandlerCandidate and
         exists(
           DataFlow::Node input, TypeTrackingPseudoProperty key, CollectionFlowStep store,
           CollectionFlowStep load, DataFlow::Node storeTo, DataFlow::Node loadFrom

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -234,6 +234,51 @@ module HTTP {
   }
 
   /**
+   * Holds if `call` decorates the function `pred`.
+   * This means that `call` returns a function that forwards its arguments to `pred`. 
+   * Only holds when the decorator looks like it is decorating a route-handler.
+   */
+  private predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
+    // indirect route-handler `result` is given to function `outer`, which returns function `inner` which calls the function `pred`.
+    exists(int i, Function outer, Function inner |
+      decoratee = call.getArgument(i).getALocalSource() and
+      outer = call.getACallee() and
+      inner = outer.getAReturnedExpr() and
+      isAForwardingRouteHandlerCall(DataFlow::parameterNode(outer.getParameter(i)), inner.flow())
+    )
+  }
+
+  /**
+   * Holds if `f` looks like a route-handler and a call to `callee` inside `f` forwards all of the parameters from `f` to that call,
+   */
+  private predicate isAForwardingRouteHandlerCall(
+    DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f
+  ) {
+    exists(DataFlow::CallNode call | call = callee.getACall() |
+      forall(int arg | arg = [0 .. f.getNumParameter() - 1] |
+        f.getParameter(arg).flowsTo(call.getArgument(arg))
+      ) and
+      call.getContainer() = f.getFunction()
+    )
+  }
+
+  /**
+   * Holds if there exists a step from `pred` to `succ` for a RouteHandler - beyond the usual steps defined by TypeTracking.
+   */
+  predicate routeHandlerStep(DataFlow::SourceNode pred, DataFlow::SourceNode succ) {
+    isDecoratedCall(succ, pred)
+    or
+    // A forwarding call
+    isAForwardingRouteHandlerCall(pred, succ)
+    or
+    // a container containing route-handlers.
+    exists(HTTP::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))
+    or
+    // (function (req, res) {}).bind(this);
+    exists(DataFlow::PartialInvokeNode call | succ = call.getBoundFunction(pred, 0))
+  }
+
+  /**
    * An expression that sets up a route on a server.
    */
   abstract class RouteSetup extends Expr { }
@@ -596,7 +641,7 @@ module HTTP {
     DataFlow::SourceNode getAPossiblyDecoratedHandler(RouteHandlerCandidate candidate) {
       result = candidate
       or
-      Express::isDecoratedCall(result, candidate)
+      isDecoratedCall(result, candidate)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -275,7 +275,9 @@ module HTTP {
     exists(HTTP::RouteHandlerCandidateContainer container | pred = container.getRouteHandler(succ))
     or
     // (function (req, res) {}).bind(this);
-    exists(DataFlow::PartialInvokeNode call | succ = call.getBoundFunction(pred, 0))
+    exists(DataFlow::PartialInvokeNode call |
+      succ = call.getBoundFunction(any(DataFlow::Node n | pred.flowsTo(n)), 0)
+    )
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -235,7 +235,7 @@ module HTTP {
 
   /**
    * Holds if `call` decorates the function `pred`.
-   * This means that `call` returns a function that forwards its arguments to `pred`. 
+   * This means that `call` returns a function that forwards its arguments to `pred`.
    * Only holds when the decorator looks like it is decorating a route-handler.
    */
   private predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
@@ -605,7 +605,8 @@ module HTTP {
         )
       }
 
-      override RouteHandlerCandidate getRouteHandler(DataFlow::SourceNode access) {
+      override DataFlow::SourceNode getRouteHandler(DataFlow::SourceNode access) {
+        result instanceof RouteHandlerCandidate and
         exists(DataFlow::PropWrite write, DataFlow::PropRead read |
           access = read and
           ref(this).getAPropertyRead() = read and

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -596,7 +596,7 @@ module HTTP {
     DataFlow::SourceNode getAPossiblyDecoratedHandler(RouteHandlerCandidate candidate) {
       result = candidate
       or
-      Express::decoratedRouteHandler(candidate, result)
+      Express::isDecoratedCall(result, candidate)
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -249,7 +249,7 @@ module HTTP {
   }
 
   /**
-   * Holds if `f` looks like a route-handler and a call to `callee` inside `f` forwards all of the parameters from `f` to that call,
+   * Holds if `f` looks like a route-handler and a call to `callee` inside `f` forwards all of the parameters from `f` to that call.
    */
   private predicate isAForwardingRouteHandlerCall(
     DataFlow::SourceNode callee, HTTP::RouteHandlerCandidate f

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -574,8 +574,7 @@ module HTTP {
           read = DataFlow::lvalueNode(any(ForOfStmt stmt).getLValue())
           or
           // for forwarding calls to an element where the key is determined by the request.
-          getRequestParameterRead(read.getContainer().(Function).flow())
-              .flowsToExpr(read.getPropertyNameExpr())
+          getRequestParameterRead().flowsToExpr(read.getPropertyNameExpr())
         )
       }
     }
@@ -583,12 +582,12 @@ module HTTP {
     /**
      * Gets a (chained) property-read/method-call on the request parameter of the route-handler `f`.
      */
-    private DataFlow::SourceNode getRequestParameterRead(RouteHandlerCandidate f) {
-      result = f.getParameter(0)
+    private DataFlow::SourceNode getRequestParameterRead() {
+      result = any(RouteHandlerCandidate f).getParameter(0)
       or
-      result = getRequestParameterRead(f).getAPropertyRead()
+      result = getRequestParameterRead().getAPropertyRead()
       or
-      result = getRequestParameterRead(f).getAMethodCall()
+      result = getRequestParameterRead().getAMethodCall()
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -726,13 +726,8 @@ module NodeJSLib {
         astNode.getParameter(0).getName() = request and
         astNode.getParameter(1).getName() = response
       |
-        not (
-          // heuristic: not a class method (Node.js invokes this with a function call)
-          astNode = any(MethodDefinition def).getBody()
-          or
-          // heuristic: does not return anything (Node.js will not use the return value)
-          exists(astNode.getAReturnStmt().getExpr())
-        )
+        // heuristic: not a class method (Node.js invokes this with a function call)
+        not astNode = any(MethodDefinition def).getBody()
       )
     }
   }

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -232,7 +232,7 @@ module NodeJSLib {
         result = succ.backtrack(t2, t)
         or
         t = t2 and
-        Express::routeHandlerStep(result, succ)
+        HTTP::routeHandlerStep(result, succ)
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -228,7 +228,12 @@ module NodeJSLib {
       t.start() and
       result = handler.flow().getALocalSource()
       or
-      exists(DataFlow::TypeBackTracker t2 | result = getARouteHandler(t2).backtrack(t2, t))
+      exists(DataFlow::TypeBackTracker t2, DataFlow::SourceNode succ | succ = getARouteHandler(t2) |
+        result = succ.backtrack(t2, t)
+        or
+        t = t2 and
+        Express::routeHandlerStep(result, succ)
+      )
     }
 
     override Expr getServer() { result = server }
@@ -727,9 +732,6 @@ module NodeJSLib {
           or
           // heuristic: does not return anything (Node.js will not use the return value)
           exists(astNode.getAReturnStmt().getExpr())
-          or
-          // heuristic: is not invoked (Node.js invokes this at a call site we cannot reason precisely about)
-          exists(DataFlow::InvokeNode cs | cs.getACallee() = astNode)
         )
       )
     }

--- a/javascript/ql/test/library-tests/frameworks/Express/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/Express/tests.expected
@@ -794,6 +794,7 @@ test_isRequest
 | src/advanced-routehandler-registration.js:123:46:123:48 | req |
 | src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:46:124:48 | req |
+| src/advanced-routehandler-registration.js:146:29:146:31 | req |
 | src/advanced-routehandler-registration.js:156:22:156:24 | req |
 | src/advanced-routehandler-registration.js:156:47:156:49 | req |
 | src/advanced-routehandler-registration.js:157:28:157:30 | req |
@@ -925,10 +926,16 @@ test_RouteSetup_getRouter
 test_RedirectInvocation
 | src/express.js:5:3:5:35 | res.red ... rget")) | src/express.js:4:23:9:1 | functio ... res);\\n} |
 test_StandardRouteHandler
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:51:10:51:12 | req | src/advanced-routehandler-registration.js:51:15:51:17 | res |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:64:10:64:12 | req | src/advanced-routehandler-registration.js:64:15:64:17 | res |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:68:18:68:20 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:73:10:73:12 | req | src/advanced-routehandler-registration.js:73:15:73:17 | res |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:92:10:92:12 | req | src/advanced-routehandler-registration.js:92:15:92:17 | res |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:2:11:2:19 | express() | src/advanced-routehandler-registration.js:111:10:111:12 | req | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/csurf-example.js:20:18:23:1 | functio ... () })\\n} | src/csurf-example.js:7:11:7:19 | express() | src/csurf-example.js:20:28:20:30 | req | src/csurf-example.js:20:33:20:35 | res |
 | src/csurf-example.js:25:22:27:1 | functio ... ere')\\n} | src/csurf-example.js:7:11:7:19 | express() | src/csurf-example.js:25:32:25:34 | req | src/csurf-example.js:25:37:25:39 | res |
@@ -1024,29 +1031,42 @@ test_ResponseExpr
 | src/advanced-routehandler-registration.js:16:12:16:14 | res | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:24:12:24:14 | res | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:12:25:14 | res | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:46:25:46:27 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:47:32:47:34 | res | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:47:32:47:34 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:15:51:17 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:45:51:47 | res | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:59:25:59:27 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:60:23:60:25 | res | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:60:23:60:25 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:15:64:17 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:50:64:52 | res | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:68:18:68:20 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:69:25:69:27 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:70:23:70:25 | res | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:70:23:70:25 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:15:73:17 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:52:73:54 | res | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:81:25:81:27 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:82:32:82:34 | res | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:82:32:82:34 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:15:92:17 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:45:92:47 | res | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:100:25:100:27 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:101:36:101:38 | res | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:101:36:101:38 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:15:111:17 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:45:111:47 | res | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:123:26:123:28 | res | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:124:26:124:28 | res | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:146:34:146:36 | res | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined |
 | src/advanced-routehandler-registration.js:156:27:156:29 | res | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:157:33:157:35 | res | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
 | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined |
@@ -1528,29 +1548,42 @@ test_RouteHandler_getAResponseExpr
 | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:16:12:16:14 | res |
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:12:24:14 | res |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:12:25:14 | res |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:25:46:27 | res |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:47:32:47:34 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:47:32:47:34 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:15:51:17 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:45:51:47 | res |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:25:59:27 | res |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:60:23:60:25 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:60:23:60:25 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:15:64:17 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:50:64:52 | res |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:18:68:20 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:18:68:20 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:25:69:27 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:70:23:70:25 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:18:68:20 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:70:23:70:25 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:15:73:17 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:52:73:54 | res |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:25:81:27 | res |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:82:32:82:34 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:82:32:82:34 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:15:92:17 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:45:92:47 | res |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:25:100:27 | res |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:101:36:101:38 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:101:36:101:38 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:45:111:47 | res |
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:26:123:28 | res |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:26:124:28 | res |
+| src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined | src/advanced-routehandler-registration.js:146:34:146:36 | res |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:27:156:29 | res |
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:33:157:35 | res |
 | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res |
@@ -1690,6 +1723,7 @@ test_isResponse
 | src/advanced-routehandler-registration.js:111:45:111:47 | res |
 | src/advanced-routehandler-registration.js:123:26:123:28 | res |
 | src/advanced-routehandler-registration.js:124:26:124:28 | res |
+| src/advanced-routehandler-registration.js:146:34:146:36 | res |
 | src/advanced-routehandler-registration.js:156:27:156:29 | res |
 | src/advanced-routehandler-registration.js:157:33:157:35 | res |
 | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res |
@@ -1828,11 +1862,25 @@ test_RouteSetup_getARouteHandler
 | src/advanced-routehandler-registration.js:28:3:28:24 | app.get ... es2[p]) | src/advanced-routehandler-registration.js:27:12:27:12 | p |
 | src/advanced-routehandler-registration.js:28:3:28:24 | app.get ... es2[p]) | src/advanced-routehandler-registration.js:28:14:28:23 | routes2[p] |
 | src/advanced-routehandler-registration.js:37:3:37:12 | app.use(h) | src/advanced-routehandler-registration.js:36:12:36:12 | h |
+| src/advanced-routehandler-registration.js:51:1:51:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:51:1:51:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:51:1:51:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:51:23:51:38 | myRouter1.handle |
+| src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:55:12:55:20 | undefined |
+| src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:60:5:60:16 | this.handler |
 | src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:64:1:64:54 | app.use ... , res)) | src/advanced-routehandler-registration.js:64:23:64:43 | mySimpl ... .handle |
+| src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
+| src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:70:5:70:16 | this.handler |
 | src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:73:1:73:56 | app.use ... , res)) | src/advanced-routehandler-registration.js:73:23:73:45 | mySimpl ... .handle |
+| src/advanced-routehandler-registration.js:92:1:92:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:92:1:92:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:92:1:92:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:92:23:92:38 | myRouter3.handle |
+| src/advanced-routehandler-registration.js:111:1:111:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:111:1:111:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:111:1:111:61 | app.use ... ever")) | src/advanced-routehandler-registration.js:111:23:111:38 | myRouter4.handle |
 | src/advanced-routehandler-registration.js:116:3:116:31 | app.get ... tes[p]) | src/advanced-routehandler-registration.js:116:14:116:30 | importedRoutes[p] |
 | src/advanced-routehandler-registration.js:116:3:116:31 | app.get ... tes[p]) | src/route-collection.js:2:6:2:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:116:3:116:31 | app.get ... tes[p]) | src/route-collection.js:3:6:3:35 | (req, r ... og(req) |
@@ -1853,6 +1901,8 @@ test_RouteSetup_getARouteHandler
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/advanced-routehandler-registration.js:139:9:139:30 | bulkReq ... ky.path |
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/advanced-routehandler-registration.js:139:33:139:57 | bulkReq ... handler |
 | src/advanced-routehandler-registration.js:139:1:139:58 | app.get ... andler) | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined |
+| src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined |
+| src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:147:9:147:25 | handlers.handlerA |
 | src/advanced-routehandler-registration.js:147:1:147:37 | app.use ... (data)) | src/advanced-routehandler-registration.js:147:9:147:36 | handler ... d(data) |
 | src/advanced-routehandler-registration.js:150:2:150:14 | app.get(k, v) | src/advanced-routehandler-registration.js:150:10:150:10 | k |
 | src/advanced-routehandler-registration.js:150:2:150:14 | app.get(k, v) | src/advanced-routehandler-registration.js:150:13:150:13 | v |
@@ -2240,13 +2290,20 @@ test_RouteHandler
 | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:16:7:16:9 | req | src/advanced-routehandler-registration.js:16:12:16:14 | res |
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:7:24:9 | req | src/advanced-routehandler-registration.js:24:12:24:14 | res |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:7:25:9 | req | src/advanced-routehandler-registration.js:25:12:25:14 | res |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:46:25:46:27 | res |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:10:51:12 | req | src/advanced-routehandler-registration.js:51:15:51:17 | res |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:59:25:59:27 | res |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:10:64:12 | req | src/advanced-routehandler-registration.js:64:15:64:17 | res |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:68:18:68:20 | res |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:69:25:69:27 | res |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:10:73:12 | req | src/advanced-routehandler-registration.js:73:15:73:17 | res |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:81:25:81:27 | res |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:10:92:12 | req | src/advanced-routehandler-registration.js:92:15:92:17 | res |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:100:25:100:27 | res |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:10:111:12 | req | src/advanced-routehandler-registration.js:111:15:111:17 | res |
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:21:123:23 | req | src/advanced-routehandler-registration.js:123:26:123:28 | res |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:21:124:23 | req | src/advanced-routehandler-registration.js:124:26:124:28 | res |
+| src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined | src/advanced-routehandler-registration.js:146:29:146:31 | req | src/advanced-routehandler-registration.js:146:34:146:36 | res |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:22:156:24 | req | src/advanced-routehandler-registration.js:156:27:156:29 | res |
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:28:157:30 | req | src/advanced-routehandler-registration.js:157:33:157:35 | res |
 | src/controllers/handler-in-bulk-require.js:1:44:1:66 | (req, r ... defined | src/controllers/handler-in-bulk-require.js:1:45:1:47 | req | src/controllers/handler-in-bulk-require.js:1:50:1:52 | res |
@@ -2403,25 +2460,39 @@ test_RequestExpr
 | src/advanced-routehandler-registration.js:24:32:24:34 | req | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:7:25:9 | req | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:25:32:25:34 | req | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:46:20:46:22 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:47:27:47:29 | req | src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:47:27:47:29 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:10:51:12 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:51:40:51:42 | req | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:59:20:59:22 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:60:18:60:20 | req | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:60:18:60:20 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:10:64:12 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:64:45:64:47 | req | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:68:13:68:15 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:68:38:68:40 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:69:20:69:22 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:70:18:70:20 | req | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:70:18:70:20 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:10:73:12 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
 | src/advanced-routehandler-registration.js:73:47:73:49 | req | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) |
+| src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:81:20:81:22 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:82:27:82:29 | req | src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:82:27:82:29 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:10:92:12 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:92:40:92:42 | req | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:100:20:100:22 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
+| src/advanced-routehandler-registration.js:101:31:101:33 | req | src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } |
 | src/advanced-routehandler-registration.js:101:31:101:33 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:10:111:12 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
 | src/advanced-routehandler-registration.js:111:40:111:42 | req | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") |
@@ -2429,6 +2500,7 @@ test_RequestExpr
 | src/advanced-routehandler-registration.js:123:46:123:48 | req | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:124:21:124:23 | req | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:124:46:124:48 | req | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) |
+| src/advanced-routehandler-registration.js:146:29:146:31 | req | src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined |
 | src/advanced-routehandler-registration.js:156:22:156:24 | req | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:156:47:156:49 | req | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) |
 | src/advanced-routehandler-registration.js:157:28:157:30 | req | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) |
@@ -2515,24 +2587,38 @@ test_RouteHandler_getARequestExpr
 | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:24:32:24:34 | req |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:7:25:9 | req |
 | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:25:32:25:34 | req |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:46:20:46:22 | req |
+| src/advanced-routehandler-registration.js:46:11:48:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:47:27:47:29 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:46:20:46:22 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:47:27:47:29 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:10:51:12 | req |
 | src/advanced-routehandler-registration.js:51:9:51:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:51:40:51:42 | req |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:59:20:59:22 | req |
+| src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:60:18:60:20 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:59:20:59:22 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:60:18:60:20 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:10:64:12 | req |
 | src/advanced-routehandler-registration.js:64:9:64:53 | (req, r ... q, res) | src/advanced-routehandler-registration.js:64:45:64:47 | req |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
+| src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:68:38:68:40 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:13:68:15 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:68:38:68:40 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:69:20:69:22 | req |
+| src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:70:18:70:20 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:13:68:15 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:68:38:68:40 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:69:20:69:22 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:70:18:70:20 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:10:73:12 | req |
 | src/advanced-routehandler-registration.js:73:9:73:55 | (req, r ... q, res) | src/advanced-routehandler-registration.js:73:47:73:49 | req |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:81:20:81:22 | req |
+| src/advanced-routehandler-registration.js:81:11:83:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:82:27:82:29 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:81:20:81:22 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:82:27:82:29 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:10:92:12 | req |
 | src/advanced-routehandler-registration.js:92:9:92:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:92:40:92:42 | req |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:100:20:100:22 | req |
+| src/advanced-routehandler-registration.js:100:11:102:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:101:31:101:33 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:100:20:100:22 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:101:31:101:33 | req |
 | src/advanced-routehandler-registration.js:111:9:111:60 | (req, r ... tever") | src/advanced-routehandler-registration.js:111:10:111:12 | req |
@@ -2541,6 +2627,7 @@ test_RouteHandler_getARequestExpr
 | src/advanced-routehandler-registration.js:123:20:123:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:123:46:123:48 | req |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:21:124:23 | req |
 | src/advanced-routehandler-registration.js:124:20:124:49 | (req, r ... og(req) | src/advanced-routehandler-registration.js:124:46:124:48 | req |
+| src/advanced-routehandler-registration.js:146:28:146:50 | (req, r ... defined | src/advanced-routehandler-registration.js:146:29:146:31 | req |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:22:156:24 | req |
 | src/advanced-routehandler-registration.js:156:21:156:50 | (req, r ... og(req) | src/advanced-routehandler-registration.js:156:47:156:49 | req |
 | src/advanced-routehandler-registration.js:157:27:157:56 | (req, r ... og(req) | src/advanced-routehandler-registration.js:157:28:157:30 | req |
@@ -2611,6 +2698,9 @@ getRouteHandlerContainerStep
 | src/advanced-routehandler-registration.js:14:15:17:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:16:6:16:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:18:12:18:18 | handler |
 | src/advanced-routehandler-registration.js:23:15:26:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:24:6:24:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:28:14:28:23 | routes2[p] |
 | src/advanced-routehandler-registration.js:23:15:26:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:25:6:25:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:28:14:28:23 | routes2[p] |
+| src/advanced-routehandler-registration.js:54:22:62:1 | {\\n  han ... ;\\n  }\\n} | src/advanced-routehandler-registration.js:59:11:61:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:64:23:64:43 | mySimpl ... .handle |
+| src/advanced-routehandler-registration.js:67:24:72:1 | {\\n  han ... ;\\n  }\\n} | src/advanced-routehandler-registration.js:68:12:68:41 | (req, r ... og(req) | src/advanced-routehandler-registration.js:70:5:70:16 | this.handler |
+| src/advanced-routehandler-registration.js:67:24:72:1 | {\\n  han ... ;\\n  }\\n} | src/advanced-routehandler-registration.js:69:11:71:3 | functio ... s);\\n  } | src/advanced-routehandler-registration.js:73:23:73:45 | mySimpl ... .handle |
 | src/advanced-routehandler-registration.js:85:15:88:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:86:6:86:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:90:20:90:29 | routes3[p] |
 | src/advanced-routehandler-registration.js:85:15:88:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:87:6:87:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:90:20:90:29 | routes3[p] |
 | src/advanced-routehandler-registration.js:104:15:107:1 | {\\n  a:  ... (req)\\n} | src/advanced-routehandler-registration.js:105:6:105:35 | (req, r ... og(req) | src/advanced-routehandler-registration.js:109:20:109:29 | routes4[p] |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/AdditionalRouteHandlers.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/AdditionalRouteHandlers.expected
@@ -46,7 +46,9 @@
 | src/tst.js:43:18:43:38 | functio ... res) {} |
 | src/tst.js:46:1:46:23 | functio ... res) {} |
 | src/tst.js:52:1:54:1 | functio ... req()\\n} |
+| src/tst.js:56:1:58:1 | functio ... s) {\\n\\n} |
 | src/tst.js:61:1:63:1 | functio ... turn;\\n} |
+| src/tst.js:65:1:67:1 | functio ... rn x;\\n} |
 | src/tst.js:70:5:72:5 | functio ... \\n\\n    } |
 | src/tst.js:74:5:76:5 | functio ... \\n\\n    } |
 | src/tst.js:79:5:81:5 | functio ... \\n\\n    } |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandler.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandler.expected
@@ -1,6 +1,8 @@
 | src/RouterExample.js:4:65:10:1 | (req, r ... ;\\n  }\\n} |
 | src/app-in-property.js:6:13:6:32 | function(req, res){} |
 | src/app-in-property.js:14:21:14:40 | function(req, res){} |
+| src/bound-handler.js:4:1:4:28 | functio ...  res){} |
+| src/bound-handler.js:9:12:9:31 | function(req, res){} |
 | src/connect.js:5:9:5:27 | function(req,res){} |
 | src/connect.js:8:12:8:31 | function(req, res){} |
 | src/connect.js:12:9:12:27 | function(req,res){} |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/RouteHandlerCandidate.expected
@@ -47,7 +47,9 @@
 | src/tst.js:43:18:43:38 | functio ... res) {} |
 | src/tst.js:46:1:46:23 | functio ... res) {} |
 | src/tst.js:52:1:54:1 | functio ... req()\\n} |
+| src/tst.js:56:1:58:1 | functio ... s) {\\n\\n} |
 | src/tst.js:61:1:63:1 | functio ... turn;\\n} |
+| src/tst.js:65:1:67:1 | functio ... rn x;\\n} |
 | src/tst.js:70:5:72:5 | functio ... \\n\\n    } |
 | src/tst.js:74:5:76:5 | functio ... \\n\\n    } |
 | src/tst.js:79:5:81:5 | functio ... \\n\\n    } |

--- a/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP-heuristics/UnpromotedRouteHandlerCandidate.expected
@@ -1,5 +1,3 @@
-| src/bound-handler.js:4:1:4:28 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
-| src/bound-handler.js:9:12:9:31 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/hapi.js:1:1:1:30 | functio ... t, h){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/iterated-handlers.js:4:2:4:22 | functio ...  res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/route-objects.js:7:19:7:38 | function(req, res){} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
@@ -11,6 +9,8 @@
 | src/route-objects.js:56:12:58:5 | functio ... ;\\n    } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/tst.js:46:1:46:23 | functio ... res) {} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/tst.js:52:1:54:1 | functio ... req()\\n} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
+| src/tst.js:56:1:58:1 | functio ... s) {\\n\\n} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/tst.js:61:1:63:1 | functio ... turn;\\n} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
+| src/tst.js:65:1:67:1 | functio ... rn x;\\n} | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/tst.js:70:5:72:5 | functio ... \\n\\n    } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |
 | src/tst.js:109:16:111:9 | functio ...       } | A `RouteHandlerCandidate` that did not get promoted to `RouteHandler`, and it is not used in a `RouteSetupCandidate`. |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/indirect.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/indirect.js
@@ -1,0 +1,36 @@
+var http = require('http');
+
+function decorate(method) {
+  return function(req, res) {
+    return method.call(this, req, res);
+  };
+}
+
+function Server(routes) {
+  this.routes = routes;
+}
+
+Server.prototype = {
+  requestHandler: function() {
+    var routes = this.routes;
+    return function(req, res) { // route handler
+      var handler = routes[req.url] || routes['*'];
+
+      return handler.call(this, req, res);
+    }.bind(this);
+  },
+};
+
+var routes = {
+  '/foo/bar': decorate((req, res) => { // route handler
+    res.end("foo");
+  }),
+  '/bar/foo': function(req, res) { // route handler
+    res.end("bar");
+  }
+};
+
+var appServer = new Server(routes);
+var server = http.createServer(appServer.requestHandler());
+
+server.listen(8080, () => {});

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/indirect2.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/src/indirect2.js
@@ -1,0 +1,18 @@
+var http = require('http');
+
+// These are exceptions where we override the routes
+var handlers = {
+  someKey: myIndirectHandler
+};
+
+
+function get(req, res) { // route handler
+  handlers[req.params.key.toLowerCase()](req, res);
+}
+
+function myIndirectHandler(req, res) { // route handler
+  res.setHeader('Content-Type', 'application/json');
+  res.send("\"some result\"");
+}
+
+var server = http.createServer(get);

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -10,6 +10,7 @@ test_isCreateServer
 | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_RequestInputAccess
 | src/http.js:6:26:6:32 | req.url | url | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:8:3:8:20 | req.headers.cookie | cookie | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
@@ -72,6 +73,7 @@ test_RouteSetup_getServer
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_ClientRequest
 | src/http.js:18:1:18:30 | http.re ... uth" }) |
 | src/http.js:21:15:26:6 | http.re ... \\n    }) |
@@ -94,6 +96,7 @@ test_ServerDefinition
 | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_HeaderAccess
 | src/http.js:9:3:9:17 | req.headers.foo | foo |
 | src/https.js:9:3:9:17 | req.headers.foo | foo |
@@ -159,6 +162,9 @@ test_RouteSetup_getARouteHandler
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:19:70:35 | getArrowHandler() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:14:19:21:3 | return of method requestHandler |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:16 | functio ... d(this) |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:32:34:57 | appServ ... ndler() |
 test_ClientRequest_getADataNode
 | src/http.js:27:16:27:73 | http.re ... POST'}) | src/http.js:50:16:50:22 | 'stuff' |
 | src/http.js:27:16:27:73 | http.re ... POST'}) | src/http.js:51:14:51:25 | 'more stuff' |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -66,6 +66,10 @@ test_ResponseExpr
 | src/indirect2.js:15:3:15:5 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:16:26:16:28 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:38:19:40 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:25:30:25:32 | res | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:26:5:26:7 | res | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:28:29:28:31 | res | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
+| src/indirect.js:29:5:29:7 | res | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_HeaderDefinition
 | src/http.js:7:3:7:42 | res.wri ... rget }) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:13:3:13:44 | res.set ... /html') | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -151,6 +155,10 @@ test_RouteHandler_getAResponseExpr
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:15:3:15:5 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:26:16:28 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:38:19:40 | res |
+| src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:25:30:25:32 | res |
+| src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:26:5:26:7 | res |
+| src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:28:29:28:31 | res |
+| src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:29:5:29:7 | res |
 test_ServerDefinition_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
@@ -166,12 +174,16 @@ test_ServerDefinition_getARouteHandler
 | src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
 | src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_ResponseSendArgument
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:11:15:15 | "bar" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:64:11:64:16 | "bar2" | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:14:13:14:17 | "foo" | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:11:15:15 | "bar" | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect.js:26:13:26:17 | "foo" | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:29:13:29:17 | "bar" | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_RouteSetup_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
@@ -196,6 +208,8 @@ test_RouteSetup_getARouteHandler
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:16 | functio ... d(this) |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:17:21:17:35 | routes[req.url] |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:17:40:17:50 | routes['*'] |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:32:34:57 | appServ ... ndler() |
 test_ClientRequest_getADataNode
 | src/http.js:27:16:27:73 | http.re ... POST'}) | src/http.js:50:16:50:22 | 'stuff' |
@@ -229,6 +243,8 @@ test_RouteHandler
 | src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
+| src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
+| src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_RequestExpr
 | createServer.js:2:30:2:32 | req | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:33:3:35 | req | createServer.js:3:23:3:44 | functio ... res) {} |
@@ -255,6 +271,8 @@ test_RequestExpr
 | src/indirect.js:16:21:16:23 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:17:28:17:30 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:33:19:35 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:25:25:25:27 | req | src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } |
+| src/indirect.js:28:24:28:26 | req | src/indirect.js:28:15:30:3 | functio ... ");\\n  } |
 test_SystemCommandExecution_getAnArgumentForCommand
 | exec.js:3:1:3:38 | cp.exec ... "], cb) | exec.js:3:21:3:33 | ["--version"] |
 | exec.js:4:1:4:47 | cp.exec ... sion"]) | exec.js:4:23:4:46 | ["-c",  ... rsion"] |
@@ -290,3 +308,5 @@ test_RouteHandler_getARequestExpr
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:21:16:23 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:17:28:17:30 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:33:19:35 | req |
+| src/indirect.js:25:24:27:3 | (req, r ... ");\\n  } | src/indirect.js:25:25:25:27 | req |
+| src/indirect.js:28:15:30:3 | functio ... ");\\n  } | src/indirect.js:28:24:28:26 | req |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -10,6 +10,7 @@ test_isCreateServer
 | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_RequestInputAccess
 | src/http.js:6:26:6:32 | req.url | url | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
@@ -24,9 +25,11 @@ test_RouteHandler_getAResponseHeader
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | content-type | src/http.js:13:3:13:44 | res.set ... /html') |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | location | src/https.js:7:3:7:42 | res.wri ... rget }) |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | content-type | src/https.js:13:3:13:44 | res.set ... /html') |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | content-type | src/indirect2.js:14:3:14:51 | res.set ... /json') |
 test_HeaderDefinition_defines
 | src/http.js:13:3:13:44 | res.set ... /html') | content-type | text/html |
 | src/https.js:13:3:13:44 | res.set ... /html') | content-type | text/html |
+| src/indirect2.js:14:3:14:51 | res.set ... /json') | content-type | application/json |
 test_SystemCommandExecution
 | es6-imported-exec.js:3:1:3:11 | exec("cmd") | es6-imported-exec.js:3:6:3:10 | "cmd" |
 | exec.js:3:1:3:38 | cp.exec ... "], cb) | exec.js:3:13:3:18 | "node" |
@@ -56,6 +59,11 @@ test_ResponseExpr
 | src/https.js:13:3:13:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:14:3:14:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:3:15:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect2.js:9:19:9:21 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:10:47:10:49 | res | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:13:33:13:35 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
+| src/indirect2.js:14:3:14:5 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
+| src/indirect2.js:15:3:15:5 | res | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:16:26:16:28 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:38:19:40 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_HeaderDefinition
@@ -64,6 +72,7 @@ test_HeaderDefinition
 | src/http.js:63:3:63:40 | res.set ... , "23") | src/http.js:62:19:65:1 | functio ... r2");\\n} |
 | src/https.js:7:3:7:42 | res.wri ... rget }) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:13:3:13:44 | res.set ... /html') | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect2.js:14:3:14:51 | res.set ... /json') | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 test_RouteSetup_getServer
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:1:3:45 | https.c ... es) {}) |
@@ -76,6 +85,7 @@ test_RouteSetup_getServer
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_ClientRequest
 | src/http.js:18:1:18:30 | http.re ... uth" }) |
@@ -87,6 +97,7 @@ test_HeaderDefinition_getAHeaderName
 | src/http.js:13:3:13:44 | res.set ... /html') | content-type |
 | src/https.js:7:3:7:42 | res.wri ... rget }) | location |
 | src/https.js:13:3:13:44 | res.set ... /html') | content-type |
+| src/indirect2.js:14:3:14:51 | res.set ... /json') | content-type |
 test_ServerDefinition
 | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) |
@@ -99,6 +110,7 @@ test_ServerDefinition
 | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_HeaderAccess
 | src/http.js:9:3:9:17 | req.headers.foo | foo |
@@ -109,6 +121,7 @@ test_HeaderDefinition_getNameExpr
 | src/http.js:63:3:63:40 | res.set ... , "23") | src/http.js:63:17:63:33 | req.query.myParam |
 | src/https.js:7:3:7:42 | res.wri ... rget }) | src/https.js:7:17:7:19 | 302 |
 | src/https.js:13:3:13:44 | res.set ... /html') | src/https.js:13:17:13:30 | 'Content-Type' |
+| src/indirect2.js:14:3:14:51 | res.set ... /json') | src/indirect2.js:14:17:14:30 | 'Content-Type' |
 test_RouteHandler_getAResponseExpr
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:35:2:37 | res |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:38:3:40 | res |
@@ -131,6 +144,11 @@ test_RouteHandler_getAResponseExpr
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:13:3:13:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:14:3:14:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:15:3:15:5 | res |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:19:9:21 | res |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:47:10:49 | res |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:13:33:13:35 | res |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:14:3:14:5 | res |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:15:3:15:5 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:26:16:28 | res |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:38:19:40 | res |
 test_ServerDefinition_getARouteHandler
@@ -145,6 +163,8 @@ test_ServerDefinition_getARouteHandler
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_ResponseSendArgument
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -168,6 +188,9 @@ test_RouteSetup_getARouteHandler
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:70:19:70:35 | getArrowHandler() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:10:3:10:40 | handler ... Case()] |
+| src/indirect2.js:18:14:18:35 | http.cr ... er(get) | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:14:19:21:3 | return of method requestHandler |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:16 | functio ... d(this) |
@@ -203,6 +226,8 @@ test_RouteHandler
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:18:14:18:35 | http.cr ... er(get) |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_RequestExpr
 | createServer.js:2:30:2:32 | req | createServer.js:2:20:2:41 | functio ... res) {} |
@@ -223,6 +248,10 @@ test_RequestExpr
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:29:12:31 | req | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect2.js:9:14:9:16 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:10:12:10:14 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:10:42:10:44 | req | src/indirect2.js:9:1:11:1 | functio ... res);\\n} |
+| src/indirect2.js:13:28:13:30 | req | src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} |
 | src/indirect.js:16:21:16:23 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:17:28:17:30 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:19:33:19:35 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
@@ -254,6 +283,10 @@ test_RouteHandler_getARequestExpr
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:9:3:9:5 | req |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:29:12:31 | req |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:9:14:9:16 | req |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:12:10:14 | req |
+| src/indirect2.js:9:1:11:1 | functio ... res);\\n} | src/indirect2.js:10:42:10:44 | req |
+| src/indirect2.js:13:1:16:1 | functio ... \\"");\\n} | src/indirect2.js:13:28:13:30 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:21:16:23 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:17:28:17:30 | req |
 | src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:33:19:35 | req |

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -18,6 +18,7 @@ test_RequestInputAccess
 | src/https.js:6:26:6:32 | req.url | url | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:8:3:8:20 | req.headers.cookie | cookie | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:17 | req.headers.foo | header | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
+| src/indirect.js:17:28:17:34 | req.url | url | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_RouteHandler_getAResponseHeader
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | location | src/http.js:7:3:7:42 | res.wri ... rget }) |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | content-type | src/http.js:13:3:13:44 | res.set ... /html') |
@@ -55,6 +56,8 @@ test_ResponseExpr
 | src/https.js:13:3:13:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:14:3:14:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/https.js:15:3:15:5 | res | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect.js:16:26:16:28 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:19:38:19:40 | res | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_HeaderDefinition
 | src/http.js:7:3:7:42 | res.wri ... rget }) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:13:3:13:44 | res.set ... /html') | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -128,6 +131,8 @@ test_RouteHandler_getAResponseExpr
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:13:3:13:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:14:3:14:5 | res |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:15:3:15:5 | res |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:26:16:28 | res |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:38:19:40 | res |
 test_ServerDefinition_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
@@ -140,6 +145,7 @@ test_ServerDefinition_getARouteHandler
 | src/http.js:70:1:70:36 | http.cr ... dler()) | src/http.js:68:12:68:27 | (req,res) => f() |
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_ResponseSendArgument
 | src/http.js:14:13:14:17 | "foo" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:15:11:15:15 | "bar" | src/http.js:12:19:16:1 | functio ... ar");\\n} |
@@ -163,7 +169,10 @@ test_RouteSetup_getARouteHandler
 | src/https.js:4:14:10:2 | https.c ... foo;\\n}) | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:1:16:2 | https.c ... r");\\n}) | src/https.js:12:20:16:1 | functio ... ar");\\n} |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:14:19:21:3 | return of method requestHandler |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:16:12:20:16 | functio ... d(this) |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:17:21:17:35 | routes[req.url] |
+| src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:17:40:17:50 | routes['*'] |
 | src/indirect.js:34:14:34:58 | http.cr ... dler()) | src/indirect.js:34:32:34:57 | appServ ... ndler() |
 test_ClientRequest_getADataNode
 | src/http.js:27:16:27:73 | http.re ... POST'}) | src/http.js:50:16:50:22 | 'stuff' |
@@ -181,6 +190,7 @@ test_RemoteFlowSources
 | src/https.js:6:26:6:32 | req.url |
 | src/https.js:8:3:8:20 | req.headers.cookie |
 | src/https.js:9:3:9:17 | req.headers.foo |
+| src/indirect.js:17:28:17:34 | req.url |
 test_RouteHandler
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:1:3:45 | https.c ... es) {}) |
@@ -193,6 +203,7 @@ test_RouteHandler
 | src/http.js:68:12:68:27 | (req,res) => f() | src/http.js:70:1:70:36 | http.cr ... dler()) |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:4:14:10:2 | https.c ... foo;\\n}) |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:1:16:2 | https.c ... r");\\n}) |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:34:14:34:58 | http.cr ... dler()) |
 test_RequestExpr
 | createServer.js:2:30:2:32 | req | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:33:3:35 | req | createServer.js:3:23:3:44 | functio ... res) {} |
@@ -212,6 +223,9 @@ test_RequestExpr
 | src/https.js:8:3:8:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:9:3:9:5 | req | src/https.js:4:33:10:1 | functio ... .foo;\\n} |
 | src/https.js:12:29:12:31 | req | src/https.js:12:20:16:1 | functio ... ar");\\n} |
+| src/indirect.js:16:21:16:23 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:17:28:17:30 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
+| src/indirect.js:19:33:19:35 | req | src/indirect.js:16:12:20:5 | functio ... ;\\n    } |
 test_SystemCommandExecution_getAnArgumentForCommand
 | exec.js:3:1:3:38 | cp.exec ... "], cb) | exec.js:3:21:3:33 | ["--version"] |
 | exec.js:4:1:4:47 | cp.exec ... sion"]) | exec.js:4:23:4:46 | ["-c",  ... rsion"] |
@@ -240,3 +254,6 @@ test_RouteHandler_getARequestExpr
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:8:3:8:5 | req |
 | src/https.js:4:33:10:1 | functio ... .foo;\\n} | src/https.js:9:3:9:5 | req |
 | src/https.js:12:20:16:1 | functio ... ar");\\n} | src/https.js:12:29:12:31 | req |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:16:21:16:23 | req |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:17:28:17:30 | req |
+| src/indirect.js:16:12:20:5 | functio ... ;\\n    } | src/indirect.js:19:33:19:35 | req |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
@@ -1,4 +1,5 @@
 | MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:26:12:1 | functio ... il"];\\n} | here |
+| MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:30:27:6 | errorCa ... \\n    }) | here |
 | csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:53:45:3 | functio ... e')\\n  } | here |
 | csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:40:34:1 | functio ... sed')\\n} | here |
 | lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:42:29:1 | functio ... sed')\\n} | here |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddleware.expected
@@ -1,5 +1,6 @@
 | MissingCsrfMiddlewareBad.js:7:9:7:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:10:26:12:1 | functio ... il"];\\n} | here |
 | MissingCsrfMiddlewareBad.js:17:13:17:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:25:30:27:6 | errorCa ... \\n    }) | here |
+| MissingCsrfMiddlewareBad.js:33:13:33:26 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | MissingCsrfMiddlewareBad.js:41:30:43:6 | errorCa ... \\n    }) | here |
 | csurf_api_example.js:42:37:42:50 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_api_example.js:42:53:45:3 | functio ... e')\\n  } | here |
 | csurf_example.js:18:9:18:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | csurf_example.js:31:40:34:1 | functio ... sed')\\n} | here |
 | lusca_example.js:9:9:9:22 | cookieParser() | This cookie middleware is serving a request handler $@ without CSRF protection. | lusca_example.js:26:42:29:1 | functio ... sed')\\n} | here |

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareBad.js
@@ -26,3 +26,19 @@ app.post('/changeEmail', function (req, res) {
         let newEmail = req.cookies["newEmail"];
     }));
 })
+
+(function () {
+    var app = express();
+
+    app.use(cookieParser());
+    app.use(passport.authorize({ session: true }));
+
+    const errorCatch = (fn) =>
+        (req, res, next) => {
+            fn.call(this, req, res, next).catch((e) => console.log("Caught " + e));
+        };
+
+    app.post('/changeEmail', errorCatch(async function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    }));
+})

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareBad.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareBad.js
@@ -1,12 +1,28 @@
-var express = require('express')
-var cookieParser = require('cookie-parser')
-var passport = require('passport')
+var express = require('express');
+var cookieParser = require('cookie-parser');
+var passport = require('passport');
 
-var app = express()
+var app = express();
 
-app.use(cookieParser())
-app.use(passport.authorize({ session: true }))
+app.use(cookieParser());
+app.use(passport.authorize({ session: true }));
 
 app.post('/changeEmail', function (req, res) {
     let newEmail = req.cookies["newEmail"];
+});
+
+(function () {
+    var app = express();
+
+    app.use(cookieParser());
+    app.use(passport.authorize({ session: true }));
+
+    const errorCatch = (fn) =>
+        (req, res, next) => {
+            fn(req, res, next).catch((e) => console.log("Caught " + e));
+        };
+
+    app.post('/changeEmail', errorCatch(async function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    }));
 })


### PR DESCRIPTION
Gets a TP for CVE-2020-15135 (after https://github.com/github/codeql/pull/4247 is merged).  
Only the first commit is needed to get the TP.   

The other commits tries to generalize a bit, in order to support these two examples of indirect route handlers: [one](https://github.com/mozilla-b2g/gaia/blob/975a35c0f5010df341e96d6c5ec60217f5347412/apps/homescreen/test/marionette_disabled/server/child.js#L105-L117), [two](https://github.com/johnpapa/ng-demos/blob/7d4c65043abbf5f066adffc3acf37f9f58b442a2/cc-bmean/src/server/routes/index.js#L44). 

~~[An evaluation](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1600296548927) shows a decent amount of new route-handlers found.~~  
~~And performance is "not great not terrible" - I'll look into it.~~ 
[An evaluation](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-erik-krogh.northeurope.cloudapp.azure.com_1600395759536) shows a decent amount of new route-handlers found.   
And performance looks good. 