### PR TITLE
C++: Fix bad join order introduced by #4270

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -562,10 +562,11 @@ private predicate getFieldSizeOfClass(Class c, Type type, int size) {
   )
 }
 
-private predicate isSingleFieldClass(Type type, Class cTo) {
-  exists(int size |
-    cTo.getSize() = size and
-    getFieldSizeOfClass(cTo, type, size)
+private predicate isSingleFieldClass(Type type, Operand op) {
+  exists(int size, Class c |
+    c = op.getType().getUnderlyingType() and
+    c.getSize() = size and
+    getFieldSizeOfClass(c, type, size)
   )
 }
 
@@ -601,7 +602,7 @@ private predicate simpleOperandLocalFlowStep(Instruction iFrom, Operand opTo) {
   exists(LoadInstruction load |
     load.getSourceValueOperand() = opTo and
     opTo.getAnyDef() = iFrom and
-    isSingleFieldClass(iFrom.getResultType(), opTo.getType().getUnderlyingType())
+    isSingleFieldClass(iFrom.getResultType(), opTo)
   )
 }
 


### PR DESCRIPTION
Before this PR (on Linux):

```
Tuple counts for DataFlowUtil::simpleOperandLocalFlowStep#ff:
12728043   ~0%      {2} r1 = Operand::Operand::getAnyDef_dispred#3#ff AS L AND NOT SSAConstruction::Cached::hasConflatedMemoryResult#f@staged_ext AS R(L.<1>)
360208     ~0%      {2} r2 = JOIN r1 WITH Operand::SideEffectOperand#class#fff AS R ON FIRST 1 OUTPUT r1.<0>, r1.<1>
360208     ~0%      {2} r3 = STREAM DEDUP r2
360208     ~2%      {3} r4 = JOIN r3 WITH Operand::NonPhiOperand#3#fff AS R ON FIRST 1 OUTPUT R.<1>, r3.<0>, r3.<1>
232375     ~3%      {2} r5 = JOIN r4 WITH Instruction::ReadSideEffectInstruction#class#ff AS R ON FIRST 1 OUTPUT r4.<2>, r4.<1>
13550142   ~0%      {2} r6 = Operand::Operand::getDef_dispred#3#ff_10#join_rhs \/ r5
1791716    ~2%      {2} r7 = JOIN Operand::LoadOperand#class#3#fff AS L WITH Operand::NonPhiMemoryOperand::getAnyDef_dispred#3#ff AS R ON FIRST 1 OUTPUT R.<1>, R.<0>
99768      ~0%      {3} r8 = JOIN r7 WITH Instruction::InitializeIndirectionInstruction::getParameter_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r7.<1>, r7.<0>
102624     ~3%      {3} r9 = JOIN r8 WITH Parameter::Parameter::getType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r8.<1>, r8.<2>
102624     ~3%      {3} r10 = JOIN r9 WITH Type::Type::getUnspecifiedType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r9.<1>, r9.<2>
102624     ~2%      {3} r11 = JOIN r10 WITH Type::DerivedType::getBaseType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r10.<1>, r10.<2>
761022     ~2%      {3} r12 = JOIN r11 WITH Type::Type::getUnspecifiedType_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r11.<1>, R.<1>, r11.<2>
5847       ~0%      {2} r13 = JOIN r12 WITH Operand::Operand::getType_dispred#ff AS R ON FIRST 2 OUTPUT r12.<2>, r12.<0>
13555989   ~0%      {2} r14 = r6 \/ r13
2592354    ~0%      {2} r15 = JOIN project#Instruction::CopyInstruction::getSourceValueOperand_dispred#3#ff AS L WITH Operand::Operand::getAnyDef_dispred#3#ff AS R ON FIRST 1 OUTPUT R.<1>, R.<0>
2603673    ~6%      {3} r16 = JOIN r15 WITH Instruction::Instruction::getResultType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r15.<1>, r15.<0>
3645535691 ~0%      {4} r17 = JOIN r16 WITH DataFlowUtil::getFieldSizeOfClass#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, R.<2>, r16.<1>, r16.<2>
328752799  ~0%      {3} r18 = JOIN r17 WITH Type::Type::getSize_dispred#ff AS R ON FIRST 2 OUTPUT r17.<0>, r17.<2>, r17.<3>
338707195  ~0%      {3} r19 = JOIN r18 WITH Type::Type::getUnderlyingType_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r18.<1>, R.<1>, r18.<2>
52         ~1%      {2} r20 = JOIN r19 WITH Operand::Operand::getType_dispred#ff AS R ON FIRST 2 OUTPUT r19.<2>, r19.<0>
13556041   ~0%      {2} r21 = r14 \/ r20
                    return r21
```

and with this PR:
```
Tuple counts for DataFlowUtil::simpleOperandLocalFlowStep#ff:
12728043 ~0%      {2} r1 = Operand::Operand::getAnyDef_dispred#3#ff AS L AND NOT SSAConstruction::Cached::hasConflatedMemoryResult#f@staged_ext AS R(L.<1>)
360208   ~0%      {2} r2 = JOIN r1 WITH Operand::SideEffectOperand#class#fff AS R ON FIRST 1 OUTPUT r1.<0>, r1.<1>
360208   ~0%      {2} r3 = STREAM DEDUP r2
360208   ~2%      {3} r4 = JOIN r3 WITH Operand::NonPhiOperand#3#fff AS R ON FIRST 1 OUTPUT R.<1>, r3.<0>, r3.<1>
232375   ~3%      {2} r5 = JOIN r4 WITH Instruction::ReadSideEffectInstruction#class#ff AS R ON FIRST 1 OUTPUT r4.<2>, r4.<1>
13550142 ~0%      {2} r6 = Operand::Operand::getDef_dispred#3#ff_10#join_rhs \/ r5
1791716  ~2%      {2} r7 = JOIN Operand::LoadOperand#class#3#fff AS L WITH Operand::NonPhiMemoryOperand::getAnyDef_dispred#3#ff AS R ON FIRST 1 OUTPUT R.<1>, R.<0>
99768    ~0%      {3} r8 = JOIN r7 WITH Instruction::InitializeIndirectionInstruction::getParameter_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r7.<1>, r7.<0>
102624   ~3%      {3} r9 = JOIN r8 WITH Parameter::Parameter::getType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r8.<1>, r8.<2>
102624   ~3%      {3} r10 = JOIN r9 WITH Type::Type::getUnspecifiedType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r9.<1>, r9.<2>
102624   ~2%      {3} r11 = JOIN r10 WITH Type::DerivedType::getBaseType_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r10.<1>, r10.<2>
761022   ~2%      {3} r12 = JOIN r11 WITH Type::Type::getUnspecifiedType_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r11.<1>, R.<1>, r11.<2>
5847     ~0%      {2} r13 = JOIN r12 WITH Operand::Operand::getType_dispred#ff AS R ON FIRST 2 OUTPUT r12.<2>, r12.<0>
13555989 ~0%      {2} r14 = r6 \/ r13
2592354  ~0%      {2} r15 = JOIN project#Instruction::CopyInstruction::getSourceValueOperand_dispred#3#ff AS L WITH Operand::Operand::getAnyDef_dispred#3#ff AS R ON FIRST 1 OUTPUT R.<0>, R.<1>
2592354  ~0%      {2} r16 = STREAM DEDUP r15
6250     ~0%      {3} r17 = JOIN r16 WITH DataFlowUtil::isSingleFieldClass#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r16.<1>, R.<1>, r16.<0>
52       ~1%      {2} r18 = JOIN r17 WITH Instruction::Instruction::getResultType_dispred#ff AS R ON FIRST 2 OUTPUT r17.<0>, r17.<2>
13556041 ~0%      {2} r19 = r14 \/ r18
                  return r19
```

Note that the final tuple counts are identical between the two versions.