### PR TITLE
C++: Cache simpleLocalFlowStep instead of simpleInstructionLocalFlowStep

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -545,6 +545,7 @@ predicate localFlowStep(Node nodeFrom, Node nodeTo) { simpleLocalFlowStep(nodeFr
  * This is the local flow predicate that's used as a building block in global
  * data flow. It may have less flow than the `localFlowStep` predicate.
  */
+cached
 predicate simpleLocalFlowStep(Node nodeFrom, Node nodeTo) {
   // Operand -> Instruction flow
   simpleInstructionLocalFlowStep(nodeFrom.asOperand(), nodeTo.asInstruction())
@@ -606,7 +607,6 @@ private predicate simpleOperandLocalFlowStep(Instruction iFrom, Operand opTo) {
   )
 }
 
-cached
 private predicate simpleInstructionLocalFlowStep(Operand opFrom, Instruction iTo) {
   iTo.(CopyInstruction).getSourceValueOperand() = opFrom
   or


### PR DESCRIPTION
`simpleOperandLocalFlowStep` wasn't cached previously. @jbj suggested that it might be better to cache `simpleLocalFlowStep` (which uses both `simpleInstructionLocalFlowStep` and `simpleOperandLocalFlowStep`).

On [CPP-differences](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1437/) it looks like we eliminated the performance regressions caused by #3933. 🎉 