### PR TITLE
C#: Model assertions in the CFG

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -39,7 +39,7 @@ module Stages {
 
     cached
     private predicate forceCachingInSameStageRev() {
-      any(ControlFlowElement cfe).controlsBlock(_, _)
+      any(ControlFlowElement cfe).controlsBlock(_, _, _)
       or
       exists(GuardedExpr ge)
       or

--- a/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
+++ b/csharp/ql/src/semmle/code/csharp/commons/Assertions.qll
@@ -62,7 +62,7 @@ class Assertion extends MethodCall {
    * does not work.
    */
   pragma[nomagic]
-  private predicate immediatelyDominatesBlockSplit(BasicBlock succ) {
+  deprecated private predicate immediatelyDominatesBlockSplit(BasicBlock succ) {
     // Only calculate dominance by explicit recursion for split nodes;
     // all other nodes can use regular CFG dominance
     this instanceof ControlFlow::Internal::SplitControlFlowElement and
@@ -78,11 +78,11 @@ class Assertion extends MethodCall {
   }
 
   pragma[noinline]
-  private predicate strictlyDominatesJoinBlockPredecessor(JoinBlock jb, int i) {
+  deprecated private predicate strictlyDominatesJoinBlockPredecessor(JoinBlock jb, int i) {
     this.strictlyDominatesSplit(jb.getJoinBlockPredecessor(i))
   }
 
-  private predicate strictlyDominatesJoinBlockSplit(JoinBlock jb, int i) {
+  deprecated private predicate strictlyDominatesJoinBlockSplit(JoinBlock jb, int i) {
     i = -1 and
     this.strictlyDominatesJoinBlockPredecessor(jb, _)
     or
@@ -95,7 +95,7 @@ class Assertion extends MethodCall {
   }
 
   pragma[nomagic]
-  private predicate strictlyDominatesSplit(BasicBlock bb) {
+  deprecated private predicate strictlyDominatesSplit(BasicBlock bb) {
     this.immediatelyDominatesBlockSplit(bb)
     or
     // Equivalent with
@@ -121,6 +121,8 @@ class Assertion extends MethodCall {
   }
 
   /**
+   * DEPRECATED: Use `getExpr().controlsBlock()` instead.
+   *
    * Holds if this assertion strictly dominates basic block `bb`. That is, `bb`
    * can only be reached from the callable entry point by going via *some* basic
    * block containing this element.
@@ -130,7 +132,7 @@ class Assertion extends MethodCall {
    * in that it takes control flow splitting into account.
    */
   pragma[nomagic]
-  predicate strictlyDominates(BasicBlock bb) {
+  deprecated predicate strictlyDominates(BasicBlock bb) {
     this.strictlyDominatesSplit(bb)
     or
     this.getAControlFlowNode().getBasicBlock().strictlyDominates(bb)

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -128,37 +128,42 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * does not work.
    */
   pragma[nomagic]
-  private predicate immediatelyControlsBlockSplit(BasicBlock succ, ConditionalSuccessor s) {
-    exists(ConditionBlock cb | this.immediatelyControlsBlockSplit0(cb, succ, s) |
-      forall(BasicBlock pred, SuccessorType t |
-        this.immediatelyControlsBlockSplit1(cb, succ, s, pred, t)
-      |
-        this.immediatelyControlsBlockSplit2(cb, succ, s, pred, t)
-      )
+  private predicate immediatelyControlsBlockSplit(
+    BasicBlock succ, ConditionalSuccessor s, ConditionBlock cb
+  ) {
+    this.immediatelyControlsBlockSplit0(cb, succ, s) and
+    forall(BasicBlock pred, SuccessorType t |
+      this.immediatelyControlsBlockSplit1(cb, succ, s, pred, t)
+    |
+      this.immediatelyControlsBlockSplit2(cb, succ, s, pred, t)
     )
   }
 
   pragma[noinline]
-  private predicate controlsJoinBlockPredecessor(JoinBlock controlled, ConditionalSuccessor s, int i) {
-    this.controlsBlockSplit(controlled.getJoinBlockPredecessor(i), s)
+  private predicate controlsJoinBlockPredecessor(
+    JoinBlock controlled, ConditionalSuccessor s, int i, ConditionBlock cb
+  ) {
+    this.controlsBlockSplit(controlled.getJoinBlockPredecessor(i), s, cb)
   }
 
   private predicate controlsJoinBlockSplit(JoinBlock controlled, ConditionalSuccessor s, int i) {
     i = -1 and
-    this.controlsJoinBlockPredecessor(controlled, s, _)
+    this.controlsJoinBlockPredecessor(controlled, s, _, _)
     or
     this.controlsJoinBlockSplit(controlled, s, i - 1) and
     (
-      this.controlsJoinBlockPredecessor(controlled, s, i)
+      this.controlsJoinBlockPredecessor(controlled, s, i, _)
       or
       controlled.dominates(controlled.getJoinBlockPredecessor(i))
     )
   }
 
   cached
-  private predicate controlsBlockSplit(BasicBlock controlled, ConditionalSuccessor s) {
+  private predicate controlsBlockSplit(
+    BasicBlock controlled, ConditionalSuccessor s, ConditionBlock cb
+  ) {
     Stages::GuardsStage::forceCachingInSameStage() and
-    this.immediatelyControlsBlockSplit(controlled, s)
+    this.immediatelyControlsBlockSplit(controlled, s, cb)
     or
     // Equivalent with
     //
@@ -178,10 +183,11 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
       last = max(int i | exists(controlled.(JoinBlock).getJoinBlockPredecessor(i)))
     |
       this.controlsJoinBlockSplit(controlled, s, last)
-    )
+    ) and
+    this.controlsJoinBlockPredecessor(controlled, s, _, cb)
     or
     not controlled instanceof JoinBlock and
-    this.controlsBlockSplit(controlled.getAPredecessor(), s)
+    this.controlsBlockSplit(controlled.getAPredecessor(), s, cb)
   }
 
   /**
@@ -200,16 +206,25 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * ```
    *
    * as control flow splitting is taken into account.
+   *
+   * `cb` records all of the possible condition blocks for this control flow element
+   * that a path from the callable entry point to `controlled` may go through.
    */
-  predicate controlsBlock(BasicBlock controlled, ConditionalSuccessor s) {
-    this.controlsBlockSplit(controlled, s)
+  predicate controlsBlock(BasicBlock controlled, ConditionalSuccessor s, ConditionBlock cb) {
+    this.controlsBlockSplit(controlled, s, cb)
     or
-    exists(ConditionBlock cb | cb.getLastNode() = this.getAControlFlowNode() |
-      cb.controls(controlled, s)
-    )
+    cb.getLastNode() = this.getAControlFlowNode() and
+    cb.controls(controlled, s)
+  }
+
+  /** DEPRECATED: Use `controlsBlock/3` instead. */
+  deprecated predicate controlsBlock(BasicBlock controlled, ConditionalSuccessor s) {
+    this.controlsBlock(controlled, s, _)
   }
 
   /**
+   * DEPRECATED.
+   *
    * Holds if control flow element `controlled` is controlled by this control flow
    * element with conditional value `s`. That is, `controlled` can only be reached
    * from the callable entry point by going via the `s` edge out of this element.
@@ -227,7 +242,7 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    */
   // potentially very large predicate, so must be inlined
   pragma[inline]
-  predicate controlsElement(ControlFlowElement controlled, ConditionalSuccessor s) {
+  deprecated predicate controlsElement(ControlFlowElement controlled, ConditionalSuccessor s) {
     forex(BasicBlock bb | bb = controlled.getAControlFlowNode().getBasicBlock() |
       this.controlsBlock(bb, s)
     )

--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowElement.qll
@@ -126,6 +126,9 @@ class ControlFlowElement extends ExprOrStmtParent, @control_flow_element {
    * ```
    *
    * does not work.
+   *
+   * `cb` records all of the possible condition blocks for this control flow element
+   * that a path from the callable entry point to `succ` may go through.
    */
   pragma[nomagic]
   private predicate immediatelyControlsBlockSplit(

--- a/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/internal/Splitting.qll
@@ -409,7 +409,7 @@ module AssertionSplitting {
    * ```
    *
    * we record whether `i >= 0` evaluates to `true` or `false`, and restrict the
-   * edges out out of the assertion accordingly.
+   * edges out of the assertion accordingly.
    */
   class AssertionSplitImpl extends SplitImpl, TAssertionSplit {
     Assertion a;

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -733,7 +733,7 @@ private module Cached {
       viableConstantBooleanParamArg(paramNode, bs.getValue().booleanNot(), call) and
       paramNode.getDefinition() = param and
       param.getARead() = guard and
-      guard.controlsBlock(n.getControlFlowNode().getBasicBlock(), bs)
+      guard.controlsBlock(n.getControlFlowNode().getBasicBlock(), bs, _)
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/ConditionalBypass.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/ConditionalBypass.qll
@@ -61,7 +61,9 @@ module UserControlledBypassOfSensitiveMethod {
   private predicate conditionControlsCall0(
     SensitiveExecutionMethodCall call, Expr e, ControlFlow::SuccessorTypes::BooleanSuccessor s
   ) {
-    forex(BasicBlock bb | bb = call.getAControlFlowNode().getBasicBlock() | e.controlsBlock(bb, s))
+    forex(BasicBlock bb | bb = call.getAControlFlowNode().getBasicBlock() |
+      e.controlsBlock(bb, s, _)
+    )
   }
 
   private predicate conditionControlsCall(

--- a/csharp/ql/test/library-tests/controlflow/graph/Assert.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Assert.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+class AssertTests
+{
+    void M1(bool b)
+    {
+        string s = b ? null : "";
+        Debug.Assert(s != null);
+        Console.WriteLine(s.Length);
+    }
+
+    void M2(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsNull(s);
+        Console.WriteLine(s.Length);
+    }
+
+    void M3(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsNotNull(s);
+        Console.WriteLine(s.Length);
+    }
+
+    void M4(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsTrue(s == null);
+        Console.WriteLine(s.Length);
+    }
+
+    void M5(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsTrue(s != null);
+        Console.WriteLine(s.Length);
+    }
+
+    void M6(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsFalse(s != null);
+        Console.WriteLine(s.Length);
+    }
+
+    void M7(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsFalse(s == null);
+        Console.WriteLine(s.Length);
+    }
+
+    void M8(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsTrue(s != null && b);
+        Console.WriteLine(s.Length);
+    }
+
+    void M9(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsFalse(s == null || b);
+        Console.WriteLine(s.Length);
+    }
+
+    void M10(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsTrue(s == null && b);
+        Console.WriteLine(s.Length);
+    }
+
+    void M11(bool b)
+    {
+        string s = b ? null : "";
+        Assert.IsFalse(s != null || b);
+        Console.WriteLine(s.Length);
+    }
+
+    void M12(bool b)
+    {
+        string s = b ? null : "";
+        Debug.Assert(s != null);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsNull(s);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsNotNull(s);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsTrue(s == null);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsTrue(s != null);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsFalse(s != null);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsFalse(s == null);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsTrue(s != null && b);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsFalse(s == null || !b);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsTrue(s == null && b);
+        Console.WriteLine(s.Length);
+
+        s = b ? null : "";
+        Assert.IsFalse(s != null || !b);
+        Console.WriteLine(s.Length);
+    }
+}

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -16,75 +16,124 @@
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 6 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 10 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:20 | access to parameter b | 5 |
-| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | exit M1 | 11 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 | 1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:22:10:30 | ... != ... | 5 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | 1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | 1 |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | 1 |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:35 | call to method WriteLine | 5 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:20 | access to parameter b | 5 |
-| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | exit M2 | 9 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 | 1 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:23:17:23 | access to local variable s | 3 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | 1 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | 1 |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | 1 |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:35 | call to method WriteLine | 5 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:20 | access to parameter b | 5 |
-| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | exit M3 | 9 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 | 1 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:26:24:26 | access to local variable s | 3 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | 1 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | 1 |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | 1 |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:35 | call to method WriteLine | 5 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:20 | access to parameter b | 5 |
-| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | exit M4 | 11 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 | 1 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:23:31:31 | ... == ... | 5 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | 1 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | 1 |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:35 | call to method WriteLine | 5 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:20 | access to parameter b | 5 |
-| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | exit M5 | 11 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 | 1 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:23:38:31 | ... != ... | 5 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | 1 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | 1 |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:35 | call to method WriteLine | 5 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:20 | access to parameter b | 5 |
-| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | exit M6 | 11 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 | 1 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:24:45:32 | ... != ... | 5 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | 1 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | 1 |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | 1 |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:35 | call to method WriteLine | 5 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:20 | access to parameter b | 5 |
-| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | exit M7 | 11 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 | 1 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:24:52:32 | ... == ... | 5 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | 1 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | 1 |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | 1 |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:35 | call to method WriteLine | 5 |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:20:58:20 | access to parameter b | 5 |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:23:59:31 | ... != ... | 6 |
-| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null | 1 |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" | 1 |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 | 6 |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | 1 |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 | 1 |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | 7 |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | 7 |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | 1 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:60:9:60:35 | call to method WriteLine | 6 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:20:65:20 | access to parameter b | 5 |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:24:66:32 | ... == ... | 6 |
-| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null | 1 |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" | 1 |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 | 6 |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | 1 |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 | 1 |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | 7 |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | 7 |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | 1 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:67:9:67:35 | call to method WriteLine | 6 |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | 1 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:20:72:20 | access to parameter b | 5 |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:23:73:31 | ... == ... | 6 |
-| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null | 1 |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" | 1 |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 | 6 |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | 1 |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 | 1 |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | 7 |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | 7 |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | 1 |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | 1 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:74:9:74:35 | call to method WriteLine | 6 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:20:79:20 | access to parameter b | 5 |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:24:80:32 | ... != ... | 6 |
-| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null | 1 |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" | 1 |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 | 6 |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | 1 |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 | 1 |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | 7 |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | 7 |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | 1 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:81:9:81:35 | call to method WriteLine | 6 |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | 1 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:20:86:20 | access to parameter b | 5 |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | 101 |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | 101 |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | 15 |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | 15 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 | 1 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | 6 |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | 6 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | 1 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | 1 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | 12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | 12 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | 1 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | 1 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | 12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | 12 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | 1 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | 1 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | 14 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | 14 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | 1 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | 14 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | 14 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | 1 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | 14 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | 14 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | 1 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | 1 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | 14 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | 14 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | 1 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | 1 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | 15 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | 15 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | 1 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | 1 |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | 1 |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | 15 |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | 15 |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | 2 |
-| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | 2 |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:126:24:126:25 | "" | 9 |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:126:17:126:20 | null | 9 |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | 1 |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | 1 |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:24:127:32 | ... != ... | 6 |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | 6 |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | 2 |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | 16 |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | 1 |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | 17 |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | 1 |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | 16 |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | 1 |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:128:9:128:35 | call to method WriteLine | 7 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 33 |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... | 3 |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | exit + | 5 |
@@ -274,7 +323,10 @@
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:38:116:38 | 1 | 1 |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | 6 |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | 6 |
-| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | 4 |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b | 2 |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | 1 |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | 1 |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | 1 |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | 7 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | exit ToInt32 | 6 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | exit ToBool | 7 |

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -15,6 +15,76 @@
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | exit M2 | 5 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | exit M3 | 6 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | exit M4 | 10 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:20:9:20 | access to parameter b | 5 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | exit M1 | 11 |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | 1 |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | 1 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:20:16:20 | access to parameter b | 5 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | exit M2 | 9 |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | 1 |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | 1 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:20:23:20 | access to parameter b | 5 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | exit M3 | 9 |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | 1 |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | 1 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:20:30:20 | access to parameter b | 5 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | exit M4 | 11 |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | 1 |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | 1 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:20:37:20 | access to parameter b | 5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | exit M5 | 11 |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | 1 |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | 1 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:20:44:20 | access to parameter b | 5 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | exit M6 | 11 |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | 1 |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | 1 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:20:51:20 | access to parameter b | 5 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | exit M7 | 11 |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | 1 |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | 1 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:20:58:20 | access to parameter b | 5 |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:23:59:31 | ... != ... | 6 |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null | 1 |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" | 1 |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 | 6 |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | 1 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:20:65:20 | access to parameter b | 5 |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:24:66:32 | ... == ... | 6 |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null | 1 |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" | 1 |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 | 6 |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | 1 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:20:72:20 | access to parameter b | 5 |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:23:73:31 | ... == ... | 6 |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null | 1 |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" | 1 |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 | 6 |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | 1 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:20:79:20 | access to parameter b | 5 |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:24:80:32 | ... != ... | 6 |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null | 1 |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" | 1 |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 | 6 |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | 1 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:20:86:20 | access to parameter b | 5 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | 101 |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | 101 |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | 15 |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | 15 |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | 1 |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | 1 |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | 15 |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | 15 |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | 2 |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | 2 |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:126:24:126:25 | "" | 9 |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:126:17:126:20 | null | 9 |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | 1 |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | 1 |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:24:127:32 | ... != ... | 6 |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | 6 |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | 2 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | exit M | 33 |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | exit (...) => ... | 3 |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | exit + | 5 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1,4 +1,51 @@
 conditionBlock
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null | true |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" | false |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null | true |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" | false |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null | true |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" | false |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null | true |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" | false |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null | true |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" | false |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null | true |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" | false |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null | true |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" | false |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | null | true |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | "" | false |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:36:59:36 | access to parameter b | true |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | null | true |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | "" | false |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:37:66:37 | access to parameter b | false |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | null | true |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | "" | false |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:36:73:36 | access to parameter b | true |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | null | true |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | "" | false |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:37:127:38 | !... | false |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:26:7:28 | String arg | false |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:10:21:10:26 | break; | false |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:10:21:10:26 | break; | true |
@@ -792,6 +839,72 @@ conditionBlock
 | cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:268:9:276:9 | try {...} ... | false |
 | cflow.cs:298:10:298:10 | enter M | cflow.cs:300:56:300:56 | access to parameter s | false |
 conditionFlow
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | true |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | false |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | true |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | false |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | true |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | false |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | true |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | false |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | true |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | false |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | true |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | false |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | true |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | false |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null | true |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" | false |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue | false |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" | false |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse | true |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b | false |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" | false |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue | false |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" | false |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse | true |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | false |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | true |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | false |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | true |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | false |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | true |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | false |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | true |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | false |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | true |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | false |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | true |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | false |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | true |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" | false |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | true |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | true |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" | false |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | true |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | false |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" | false |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null | true |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse | true |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... | false |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | false |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:10:21:10:26 | break; | true |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 | false |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -1,51 +1,299 @@
 conditionBlock
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null | true |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" | false |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | false |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | true |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null | true |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" | false |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | false |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | true |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null | true |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" | false |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | true |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | false |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null | true |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" | false |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null | true |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" | false |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null | true |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" | false |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | false |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null | true |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" | false |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | null | true |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | "" | false |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:36:59:36 | access to parameter b | true |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | null | true |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | "" | false |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:37:66:37 | access to parameter b | false |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | null | true |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | "" | false |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:36:73:36 | access to parameter b | true |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | null | true |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | "" | false |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null | true |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" | false |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | false |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | true |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | true |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | true |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | [b (line 63): true] null | true |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | [b (line 63): false] "" | false |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | false |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | true |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | false |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | false |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | [b (line 70): true] null | true |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | [b (line 70): false] "" | false |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | false |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | true |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | true |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | true |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | [b (line 77): true] null | true |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | [b (line 77): false] "" | false |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | false |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | true |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | false |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | false |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | false |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | false |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | false |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | true |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | false |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:37:127:38 | !... | false |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | false |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | false |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | true |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | true |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:26:7:28 | String arg | false |
 | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:10:21:10:26 | break; | false |
 | BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:10:21:10:26 | break; | true |
@@ -194,6 +442,8 @@ conditionBlock
 | ExitMethods.cs:109:13:109:21 | enter ThrowExpr | ExitMethods.cs:111:69:111:75 | "input" | false |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:34:116:34 | 0 | true |
 | ExitMethods.cs:114:16:114:34 | enter ExtensionMethodCall | ExitMethods.cs:116:38:116:38 | 1 | false |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | true |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | false |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | true |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | false |
 | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | false |
@@ -841,70 +1091,114 @@ conditionBlock
 conditionFlow
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | true |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | false |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | false |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | true |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | true |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | false |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | true |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | false |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | true |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | false |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | true |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | false |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | true |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | true |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | false |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | false |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | true |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | false |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null | true |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" | false |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue | false |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b | true |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null | true |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" | false |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse | true |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b | false |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null | true |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" | false |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue | false |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b | true |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null | true |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" | false |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse | true |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | true |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | true |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | true |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | false |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | false |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | false |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | true |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | true |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | false |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | false |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | false |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | true |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | false |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | true |
 | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | false |
 | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | true |
 | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | false |
 | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | true |
 | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | false |
 | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | true |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | false |
 | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | true |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | false |
 | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | true |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | false |
 | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | true |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
 | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | false |
 | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | true |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" | false |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | true |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | true |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... | false |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | false |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | true |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | true |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | false |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | true |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" | false |
-| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null | true |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse | true |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... | false |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | false |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | true |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | false |
 | BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:10:21:10:26 | break; | true |
 | BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 | false |
@@ -1025,6 +1319,10 @@ conditionFlow
 | ExitMethods.cs:111:16:111:25 | ... != ... | ExitMethods.cs:111:69:111:75 | "input" | false |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:34:116:34 | 0 | true |
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:38:116:38 | 1 | false |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | false |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | true |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | false |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | true |
 | Finally.cs:26:48:26:51 | [exception: Exception] true | Finally.cs:27:9:29:9 | {...} | true |
 | Finally.cs:34:21:34:24 | true | Finally.cs:34:27:34:32 | throw ...; | true |
 | Finally.cs:61:48:61:51 | [exception: Exception] true | Finally.cs:62:9:64:9 | {...} | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -308,6 +308,491 @@ dominance
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:31:9:52 | { ..., ... } |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:11:9:11:36 | ...; |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | call to method Assert |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:18:9:18:36 | ...; |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | call to method IsNull |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | call to method IsNotNull |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:32:9:32:36 | ...; |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | call to method IsTrue |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:39:9:39:36 | ...; |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | call to method IsTrue |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:46:9:46:36 | ...; |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | call to method IsFalse |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:53:9:53:36 | ...; |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | call to method IsFalse |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:38 | ...; |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:60:9:60:36 | ...; |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:28:59:31 | null |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s |
+| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:31 | ... != ... |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:39 | ...; |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:67:9:67:36 | ...; |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:29:66:32 | null |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s |
+| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:32 | ... == ... |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:38 | ...; |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:74:9:74:36 | ...; |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:28:73:31 | null |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s |
+| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:31 | ... == ... |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:39 | ...; |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:81:9:81:36 | ...; |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:29:80:32 | null |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s |
+| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:32 | ... != ... |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
+| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
+| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
+| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
+| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
+| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
+| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
+| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
+| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
+| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
+| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
+| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
+| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
+| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
+| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): false] ...; |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
+| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): false] ...; |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
+| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
+| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
+| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null |
+| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
+| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): false] ...; |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
+| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): false] null |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): false] ...; |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
+| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
+| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
+| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null |
+| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
+| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): false] ...; |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
+| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
+| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): false] null |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
+| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): false] ...; |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
+| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
+| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:40 | ...; |
+| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null |
+| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:128:9:128:36 | ...; |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:29:127:32 | null |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:24 | access to local variable s |
+| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:32 | ... != ... |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 |
@@ -3516,6 +4001,491 @@ postDominance
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:48:9:48 | 3 |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:33:9:40 | { ..., ... } |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:45:9:45 | 2 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:11:9:11:35 | call to method WriteLine |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:8:5:12:5 | {...} |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:22:10:30 | ... != ... |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:9:10:32 | ...; |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:27:10:30 | null |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:22 | access to local variable s |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:11:27:11:34 | access to property Length |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:10:9:10:31 | call to method Assert |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:9:11:36 | ...; |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:18:9:18:35 | call to method WriteLine |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:15:5:19:5 | {...} |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:25 | ...; |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:27:18:34 | access to property Length |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:17:9:17:24 | call to method IsNull |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:9:18:36 | ...; |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:25:9:25:35 | call to method WriteLine |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:22:5:26:5 | {...} |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:28 | ...; |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:27:25:34 | access to property Length |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:24:9:24:27 | call to method IsNotNull |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:9:25:36 | ...; |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:32:9:32:35 | call to method WriteLine |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:29:5:33:5 | {...} |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:23:31:31 | ... == ... |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:9:31:33 | ...; |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:28:31:31 | null |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:23 | access to local variable s |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:32:27:32:34 | access to property Length |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:31:9:31:32 | call to method IsTrue |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:9:32:36 | ...; |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:39:9:39:35 | call to method WriteLine |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:36:5:40:5 | {...} |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:23:38:31 | ... != ... |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:9:38:33 | ...; |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:28:38:31 | null |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:23 | access to local variable s |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:39:27:39:34 | access to property Length |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:38:9:38:32 | call to method IsTrue |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:9:39:36 | ...; |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:46:9:46:35 | call to method WriteLine |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:43:5:47:5 | {...} |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:24:45:32 | ... != ... |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:9:45:34 | ...; |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:29:45:32 | null |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:24 | access to local variable s |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:46:27:46:34 | access to property Length |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:45:9:45:33 | call to method IsFalse |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:9:46:36 | ...; |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:53:9:53:35 | call to method WriteLine |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:50:5:54:5 | {...} |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:24:52:32 | ... == ... |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:9:52:34 | ...; |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:29:52:32 | null |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:24 | access to local variable s |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:53:27:53:34 | access to property Length |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:52:9:52:33 | call to method IsFalse |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:9:53:36 | ...; |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:60:9:60:35 | call to method WriteLine |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:57:5:61:5 | {...} |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:9:58:33 | ... ...; |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:23:59:31 | ... != ... |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:58:16:58:32 | String s = ... |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:28:59:31 | null |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:9:59:38 | ...; |
+| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:23 | access to local variable s |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:27:60:34 | access to property Length |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:9:60:36 | ...; |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:67:9:67:35 | call to method WriteLine |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:64:5:68:5 | {...} |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:9:65:33 | ... ...; |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:24:66:32 | ... == ... |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:65:16:65:32 | String s = ... |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:29:66:32 | null |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:9:66:39 | ...; |
+| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:24 | access to local variable s |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:27:67:34 | access to property Length |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:9:67:36 | ...; |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:74:9:74:35 | call to method WriteLine |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:71:5:75:5 | {...} |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:9:72:33 | ... ...; |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:23:73:31 | ... == ... |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:72:16:72:32 | String s = ... |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:28:73:31 | null |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:9:73:38 | ...; |
+| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:23 | access to local variable s |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:27:74:34 | access to property Length |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:9:74:36 | ...; |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:81:9:81:35 | call to method WriteLine |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:78:5:82:5 | {...} |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:9:79:33 | ... ...; |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:24:80:32 | ... != ... |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:79:16:79:32 | String s = ... |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:29:80:32 | null |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:9:80:39 | ...; |
+| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:24 | access to local variable s |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:27:81:34 | access to property Length |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:9:81:36 | ...; |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:128:9:128:35 | call to method WriteLine |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:85:5:129:5 | {...} |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... |
+| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:9:87:32 | [b (line 84): true] ...; |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:27:87:30 | [b (line 84): false] null |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:27:87:30 | [b (line 84): true] null |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:90:24:90:25 | [b (line 84): false] "" |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:90:17:90:20 | [b (line 84): true] null |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:25 | [b (line 84): true] ...; |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:94:24:94:25 | [b (line 84): false] "" |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:94:17:94:20 | [b (line 84): true] null |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |
+| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:28 | [b (line 84): true] ...; |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:98:24:98:25 | [b (line 84): false] "" |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:98:17:98:20 | [b (line 84): true] null |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... |
+| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:9:99:33 | [b (line 84): true] ...; |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:28:99:31 | [b (line 84): false] null |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:28:99:31 | [b (line 84): true] null |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:102:24:102:25 | [b (line 84): false] "" |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:102:17:102:20 | [b (line 84): true] null |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... |
+| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:9:103:33 | [b (line 84): true] ...; |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:28:103:31 | [b (line 84): false] null |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:28:103:31 | [b (line 84): true] null |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:106:24:106:25 | [b (line 84): false] "" |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:106:17:106:20 | [b (line 84): true] null |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... |
+| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:9:107:34 | [b (line 84): true] ...; |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:29:107:32 | [b (line 84): false] null |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:29:107:32 | [b (line 84): true] null |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:110:24:110:25 | [b (line 84): false] "" |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:110:17:110:20 | [b (line 84): true] null |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... |
+| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:9:111:34 | [b (line 84): true] ...; |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:29:111:32 | [b (line 84): false] null |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:29:111:32 | [b (line 84): true] null |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:114:24:114:25 | [b (line 84): false] "" |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:114:17:114:20 | [b (line 84): true] null |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:28:115:31 | [b (line 84): false] null |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:28:115:31 | [b (line 84): true] null |
+| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |
+| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
+| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): false] ...; |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
+| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:118:24:118:25 | [b (line 84): false] "" |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:118:17:118:20 | [b (line 84): true] null |
+| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:9:118:26 | [b (line 84): false] ...; |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
+| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): false] null |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): true] null |
+| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; |
+| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
+| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
+| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:9:120:36 | [b (line 84): false] ...; |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
+| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:122:24:122:25 | [b (line 84): false] "" |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:122:17:122:20 | [b (line 84): true] null |
+| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:9:122:26 | [b (line 84): false] ...; |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
+| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): false] null |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): true] null |
+| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; |
+| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
+| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
+| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
+| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): false] ...; |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
+| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:17:126:20 | null |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:24:126:25 | "" |
+| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
+| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:9:126:26 | [b (line 84): false] ...; |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
+| Assert.cs:126:17:126:20 | null | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:126:24:126:25 | "" | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:24:127:32 | ... != ... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:38:127:38 | access to parameter b |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:126:9:126:25 | ... = ... |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:29:127:32 | null |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:9:127:40 | ...; |
+| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:24 | access to local variable s |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:34 | access to property Length |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:9:128:36 | ...; |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:27:128:27 | access to local variable s |
 | Assignments.cs:3:10:3:10 | exit M | Assignments.cs:14:9:14:35 | ... += ... |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:4:5:15:5 | {...} |
@@ -6353,6 +7323,168 @@ blockDominance
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | enter M2 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:16:58:32 | String s = ... |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | null |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:16:65:32 | String s = ... |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | null |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:16:72:32 | String s = ... |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | null |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:16:79:32 | String s = ... |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | null |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:126:9:126:25 | ... = ... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:9:126:25 | ... = ... |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |
@@ -8813,6 +9945,185 @@ postBlockDominance
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | enter M2 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:16:58:32 | String s = ... |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:24:58:27 | null |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:16:65:32 | String s = ... |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:24:65:27 | null |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:16:72:32 | String s = ... |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:24:72:27 | null |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:16:79:32 | String s = ... |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:24:79:27 | null |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:9:126:25 | ... = ... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:126:9:126:25 | ... = ... |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -315,12 +315,12 @@ dominance
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b |
-| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:11:9:11:36 | ...; |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null |
-| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | call to method Assert |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... |
-| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 |
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine |
@@ -331,10 +331,10 @@ dominance
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b |
-| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:18:9:18:36 | ...; |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s |
-| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | call to method IsNull |
-| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine |
@@ -345,10 +345,10 @@ dominance
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b |
-| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s |
-| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | call to method IsNotNull |
-| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine |
@@ -359,12 +359,12 @@ dominance
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b |
-| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:32:9:32:36 | ...; |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null |
-| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | call to method IsTrue |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... |
-| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 |
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine |
@@ -375,12 +375,12 @@ dominance
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b |
-| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:39:9:39:36 | ...; |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null |
-| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | call to method IsTrue |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... |
-| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 |
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine |
@@ -391,12 +391,12 @@ dominance
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b |
-| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:46:9:46:36 | ...; |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null |
-| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | call to method IsFalse |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... |
-| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 |
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine |
@@ -407,84 +407,112 @@ dominance
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b |
-| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:53:9:53:36 | ...; |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null |
-| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | call to method IsFalse |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... |
-| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 |
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:38 | ...; |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:60:9:60:36 | ...; |
-| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:23:59:36 | ... && ... |
-| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:28:59:31 | null |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s |
-| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:31 | ... != ... |
-| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
+| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:39 | ...; |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:67:9:67:36 | ...; |
-| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:24:66:37 | ... \|\| ... |
-| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:29:66:32 | null |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s |
-| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:32 | ... == ... |
-| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
+| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:38 | ...; |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:74:9:74:36 | ...; |
-| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:23:73:36 | ... && ... |
-| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:28:73:31 | null |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s |
-| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:31 | ... == ... |
-| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
+| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:39 | ...; |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:81:9:81:36 | ...; |
-| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:24:80:37 | ... \|\| ... |
-| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:29:80:32 | null |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s |
-| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:32 | ... != ... |
-| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
+| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine |
@@ -498,14 +526,16 @@ dominance
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
-| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
-| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null |
 | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null |
-| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert |
-| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
 | Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... |
 | Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
 | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |
@@ -526,12 +556,14 @@ dominance
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
-| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
-| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
-| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull |
-| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
 | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |
 | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
 | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |
@@ -550,12 +582,14 @@ dominance
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
-| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
-| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
-| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull |
-| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
 | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |
 | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
 | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |
@@ -574,14 +608,16 @@ dominance
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
-| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
-| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null |
 | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null |
-| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... |
 | Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
 | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |
@@ -602,14 +638,16 @@ dominance
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
-| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
-| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null |
 | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null |
-| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... |
 | Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
 | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |
@@ -630,14 +668,16 @@ dominance
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
-| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
-| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null |
 | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null |
-| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... |
 | Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
 | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |
@@ -658,14 +698,16 @@ dominance
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
-| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
-| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null |
 | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null |
-| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... |
 | Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
 | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |
@@ -686,110 +728,73 @@ dominance
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): false] ...; |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null |
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
-| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): false] ...; |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
-| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
-| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
-| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null |
-| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
-| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): false] ...; |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
-| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
-| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): false] null |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
-| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
-| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): false] ...; |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
-| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
-| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
-| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null |
-| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
-| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): false] ...; |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
-| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
-| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): false] null |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
-| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
-| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): false] ...; |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
-| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
-| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:40 | ...; |
-| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" |
-| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null |
-| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:128:9:128:36 | ...; |
-| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:24:127:38 | ... \|\| ... |
-| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:29:127:32 | null |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:24 | access to local variable s |
-| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:32 | ... != ... |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b |
-| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length |
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine |
@@ -1476,23 +1481,23 @@ dominance
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:30 | call to method Contains |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; |
-| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false |
-| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | call to method IsTrue |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; |
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
-| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
-| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | call to method IsFalse |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; |
-| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access |
-| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | call to method AssertFalse |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 |
@@ -4001,6 +4006,7 @@ postDominance
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:48:9:48 | 3 |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:33:9:40 | { ..., ... } |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:45:9:45 | 2 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
 | Assert.cs:7:10:7:11 | exit M1 | Assert.cs:11:9:11:35 | call to method WriteLine |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:8:5:12:5 | {...} |
@@ -4008,15 +4014,15 @@ postDominance
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:32 | ... ? ... : ... |
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:9:9:33 | ... ...; |
-| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:22:10:30 | ... != ... |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:9:10:32 | ...; |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:27:10:30 | null |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:22 | access to local variable s |
 | Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:11:27:11:34 | access to property Length |
-| Assert.cs:11:9:11:36 | ...; | Assert.cs:10:9:10:31 | call to method Assert |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:9:11:36 | ...; |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
 | Assert.cs:14:10:14:11 | exit M2 | Assert.cs:18:9:18:35 | call to method WriteLine |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:15:5:19:5 | {...} |
@@ -4024,13 +4030,13 @@ postDominance
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:32 | ... ? ... : ... |
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:9:16:33 | ... ...; |
-| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:25 | ...; |
 | Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:27:18:34 | access to property Length |
-| Assert.cs:18:9:18:36 | ...; | Assert.cs:17:9:17:24 | call to method IsNull |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:9:18:36 | ...; |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
 | Assert.cs:21:10:21:11 | exit M3 | Assert.cs:25:9:25:35 | call to method WriteLine |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:22:5:26:5 | {...} |
@@ -4038,13 +4044,13 @@ postDominance
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:32 | ... ? ... : ... |
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:9:23:33 | ... ...; |
-| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:28 | ...; |
 | Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:27:25:34 | access to property Length |
-| Assert.cs:25:9:25:36 | ...; | Assert.cs:24:9:24:27 | call to method IsNotNull |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:9:25:36 | ...; |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:28:10:28:11 | exit M4 | Assert.cs:32:9:32:35 | call to method WriteLine |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:29:5:33:5 | {...} |
@@ -4052,15 +4058,15 @@ postDominance
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:32 | ... ? ... : ... |
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:9:30:33 | ... ...; |
-| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:23:31:31 | ... == ... |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:9:31:33 | ...; |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:28:31:31 | null |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:23 | access to local variable s |
 | Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:32:27:32:34 | access to property Length |
-| Assert.cs:32:9:32:36 | ...; | Assert.cs:31:9:31:32 | call to method IsTrue |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:9:32:36 | ...; |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
 | Assert.cs:35:10:35:11 | exit M5 | Assert.cs:39:9:39:35 | call to method WriteLine |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:36:5:40:5 | {...} |
@@ -4068,15 +4074,15 @@ postDominance
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:32 | ... ? ... : ... |
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:9:37:33 | ... ...; |
-| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:23:38:31 | ... != ... |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:9:38:33 | ...; |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:28:38:31 | null |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:23 | access to local variable s |
 | Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:39:27:39:34 | access to property Length |
-| Assert.cs:39:9:39:36 | ...; | Assert.cs:38:9:38:32 | call to method IsTrue |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:9:39:36 | ...; |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:42:10:42:11 | exit M6 | Assert.cs:46:9:46:35 | call to method WriteLine |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:43:5:47:5 | {...} |
@@ -4084,15 +4090,15 @@ postDominance
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:32 | ... ? ... : ... |
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:9:44:33 | ... ...; |
-| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:24:45:32 | ... != ... |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:9:45:34 | ...; |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:29:45:32 | null |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:24 | access to local variable s |
 | Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:46:27:46:34 | access to property Length |
-| Assert.cs:46:9:46:36 | ...; | Assert.cs:45:9:45:33 | call to method IsFalse |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:9:46:36 | ...; |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
 | Assert.cs:49:10:49:11 | exit M7 | Assert.cs:53:9:53:35 | call to method WriteLine |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:50:5:54:5 | {...} |
@@ -4100,87 +4106,133 @@ postDominance
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:32 | ... ? ... : ... |
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:9:51:33 | ... ...; |
-| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:24:52:32 | ... == ... |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:9:52:34 | ...; |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:29:52:32 | null |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:24 | access to local variable s |
 | Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:53:27:53:34 | access to property Length |
-| Assert.cs:53:9:53:36 | ...; | Assert.cs:52:9:52:33 | call to method IsFalse |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:9:53:36 | ...; |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:60:9:60:35 | call to method WriteLine |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | enter M8 |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:57:5:61:5 | {...} |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:24:58:27 | null |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:58:24:58:27 | [b (line 56): true] null |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... |
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:9:58:33 | ... ...; |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:23:59:31 | ... != ... |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:36:59:36 | access to parameter b |
-| Assert.cs:59:9:59:38 | ...; | Assert.cs:58:16:58:32 | String s = ... |
-| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:36 | ... && ... |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:28:59:31 | null |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:9:59:38 | ...; |
-| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:23 | access to local variable s |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:28:59:31 | [b (line 56): false] null |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:28:59:31 | [b (line 56): true] null |
+| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |
+| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:27:60:34 | access to property Length |
-| Assert.cs:60:9:60:36 | ...; | Assert.cs:59:9:59:37 | call to method IsTrue |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:9:60:36 | ...; |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:67:9:67:35 | call to method WriteLine |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | enter M9 |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:64:5:68:5 | {...} |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:24:65:27 | null |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:65:24:65:27 | [b (line 63): true] null |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... |
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:9:65:33 | ... ...; |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:24:66:32 | ... == ... |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:37:66:37 | access to parameter b |
-| Assert.cs:66:9:66:39 | ...; | Assert.cs:65:16:65:32 | String s = ... |
-| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:37 | ... \|\| ... |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:29:66:32 | null |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:9:66:39 | ...; |
-| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:24 | access to local variable s |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:29:66:32 | [b (line 63): false] null |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:29:66:32 | [b (line 63): true] null |
+| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |
+| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:27:67:34 | access to property Length |
-| Assert.cs:67:9:67:36 | ...; | Assert.cs:66:9:66:38 | call to method IsFalse |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:9:67:36 | ...; |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:74:9:74:35 | call to method WriteLine |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | enter M10 |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:71:5:75:5 | {...} |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:24:72:27 | null |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:72:24:72:27 | [b (line 70): true] null |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... |
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:9:72:33 | ... ...; |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:23:73:31 | ... == ... |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:36:73:36 | access to parameter b |
-| Assert.cs:73:9:73:38 | ...; | Assert.cs:72:16:72:32 | String s = ... |
-| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:36 | ... && ... |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:28:73:31 | null |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:9:73:38 | ...; |
-| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:23 | access to local variable s |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:28:73:31 | [b (line 70): false] null |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:28:73:31 | [b (line 70): true] null |
+| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |
+| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:27:74:34 | access to property Length |
-| Assert.cs:74:9:74:36 | ...; | Assert.cs:73:9:73:37 | call to method IsTrue |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:9:74:36 | ...; |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:81:9:81:35 | call to method WriteLine |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | enter M11 |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:78:5:82:5 | {...} |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:24:79:27 | null |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:79:24:79:27 | [b (line 77): true] null |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... |
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:9:79:33 | ... ...; |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:24:80:32 | ... != ... |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:37:80:37 | access to parameter b |
-| Assert.cs:80:9:80:39 | ...; | Assert.cs:79:16:79:32 | String s = ... |
-| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:37 | ... \|\| ... |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:29:80:32 | null |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:9:80:39 | ...; |
-| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:24 | access to local variable s |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:29:80:32 | [b (line 77): false] null |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:29:80:32 | [b (line 77): true] null |
+| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |
+| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:27:81:34 | access to property Length |
-| Assert.cs:81:9:81:36 | ...; | Assert.cs:80:9:80:38 | call to method IsFalse |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:9:81:36 | ...; |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
 | Assert.cs:84:10:84:12 | exit M12 | Assert.cs:128:9:128:35 | call to method WriteLine |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | enter M12 |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:85:5:129:5 | {...} |
@@ -4188,8 +4240,6 @@ postDominance
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:32 | ... ? ... : ... |
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:9:86:33 | ... ...; |
-| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... |
-| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |
@@ -4200,8 +4250,8 @@ postDominance
 | Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s |
 | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length |
 | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length |
-| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert |
-| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
 | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |
 | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |
 | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s |
@@ -4216,16 +4266,14 @@ postDominance
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |
-| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |
 | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |
 | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:25 | [b (line 84): true] ...; |
 | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length |
 | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length |
-| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull |
-| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
 | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |
 | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |
 | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |
@@ -4240,16 +4288,14 @@ postDominance
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |
-| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |
 | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |
 | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:28 | [b (line 84): true] ...; |
 | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length |
 | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length |
-| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull |
-| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
 | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |
 | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |
 | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |
@@ -4264,8 +4310,6 @@ postDominance
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... |
-| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |
@@ -4276,8 +4320,8 @@ postDominance
 | Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length |
 | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length |
-| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |
 | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |
 | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s |
@@ -4292,8 +4336,6 @@ postDominance
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... |
-| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |
@@ -4304,8 +4346,8 @@ postDominance
 | Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s |
 | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length |
 | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length |
-| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |
 | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |
 | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s |
@@ -4320,8 +4362,6 @@ postDominance
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... |
-| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |
@@ -4332,8 +4372,8 @@ postDominance
 | Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length |
 | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length |
-| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |
 | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |
 | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s |
@@ -4348,8 +4388,6 @@ postDominance
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... |
-| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |
@@ -4360,8 +4398,8 @@ postDominance
 | Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s |
 | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length |
 | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length |
-| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |
 | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |
 | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s |
@@ -4376,10 +4414,9 @@ postDominance
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... |
@@ -4390,100 +4427,55 @@ postDominance
 | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |
-| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |
-| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): false] ...; |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |
-| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:118:24:118:25 | [b (line 84): false] "" |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:118:17:118:20 | [b (line 84): true] null |
-| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:9:118:26 | [b (line 84): false] ...; |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |
-| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): false] null |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:29:119:32 | [b (line 84): true] null |
-| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |
-| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |
-| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |
-| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:9:120:36 | [b (line 84): false] ...; |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |
-| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:122:24:122:25 | [b (line 84): false] "" |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:122:17:122:20 | [b (line 84): true] null |
-| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:9:122:26 | [b (line 84): false] ...; |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |
-| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): false] null |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:28:123:31 | [b (line 84): true] null |
-| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |
-| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |
-| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |
-| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): false] ...; |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |
-| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:17:126:20 | null |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:24:126:25 | "" |
-| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:126:17:126:20 | [b (line 84): true] null |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |
-| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:9:126:26 | [b (line 84): false] ...; |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |
-| Assert.cs:126:17:126:20 | null | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:24:126:25 | "" | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:24:127:32 | ... != ... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:38:127:38 | access to parameter b |
-| Assert.cs:127:9:127:40 | ...; | Assert.cs:126:9:126:25 | ... = ... |
-| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:38 | ... \|\| ... |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:29:127:32 | null |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:9:127:40 | ...; |
-| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:24 | access to local variable s |
-| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:29:127:32 | [b (line 84): true] null |
+| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:34 | access to property Length |
-| Assert.cs:128:9:128:36 | ...; | Assert.cs:127:9:127:39 | call to method IsFalse |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:9:128:36 | ...; |
 | Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:27:128:27 | access to local variable s |
 | Assignments.cs:3:10:3:10 | exit M | Assignments.cs:14:9:14:35 | ... += ... |
@@ -5156,9 +5148,9 @@ postDominance
 | ExitMethods.cs:116:16:116:30 | call to method Contains | ExitMethods.cs:116:27:116:29 | - |
 | ExitMethods.cs:116:16:116:38 | ... ? ... : ... | ExitMethods.cs:115:5:117:5 | {...} |
 | ExitMethods.cs:116:27:116:29 | - | ExitMethods.cs:116:16:116:16 | access to parameter s |
-| ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:121:9:121:28 | call to method IsTrue |
+| ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
-| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:121:23:121:27 | false |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:121:23:121:27 | false |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:120:5:123:5 | {...} |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:29 | ...; |
 | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion |
@@ -5166,12 +5158,12 @@ postDominance
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:127:9:127:26 | this access |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:27 | ...; |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:126:5:129:5 | {...} |
-| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse |
-| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:48:131:48 | access to parameter b |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
-| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:135:9:135:25 | call to method AssertFalse |
+| ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
-| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:135:21:135:24 | true |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:135:21:135:24 | true |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:26 | ...; |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:134:5:137:5 | {...} |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | this access |
@@ -7324,167 +7316,464 @@ blockDominance
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | exit M1 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:24:9:27 | null |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | exit M1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | exit M2 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:24:16:27 | null |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | exit M2 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | exit M3 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:24:23:27 | null |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | exit M3 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | exit M4 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:24:30:27 | null |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | exit M4 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | exit M5 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:24:37:27 | null |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | exit M5 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | exit M6 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:24:44:27 | null |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | exit M6 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | exit M7 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:24:51:27 | null |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | exit M7 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | enter M8 |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:16:58:32 | String s = ... |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | null |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:9:59:37 | call to method IsTrue |
-| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | access to parameter b |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:37 | call to method IsTrue |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:36:59:36 | access to parameter b |
-| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | exit M8 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:24:58:27 | [b (line 56): true] null |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:16:65:32 | String s = ... |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | null |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:9:66:38 | call to method IsFalse |
-| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | access to parameter b |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:38 | call to method IsFalse |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:37:66:37 | access to parameter b |
-| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | exit M9 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:16:72:32 | String s = ... |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | null |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:9:73:37 | call to method IsTrue |
-| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | access to parameter b |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:37 | call to method IsTrue |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:36:73:36 | access to parameter b |
-| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | exit M10 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:24:72:27 | [b (line 70): true] null |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:24:72:27 | [b (line 70): true] null |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:16:79:32 | String s = ... |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | null |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:9:80:38 | call to method IsFalse |
-| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | access to parameter b |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:38 | call to method IsFalse |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:37:80:37 | access to parameter b |
-| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | exit M11 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | exit M12 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:126:9:126:25 | ... = ... |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | call to method IsFalse |
-| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:9:126:25 | ... = ... |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:39 | call to method IsFalse |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:37:127:38 | !... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |
@@ -7927,6 +8216,12 @@ blockDominance
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | enter ToBool |
@@ -9946,184 +10241,262 @@ postBlockDominance
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | enter M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | enter M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | enter M1 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | exit M1 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:16:9:32 | String s = ... |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:24:9:27 | null |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | enter M1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:31:9:32 | "" |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:10:9:10:31 | [assertion success] call to method Assert |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | enter M2 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | exit M2 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:16:16:32 | String s = ... |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:24:16:27 | null |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | enter M2 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:31:16:32 | "" |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | enter M3 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | exit M3 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:16:23:32 | String s = ... |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:24:23:27 | null |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | enter M3 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:31:23:32 | "" |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | enter M4 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | exit M4 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:16:30:32 | String s = ... |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:24:30:27 | null |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | enter M4 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:31:30:32 | "" |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | enter M5 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | exit M5 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:16:37:32 | String s = ... |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:24:37:27 | null |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | enter M5 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:31:37:32 | "" |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | enter M6 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | exit M6 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:16:44:32 | String s = ... |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:24:44:27 | null |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | enter M6 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:31:44:32 | "" |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | enter M7 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | exit M7 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:16:51:32 | String s = ... |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:24:51:27 | null |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | enter M7 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:31:51:32 | "" |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | enter M8 |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | enter M8 |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:24:58:27 | null |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | enter M8 |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:16:58:32 | String s = ... |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:24:58:27 | null |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:58:31:58:32 | "" |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:36:59:36 | access to parameter b |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | enter M8 |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | exit M8 |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:58:24:58:27 | [b (line 56): true] null |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:24:58:27 | [b (line 56): true] null |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:58:31:58:32 | [b (line 56): false] "" |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | enter M9 |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | enter M9 |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:24:65:27 | null |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | enter M9 |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:16:65:32 | String s = ... |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:24:65:27 | null |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:65:31:65:32 | "" |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:37:66:37 | access to parameter b |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | enter M9 |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | exit M9 |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:31:65:32 | [b (line 63): false] "" |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:65:24:65:27 | [b (line 63): true] null |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | enter M10 |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | enter M10 |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:24:72:27 | null |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | enter M10 |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:16:72:32 | String s = ... |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:24:72:27 | null |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:72:31:72:32 | "" |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:36:73:36 | access to parameter b |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | enter M10 |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | exit M10 |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:72:24:72:27 | [b (line 70): true] null |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:24:72:27 | [b (line 70): true] null |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:72:31:72:32 | [b (line 70): false] "" |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | enter M11 |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | enter M11 |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:24:79:27 | null |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | enter M11 |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:16:79:32 | String s = ... |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:24:79:27 | null |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:79:31:79:32 | "" |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:37:80:37 | access to parameter b |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | enter M11 |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | exit M11 |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:31:79:32 | [b (line 77): false] "" |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:79:24:79:27 | [b (line 77): true] null |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | enter M12 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | exit M12 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:86:24:86:27 | [b (line 84): true] null |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:24:86:27 | [b (line 84): true] null |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | enter M12 |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:9:126:25 | ... = ... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | enter M12 |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:86:24:86:27 | [b (line 84): true] null |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:86:31:86:32 | [b (line 84): false] "" |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): false] !... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:119:37:119:38 | [b (line 84): true] !... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:126:9:126:25 | ... = ... |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:37:127:38 | !... |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:37:127:38 | [b (line 84): true] !... |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | enter M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | enter (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | enter + |
@@ -10514,6 +10887,12 @@ postBlockDominance
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | enter FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | enter AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | enter ToInt32 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | enter ToBool |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -334,7 +334,8 @@ nodeEnclosing
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:7:10:7:11 | M1 |
-| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:7:10:7:11 | M1 |
@@ -352,7 +353,8 @@ nodeEnclosing
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:14:10:14:11 | M2 |
-| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | M2 |
@@ -368,7 +370,8 @@ nodeEnclosing
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:21:10:21:11 | M3 |
-| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | M3 |
@@ -384,7 +387,8 @@ nodeEnclosing
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:28:10:28:11 | M4 |
-| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:31:23:31:31 | ... == ... | Assert.cs:28:10:28:11 | M4 |
@@ -402,7 +406,8 @@ nodeEnclosing
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:35:10:35:11 | M5 |
-| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:38:23:38:31 | ... != ... | Assert.cs:35:10:35:11 | M5 |
@@ -420,7 +425,8 @@ nodeEnclosing
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:42:10:42:11 | M6 |
-| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:42:10:42:11 | M6 |
@@ -438,7 +444,8 @@ nodeEnclosing
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:49:10:49:11 | M7 |
-| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:49:10:49:11 | M7 |
@@ -451,18 +458,26 @@ nodeEnclosing
 | Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:24:58:27 | null | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:9:59:38 | ...; | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:28:59:31 | null | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:56:10:56:11 | M8 |
@@ -471,18 +486,26 @@ nodeEnclosing
 | Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:24:65:27 | null | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:9:66:39 | ...; | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:29:66:32 | null | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:63:10:63:11 | M9 |
@@ -491,18 +514,26 @@ nodeEnclosing
 | Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:24:72:27 | null | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:9:73:38 | ...; | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:28:73:31 | null | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:70:10:70:12 | M10 |
@@ -511,18 +542,26 @@ nodeEnclosing
 | Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:24:79:27 | null | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:9:80:39 | ...; | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:29:80:32 | null | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:77:10:77:12 | M11 |
@@ -537,8 +576,10 @@ nodeEnclosing
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -565,8 +606,10 @@ nodeEnclosing
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -589,8 +632,10 @@ nodeEnclosing
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -613,8 +658,10 @@ nodeEnclosing
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -641,8 +688,10 @@ nodeEnclosing
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -669,8 +718,10 @@ nodeEnclosing
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -697,8 +748,10 @@ nodeEnclosing
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -725,8 +778,9 @@ nodeEnclosing
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -739,97 +793,59 @@ nodeEnclosing
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:17:126:20 | null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:24:126:25 | "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:9:127:40 | ...; | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:29:127:32 | null | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:84:10:84:12 | M12 |
@@ -1589,7 +1605,7 @@ nodeEnclosing
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:119:17:119:32 | FailingAssertion |
-| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:119:17:119:32 | FailingAssertion |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
@@ -1600,12 +1616,13 @@ nodeEnclosing
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
-| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
-| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
@@ -4145,75 +4162,124 @@ blockEnclosing
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | M4 |
 | Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:24:9:27 | null | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:7:10:7:11 | M1 |
 | Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:24:16:27 | null | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:14:10:14:11 | M2 |
 | Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:24:23:27 | null | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
 | Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:24:30:27 | null | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
 | Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:24:37:27 | null | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
 | Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:24:44:27 | null | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
 | Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:24:51:27 | null | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:24:58:27 | null | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:56:10:56:11 | M8 |
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:24:65:27 | null | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:63:10:63:11 | M9 |
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:24:72:27 | null | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:70:10:70:12 | M10 |
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:24:79:27 | null | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:77:10:77:12 | M11 |
 | Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | + |
@@ -4404,6 +4470,9 @@ blockEnclosing
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:119:17:119:32 | FailingAssertion |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:125:17:125:33 | FailingAssertion2 |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:10:131:20 | exit AssertFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | AssertFalse |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:133:17:133:33 | FailingAssertion3 |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:5:23:5:29 | ToInt32 |
 | Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:10:24:10:29 | ToBool |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -325,6 +325,515 @@ nodeEnclosing
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:12:9:13 | M4 |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:12:9:13 | M4 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:7:10:7:11 | exit M1 | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:24:9:27 | null | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:10:27:10:30 | null | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:14:10:14:11 | exit M2 | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:24:16:27 | null | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:21:10:21:11 | exit M3 | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:24:23:27 | null | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:28:10:28:11 | exit M4 | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:24:30:27 | null | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:31:28:31:31 | null | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:35:10:35:11 | exit M5 | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:24:37:27 | null | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:38:28:38:31 | null | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:42:10:42:11 | exit M6 | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:24:44:27 | null | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:45:29:45:32 | null | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:49:10:49:11 | exit M7 | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:24:51:27 | null | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:52:29:52:32 | null | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:56:10:56:11 | exit M8 | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:24:58:27 | null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:28:59:31 | null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:63:10:63:11 | exit M9 | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:24:65:27 | null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:29:66:32 | null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:70:10:70:12 | exit M10 | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:24:72:27 | null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:28:73:31 | null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:77:10:77:12 | exit M11 | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:24:79:27 | null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:29:80:32 | null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:84:10:84:12 | exit M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:17:126:20 | null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:24:126:25 | "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:29:127:32 | null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:84:10:84:12 | M12 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:3:10:3:10 | exit M | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:3:10:3:10 | M |
@@ -3635,6 +4144,76 @@ blockEnclosing
 | ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:12:5:13 | M2 |
 | ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:11:7:12 | M3 |
 | ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:12:9:13 | M4 |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:24:9:27 | null | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:7:10:7:11 | M1 |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:24:16:27 | null | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:14:10:14:11 | M2 |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:24:23:27 | null | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:21:10:21:11 | M3 |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:24:30:27 | null | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:28:10:28:11 | M4 |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:24:37:27 | null | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:35:10:35:11 | M5 |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:24:44:27 | null | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:42:10:42:11 | M6 |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:24:51:27 | null | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:49:10:49:11 | M7 |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:24:58:27 | null | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:56:10:56:11 | M8 |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:24:65:27 | null | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:63:10:63:11 | M9 |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:24:72:27 | null | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:70:10:70:12 | M10 |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:24:79:27 | null | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:77:10:77:12 | M11 |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:84:10:84:12 | M12 |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:84:10:84:12 | M12 |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:3:10:3:10 | M |
 | Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:18:14:35 | (...) => ... |
 | Assignments.cs:17:40:17:40 | enter + | Assignments.cs:17:40:17:40 | + |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -307,6 +307,358 @@
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:45:9:45 | 2 |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:45:9:45 | 2 |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:8:5:12:5 | {...} |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:9:9:33 | ... ...; |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:32 | ... ? ... : ... |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:22:10:22 | access to local variable s |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:9:10:32 | ...; |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:22:10:22 | access to local variable s |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:22 | access to local variable s |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:27:10:30 | null |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:9:11:36 | ...; |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:27 | access to local variable s |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:15:5:19:5 | {...} |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:9:16:33 | ... ...; |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:32 | ... ? ... : ... |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:23:17:23 | access to local variable s |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:9:17:25 | ...; |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:23:17:23 | access to local variable s |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:9:18:36 | ...; |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:27 | access to local variable s |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:22:5:26:5 | {...} |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:9:23:33 | ... ...; |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:32 | ... ? ... : ... |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:26:24:26 | access to local variable s |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:9:24:28 | ...; |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:26:24:26 | access to local variable s |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:9:25:36 | ...; |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:27 | access to local variable s |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:29:5:33:5 | {...} |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:9:30:33 | ... ...; |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:32 | ... ? ... : ... |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:23:31:23 | access to local variable s |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:9:31:33 | ...; |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:23:31:23 | access to local variable s |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:23:31:23 | access to local variable s |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:28:31:31 | null |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:9:32:36 | ...; |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:27 | access to local variable s |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:36:5:40:5 | {...} |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:9:37:33 | ... ...; |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:32 | ... ? ... : ... |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:23:38:23 | access to local variable s |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:9:38:33 | ...; |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:23:38:23 | access to local variable s |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:23:38:23 | access to local variable s |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:28:38:31 | null |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:9:39:36 | ...; |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:27 | access to local variable s |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:43:5:47:5 | {...} |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:9:44:33 | ... ...; |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:32 | ... ? ... : ... |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:24:45:24 | access to local variable s |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:9:45:34 | ...; |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:24:45:24 | access to local variable s |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:24 | access to local variable s |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:29:45:32 | null |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:9:46:36 | ...; |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:27 | access to local variable s |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:50:5:54:5 | {...} |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:9:51:33 | ... ...; |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:32 | ... ? ... : ... |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:24:52:24 | access to local variable s |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:9:52:34 | ...; |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:24:52:24 | access to local variable s |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:29:52:32 | null |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:9:53:36 | ...; |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:57:5:61:5 | {...} |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:9:58:33 | ... ...; |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:32 | ... ? ... : ... |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:9:59:38 | ...; |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:36 | ... && ... |
+| Assert.cs:59:28:59:31 | null | Assert.cs:59:28:59:31 | null |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:9:60:36 | ...; |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:64:5:68:5 | {...} |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:9:65:33 | ... ...; |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:32 | ... ? ... : ... |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:9:66:39 | ...; |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:37 | ... \|\| ... |
+| Assert.cs:66:29:66:32 | null | Assert.cs:66:29:66:32 | null |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:9:67:36 | ...; |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:27 | access to local variable s |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:71:5:75:5 | {...} |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:9:72:33 | ... ...; |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:32 | ... ? ... : ... |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:9:73:38 | ...; |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:36 | ... && ... |
+| Assert.cs:73:28:73:31 | null | Assert.cs:73:28:73:31 | null |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:9:74:36 | ...; |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:27 | access to local variable s |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:78:5:82:5 | {...} |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:9:79:33 | ... ...; |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:32 | ... ? ... : ... |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:9:80:39 | ...; |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:37 | ... \|\| ... |
+| Assert.cs:80:29:80:32 | null | Assert.cs:80:29:80:32 | null |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:9:81:36 | ...; |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:27 | access to local variable s |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:85:5:129:5 | {...} |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:9:86:33 | ... ...; |
+| Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:32 | ... ? ... : ... |
+| Assert.cs:86:24:86:27 | null | Assert.cs:86:24:86:27 | null |
+| Assert.cs:86:31:86:32 | "" | Assert.cs:86:31:86:32 | "" |
+| Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:22:87:22 | access to local variable s |
+| Assert.cs:87:9:87:32 | ...; | Assert.cs:87:9:87:32 | ...; |
+| Assert.cs:87:22:87:22 | access to local variable s | Assert.cs:87:22:87:22 | access to local variable s |
+| Assert.cs:87:22:87:30 | ... != ... | Assert.cs:87:22:87:22 | access to local variable s |
+| Assert.cs:87:27:87:30 | null | Assert.cs:87:27:87:30 | null |
+| Assert.cs:88:9:88:35 | call to method WriteLine | Assert.cs:88:27:88:27 | access to local variable s |
+| Assert.cs:88:9:88:36 | ...; | Assert.cs:88:9:88:36 | ...; |
+| Assert.cs:88:27:88:27 | access to local variable s | Assert.cs:88:27:88:27 | access to local variable s |
+| Assert.cs:88:27:88:34 | access to property Length | Assert.cs:88:27:88:27 | access to local variable s |
+| Assert.cs:90:9:90:25 | ... = ... | Assert.cs:90:13:90:25 | ... ? ... : ... |
+| Assert.cs:90:9:90:26 | ...; | Assert.cs:90:9:90:26 | ...; |
+| Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b |
+| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:13:90:25 | ... ? ... : ... |
+| Assert.cs:90:17:90:20 | null | Assert.cs:90:17:90:20 | null |
+| Assert.cs:90:24:90:25 | "" | Assert.cs:90:24:90:25 | "" |
+| Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:23:91:23 | access to local variable s |
+| Assert.cs:91:9:91:25 | ...; | Assert.cs:91:9:91:25 | ...; |
+| Assert.cs:91:23:91:23 | access to local variable s | Assert.cs:91:23:91:23 | access to local variable s |
+| Assert.cs:92:9:92:35 | call to method WriteLine | Assert.cs:92:27:92:27 | access to local variable s |
+| Assert.cs:92:9:92:36 | ...; | Assert.cs:92:9:92:36 | ...; |
+| Assert.cs:92:27:92:27 | access to local variable s | Assert.cs:92:27:92:27 | access to local variable s |
+| Assert.cs:92:27:92:34 | access to property Length | Assert.cs:92:27:92:27 | access to local variable s |
+| Assert.cs:94:9:94:25 | ... = ... | Assert.cs:94:13:94:25 | ... ? ... : ... |
+| Assert.cs:94:9:94:26 | ...; | Assert.cs:94:9:94:26 | ...; |
+| Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b |
+| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:13:94:25 | ... ? ... : ... |
+| Assert.cs:94:17:94:20 | null | Assert.cs:94:17:94:20 | null |
+| Assert.cs:94:24:94:25 | "" | Assert.cs:94:24:94:25 | "" |
+| Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:26:95:26 | access to local variable s |
+| Assert.cs:95:9:95:28 | ...; | Assert.cs:95:9:95:28 | ...; |
+| Assert.cs:95:26:95:26 | access to local variable s | Assert.cs:95:26:95:26 | access to local variable s |
+| Assert.cs:96:9:96:35 | call to method WriteLine | Assert.cs:96:27:96:27 | access to local variable s |
+| Assert.cs:96:9:96:36 | ...; | Assert.cs:96:9:96:36 | ...; |
+| Assert.cs:96:27:96:27 | access to local variable s | Assert.cs:96:27:96:27 | access to local variable s |
+| Assert.cs:96:27:96:34 | access to property Length | Assert.cs:96:27:96:27 | access to local variable s |
+| Assert.cs:98:9:98:25 | ... = ... | Assert.cs:98:13:98:25 | ... ? ... : ... |
+| Assert.cs:98:9:98:26 | ...; | Assert.cs:98:9:98:26 | ...; |
+| Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b |
+| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:13:98:25 | ... ? ... : ... |
+| Assert.cs:98:17:98:20 | null | Assert.cs:98:17:98:20 | null |
+| Assert.cs:98:24:98:25 | "" | Assert.cs:98:24:98:25 | "" |
+| Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:23:99:23 | access to local variable s |
+| Assert.cs:99:9:99:33 | ...; | Assert.cs:99:9:99:33 | ...; |
+| Assert.cs:99:23:99:23 | access to local variable s | Assert.cs:99:23:99:23 | access to local variable s |
+| Assert.cs:99:23:99:31 | ... == ... | Assert.cs:99:23:99:23 | access to local variable s |
+| Assert.cs:99:28:99:31 | null | Assert.cs:99:28:99:31 | null |
+| Assert.cs:100:9:100:35 | call to method WriteLine | Assert.cs:100:27:100:27 | access to local variable s |
+| Assert.cs:100:9:100:36 | ...; | Assert.cs:100:9:100:36 | ...; |
+| Assert.cs:100:27:100:27 | access to local variable s | Assert.cs:100:27:100:27 | access to local variable s |
+| Assert.cs:100:27:100:34 | access to property Length | Assert.cs:100:27:100:27 | access to local variable s |
+| Assert.cs:102:9:102:25 | ... = ... | Assert.cs:102:13:102:25 | ... ? ... : ... |
+| Assert.cs:102:9:102:26 | ...; | Assert.cs:102:9:102:26 | ...; |
+| Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b |
+| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:13:102:25 | ... ? ... : ... |
+| Assert.cs:102:17:102:20 | null | Assert.cs:102:17:102:20 | null |
+| Assert.cs:102:24:102:25 | "" | Assert.cs:102:24:102:25 | "" |
+| Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:23:103:23 | access to local variable s |
+| Assert.cs:103:9:103:33 | ...; | Assert.cs:103:9:103:33 | ...; |
+| Assert.cs:103:23:103:23 | access to local variable s | Assert.cs:103:23:103:23 | access to local variable s |
+| Assert.cs:103:23:103:31 | ... != ... | Assert.cs:103:23:103:23 | access to local variable s |
+| Assert.cs:103:28:103:31 | null | Assert.cs:103:28:103:31 | null |
+| Assert.cs:104:9:104:35 | call to method WriteLine | Assert.cs:104:27:104:27 | access to local variable s |
+| Assert.cs:104:9:104:36 | ...; | Assert.cs:104:9:104:36 | ...; |
+| Assert.cs:104:27:104:27 | access to local variable s | Assert.cs:104:27:104:27 | access to local variable s |
+| Assert.cs:104:27:104:34 | access to property Length | Assert.cs:104:27:104:27 | access to local variable s |
+| Assert.cs:106:9:106:25 | ... = ... | Assert.cs:106:13:106:25 | ... ? ... : ... |
+| Assert.cs:106:9:106:26 | ...; | Assert.cs:106:9:106:26 | ...; |
+| Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b |
+| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:13:106:25 | ... ? ... : ... |
+| Assert.cs:106:17:106:20 | null | Assert.cs:106:17:106:20 | null |
+| Assert.cs:106:24:106:25 | "" | Assert.cs:106:24:106:25 | "" |
+| Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:24:107:24 | access to local variable s |
+| Assert.cs:107:9:107:34 | ...; | Assert.cs:107:9:107:34 | ...; |
+| Assert.cs:107:24:107:24 | access to local variable s | Assert.cs:107:24:107:24 | access to local variable s |
+| Assert.cs:107:24:107:32 | ... != ... | Assert.cs:107:24:107:24 | access to local variable s |
+| Assert.cs:107:29:107:32 | null | Assert.cs:107:29:107:32 | null |
+| Assert.cs:108:9:108:35 | call to method WriteLine | Assert.cs:108:27:108:27 | access to local variable s |
+| Assert.cs:108:9:108:36 | ...; | Assert.cs:108:9:108:36 | ...; |
+| Assert.cs:108:27:108:27 | access to local variable s | Assert.cs:108:27:108:27 | access to local variable s |
+| Assert.cs:108:27:108:34 | access to property Length | Assert.cs:108:27:108:27 | access to local variable s |
+| Assert.cs:110:9:110:25 | ... = ... | Assert.cs:110:13:110:25 | ... ? ... : ... |
+| Assert.cs:110:9:110:26 | ...; | Assert.cs:110:9:110:26 | ...; |
+| Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b |
+| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:13:110:25 | ... ? ... : ... |
+| Assert.cs:110:17:110:20 | null | Assert.cs:110:17:110:20 | null |
+| Assert.cs:110:24:110:25 | "" | Assert.cs:110:24:110:25 | "" |
+| Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:24:111:24 | access to local variable s |
+| Assert.cs:111:9:111:34 | ...; | Assert.cs:111:9:111:34 | ...; |
+| Assert.cs:111:24:111:24 | access to local variable s | Assert.cs:111:24:111:24 | access to local variable s |
+| Assert.cs:111:24:111:32 | ... == ... | Assert.cs:111:24:111:24 | access to local variable s |
+| Assert.cs:111:29:111:32 | null | Assert.cs:111:29:111:32 | null |
+| Assert.cs:112:9:112:35 | call to method WriteLine | Assert.cs:112:27:112:27 | access to local variable s |
+| Assert.cs:112:9:112:36 | ...; | Assert.cs:112:9:112:36 | ...; |
+| Assert.cs:112:27:112:27 | access to local variable s | Assert.cs:112:27:112:27 | access to local variable s |
+| Assert.cs:112:27:112:34 | access to property Length | Assert.cs:112:27:112:27 | access to local variable s |
+| Assert.cs:114:9:114:25 | ... = ... | Assert.cs:114:13:114:25 | ... ? ... : ... |
+| Assert.cs:114:9:114:26 | ...; | Assert.cs:114:9:114:26 | ...; |
+| Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b |
+| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:13:114:25 | ... ? ... : ... |
+| Assert.cs:114:17:114:20 | null | Assert.cs:114:17:114:20 | null |
+| Assert.cs:114:24:114:25 | "" | Assert.cs:114:24:114:25 | "" |
+| Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:23:115:36 | ... && ... |
+| Assert.cs:115:9:115:38 | ...; | Assert.cs:115:9:115:38 | ...; |
+| Assert.cs:115:23:115:23 | access to local variable s | Assert.cs:115:23:115:23 | access to local variable s |
+| Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:23 | access to local variable s |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:36 | ... && ... |
+| Assert.cs:115:28:115:31 | null | Assert.cs:115:28:115:31 | null |
+| Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b |
+| Assert.cs:116:9:116:35 | call to method WriteLine | Assert.cs:116:27:116:27 | access to local variable s |
+| Assert.cs:116:9:116:36 | ...; | Assert.cs:116:9:116:36 | ...; |
+| Assert.cs:116:27:116:27 | access to local variable s | Assert.cs:116:27:116:27 | access to local variable s |
+| Assert.cs:116:27:116:34 | access to property Length | Assert.cs:116:27:116:27 | access to local variable s |
+| Assert.cs:118:9:118:25 | ... = ... | Assert.cs:118:13:118:25 | ... ? ... : ... |
+| Assert.cs:118:9:118:26 | ...; | Assert.cs:118:9:118:26 | ...; |
+| Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b |
+| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:13:118:25 | ... ? ... : ... |
+| Assert.cs:118:17:118:20 | null | Assert.cs:118:17:118:20 | null |
+| Assert.cs:118:24:118:25 | "" | Assert.cs:118:24:118:25 | "" |
+| Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:24:119:38 | ... \|\| ... |
+| Assert.cs:119:9:119:40 | ...; | Assert.cs:119:9:119:40 | ...; |
+| Assert.cs:119:24:119:24 | access to local variable s | Assert.cs:119:24:119:24 | access to local variable s |
+| Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:24 | access to local variable s |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:38 | ... \|\| ... |
+| Assert.cs:119:29:119:32 | null | Assert.cs:119:29:119:32 | null |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:37:119:38 | !... |
+| Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b |
+| Assert.cs:120:9:120:35 | call to method WriteLine | Assert.cs:120:27:120:27 | access to local variable s |
+| Assert.cs:120:9:120:36 | ...; | Assert.cs:120:9:120:36 | ...; |
+| Assert.cs:120:27:120:27 | access to local variable s | Assert.cs:120:27:120:27 | access to local variable s |
+| Assert.cs:120:27:120:34 | access to property Length | Assert.cs:120:27:120:27 | access to local variable s |
+| Assert.cs:122:9:122:25 | ... = ... | Assert.cs:122:13:122:25 | ... ? ... : ... |
+| Assert.cs:122:9:122:26 | ...; | Assert.cs:122:9:122:26 | ...; |
+| Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b |
+| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:13:122:25 | ... ? ... : ... |
+| Assert.cs:122:17:122:20 | null | Assert.cs:122:17:122:20 | null |
+| Assert.cs:122:24:122:25 | "" | Assert.cs:122:24:122:25 | "" |
+| Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:23:123:36 | ... && ... |
+| Assert.cs:123:9:123:38 | ...; | Assert.cs:123:9:123:38 | ...; |
+| Assert.cs:123:23:123:23 | access to local variable s | Assert.cs:123:23:123:23 | access to local variable s |
+| Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:23 | access to local variable s |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:36 | ... && ... |
+| Assert.cs:123:28:123:31 | null | Assert.cs:123:28:123:31 | null |
+| Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b |
+| Assert.cs:124:9:124:35 | call to method WriteLine | Assert.cs:124:27:124:27 | access to local variable s |
+| Assert.cs:124:9:124:36 | ...; | Assert.cs:124:9:124:36 | ...; |
+| Assert.cs:124:27:124:27 | access to local variable s | Assert.cs:124:27:124:27 | access to local variable s |
+| Assert.cs:124:27:124:34 | access to property Length | Assert.cs:124:27:124:27 | access to local variable s |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:13:126:25 | ... ? ... : ... |
+| Assert.cs:126:9:126:26 | ...; | Assert.cs:126:9:126:26 | ...; |
+| Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b |
+| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:13:126:25 | ... ? ... : ... |
+| Assert.cs:126:17:126:20 | null | Assert.cs:126:17:126:20 | null |
+| Assert.cs:126:24:126:25 | "" | Assert.cs:126:24:126:25 | "" |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:9:127:40 | ...; |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:24 | access to local variable s |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:24 | access to local variable s |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:38 | ... \|\| ... |
+| Assert.cs:127:29:127:32 | null | Assert.cs:127:29:127:32 | null |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:37:127:38 | !... |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:27:128:27 | access to local variable s |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:9:128:36 | ...; |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:27 | access to local variable s |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:27:128:27 | access to local variable s |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:4:5:15:5 | {...} |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:9:5:18 | ... ...; |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:17:5:17 | 0 |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -307,6 +307,7 @@
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:43:9:50 | { ..., ... } | normal |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:45:9:45 | 2 | normal |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 | normal |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:10:9:10:31 | call to method Assert | exit |
 | Assert.cs:8:5:12:5 | {...} | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
 | Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:16:9:32 | String s = ... | normal |
 | Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... | normal |
@@ -316,15 +317,19 @@
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:31:9:32 | "" | normal |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | normal |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | normal |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:9:10:31 | call to method Assert | exit |
 | Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:9:10:31 | call to method Assert | normal |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:9:10:31 | call to method Assert | exit |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:9:10:31 | call to method Assert | normal |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:22:10:22 | access to local variable s | normal |
-| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:30 | ... != ... | normal |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:30 | ... != ... | false |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:30 | ... != ... | true |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:27:10:30 | null | normal |
 | Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
 | Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:27 | access to local variable s | normal |
 | Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:34 | access to property Length | normal |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:17:9:17:24 | call to method IsNull | throw(AssertFailedException) |
 | Assert.cs:15:5:19:5 | {...} | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
 | Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:16:16:32 | String s = ... | normal |
 | Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... | normal |
@@ -335,12 +340,16 @@
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | normal |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | normal |
 | Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:9:17:24 | call to method IsNull | normal |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:9:17:24 | call to method IsNull | throw(AssertFailedException) |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:9:17:24 | call to method IsNull | normal |
-| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:23:17:23 | access to local variable s | normal |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:9:17:24 | call to method IsNull | throw(AssertFailedException) |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:23:17:23 | access to local variable s | non-null |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:23:17:23 | access to local variable s | null |
 | Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:27 | access to local variable s | normal |
 | Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:34 | access to property Length | normal |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:24:9:24:27 | call to method IsNotNull | throw(AssertFailedException) |
 | Assert.cs:22:5:26:5 | {...} | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
 | Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:16:23:32 | String s = ... | normal |
 | Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... | normal |
@@ -351,12 +360,16 @@
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | normal |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | normal |
 | Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:9:24:27 | call to method IsNotNull | normal |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:9:24:27 | call to method IsNotNull | throw(AssertFailedException) |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:9:24:27 | call to method IsNotNull | normal |
-| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:26:24:26 | access to local variable s | normal |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:9:24:27 | call to method IsNotNull | throw(AssertFailedException) |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:26:24:26 | access to local variable s | non-null |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:26:24:26 | access to local variable s | null |
 | Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:27 | access to local variable s | normal |
 | Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:34 | access to property Length | normal |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:31:9:31:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:29:5:33:5 | {...} | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
 | Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:16:30:32 | String s = ... | normal |
 | Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... | normal |
@@ -367,14 +380,18 @@
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | normal |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | normal |
 | Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:9:31:32 | call to method IsTrue | normal |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:9:31:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:9:31:32 | call to method IsTrue | normal |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:9:31:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:23:31:23 | access to local variable s | normal |
-| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:23:31:31 | ... == ... | normal |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:23:31:31 | ... == ... | false |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:23:31:31 | ... == ... | true |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:28:31:31 | null | normal |
 | Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
 | Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:27 | access to local variable s | normal |
 | Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:34 | access to property Length | normal |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:38:9:38:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:36:5:40:5 | {...} | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
 | Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:16:37:32 | String s = ... | normal |
 | Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... | normal |
@@ -385,14 +402,18 @@
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | normal |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | normal |
 | Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:9:38:32 | call to method IsTrue | normal |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:9:38:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:9:38:32 | call to method IsTrue | normal |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:9:38:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:23:38:23 | access to local variable s | normal |
-| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:23:38:31 | ... != ... | normal |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:23:38:31 | ... != ... | false |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:23:38:31 | ... != ... | true |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:28:38:31 | null | normal |
 | Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
 | Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:27 | access to local variable s | normal |
 | Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:34 | access to property Length | normal |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:45:9:45:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:43:5:47:5 | {...} | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
 | Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:16:44:32 | String s = ... | normal |
 | Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... | normal |
@@ -403,14 +424,18 @@
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | normal |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | normal |
 | Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:9:45:33 | call to method IsFalse | normal |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:9:45:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:9:45:33 | call to method IsFalse | normal |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:9:45:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:24:45:24 | access to local variable s | normal |
-| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:32 | ... != ... | normal |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:32 | ... != ... | false |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:32 | ... != ... | true |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:29:45:32 | null | normal |
 | Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:27 | access to local variable s | normal |
 | Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:34 | access to property Length | normal |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:52:9:52:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:50:5:54:5 | {...} | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
 | Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:16:51:32 | String s = ... | normal |
 | Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... | normal |
@@ -421,14 +446,18 @@
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | normal |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | normal |
 | Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:9:52:33 | call to method IsFalse | normal |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:9:52:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:9:52:33 | call to method IsFalse | normal |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:9:52:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:24:52:24 | access to local variable s | normal |
-| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:32 | ... == ... | normal |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:32 | ... == ... | false |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:32 | ... == ... | true |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:29:52:32 | null | normal |
 | Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:27 | access to local variable s | normal |
 | Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:34 | access to property Length | normal |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:59:9:59:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:16:58:32 | String s = ... | normal |
 | Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... | normal |
@@ -439,18 +468,23 @@
 | Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null | normal |
 | Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" | normal |
 | Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue | normal |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:59:9:59:38 | ...; | Assert.cs:59:9:59:37 | call to method IsTrue | normal |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:9:59:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | normal |
 | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | false |
 | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | true |
 | Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:31 | ... != ... | false |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | normal |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | false |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | true |
 | Assert.cs:59:28:59:31 | null | Assert.cs:59:28:59:31 | null | normal |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | normal |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | false |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | true |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:27 | access to local variable s | normal |
 | Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:34 | access to property Length | normal |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:66:9:66:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:16:65:32 | String s = ... | normal |
 | Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... | normal |
@@ -461,18 +495,23 @@
 | Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null | normal |
 | Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" | normal |
 | Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse | normal |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:66:9:66:39 | ...; | Assert.cs:66:9:66:38 | call to method IsFalse | normal |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:9:66:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | normal |
 | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | false |
 | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | true |
 | Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:32 | ... == ... | true |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | normal |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | false |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | true |
 | Assert.cs:66:29:66:32 | null | Assert.cs:66:29:66:32 | null | normal |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | normal |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | false |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | true |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:27 | access to local variable s | normal |
 | Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:34 | access to property Length | normal |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:73:9:73:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:16:72:32 | String s = ... | normal |
 | Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... | normal |
@@ -483,18 +522,23 @@
 | Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null | normal |
 | Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" | normal |
 | Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue | normal |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:73:9:73:38 | ...; | Assert.cs:73:9:73:37 | call to method IsTrue | normal |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:9:73:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | normal |
 | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | false |
 | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | true |
 | Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:31 | ... == ... | false |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | normal |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | false |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | true |
 | Assert.cs:73:28:73:31 | null | Assert.cs:73:28:73:31 | null | normal |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | normal |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | false |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | true |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:27 | access to local variable s | normal |
 | Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:34 | access to property Length | normal |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:80:9:80:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:16:79:32 | String s = ... | normal |
 | Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... | normal |
@@ -505,18 +549,33 @@
 | Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null | normal |
 | Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" | normal |
 | Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse | normal |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:80:9:80:39 | ...; | Assert.cs:80:9:80:38 | call to method IsFalse | normal |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:9:80:38 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | normal |
 | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | false |
 | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | true |
 | Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:32 | ... != ... | true |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | normal |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | true |
 | Assert.cs:80:29:80:32 | null | Assert.cs:80:29:80:32 | null | normal |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | normal |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | false |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | true |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:27 | access to local variable s | normal |
 | Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:34 | access to property Length | normal |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:87:9:87:31 | call to method Assert | exit |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:91:9:91:24 | call to method IsNull | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:95:9:95:27 | call to method IsNotNull | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:99:9:99:32 | call to method IsTrue | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:103:9:103:32 | call to method IsTrue | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:107:9:107:33 | call to method IsFalse | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:111:9:111:33 | call to method IsFalse | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:115:9:115:37 | call to method IsTrue | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:119:9:119:39 | call to method IsFalse | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:123:9:123:37 | call to method IsTrue | throw(AssertFailedException) |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:127:9:127:39 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:85:5:129:5 | {...} | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
 | Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:16:86:32 | String s = ... | normal |
 | Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:16:86:32 | String s = ... | normal |
@@ -526,10 +585,13 @@
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:31:86:32 | "" | normal |
 | Assert.cs:86:24:86:27 | null | Assert.cs:86:24:86:27 | null | normal |
 | Assert.cs:86:31:86:32 | "" | Assert.cs:86:31:86:32 | "" | normal |
+| Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:9:87:31 | call to method Assert | exit |
 | Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:9:87:31 | call to method Assert | normal |
+| Assert.cs:87:9:87:32 | ...; | Assert.cs:87:9:87:31 | call to method Assert | exit |
 | Assert.cs:87:9:87:32 | ...; | Assert.cs:87:9:87:31 | call to method Assert | normal |
 | Assert.cs:87:22:87:22 | access to local variable s | Assert.cs:87:22:87:22 | access to local variable s | normal |
-| Assert.cs:87:22:87:30 | ... != ... | Assert.cs:87:22:87:30 | ... != ... | normal |
+| Assert.cs:87:22:87:30 | ... != ... | Assert.cs:87:22:87:30 | ... != ... | false |
+| Assert.cs:87:22:87:30 | ... != ... | Assert.cs:87:22:87:30 | ... != ... | true |
 | Assert.cs:87:27:87:30 | null | Assert.cs:87:27:87:30 | null | normal |
 | Assert.cs:88:9:88:35 | call to method WriteLine | Assert.cs:88:9:88:35 | call to method WriteLine | normal |
 | Assert.cs:88:9:88:36 | ...; | Assert.cs:88:9:88:35 | call to method WriteLine | normal |
@@ -544,8 +606,11 @@
 | Assert.cs:90:17:90:20 | null | Assert.cs:90:17:90:20 | null | normal |
 | Assert.cs:90:24:90:25 | "" | Assert.cs:90:24:90:25 | "" | normal |
 | Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:9:91:24 | call to method IsNull | normal |
+| Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:9:91:24 | call to method IsNull | throw(AssertFailedException) |
 | Assert.cs:91:9:91:25 | ...; | Assert.cs:91:9:91:24 | call to method IsNull | normal |
-| Assert.cs:91:23:91:23 | access to local variable s | Assert.cs:91:23:91:23 | access to local variable s | normal |
+| Assert.cs:91:9:91:25 | ...; | Assert.cs:91:9:91:24 | call to method IsNull | throw(AssertFailedException) |
+| Assert.cs:91:23:91:23 | access to local variable s | Assert.cs:91:23:91:23 | access to local variable s | non-null |
+| Assert.cs:91:23:91:23 | access to local variable s | Assert.cs:91:23:91:23 | access to local variable s | null |
 | Assert.cs:92:9:92:35 | call to method WriteLine | Assert.cs:92:9:92:35 | call to method WriteLine | normal |
 | Assert.cs:92:9:92:36 | ...; | Assert.cs:92:9:92:35 | call to method WriteLine | normal |
 | Assert.cs:92:27:92:27 | access to local variable s | Assert.cs:92:27:92:27 | access to local variable s | normal |
@@ -559,8 +624,11 @@
 | Assert.cs:94:17:94:20 | null | Assert.cs:94:17:94:20 | null | normal |
 | Assert.cs:94:24:94:25 | "" | Assert.cs:94:24:94:25 | "" | normal |
 | Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:9:95:27 | call to method IsNotNull | normal |
+| Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:9:95:27 | call to method IsNotNull | throw(AssertFailedException) |
 | Assert.cs:95:9:95:28 | ...; | Assert.cs:95:9:95:27 | call to method IsNotNull | normal |
-| Assert.cs:95:26:95:26 | access to local variable s | Assert.cs:95:26:95:26 | access to local variable s | normal |
+| Assert.cs:95:9:95:28 | ...; | Assert.cs:95:9:95:27 | call to method IsNotNull | throw(AssertFailedException) |
+| Assert.cs:95:26:95:26 | access to local variable s | Assert.cs:95:26:95:26 | access to local variable s | non-null |
+| Assert.cs:95:26:95:26 | access to local variable s | Assert.cs:95:26:95:26 | access to local variable s | null |
 | Assert.cs:96:9:96:35 | call to method WriteLine | Assert.cs:96:9:96:35 | call to method WriteLine | normal |
 | Assert.cs:96:9:96:36 | ...; | Assert.cs:96:9:96:35 | call to method WriteLine | normal |
 | Assert.cs:96:27:96:27 | access to local variable s | Assert.cs:96:27:96:27 | access to local variable s | normal |
@@ -574,9 +642,12 @@
 | Assert.cs:98:17:98:20 | null | Assert.cs:98:17:98:20 | null | normal |
 | Assert.cs:98:24:98:25 | "" | Assert.cs:98:24:98:25 | "" | normal |
 | Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:9:99:32 | call to method IsTrue | normal |
+| Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:9:99:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:99:9:99:33 | ...; | Assert.cs:99:9:99:32 | call to method IsTrue | normal |
+| Assert.cs:99:9:99:33 | ...; | Assert.cs:99:9:99:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:99:23:99:23 | access to local variable s | Assert.cs:99:23:99:23 | access to local variable s | normal |
-| Assert.cs:99:23:99:31 | ... == ... | Assert.cs:99:23:99:31 | ... == ... | normal |
+| Assert.cs:99:23:99:31 | ... == ... | Assert.cs:99:23:99:31 | ... == ... | false |
+| Assert.cs:99:23:99:31 | ... == ... | Assert.cs:99:23:99:31 | ... == ... | true |
 | Assert.cs:99:28:99:31 | null | Assert.cs:99:28:99:31 | null | normal |
 | Assert.cs:100:9:100:35 | call to method WriteLine | Assert.cs:100:9:100:35 | call to method WriteLine | normal |
 | Assert.cs:100:9:100:36 | ...; | Assert.cs:100:9:100:35 | call to method WriteLine | normal |
@@ -591,9 +662,12 @@
 | Assert.cs:102:17:102:20 | null | Assert.cs:102:17:102:20 | null | normal |
 | Assert.cs:102:24:102:25 | "" | Assert.cs:102:24:102:25 | "" | normal |
 | Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:9:103:32 | call to method IsTrue | normal |
+| Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:9:103:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:103:9:103:33 | ...; | Assert.cs:103:9:103:32 | call to method IsTrue | normal |
+| Assert.cs:103:9:103:33 | ...; | Assert.cs:103:9:103:32 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:103:23:103:23 | access to local variable s | Assert.cs:103:23:103:23 | access to local variable s | normal |
-| Assert.cs:103:23:103:31 | ... != ... | Assert.cs:103:23:103:31 | ... != ... | normal |
+| Assert.cs:103:23:103:31 | ... != ... | Assert.cs:103:23:103:31 | ... != ... | false |
+| Assert.cs:103:23:103:31 | ... != ... | Assert.cs:103:23:103:31 | ... != ... | true |
 | Assert.cs:103:28:103:31 | null | Assert.cs:103:28:103:31 | null | normal |
 | Assert.cs:104:9:104:35 | call to method WriteLine | Assert.cs:104:9:104:35 | call to method WriteLine | normal |
 | Assert.cs:104:9:104:36 | ...; | Assert.cs:104:9:104:35 | call to method WriteLine | normal |
@@ -608,9 +682,12 @@
 | Assert.cs:106:17:106:20 | null | Assert.cs:106:17:106:20 | null | normal |
 | Assert.cs:106:24:106:25 | "" | Assert.cs:106:24:106:25 | "" | normal |
 | Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:9:107:33 | call to method IsFalse | normal |
+| Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:9:107:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:107:9:107:34 | ...; | Assert.cs:107:9:107:33 | call to method IsFalse | normal |
+| Assert.cs:107:9:107:34 | ...; | Assert.cs:107:9:107:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:107:24:107:24 | access to local variable s | Assert.cs:107:24:107:24 | access to local variable s | normal |
-| Assert.cs:107:24:107:32 | ... != ... | Assert.cs:107:24:107:32 | ... != ... | normal |
+| Assert.cs:107:24:107:32 | ... != ... | Assert.cs:107:24:107:32 | ... != ... | false |
+| Assert.cs:107:24:107:32 | ... != ... | Assert.cs:107:24:107:32 | ... != ... | true |
 | Assert.cs:107:29:107:32 | null | Assert.cs:107:29:107:32 | null | normal |
 | Assert.cs:108:9:108:35 | call to method WriteLine | Assert.cs:108:9:108:35 | call to method WriteLine | normal |
 | Assert.cs:108:9:108:36 | ...; | Assert.cs:108:9:108:35 | call to method WriteLine | normal |
@@ -625,9 +702,12 @@
 | Assert.cs:110:17:110:20 | null | Assert.cs:110:17:110:20 | null | normal |
 | Assert.cs:110:24:110:25 | "" | Assert.cs:110:24:110:25 | "" | normal |
 | Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:9:111:33 | call to method IsFalse | normal |
+| Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:9:111:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:111:9:111:34 | ...; | Assert.cs:111:9:111:33 | call to method IsFalse | normal |
+| Assert.cs:111:9:111:34 | ...; | Assert.cs:111:9:111:33 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:111:24:111:24 | access to local variable s | Assert.cs:111:24:111:24 | access to local variable s | normal |
-| Assert.cs:111:24:111:32 | ... == ... | Assert.cs:111:24:111:32 | ... == ... | normal |
+| Assert.cs:111:24:111:32 | ... == ... | Assert.cs:111:24:111:32 | ... == ... | false |
+| Assert.cs:111:24:111:32 | ... == ... | Assert.cs:111:24:111:32 | ... == ... | true |
 | Assert.cs:111:29:111:32 | null | Assert.cs:111:29:111:32 | null | normal |
 | Assert.cs:112:9:112:35 | call to method WriteLine | Assert.cs:112:9:112:35 | call to method WriteLine | normal |
 | Assert.cs:112:9:112:36 | ...; | Assert.cs:112:9:112:35 | call to method WriteLine | normal |
@@ -642,14 +722,18 @@
 | Assert.cs:114:17:114:20 | null | Assert.cs:114:17:114:20 | null | normal |
 | Assert.cs:114:24:114:25 | "" | Assert.cs:114:24:114:25 | "" | normal |
 | Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:9:115:37 | call to method IsTrue | normal |
+| Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:9:115:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:115:9:115:38 | ...; | Assert.cs:115:9:115:37 | call to method IsTrue | normal |
+| Assert.cs:115:9:115:38 | ...; | Assert.cs:115:9:115:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:115:23:115:23 | access to local variable s | Assert.cs:115:23:115:23 | access to local variable s | normal |
 | Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | false |
 | Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | true |
 | Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:31 | ... != ... | false |
-| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | normal |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | false |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | true |
 | Assert.cs:115:28:115:31 | null | Assert.cs:115:28:115:31 | null | normal |
-| Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | normal |
+| Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | false |
+| Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | true |
 | Assert.cs:116:9:116:35 | call to method WriteLine | Assert.cs:116:9:116:35 | call to method WriteLine | normal |
 | Assert.cs:116:9:116:36 | ...; | Assert.cs:116:9:116:35 | call to method WriteLine | normal |
 | Assert.cs:116:27:116:27 | access to local variable s | Assert.cs:116:27:116:27 | access to local variable s | normal |
@@ -663,15 +747,20 @@
 | Assert.cs:118:17:118:20 | null | Assert.cs:118:17:118:20 | null | normal |
 | Assert.cs:118:24:118:25 | "" | Assert.cs:118:24:118:25 | "" | normal |
 | Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:9:119:39 | call to method IsFalse | normal |
+| Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:9:119:39 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:119:9:119:40 | ...; | Assert.cs:119:9:119:39 | call to method IsFalse | normal |
+| Assert.cs:119:9:119:40 | ...; | Assert.cs:119:9:119:39 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:119:24:119:24 | access to local variable s | Assert.cs:119:24:119:24 | access to local variable s | normal |
 | Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | false |
 | Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | true |
 | Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:32 | ... == ... | true |
-| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | normal |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | false [true] |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | true [false] |
 | Assert.cs:119:29:119:32 | null | Assert.cs:119:29:119:32 | null | normal |
-| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | normal |
-| Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | normal |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | false [true] |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | true [false] |
+| Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | false |
+| Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | true |
 | Assert.cs:120:9:120:35 | call to method WriteLine | Assert.cs:120:9:120:35 | call to method WriteLine | normal |
 | Assert.cs:120:9:120:36 | ...; | Assert.cs:120:9:120:35 | call to method WriteLine | normal |
 | Assert.cs:120:27:120:27 | access to local variable s | Assert.cs:120:27:120:27 | access to local variable s | normal |
@@ -685,14 +774,18 @@
 | Assert.cs:122:17:122:20 | null | Assert.cs:122:17:122:20 | null | normal |
 | Assert.cs:122:24:122:25 | "" | Assert.cs:122:24:122:25 | "" | normal |
 | Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:9:123:37 | call to method IsTrue | normal |
+| Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:9:123:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:123:9:123:38 | ...; | Assert.cs:123:9:123:37 | call to method IsTrue | normal |
+| Assert.cs:123:9:123:38 | ...; | Assert.cs:123:9:123:37 | call to method IsTrue | throw(AssertFailedException) |
 | Assert.cs:123:23:123:23 | access to local variable s | Assert.cs:123:23:123:23 | access to local variable s | normal |
 | Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | false |
 | Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | true |
 | Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:31 | ... == ... | false |
-| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | normal |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | false |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | true |
 | Assert.cs:123:28:123:31 | null | Assert.cs:123:28:123:31 | null | normal |
-| Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | normal |
+| Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | false |
+| Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | true |
 | Assert.cs:124:9:124:35 | call to method WriteLine | Assert.cs:124:9:124:35 | call to method WriteLine | normal |
 | Assert.cs:124:9:124:36 | ...; | Assert.cs:124:9:124:35 | call to method WriteLine | normal |
 | Assert.cs:124:27:124:27 | access to local variable s | Assert.cs:124:27:124:27 | access to local variable s | normal |
@@ -706,15 +799,20 @@
 | Assert.cs:126:17:126:20 | null | Assert.cs:126:17:126:20 | null | normal |
 | Assert.cs:126:24:126:25 | "" | Assert.cs:126:24:126:25 | "" | normal |
 | Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse | normal |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:127:9:127:40 | ...; | Assert.cs:127:9:127:39 | call to method IsFalse | normal |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:9:127:39 | call to method IsFalse | throw(AssertFailedException) |
 | Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:24 | access to local variable s | normal |
 | Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | false |
 | Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | true |
 | Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:32 | ... != ... | true |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | normal |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | false [true] |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | true [false] |
 | Assert.cs:127:29:127:32 | null | Assert.cs:127:29:127:32 | null | normal |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | normal |
-| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | normal |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | false [true] |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | true [false] |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | false |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | true |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:27 | access to local variable s | normal |
@@ -1477,7 +1575,7 @@
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
 | ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:9:121:28 | call to method IsTrue | throw(AssertFailedException) |
-| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false | normal |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:23:121:27 | false | false |
 | ExitMethods.cs:122:9:122:18 | ... ...; | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
 | ExitMethods.cs:122:13:122:17 | Int32 x = ... | ExitMethods.cs:122:13:122:17 | Int32 x = ... | normal |
 | ExitMethods.cs:122:17:122:17 | 0 | ExitMethods.cs:122:17:122:17 | 0 | normal |
@@ -1490,13 +1588,15 @@
 | ExitMethods.cs:128:13:128:17 | Int32 x = ... | ExitMethods.cs:128:13:128:17 | Int32 x = ... | normal |
 | ExitMethods.cs:128:17:128:17 | 0 | ExitMethods.cs:128:17:128:17 | 0 | normal |
 | ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse | normal |
-| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b | normal |
+| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:33:131:49 | call to method IsFalse | throw(AssertFailedException) |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b | false |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:48:131:48 | access to parameter b | true |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
 | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:9:135:25 | this access | normal |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | throw(AssertFailedException) |
-| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true | normal |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:21:135:24 | true | true |
 | ExitMethods.cs:136:9:136:18 | ... ...; | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
 | ExitMethods.cs:136:13:136:17 | Int32 x = ... | ExitMethods.cs:136:13:136:17 | Int32 x = ... | normal |
 | ExitMethods.cs:136:17:136:17 | 0 | ExitMethods.cs:136:17:136:17 | 0 | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -307,6 +307,418 @@
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:43:9:50 | { ..., ... } | normal |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:45:9:45 | 2 | normal |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:48:9:48 | 3 | normal |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:16:9:32 | String s = ... | normal |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:9:16:9:32 | String s = ... | normal |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b | false |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:20:9:20 | access to parameter b | true |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:24:9:27 | null | normal |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:31:9:32 | "" | normal |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:24:9:27 | null | normal |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:31:9:32 | "" | normal |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:10:9:10:31 | call to method Assert | normal |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:9:10:31 | call to method Assert | normal |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:22:10:22 | access to local variable s | normal |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:30 | ... != ... | normal |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:27:10:30 | null | normal |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:9:11:35 | call to method WriteLine | normal |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:27 | access to local variable s | normal |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:27:11:34 | access to property Length | normal |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:16:16:32 | String s = ... | normal |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:16:16:16:32 | String s = ... | normal |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b | false |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:20:16:20 | access to parameter b | true |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:24:16:27 | null | normal |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:31:16:32 | "" | normal |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:24:16:27 | null | normal |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:31:16:32 | "" | normal |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:17:9:17:24 | call to method IsNull | normal |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:9:17:24 | call to method IsNull | normal |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:23:17:23 | access to local variable s | normal |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:9:18:35 | call to method WriteLine | normal |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:27 | access to local variable s | normal |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:27:18:34 | access to property Length | normal |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:16:23:32 | String s = ... | normal |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:23:16:23:32 | String s = ... | normal |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b | false |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:20:23:20 | access to parameter b | true |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:24:23:27 | null | normal |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:31:23:32 | "" | normal |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:24:23:27 | null | normal |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:31:23:32 | "" | normal |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:24:9:24:27 | call to method IsNotNull | normal |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:9:24:27 | call to method IsNotNull | normal |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:26:24:26 | access to local variable s | normal |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:9:25:35 | call to method WriteLine | normal |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:27 | access to local variable s | normal |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:27:25:34 | access to property Length | normal |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:16:30:32 | String s = ... | normal |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:30:16:30:32 | String s = ... | normal |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b | false |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:20:30:20 | access to parameter b | true |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:24:30:27 | null | normal |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:31:30:32 | "" | normal |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:24:30:27 | null | normal |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:31:30:32 | "" | normal |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:31:9:31:32 | call to method IsTrue | normal |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:9:31:32 | call to method IsTrue | normal |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:23:31:23 | access to local variable s | normal |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:23:31:31 | ... == ... | normal |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:28:31:31 | null | normal |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:9:32:35 | call to method WriteLine | normal |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:27 | access to local variable s | normal |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:27:32:34 | access to property Length | normal |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:16:37:32 | String s = ... | normal |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:37:16:37:32 | String s = ... | normal |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b | false |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:20:37:20 | access to parameter b | true |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:24:37:27 | null | normal |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:31:37:32 | "" | normal |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:24:37:27 | null | normal |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:31:37:32 | "" | normal |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:38:9:38:32 | call to method IsTrue | normal |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:9:38:32 | call to method IsTrue | normal |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:23:38:23 | access to local variable s | normal |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:23:38:31 | ... != ... | normal |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:28:38:31 | null | normal |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:9:39:35 | call to method WriteLine | normal |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:27 | access to local variable s | normal |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:27:39:34 | access to property Length | normal |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:16:44:32 | String s = ... | normal |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:44:16:44:32 | String s = ... | normal |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b | false |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:20:44:20 | access to parameter b | true |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:24:44:27 | null | normal |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:31:44:32 | "" | normal |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:24:44:27 | null | normal |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:31:44:32 | "" | normal |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:45:9:45:33 | call to method IsFalse | normal |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:9:45:33 | call to method IsFalse | normal |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:24:45:24 | access to local variable s | normal |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:32 | ... != ... | normal |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:29:45:32 | null | normal |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:9:46:35 | call to method WriteLine | normal |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:27 | access to local variable s | normal |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:27:46:34 | access to property Length | normal |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:16:51:32 | String s = ... | normal |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:51:16:51:32 | String s = ... | normal |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b | false |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:20:51:20 | access to parameter b | true |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:24:51:27 | null | normal |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:31:51:32 | "" | normal |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:24:51:27 | null | normal |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:31:51:32 | "" | normal |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:52:9:52:33 | call to method IsFalse | normal |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:9:52:33 | call to method IsFalse | normal |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:24:52:24 | access to local variable s | normal |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:32 | ... == ... | normal |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:29:52:32 | null | normal |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:9:53:35 | call to method WriteLine | normal |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:27 | access to local variable s | normal |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:27:53:34 | access to property Length | normal |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:16:58:32 | String s = ... | normal |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:58:16:58:32 | String s = ... | normal |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | true |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:24:58:27 | null | normal |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:31:58:32 | "" | normal |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:24:58:27 | null | normal |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:31:58:32 | "" | normal |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:59:9:59:37 | call to method IsTrue | normal |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:9:59:37 | call to method IsTrue | normal |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | normal |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | false |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:31 | ... != ... | true |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:31 | ... != ... | false |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:36:59:36 | access to parameter b | normal |
+| Assert.cs:59:28:59:31 | null | Assert.cs:59:28:59:31 | null | normal |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:36:59:36 | access to parameter b | normal |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:9:60:35 | call to method WriteLine | normal |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:27 | access to local variable s | normal |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:27:60:34 | access to property Length | normal |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:16:65:32 | String s = ... | normal |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:65:16:65:32 | String s = ... | normal |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | true |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:24:65:27 | null | normal |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:31:65:32 | "" | normal |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:24:65:27 | null | normal |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:31:65:32 | "" | normal |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:66:9:66:38 | call to method IsFalse | normal |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:9:66:38 | call to method IsFalse | normal |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | normal |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | false |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:32 | ... == ... | true |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:32 | ... == ... | true |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:37:66:37 | access to parameter b | normal |
+| Assert.cs:66:29:66:32 | null | Assert.cs:66:29:66:32 | null | normal |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:37:66:37 | access to parameter b | normal |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:9:67:35 | call to method WriteLine | normal |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:27 | access to local variable s | normal |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:27:67:34 | access to property Length | normal |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:16:72:32 | String s = ... | normal |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:72:16:72:32 | String s = ... | normal |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | false |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:24:72:27 | null | normal |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:31:72:32 | "" | normal |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:24:72:27 | null | normal |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:31:72:32 | "" | normal |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:73:9:73:37 | call to method IsTrue | normal |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:9:73:37 | call to method IsTrue | normal |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | normal |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | false |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:31 | ... == ... | true |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:31 | ... == ... | false |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:36:73:36 | access to parameter b | normal |
+| Assert.cs:73:28:73:31 | null | Assert.cs:73:28:73:31 | null | normal |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:36:73:36 | access to parameter b | normal |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:9:74:35 | call to method WriteLine | normal |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:27 | access to local variable s | normal |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:27:74:34 | access to property Length | normal |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:16:79:32 | String s = ... | normal |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:79:16:79:32 | String s = ... | normal |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | false |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:24:79:27 | null | normal |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:31:79:32 | "" | normal |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:24:79:27 | null | normal |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:31:79:32 | "" | normal |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:80:9:80:38 | call to method IsFalse | normal |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:9:80:38 | call to method IsFalse | normal |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | normal |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | false |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:32 | ... != ... | true |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:32 | ... != ... | true |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:37:80:37 | access to parameter b | normal |
+| Assert.cs:80:29:80:32 | null | Assert.cs:80:29:80:32 | null | normal |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:37:80:37 | access to parameter b | normal |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:9:81:35 | call to method WriteLine | normal |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:27 | access to local variable s | normal |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:27:81:34 | access to property Length | normal |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:16:86:32 | String s = ... | normal |
+| Assert.cs:86:16:86:32 | String s = ... | Assert.cs:86:16:86:32 | String s = ... | normal |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b | false |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:20:86:20 | access to parameter b | true |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:24:86:27 | null | normal |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:31:86:32 | "" | normal |
+| Assert.cs:86:24:86:27 | null | Assert.cs:86:24:86:27 | null | normal |
+| Assert.cs:86:31:86:32 | "" | Assert.cs:86:31:86:32 | "" | normal |
+| Assert.cs:87:9:87:31 | call to method Assert | Assert.cs:87:9:87:31 | call to method Assert | normal |
+| Assert.cs:87:9:87:32 | ...; | Assert.cs:87:9:87:31 | call to method Assert | normal |
+| Assert.cs:87:22:87:22 | access to local variable s | Assert.cs:87:22:87:22 | access to local variable s | normal |
+| Assert.cs:87:22:87:30 | ... != ... | Assert.cs:87:22:87:30 | ... != ... | normal |
+| Assert.cs:87:27:87:30 | null | Assert.cs:87:27:87:30 | null | normal |
+| Assert.cs:88:9:88:35 | call to method WriteLine | Assert.cs:88:9:88:35 | call to method WriteLine | normal |
+| Assert.cs:88:9:88:36 | ...; | Assert.cs:88:9:88:35 | call to method WriteLine | normal |
+| Assert.cs:88:27:88:27 | access to local variable s | Assert.cs:88:27:88:27 | access to local variable s | normal |
+| Assert.cs:88:27:88:34 | access to property Length | Assert.cs:88:27:88:34 | access to property Length | normal |
+| Assert.cs:90:9:90:25 | ... = ... | Assert.cs:90:9:90:25 | ... = ... | normal |
+| Assert.cs:90:9:90:26 | ...; | Assert.cs:90:9:90:25 | ... = ... | normal |
+| Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b | false |
+| Assert.cs:90:13:90:13 | access to parameter b | Assert.cs:90:13:90:13 | access to parameter b | true |
+| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:17:90:20 | null | normal |
+| Assert.cs:90:13:90:25 | ... ? ... : ... | Assert.cs:90:24:90:25 | "" | normal |
+| Assert.cs:90:17:90:20 | null | Assert.cs:90:17:90:20 | null | normal |
+| Assert.cs:90:24:90:25 | "" | Assert.cs:90:24:90:25 | "" | normal |
+| Assert.cs:91:9:91:24 | call to method IsNull | Assert.cs:91:9:91:24 | call to method IsNull | normal |
+| Assert.cs:91:9:91:25 | ...; | Assert.cs:91:9:91:24 | call to method IsNull | normal |
+| Assert.cs:91:23:91:23 | access to local variable s | Assert.cs:91:23:91:23 | access to local variable s | normal |
+| Assert.cs:92:9:92:35 | call to method WriteLine | Assert.cs:92:9:92:35 | call to method WriteLine | normal |
+| Assert.cs:92:9:92:36 | ...; | Assert.cs:92:9:92:35 | call to method WriteLine | normal |
+| Assert.cs:92:27:92:27 | access to local variable s | Assert.cs:92:27:92:27 | access to local variable s | normal |
+| Assert.cs:92:27:92:34 | access to property Length | Assert.cs:92:27:92:34 | access to property Length | normal |
+| Assert.cs:94:9:94:25 | ... = ... | Assert.cs:94:9:94:25 | ... = ... | normal |
+| Assert.cs:94:9:94:26 | ...; | Assert.cs:94:9:94:25 | ... = ... | normal |
+| Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b | false |
+| Assert.cs:94:13:94:13 | access to parameter b | Assert.cs:94:13:94:13 | access to parameter b | true |
+| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:17:94:20 | null | normal |
+| Assert.cs:94:13:94:25 | ... ? ... : ... | Assert.cs:94:24:94:25 | "" | normal |
+| Assert.cs:94:17:94:20 | null | Assert.cs:94:17:94:20 | null | normal |
+| Assert.cs:94:24:94:25 | "" | Assert.cs:94:24:94:25 | "" | normal |
+| Assert.cs:95:9:95:27 | call to method IsNotNull | Assert.cs:95:9:95:27 | call to method IsNotNull | normal |
+| Assert.cs:95:9:95:28 | ...; | Assert.cs:95:9:95:27 | call to method IsNotNull | normal |
+| Assert.cs:95:26:95:26 | access to local variable s | Assert.cs:95:26:95:26 | access to local variable s | normal |
+| Assert.cs:96:9:96:35 | call to method WriteLine | Assert.cs:96:9:96:35 | call to method WriteLine | normal |
+| Assert.cs:96:9:96:36 | ...; | Assert.cs:96:9:96:35 | call to method WriteLine | normal |
+| Assert.cs:96:27:96:27 | access to local variable s | Assert.cs:96:27:96:27 | access to local variable s | normal |
+| Assert.cs:96:27:96:34 | access to property Length | Assert.cs:96:27:96:34 | access to property Length | normal |
+| Assert.cs:98:9:98:25 | ... = ... | Assert.cs:98:9:98:25 | ... = ... | normal |
+| Assert.cs:98:9:98:26 | ...; | Assert.cs:98:9:98:25 | ... = ... | normal |
+| Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b | false |
+| Assert.cs:98:13:98:13 | access to parameter b | Assert.cs:98:13:98:13 | access to parameter b | true |
+| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:17:98:20 | null | normal |
+| Assert.cs:98:13:98:25 | ... ? ... : ... | Assert.cs:98:24:98:25 | "" | normal |
+| Assert.cs:98:17:98:20 | null | Assert.cs:98:17:98:20 | null | normal |
+| Assert.cs:98:24:98:25 | "" | Assert.cs:98:24:98:25 | "" | normal |
+| Assert.cs:99:9:99:32 | call to method IsTrue | Assert.cs:99:9:99:32 | call to method IsTrue | normal |
+| Assert.cs:99:9:99:33 | ...; | Assert.cs:99:9:99:32 | call to method IsTrue | normal |
+| Assert.cs:99:23:99:23 | access to local variable s | Assert.cs:99:23:99:23 | access to local variable s | normal |
+| Assert.cs:99:23:99:31 | ... == ... | Assert.cs:99:23:99:31 | ... == ... | normal |
+| Assert.cs:99:28:99:31 | null | Assert.cs:99:28:99:31 | null | normal |
+| Assert.cs:100:9:100:35 | call to method WriteLine | Assert.cs:100:9:100:35 | call to method WriteLine | normal |
+| Assert.cs:100:9:100:36 | ...; | Assert.cs:100:9:100:35 | call to method WriteLine | normal |
+| Assert.cs:100:27:100:27 | access to local variable s | Assert.cs:100:27:100:27 | access to local variable s | normal |
+| Assert.cs:100:27:100:34 | access to property Length | Assert.cs:100:27:100:34 | access to property Length | normal |
+| Assert.cs:102:9:102:25 | ... = ... | Assert.cs:102:9:102:25 | ... = ... | normal |
+| Assert.cs:102:9:102:26 | ...; | Assert.cs:102:9:102:25 | ... = ... | normal |
+| Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b | false |
+| Assert.cs:102:13:102:13 | access to parameter b | Assert.cs:102:13:102:13 | access to parameter b | true |
+| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:17:102:20 | null | normal |
+| Assert.cs:102:13:102:25 | ... ? ... : ... | Assert.cs:102:24:102:25 | "" | normal |
+| Assert.cs:102:17:102:20 | null | Assert.cs:102:17:102:20 | null | normal |
+| Assert.cs:102:24:102:25 | "" | Assert.cs:102:24:102:25 | "" | normal |
+| Assert.cs:103:9:103:32 | call to method IsTrue | Assert.cs:103:9:103:32 | call to method IsTrue | normal |
+| Assert.cs:103:9:103:33 | ...; | Assert.cs:103:9:103:32 | call to method IsTrue | normal |
+| Assert.cs:103:23:103:23 | access to local variable s | Assert.cs:103:23:103:23 | access to local variable s | normal |
+| Assert.cs:103:23:103:31 | ... != ... | Assert.cs:103:23:103:31 | ... != ... | normal |
+| Assert.cs:103:28:103:31 | null | Assert.cs:103:28:103:31 | null | normal |
+| Assert.cs:104:9:104:35 | call to method WriteLine | Assert.cs:104:9:104:35 | call to method WriteLine | normal |
+| Assert.cs:104:9:104:36 | ...; | Assert.cs:104:9:104:35 | call to method WriteLine | normal |
+| Assert.cs:104:27:104:27 | access to local variable s | Assert.cs:104:27:104:27 | access to local variable s | normal |
+| Assert.cs:104:27:104:34 | access to property Length | Assert.cs:104:27:104:34 | access to property Length | normal |
+| Assert.cs:106:9:106:25 | ... = ... | Assert.cs:106:9:106:25 | ... = ... | normal |
+| Assert.cs:106:9:106:26 | ...; | Assert.cs:106:9:106:25 | ... = ... | normal |
+| Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b | false |
+| Assert.cs:106:13:106:13 | access to parameter b | Assert.cs:106:13:106:13 | access to parameter b | true |
+| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:17:106:20 | null | normal |
+| Assert.cs:106:13:106:25 | ... ? ... : ... | Assert.cs:106:24:106:25 | "" | normal |
+| Assert.cs:106:17:106:20 | null | Assert.cs:106:17:106:20 | null | normal |
+| Assert.cs:106:24:106:25 | "" | Assert.cs:106:24:106:25 | "" | normal |
+| Assert.cs:107:9:107:33 | call to method IsFalse | Assert.cs:107:9:107:33 | call to method IsFalse | normal |
+| Assert.cs:107:9:107:34 | ...; | Assert.cs:107:9:107:33 | call to method IsFalse | normal |
+| Assert.cs:107:24:107:24 | access to local variable s | Assert.cs:107:24:107:24 | access to local variable s | normal |
+| Assert.cs:107:24:107:32 | ... != ... | Assert.cs:107:24:107:32 | ... != ... | normal |
+| Assert.cs:107:29:107:32 | null | Assert.cs:107:29:107:32 | null | normal |
+| Assert.cs:108:9:108:35 | call to method WriteLine | Assert.cs:108:9:108:35 | call to method WriteLine | normal |
+| Assert.cs:108:9:108:36 | ...; | Assert.cs:108:9:108:35 | call to method WriteLine | normal |
+| Assert.cs:108:27:108:27 | access to local variable s | Assert.cs:108:27:108:27 | access to local variable s | normal |
+| Assert.cs:108:27:108:34 | access to property Length | Assert.cs:108:27:108:34 | access to property Length | normal |
+| Assert.cs:110:9:110:25 | ... = ... | Assert.cs:110:9:110:25 | ... = ... | normal |
+| Assert.cs:110:9:110:26 | ...; | Assert.cs:110:9:110:25 | ... = ... | normal |
+| Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b | false |
+| Assert.cs:110:13:110:13 | access to parameter b | Assert.cs:110:13:110:13 | access to parameter b | true |
+| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:17:110:20 | null | normal |
+| Assert.cs:110:13:110:25 | ... ? ... : ... | Assert.cs:110:24:110:25 | "" | normal |
+| Assert.cs:110:17:110:20 | null | Assert.cs:110:17:110:20 | null | normal |
+| Assert.cs:110:24:110:25 | "" | Assert.cs:110:24:110:25 | "" | normal |
+| Assert.cs:111:9:111:33 | call to method IsFalse | Assert.cs:111:9:111:33 | call to method IsFalse | normal |
+| Assert.cs:111:9:111:34 | ...; | Assert.cs:111:9:111:33 | call to method IsFalse | normal |
+| Assert.cs:111:24:111:24 | access to local variable s | Assert.cs:111:24:111:24 | access to local variable s | normal |
+| Assert.cs:111:24:111:32 | ... == ... | Assert.cs:111:24:111:32 | ... == ... | normal |
+| Assert.cs:111:29:111:32 | null | Assert.cs:111:29:111:32 | null | normal |
+| Assert.cs:112:9:112:35 | call to method WriteLine | Assert.cs:112:9:112:35 | call to method WriteLine | normal |
+| Assert.cs:112:9:112:36 | ...; | Assert.cs:112:9:112:35 | call to method WriteLine | normal |
+| Assert.cs:112:27:112:27 | access to local variable s | Assert.cs:112:27:112:27 | access to local variable s | normal |
+| Assert.cs:112:27:112:34 | access to property Length | Assert.cs:112:27:112:34 | access to property Length | normal |
+| Assert.cs:114:9:114:25 | ... = ... | Assert.cs:114:9:114:25 | ... = ... | normal |
+| Assert.cs:114:9:114:26 | ...; | Assert.cs:114:9:114:25 | ... = ... | normal |
+| Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b | false |
+| Assert.cs:114:13:114:13 | access to parameter b | Assert.cs:114:13:114:13 | access to parameter b | true |
+| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:17:114:20 | null | normal |
+| Assert.cs:114:13:114:25 | ... ? ... : ... | Assert.cs:114:24:114:25 | "" | normal |
+| Assert.cs:114:17:114:20 | null | Assert.cs:114:17:114:20 | null | normal |
+| Assert.cs:114:24:114:25 | "" | Assert.cs:114:24:114:25 | "" | normal |
+| Assert.cs:115:9:115:37 | call to method IsTrue | Assert.cs:115:9:115:37 | call to method IsTrue | normal |
+| Assert.cs:115:9:115:38 | ...; | Assert.cs:115:9:115:37 | call to method IsTrue | normal |
+| Assert.cs:115:23:115:23 | access to local variable s | Assert.cs:115:23:115:23 | access to local variable s | normal |
+| Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | false |
+| Assert.cs:115:23:115:31 | ... != ... | Assert.cs:115:23:115:31 | ... != ... | true |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:23:115:31 | ... != ... | false |
+| Assert.cs:115:23:115:36 | ... && ... | Assert.cs:115:36:115:36 | access to parameter b | normal |
+| Assert.cs:115:28:115:31 | null | Assert.cs:115:28:115:31 | null | normal |
+| Assert.cs:115:36:115:36 | access to parameter b | Assert.cs:115:36:115:36 | access to parameter b | normal |
+| Assert.cs:116:9:116:35 | call to method WriteLine | Assert.cs:116:9:116:35 | call to method WriteLine | normal |
+| Assert.cs:116:9:116:36 | ...; | Assert.cs:116:9:116:35 | call to method WriteLine | normal |
+| Assert.cs:116:27:116:27 | access to local variable s | Assert.cs:116:27:116:27 | access to local variable s | normal |
+| Assert.cs:116:27:116:34 | access to property Length | Assert.cs:116:27:116:34 | access to property Length | normal |
+| Assert.cs:118:9:118:25 | ... = ... | Assert.cs:118:9:118:25 | ... = ... | normal |
+| Assert.cs:118:9:118:26 | ...; | Assert.cs:118:9:118:25 | ... = ... | normal |
+| Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b | false |
+| Assert.cs:118:13:118:13 | access to parameter b | Assert.cs:118:13:118:13 | access to parameter b | true |
+| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:17:118:20 | null | normal |
+| Assert.cs:118:13:118:25 | ... ? ... : ... | Assert.cs:118:24:118:25 | "" | normal |
+| Assert.cs:118:17:118:20 | null | Assert.cs:118:17:118:20 | null | normal |
+| Assert.cs:118:24:118:25 | "" | Assert.cs:118:24:118:25 | "" | normal |
+| Assert.cs:119:9:119:39 | call to method IsFalse | Assert.cs:119:9:119:39 | call to method IsFalse | normal |
+| Assert.cs:119:9:119:40 | ...; | Assert.cs:119:9:119:39 | call to method IsFalse | normal |
+| Assert.cs:119:24:119:24 | access to local variable s | Assert.cs:119:24:119:24 | access to local variable s | normal |
+| Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | false |
+| Assert.cs:119:24:119:32 | ... == ... | Assert.cs:119:24:119:32 | ... == ... | true |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:24:119:32 | ... == ... | true |
+| Assert.cs:119:24:119:38 | ... \|\| ... | Assert.cs:119:38:119:38 | access to parameter b | normal |
+| Assert.cs:119:29:119:32 | null | Assert.cs:119:29:119:32 | null | normal |
+| Assert.cs:119:37:119:38 | !... | Assert.cs:119:38:119:38 | access to parameter b | normal |
+| Assert.cs:119:38:119:38 | access to parameter b | Assert.cs:119:38:119:38 | access to parameter b | normal |
+| Assert.cs:120:9:120:35 | call to method WriteLine | Assert.cs:120:9:120:35 | call to method WriteLine | normal |
+| Assert.cs:120:9:120:36 | ...; | Assert.cs:120:9:120:35 | call to method WriteLine | normal |
+| Assert.cs:120:27:120:27 | access to local variable s | Assert.cs:120:27:120:27 | access to local variable s | normal |
+| Assert.cs:120:27:120:34 | access to property Length | Assert.cs:120:27:120:34 | access to property Length | normal |
+| Assert.cs:122:9:122:25 | ... = ... | Assert.cs:122:9:122:25 | ... = ... | normal |
+| Assert.cs:122:9:122:26 | ...; | Assert.cs:122:9:122:25 | ... = ... | normal |
+| Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b | false |
+| Assert.cs:122:13:122:13 | access to parameter b | Assert.cs:122:13:122:13 | access to parameter b | true |
+| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:17:122:20 | null | normal |
+| Assert.cs:122:13:122:25 | ... ? ... : ... | Assert.cs:122:24:122:25 | "" | normal |
+| Assert.cs:122:17:122:20 | null | Assert.cs:122:17:122:20 | null | normal |
+| Assert.cs:122:24:122:25 | "" | Assert.cs:122:24:122:25 | "" | normal |
+| Assert.cs:123:9:123:37 | call to method IsTrue | Assert.cs:123:9:123:37 | call to method IsTrue | normal |
+| Assert.cs:123:9:123:38 | ...; | Assert.cs:123:9:123:37 | call to method IsTrue | normal |
+| Assert.cs:123:23:123:23 | access to local variable s | Assert.cs:123:23:123:23 | access to local variable s | normal |
+| Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | false |
+| Assert.cs:123:23:123:31 | ... == ... | Assert.cs:123:23:123:31 | ... == ... | true |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:23:123:31 | ... == ... | false |
+| Assert.cs:123:23:123:36 | ... && ... | Assert.cs:123:36:123:36 | access to parameter b | normal |
+| Assert.cs:123:28:123:31 | null | Assert.cs:123:28:123:31 | null | normal |
+| Assert.cs:123:36:123:36 | access to parameter b | Assert.cs:123:36:123:36 | access to parameter b | normal |
+| Assert.cs:124:9:124:35 | call to method WriteLine | Assert.cs:124:9:124:35 | call to method WriteLine | normal |
+| Assert.cs:124:9:124:36 | ...; | Assert.cs:124:9:124:35 | call to method WriteLine | normal |
+| Assert.cs:124:27:124:27 | access to local variable s | Assert.cs:124:27:124:27 | access to local variable s | normal |
+| Assert.cs:124:27:124:34 | access to property Length | Assert.cs:124:27:124:34 | access to property Length | normal |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:126:9:126:25 | ... = ... | normal |
+| Assert.cs:126:9:126:26 | ...; | Assert.cs:126:9:126:25 | ... = ... | normal |
+| Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b | false |
+| Assert.cs:126:13:126:13 | access to parameter b | Assert.cs:126:13:126:13 | access to parameter b | true |
+| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:17:126:20 | null | normal |
+| Assert.cs:126:13:126:25 | ... ? ... : ... | Assert.cs:126:24:126:25 | "" | normal |
+| Assert.cs:126:17:126:20 | null | Assert.cs:126:17:126:20 | null | normal |
+| Assert.cs:126:24:126:25 | "" | Assert.cs:126:24:126:25 | "" | normal |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:127:9:127:39 | call to method IsFalse | normal |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:9:127:39 | call to method IsFalse | normal |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:24:127:24 | access to local variable s | normal |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | false |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:24:127:32 | ... != ... | true |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:32 | ... != ... | true |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:38:127:38 | access to parameter b | normal |
+| Assert.cs:127:29:127:32 | null | Assert.cs:127:29:127:32 | null | normal |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | normal |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:38:127:38 | access to parameter b | normal |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:9:128:35 | call to method WriteLine | normal |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:27 | access to local variable s | normal |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:27:128:34 | access to property Length | normal |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:14:9:14:35 | ... += ... | normal |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:13:5:17 | Int32 x = ... | normal |
 | Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:5:13:5:17 | Int32 x = ... | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -307,6 +307,526 @@
 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:31:9:52 | { ..., ... } | semmle.label | successor |
 | ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 | semmle.label | successor |
 | ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } | semmle.label | successor |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} | semmle.label | successor |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; | semmle.label | successor |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; | semmle.label | successor |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | semmle.label | true |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | semmle.label | false |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
+| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s | semmle.label | successor |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null | semmle.label | successor |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | call to method Assert | semmle.label | successor |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... | semmle.label | successor |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length | semmle.label | successor |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} | semmle.label | successor |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; | semmle.label | successor |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; | semmle.label | successor |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | semmle.label | true |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | semmle.label | false |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
+| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s | semmle.label | successor |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | call to method IsNull | semmle.label | successor |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length | semmle.label | successor |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} | semmle.label | successor |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; | semmle.label | successor |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; | semmle.label | successor |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | semmle.label | true |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | semmle.label | false |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
+| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s | semmle.label | successor |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | call to method IsNotNull | semmle.label | successor |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length | semmle.label | successor |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} | semmle.label | successor |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; | semmle.label | successor |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; | semmle.label | successor |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | semmle.label | true |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | semmle.label | false |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
+| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s | semmle.label | successor |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null | semmle.label | successor |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... | semmle.label | successor |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length | semmle.label | successor |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} | semmle.label | successor |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; | semmle.label | successor |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; | semmle.label | successor |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | semmle.label | true |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | semmle.label | false |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
+| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s | semmle.label | successor |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null | semmle.label | successor |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... | semmle.label | successor |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length | semmle.label | successor |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} | semmle.label | successor |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; | semmle.label | successor |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; | semmle.label | successor |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | semmle.label | true |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | semmle.label | false |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
+| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s | semmle.label | successor |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null | semmle.label | successor |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... | semmle.label | successor |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length | semmle.label | successor |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} | semmle.label | successor |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; | semmle.label | successor |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; | semmle.label | successor |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | semmle.label | true |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | semmle.label | false |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
+| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s | semmle.label | successor |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null | semmle.label | successor |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... | semmle.label | successor |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length | semmle.label | successor |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} | semmle.label | successor |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; | semmle.label | successor |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:38 | ...; | semmle.label | successor |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null | semmle.label | true |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" | semmle.label | false |
+| Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:58:24:58:27 | null | Assert.cs:58:16:58:32 | String s = ... | semmle.label | successor |
+| Assert.cs:58:31:58:32 | "" | Assert.cs:58:16:58:32 | String s = ... | semmle.label | successor |
+| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
+| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:23:59:36 | ... && ... | semmle.label | successor |
+| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:28:59:31 | null | semmle.label | successor |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b | semmle.label | true |
+| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s | semmle.label | successor |
+| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:31 | ... != ... | semmle.label | successor |
+| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:9:59:37 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length | semmle.label | successor |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} | semmle.label | successor |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; | semmle.label | successor |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:39 | ...; | semmle.label | successor |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null | semmle.label | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" | semmle.label | false |
+| Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:65:24:65:27 | null | Assert.cs:65:16:65:32 | String s = ... | semmle.label | successor |
+| Assert.cs:65:31:65:32 | "" | Assert.cs:65:16:65:32 | String s = ... | semmle.label | successor |
+| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
+| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:24:66:37 | ... \|\| ... | semmle.label | successor |
+| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:29:66:32 | null | semmle.label | successor |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse | semmle.label | true |
+| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b | semmle.label | false |
+| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s | semmle.label | successor |
+| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:32 | ... == ... | semmle.label | successor |
+| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:9:66:38 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length | semmle.label | successor |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} | semmle.label | successor |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; | semmle.label | successor |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:38 | ...; | semmle.label | successor |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null | semmle.label | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" | semmle.label | false |
+| Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:72:24:72:27 | null | Assert.cs:72:16:72:32 | String s = ... | semmle.label | successor |
+| Assert.cs:72:31:72:32 | "" | Assert.cs:72:16:72:32 | String s = ... | semmle.label | successor |
+| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
+| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:23:73:36 | ... && ... | semmle.label | successor |
+| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:28:73:31 | null | semmle.label | successor |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b | semmle.label | true |
+| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s | semmle.label | successor |
+| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:31 | ... == ... | semmle.label | successor |
+| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:9:73:37 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length | semmle.label | successor |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} | semmle.label | successor |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; | semmle.label | successor |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:39 | ...; | semmle.label | successor |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null | semmle.label | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" | semmle.label | false |
+| Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:79:24:79:27 | null | Assert.cs:79:16:79:32 | String s = ... | semmle.label | successor |
+| Assert.cs:79:31:79:32 | "" | Assert.cs:79:16:79:32 | String s = ... | semmle.label | successor |
+| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
+| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:24:80:37 | ... \|\| ... | semmle.label | successor |
+| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:29:80:32 | null | semmle.label | successor |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse | semmle.label | true |
+| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b | semmle.label | false |
+| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s | semmle.label | successor |
+| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:32 | ... != ... | semmle.label | successor |
+| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:9:80:38 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length | semmle.label | successor |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine | semmle.label | successor |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} | semmle.label | successor |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; | semmle.label | successor |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:32 | ... ? ... : ... | semmle.label | successor |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
+| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | semmle.label | successor |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | semmle.label | successor |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | semmle.label | successor |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | semmle.label | successor |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | semmle.label | successor |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | semmle.label | successor |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | semmle.label | successor |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | semmle.label | successor |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | semmle.label | successor |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | semmle.label | successor |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | semmle.label | successor |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | semmle.label | successor |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | semmle.label | successor |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | semmle.label | successor |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | semmle.label | successor |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | semmle.label | successor |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | semmle.label | successor |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | semmle.label | successor |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | semmle.label | true |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | semmle.label | true |
+| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | semmle.label | successor |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | semmle.label | successor |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | semmle.label | successor |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | semmle.label | true |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... | semmle.label | false |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | semmle.label | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | semmle.label | false |
+| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | semmle.label | successor |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | semmle.label | successor |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
+| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" | semmle.label | false |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | semmle.label | true |
+| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | semmle.label | successor |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | semmle.label | successor |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | semmle.label | successor |
+| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): false] null | semmle.label | successor |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | semmle.label | true |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | semmle.label | true |
+| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | semmle.label | successor |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | semmle.label | successor |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | semmle.label | successor |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | semmle.label | successor |
+| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
+| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:40 | ...; | semmle.label | successor |
+| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" | semmle.label | false |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null | semmle.label | true |
+| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:126:17:126:20 | null | Assert.cs:126:9:126:25 | ... = ... | semmle.label | successor |
+| Assert.cs:126:24:126:25 | "" | Assert.cs:126:9:126:25 | ... = ... | semmle.label | successor |
+| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
+| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:24:127:38 | ... \|\| ... | semmle.label | successor |
+| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:29:127:32 | null | semmle.label | successor |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse | semmle.label | true |
+| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... | semmle.label | false |
+| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:24 | access to local variable s | semmle.label | successor |
+| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:32 | ... != ... | semmle.label | successor |
+| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | semmle.label | successor |
+| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:9:127:39 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s | semmle.label | successor |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length | semmle.label | successor |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine | semmle.label | successor |
 | Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} | semmle.label | successor |
 | Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; | semmle.label | successor |
 | Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -316,10 +316,12 @@
 | Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:20:9:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:9:24:9:27 | null | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
 | Assert.cs:9:31:9:32 | "" | Assert.cs:9:16:9:32 | String s = ... | semmle.label | successor |
-| Assert.cs:10:9:10:31 | call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 | semmle.label | exit |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; | semmle.label | successor |
 | Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s | semmle.label | successor |
 | Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null | semmle.label | successor |
-| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | call to method Assert | semmle.label | successor |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | semmle.label | false |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | semmle.label | true |
 | Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... | semmle.label | successor |
 | Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 | semmle.label | successor |
 | Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s | semmle.label | successor |
@@ -334,9 +336,11 @@
 | Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:20:16:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:16:24:16:27 | null | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
 | Assert.cs:16:31:16:32 | "" | Assert.cs:16:16:16:32 | String s = ... | semmle.label | successor |
-| Assert.cs:17:9:17:24 | call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; | semmle.label | successor |
 | Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | call to method IsNull | semmle.label | successor |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | semmle.label | non-null |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | semmle.label | null |
 | Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 | semmle.label | successor |
 | Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length | semmle.label | successor |
@@ -350,9 +354,11 @@
 | Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:20:23:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:23:24:23:27 | null | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
 | Assert.cs:23:31:23:32 | "" | Assert.cs:23:16:23:32 | String s = ... | semmle.label | successor |
-| Assert.cs:24:9:24:27 | call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; | semmle.label | successor |
 | Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s | semmle.label | successor |
-| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | call to method IsNotNull | semmle.label | successor |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | semmle.label | null |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | semmle.label | non-null |
 | Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 | semmle.label | successor |
 | Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length | semmle.label | successor |
@@ -366,10 +372,12 @@
 | Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:20:30:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:30:24:30:27 | null | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
 | Assert.cs:30:31:30:32 | "" | Assert.cs:30:16:30:32 | String s = ... | semmle.label | successor |
-| Assert.cs:31:9:31:32 | call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; | semmle.label | successor |
 | Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s | semmle.label | successor |
 | Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null | semmle.label | successor |
-| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... | semmle.label | successor |
 | Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 | semmle.label | successor |
 | Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s | semmle.label | successor |
@@ -384,10 +392,12 @@
 | Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:20:37:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:37:24:37:27 | null | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
 | Assert.cs:37:31:37:32 | "" | Assert.cs:37:16:37:32 | String s = ... | semmle.label | successor |
-| Assert.cs:38:9:38:32 | call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; | semmle.label | successor |
 | Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s | semmle.label | successor |
 | Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null | semmle.label | successor |
-| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... | semmle.label | successor |
 | Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 | semmle.label | successor |
 | Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s | semmle.label | successor |
@@ -402,10 +412,12 @@
 | Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:20:44:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:44:24:44:27 | null | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
 | Assert.cs:44:31:44:32 | "" | Assert.cs:44:16:44:32 | String s = ... | semmle.label | successor |
-| Assert.cs:45:9:45:33 | call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; | semmle.label | successor |
 | Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s | semmle.label | successor |
 | Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null | semmle.label | successor |
-| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... | semmle.label | successor |
 | Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 | semmle.label | successor |
 | Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s | semmle.label | successor |
@@ -420,10 +432,12 @@
 | Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:20:51:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:51:24:51:27 | null | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
 | Assert.cs:51:31:51:32 | "" | Assert.cs:51:16:51:32 | String s = ... | semmle.label | successor |
-| Assert.cs:52:9:52:33 | call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; | semmle.label | successor |
 | Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s | semmle.label | successor |
 | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null | semmle.label | successor |
-| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | semmle.label | false |
 | Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... | semmle.label | successor |
 | Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 | semmle.label | successor |
 | Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s | semmle.label | successor |
@@ -432,20 +446,29 @@
 | Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} | semmle.label | successor |
 | Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; | semmle.label | successor |
 | Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:58:16:58:32 | String s = ... | Assert.cs:59:9:59:38 | ...; | semmle.label | successor |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | null | semmle.label | true |
-| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | "" | semmle.label | false |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; | semmle.label | successor |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; | semmle.label | successor |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | semmle.label | true |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | semmle.label | false |
 | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:58:24:58:27 | null | Assert.cs:58:16:58:32 | String s = ... | semmle.label | successor |
-| Assert.cs:58:31:58:32 | "" | Assert.cs:58:16:58:32 | String s = ... | semmle.label | successor |
-| Assert.cs:59:9:59:37 | call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
-| Assert.cs:59:9:59:38 | ...; | Assert.cs:59:23:59:36 | ... && ... | semmle.label | successor |
-| Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:28:59:31 | null | semmle.label | successor |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:9:59:37 | call to method IsTrue | semmle.label | false |
-| Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:36:59:36 | access to parameter b | semmle.label | true |
-| Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:59:28:59:31 | null | Assert.cs:59:23:59:31 | ... != ... | semmle.label | successor |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:59:9:59:37 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | semmle.label | successor |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | semmle.label | successor |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; | semmle.label | successor |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | semmle.label | successor |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | semmle.label | successor |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null | semmle.label | successor |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null | semmle.label | successor |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | semmle.label | true |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | semmle.label | true |
+| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | semmle.label | successor |
+| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | semmle.label | successor |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | semmle.label | successor |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | semmle.label | successor |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 | semmle.label | successor |
 | Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length | semmle.label | successor |
@@ -453,20 +476,29 @@
 | Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} | semmle.label | successor |
 | Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; | semmle.label | successor |
 | Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:65:16:65:32 | String s = ... | Assert.cs:66:9:66:39 | ...; | semmle.label | successor |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | null | semmle.label | true |
-| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | "" | semmle.label | false |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; | semmle.label | successor |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; | semmle.label | successor |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | semmle.label | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | semmle.label | false |
 | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:65:24:65:27 | null | Assert.cs:65:16:65:32 | String s = ... | semmle.label | successor |
-| Assert.cs:65:31:65:32 | "" | Assert.cs:65:16:65:32 | String s = ... | semmle.label | successor |
-| Assert.cs:66:9:66:38 | call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
-| Assert.cs:66:9:66:39 | ...; | Assert.cs:66:24:66:37 | ... \|\| ... | semmle.label | successor |
-| Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:29:66:32 | null | semmle.label | successor |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:9:66:38 | call to method IsFalse | semmle.label | true |
-| Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:37:66:37 | access to parameter b | semmle.label | false |
-| Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s | semmle.label | successor |
-| Assert.cs:66:29:66:32 | null | Assert.cs:66:24:66:32 | ... == ... | semmle.label | successor |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:66:9:66:38 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | semmle.label | successor |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | semmle.label | successor |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; | semmle.label | successor |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | semmle.label | successor |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null | semmle.label | successor |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null | semmle.label | successor |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | semmle.label | false |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | semmle.label | false |
+| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | semmle.label | successor |
+| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | semmle.label | successor |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | semmle.label | successor |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | semmle.label | successor |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | semmle.label | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 | semmle.label | successor |
 | Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length | semmle.label | successor |
@@ -474,20 +506,29 @@
 | Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} | semmle.label | successor |
 | Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; | semmle.label | successor |
 | Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:72:16:72:32 | String s = ... | Assert.cs:73:9:73:38 | ...; | semmle.label | successor |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | null | semmle.label | true |
-| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | "" | semmle.label | false |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; | semmle.label | successor |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; | semmle.label | successor |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | semmle.label | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | semmle.label | false |
 | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:72:24:72:27 | null | Assert.cs:72:16:72:32 | String s = ... | semmle.label | successor |
-| Assert.cs:72:31:72:32 | "" | Assert.cs:72:16:72:32 | String s = ... | semmle.label | successor |
-| Assert.cs:73:9:73:37 | call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
-| Assert.cs:73:9:73:38 | ...; | Assert.cs:73:23:73:36 | ... && ... | semmle.label | successor |
-| Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:28:73:31 | null | semmle.label | successor |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:9:73:37 | call to method IsTrue | semmle.label | false |
-| Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:36:73:36 | access to parameter b | semmle.label | true |
-| Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s | semmle.label | successor |
-| Assert.cs:73:28:73:31 | null | Assert.cs:73:23:73:31 | ... == ... | semmle.label | successor |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:73:9:73:37 | call to method IsTrue | semmle.label | successor |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | semmle.label | successor |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | semmle.label | successor |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; | semmle.label | successor |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | semmle.label | successor |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | semmle.label | successor |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null | semmle.label | successor |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null | semmle.label | successor |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | semmle.label | true |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | semmle.label | true |
+| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | semmle.label | successor |
+| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | semmle.label | successor |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | semmle.label | successor |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | semmle.label | successor |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | semmle.label | false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | semmle.label | true |
 | Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 | semmle.label | successor |
 | Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length | semmle.label | successor |
@@ -495,20 +536,29 @@
 | Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} | semmle.label | successor |
 | Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; | semmle.label | successor |
 | Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:32 | ... ? ... : ... | semmle.label | successor |
-| Assert.cs:79:16:79:32 | String s = ... | Assert.cs:80:9:80:39 | ...; | semmle.label | successor |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | null | semmle.label | true |
-| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | "" | semmle.label | false |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; | semmle.label | successor |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; | semmle.label | successor |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | semmle.label | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | semmle.label | false |
 | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | semmle.label | successor |
-| Assert.cs:79:24:79:27 | null | Assert.cs:79:16:79:32 | String s = ... | semmle.label | successor |
-| Assert.cs:79:31:79:32 | "" | Assert.cs:79:16:79:32 | String s = ... | semmle.label | successor |
-| Assert.cs:80:9:80:38 | call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
-| Assert.cs:80:9:80:39 | ...; | Assert.cs:80:24:80:37 | ... \|\| ... | semmle.label | successor |
-| Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:29:80:32 | null | semmle.label | successor |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:9:80:38 | call to method IsFalse | semmle.label | true |
-| Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:37:80:37 | access to parameter b | semmle.label | false |
-| Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s | semmle.label | successor |
-| Assert.cs:80:29:80:32 | null | Assert.cs:80:24:80:32 | ... != ... | semmle.label | successor |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:80:9:80:38 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | semmle.label | successor |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | semmle.label | successor |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; | semmle.label | successor |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | semmle.label | successor |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null | semmle.label | successor |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null | semmle.label | successor |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | semmle.label | false |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | semmle.label | false |
+| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | semmle.label | successor |
+| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | semmle.label | successor |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | semmle.label | successor |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | semmle.label | successor |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | semmle.label | false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | semmle.label | true |
 | Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 | semmle.label | successor |
 | Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length | semmle.label | successor |
@@ -523,14 +573,18 @@
 | Assert.cs:86:20:86:32 | ... ? ... : ... | Assert.cs:86:20:86:20 | access to parameter b | semmle.label | successor |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | semmle.label | successor |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | semmle.label | successor |
-| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exit |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exit |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | semmle.label | successor |
-| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | semmle.label | successor |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | semmle.label | false |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | semmle.label | true |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | semmle.label | false |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | semmle.label | true |
 | Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | semmle.label | successor |
 | Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | semmle.label | successor |
 | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; | semmle.label | successor |
@@ -551,12 +605,16 @@
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | semmle.label | successor |
-| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | semmle.label | successor |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | semmle.label | non-null |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | semmle.label | null |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | semmle.label | non-null |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | semmle.label | null |
 | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -575,12 +633,16 @@
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | semmle.label | successor |
-| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | semmle.label | successor |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | semmle.label | null |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | semmle.label | non-null |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | semmle.label | null |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | semmle.label | non-null |
 | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
@@ -599,14 +661,18 @@
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
-| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | semmle.label | true |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | semmle.label | successor |
 | Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | semmle.label | successor |
 | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; | semmle.label | successor |
@@ -627,14 +693,18 @@
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
-| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | semmle.label | true |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | semmle.label | successor |
 | Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | semmle.label | successor |
 | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; | semmle.label | successor |
@@ -655,14 +725,18 @@
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
-| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | semmle.label | true |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | semmle.label | false |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
 | Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | semmle.label | successor |
 | Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | semmle.label | successor |
 | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; | semmle.label | successor |
@@ -683,14 +757,18 @@
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
-| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | semmle.label | true |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | semmle.label | false |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | false |
 | Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | semmle.label | successor |
 | Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | semmle.label | successor |
 | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; | semmle.label | successor |
@@ -711,118 +789,79 @@
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | semmle.label | successor |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | semmle.label | successor |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | semmle.label | successor |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
 | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | semmle.label | true |
-| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
 | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | semmle.label | true |
 | Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
 | Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | semmle.label | successor |
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | semmle.label | successor |
-| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
-| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
-| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | semmle.label | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | semmle.label | successor |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | Assert.cs:118:24:118:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:118:24:118:25 | [b (line 84): false] "" | Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | semmle.label | successor |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
-| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | semmle.label | true |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): false] !... | semmle.label | false |
-| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | semmle.label | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | semmle.label | true |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:37:119:38 | [b (line 84): true] !... | semmle.label | false |
-| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:119:29:119:32 | [b (line 84): false] null | Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | semmle.label | successor |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | semmle.label | successor |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | semmle.label | successor |
-| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | semmle.label | successor |
-| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | semmle.label | true |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | semmle.label | successor |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): false] ...; | semmle.label | successor |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | Assert.cs:122:24:122:25 | [b (line 84): false] "" | semmle.label | false |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | semmle.label | true |
-| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | semmle.label | successor |
-| Assert.cs:122:24:122:25 | [b (line 84): false] "" | Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | semmle.label | successor |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): false] ...; | semmle.label | successor |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | semmle.label | successor |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | semmle.label | successor |
-| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): false] null | semmle.label | successor |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null | semmle.label | successor |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | semmle.label | false |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | semmle.label | true |
-| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | semmle.label | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | semmle.label | false |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | semmle.label | true |
-| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:123:28:123:31 | [b (line 84): false] null | Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | semmle.label | successor |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | semmle.label | successor |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | semmle.label | successor |
-| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | semmle.label | successor |
-| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): false] ...; | semmle.label | successor |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | semmle.label | true |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | semmle.label | successor |
-| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | semmle.label | successor |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | semmle.label | successor |
-| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | semmle.label | successor |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | semmle.label | successor |
-| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | semmle.label | successor |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | semmle.label | successor |
-| Assert.cs:126:9:126:25 | ... = ... | Assert.cs:127:9:127:40 | ...; | semmle.label | successor |
-| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | semmle.label | successor |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; | semmle.label | successor |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | semmle.label | successor |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | Assert.cs:126:24:126:25 | "" | semmle.label | false |
-| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | null | semmle.label | true |
-| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | semmle.label | successor |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | semmle.label | true |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | semmle.label | successor |
-| Assert.cs:126:17:126:20 | null | Assert.cs:126:9:126:25 | ... = ... | semmle.label | successor |
-| Assert.cs:126:24:126:25 | "" | Assert.cs:126:9:126:25 | ... = ... | semmle.label | successor |
-| Assert.cs:127:9:127:39 | call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
-| Assert.cs:127:9:127:40 | ...; | Assert.cs:127:24:127:38 | ... \|\| ... | semmle.label | successor |
-| Assert.cs:127:24:127:24 | access to local variable s | Assert.cs:127:29:127:32 | null | semmle.label | successor |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:9:127:39 | call to method IsFalse | semmle.label | true |
-| Assert.cs:127:24:127:32 | ... != ... | Assert.cs:127:37:127:38 | !... | semmle.label | false |
-| Assert.cs:127:24:127:38 | ... \|\| ... | Assert.cs:127:24:127:24 | access to local variable s | semmle.label | successor |
-| Assert.cs:127:29:127:32 | null | Assert.cs:127:24:127:32 | ... != ... | semmle.label | successor |
-| Assert.cs:127:37:127:38 | !... | Assert.cs:127:38:127:38 | access to parameter b | semmle.label | successor |
-| Assert.cs:127:38:127:38 | access to parameter b | Assert.cs:127:9:127:39 | call to method IsFalse | semmle.label | successor |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | semmle.label | successor |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 | semmle.label | exception(AssertFailedException) |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; | semmle.label | successor |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | semmle.label | successor |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null | semmle.label | successor |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | semmle.label | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:37:127:38 | [b (line 84): true] !... | semmle.label | false |
+| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | semmle.label | successor |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | semmle.label | successor |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | semmle.label | successor |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | semmle.label | true |
 | Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 | semmle.label | successor |
 | Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s | semmle.label | successor |
 | Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length | semmle.label | successor |
@@ -1598,23 +1637,25 @@
 | ExitMethods.cs:116:38:116:38 | 1 | ExitMethods.cs:116:9:116:39 | return ...; | semmle.label | successor |
 | ExitMethods.cs:119:17:119:32 | enter FailingAssertion | ExitMethods.cs:120:5:123:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:120:5:123:5 | {...} | ExitMethods.cs:121:9:121:29 | ...; | semmle.label | successor |
-| ExitMethods.cs:121:9:121:28 | call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:119:17:119:32 | exit FailingAssertion | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:121:9:121:29 | ...; | ExitMethods.cs:121:23:121:27 | false | semmle.label | successor |
-| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | call to method IsTrue | semmle.label | successor |
+| ExitMethods.cs:121:23:121:27 | false | ExitMethods.cs:121:9:121:28 | [assertion failure] call to method IsTrue | semmle.label | false |
 | ExitMethods.cs:125:17:125:33 | enter FailingAssertion2 | ExitMethods.cs:126:5:129:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:126:5:129:5 | {...} | ExitMethods.cs:127:9:127:27 | ...; | semmle.label | successor |
 | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | ExitMethods.cs:125:17:125:33 | exit FailingAssertion2 | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:127:9:127:26 | this access | ExitMethods.cs:127:9:127:26 | call to method FailingAssertion | semmle.label | successor |
 | ExitMethods.cs:127:9:127:27 | ...; | ExitMethods.cs:127:9:127:26 | this access | semmle.label | successor |
 | ExitMethods.cs:131:10:131:20 | enter AssertFalse | ExitMethods.cs:131:48:131:48 | access to parameter b | semmle.label | successor |
-| ExitMethods.cs:131:33:131:49 | call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
-| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | call to method IsFalse | semmle.label | successor |
+| ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | ExitMethods.cs:131:10:131:20 | exit AssertFalse | semmle.label | successor |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion failure] call to method IsFalse | semmle.label | true |
+| ExitMethods.cs:131:48:131:48 | access to parameter b | ExitMethods.cs:131:33:131:49 | [assertion success] call to method IsFalse | semmle.label | false |
 | ExitMethods.cs:133:17:133:33 | enter FailingAssertion3 | ExitMethods.cs:134:5:137:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:134:5:137:5 | {...} | ExitMethods.cs:135:9:135:26 | ...; | semmle.label | successor |
-| ExitMethods.cs:135:9:135:25 | call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | semmle.label | exception(AssertFailedException) |
+| ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:133:17:133:33 | exit FailingAssertion3 | semmle.label | exception(AssertFailedException) |
 | ExitMethods.cs:135:9:135:25 | this access | ExitMethods.cs:135:21:135:24 | true | semmle.label | successor |
 | ExitMethods.cs:135:9:135:26 | ...; | ExitMethods.cs:135:9:135:25 | this access | semmle.label | successor |
-| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | call to method AssertFalse | semmle.label | successor |
+| ExitMethods.cs:135:21:135:24 | true | ExitMethods.cs:135:9:135:25 | [assertion failure] call to method AssertFalse | semmle.label | true |
 | Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} | semmle.label | successor |
 | Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s | semmle.label | successor |
 | Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 | semmle.label | return |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1,10 +1,76 @@
 booleanNode
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | b (line 56): false |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | b (line 56): true |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | b (line 56): true |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | b (line 56): false |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | b (line 56): false |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | b (line 56): true |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | b (line 56): false |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | b (line 56): true |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | b (line 56): false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | b (line 56): true |
+| Assert.cs:59:23:59:36 | [b (line 56): false] ... && ... | b (line 56): false |
+| Assert.cs:59:23:59:36 | [b (line 56): true] ... && ... | b (line 56): true |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | b (line 56): false |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | b (line 56): true |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | b (line 56): false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | b (line 56): true |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | b (line 63): false |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | b (line 63): true |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | b (line 63): true |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | b (line 63): false |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | b (line 63): false |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | b (line 63): true |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | b (line 63): false |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | b (line 63): true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | b (line 63): false |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | b (line 63): true |
+| Assert.cs:66:24:66:37 | [b (line 63): false] ... \|\| ... | b (line 63): false |
+| Assert.cs:66:24:66:37 | [b (line 63): true] ... \|\| ... | b (line 63): true |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | b (line 63): false |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | b (line 63): true |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | b (line 63): false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | b (line 63): true |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | b (line 70): false |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | b (line 70): true |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | b (line 70): true |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | b (line 70): false |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | b (line 70): false |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | b (line 70): true |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | b (line 70): false |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | b (line 70): true |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | b (line 70): false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | b (line 70): true |
+| Assert.cs:73:23:73:36 | [b (line 70): false] ... && ... | b (line 70): false |
+| Assert.cs:73:23:73:36 | [b (line 70): true] ... && ... | b (line 70): true |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | b (line 70): false |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | b (line 70): true |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | b (line 70): false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | b (line 70): true |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | b (line 77): false |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | b (line 77): true |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | b (line 77): true |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | b (line 77): false |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | b (line 77): false |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | b (line 77): true |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | b (line 77): false |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | b (line 77): true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | b (line 77): false |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | b (line 77): true |
+| Assert.cs:80:24:80:37 | [b (line 77): false] ... \|\| ... | b (line 77): false |
+| Assert.cs:80:24:80:37 | [b (line 77): true] ... \|\| ... | b (line 77): true |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | b (line 77): false |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | b (line 77): true |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | b (line 77): false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | b (line 77): true |
 | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | b (line 84): false |
 | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | b (line 84): true |
 | Assert.cs:86:24:86:27 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:86:31:86:32 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | b (line 84): false |
-| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | b (line 84): true |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | b (line 84): false |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | b (line 84): true |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | b (line 84): false |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | b (line 84): true |
 | Assert.cs:87:9:87:32 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:87:9:87:32 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -31,8 +97,10 @@ booleanNode
 | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:90:17:90:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:90:24:90:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | b (line 84): false |
-| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | b (line 84): true |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | b (line 84): false |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | b (line 84): true |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | b (line 84): false |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | b (line 84): true |
 | Assert.cs:91:9:91:25 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:91:9:91:25 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -55,8 +123,10 @@ booleanNode
 | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:94:17:94:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:94:24:94:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | b (line 84): false |
-| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | b (line 84): true |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | b (line 84): false |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | b (line 84): true |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | b (line 84): false |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | b (line 84): true |
 | Assert.cs:95:9:95:28 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:95:9:95:28 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -79,8 +149,10 @@ booleanNode
 | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:98:17:98:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:98:24:98:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | b (line 84): false |
-| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | b (line 84): true |
 | Assert.cs:99:9:99:33 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:99:9:99:33 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -107,8 +179,10 @@ booleanNode
 | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:102:17:102:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:102:24:102:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | b (line 84): false |
-| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | b (line 84): true |
 | Assert.cs:103:9:103:33 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:103:9:103:33 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -135,8 +209,10 @@ booleanNode
 | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:106:17:106:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:106:24:106:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | b (line 84): false |
-| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | b (line 84): true |
 | Assert.cs:107:9:107:34 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:107:9:107:34 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -163,8 +239,10 @@ booleanNode
 | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:110:17:110:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:110:24:110:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | b (line 84): false |
-| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | b (line 84): true |
 | Assert.cs:111:9:111:34 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:111:9:111:34 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -191,8 +269,9 @@ booleanNode
 | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:114:17:114:20 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:114:24:114:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | b (line 84): false |
-| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | b (line 84): true |
 | Assert.cs:115:9:115:38 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:115:9:115:38 | [b (line 84): true] ...; | b (line 84): true |
 | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | b (line 84): false |
@@ -205,86 +284,57 @@ booleanNode
 | Assert.cs:115:28:115:31 | [b (line 84): true] null | b (line 84): true |
 | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
 | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
-| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:116:9:116:36 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | b (line 84): false |
 | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | b (line 84): true |
-| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | b (line 84): false |
 | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | b (line 84): true |
-| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | b (line 84): false |
 | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | b (line 84): true |
-| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:118:9:118:26 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
 | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:118:17:118:20 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:118:24:118:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | b (line 84): false |
-| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | b (line 84): true |
-| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | b (line 84): true |
 | Assert.cs:119:9:119:40 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | b (line 84): false |
 | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | b (line 84): true |
-| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | b (line 84): false |
 | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | b (line 84): true |
-| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | b (line 84): false |
 | Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | b (line 84): true |
-| Assert.cs:119:29:119:32 | [b (line 84): false] null | b (line 84): false |
 | Assert.cs:119:29:119:32 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:119:37:119:38 | [b (line 84): false] !... | b (line 84): false |
 | Assert.cs:119:37:119:38 | [b (line 84): true] !... | b (line 84): true |
-| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
 | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
-| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:120:9:120:36 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | b (line 84): false |
 | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | b (line 84): true |
-| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | b (line 84): false |
 | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | b (line 84): true |
-| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | b (line 84): false |
 | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | b (line 84): true |
-| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:122:9:122:26 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
 | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Assert.cs:122:17:122:20 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:122:24:122:25 | [b (line 84): false] "" | b (line 84): false |
-| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | b (line 84): false |
-| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | b (line 84): true |
-| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | b (line 84): true |
 | Assert.cs:123:9:123:38 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | b (line 84): false |
 | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | b (line 84): true |
-| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | b (line 84): false |
 | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | b (line 84): true |
-| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | b (line 84): false |
 | Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | b (line 84): true |
-| Assert.cs:123:28:123:31 | [b (line 84): false] null | b (line 84): false |
 | Assert.cs:123:28:123:31 | [b (line 84): true] null | b (line 84): true |
-| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
 | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
-| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | b (line 84): false |
 | Assert.cs:124:9:124:36 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | b (line 84): false |
 | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | b (line 84): true |
-| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | b (line 84): false |
 | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | b (line 84): true |
-| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | b (line 84): true |
 | Assert.cs:126:9:126:26 | [b (line 84): true] ...; | b (line 84): true |
-| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | b (line 84): false |
 | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | b (line 84): true |
-| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
 | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | b (line 84): true |
+| Assert.cs:127:24:127:38 | [b (line 84): true] ... \|\| ... | b (line 84): true |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:127:37:127:38 | [b (line 84): true] !... | b (line 84): true |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | b (line 84): true |
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | inc (line 3): true |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | inc (line 3): true |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | inc (line 3): true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -1,4 +1,290 @@
 booleanNode
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | b (line 84): false |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | b (line 84): true |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:87:9:87:31 | [b (line 84): false] call to method Assert | b (line 84): false |
+| Assert.cs:87:9:87:31 | [b (line 84): true] call to method Assert | b (line 84): true |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | b (line 84): false |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | b (line 84): true |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:91:9:91:24 | [b (line 84): false] call to method IsNull | b (line 84): false |
+| Assert.cs:91:9:91:24 | [b (line 84): true] call to method IsNull | b (line 84): true |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:95:9:95:27 | [b (line 84): false] call to method IsNotNull | b (line 84): false |
+| Assert.cs:95:9:95:27 | [b (line 84): true] call to method IsNotNull | b (line 84): true |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:99:9:99:32 | [b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:99:9:99:32 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | b (line 84): false |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | b (line 84): true |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:103:9:103:32 | [b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:103:9:103:32 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | b (line 84): false |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | b (line 84): true |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:107:9:107:33 | [b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:107:9:107:33 | [b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | b (line 84): false |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | b (line 84): true |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:111:9:111:33 | [b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:111:9:111:33 | [b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | b (line 84): false |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | b (line 84): true |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:115:9:115:37 | [b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:115:9:115:37 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | b (line 84): false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | b (line 84): true |
+| Assert.cs:115:23:115:36 | [b (line 84): false] ... && ... | b (line 84): false |
+| Assert.cs:115:23:115:36 | [b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:116:9:116:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:116:9:116:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:116:27:116:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:116:27:116:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:118:9:118:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:118:9:118:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:118:13:118:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:118:13:118:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:118:24:118:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:119:9:119:39 | [b (line 84): false] call to method IsFalse | b (line 84): false |
+| Assert.cs:119:9:119:39 | [b (line 84): true] call to method IsFalse | b (line 84): true |
+| Assert.cs:119:9:119:40 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:119:24:119:24 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:119:24:119:32 | [b (line 84): false] ... == ... | b (line 84): false |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | b (line 84): true |
+| Assert.cs:119:24:119:38 | [b (line 84): false] ... \|\| ... | b (line 84): false |
+| Assert.cs:119:24:119:38 | [b (line 84): true] ... \|\| ... | b (line 84): true |
+| Assert.cs:119:29:119:32 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:119:37:119:38 | [b (line 84): false] !... | b (line 84): false |
+| Assert.cs:119:37:119:38 | [b (line 84): true] !... | b (line 84): true |
+| Assert.cs:119:38:119:38 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:120:9:120:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:120:9:120:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:120:27:120:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:120:27:120:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:122:9:122:25 | [b (line 84): false] ... = ... | b (line 84): false |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | b (line 84): true |
+| Assert.cs:122:9:122:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:122:13:122:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:122:13:122:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:122:24:122:25 | [b (line 84): false] "" | b (line 84): false |
+| Assert.cs:123:9:123:37 | [b (line 84): false] call to method IsTrue | b (line 84): false |
+| Assert.cs:123:9:123:37 | [b (line 84): true] call to method IsTrue | b (line 84): true |
+| Assert.cs:123:9:123:38 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:123:23:123:23 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:123:23:123:31 | [b (line 84): false] ... == ... | b (line 84): false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | b (line 84): true |
+| Assert.cs:123:23:123:36 | [b (line 84): false] ... && ... | b (line 84): false |
+| Assert.cs:123:23:123:36 | [b (line 84): true] ... && ... | b (line 84): true |
+| Assert.cs:123:28:123:31 | [b (line 84): false] null | b (line 84): false |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | b (line 84): true |
+| Assert.cs:123:36:123:36 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:124:9:124:35 | [b (line 84): false] call to method WriteLine | b (line 84): false |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | b (line 84): true |
+| Assert.cs:124:9:124:36 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:124:27:124:27 | [b (line 84): false] access to local variable s | b (line 84): false |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | b (line 84): true |
+| Assert.cs:124:27:124:34 | [b (line 84): false] access to property Length | b (line 84): false |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | b (line 84): true |
+| Assert.cs:126:9:126:26 | [b (line 84): false] ...; | b (line 84): false |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | b (line 84): true |
+| Assert.cs:126:13:126:13 | [b (line 84): false] access to parameter b | b (line 84): false |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | b (line 84): true |
+| Assert.cs:126:13:126:25 | [b (line 84): false] ... ? ... : ... | b (line 84): false |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | b (line 84): true |
 | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | inc (line 3): true |
 | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | inc (line 3): true |
 | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | inc (line 3): true |
@@ -644,6 +930,18 @@ entryPoint
 | ArrayCreation.cs:5:12:5:13 | M2 | ArrayCreation.cs:5:28:5:28 | 0 |
 | ArrayCreation.cs:7:11:7:12 | M3 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] |
 | ArrayCreation.cs:9:12:9:13 | M4 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] |
+| Assert.cs:7:10:7:11 | M1 | Assert.cs:8:5:12:5 | {...} |
+| Assert.cs:14:10:14:11 | M2 | Assert.cs:15:5:19:5 | {...} |
+| Assert.cs:21:10:21:11 | M3 | Assert.cs:22:5:26:5 | {...} |
+| Assert.cs:28:10:28:11 | M4 | Assert.cs:29:5:33:5 | {...} |
+| Assert.cs:35:10:35:11 | M5 | Assert.cs:36:5:40:5 | {...} |
+| Assert.cs:42:10:42:11 | M6 | Assert.cs:43:5:47:5 | {...} |
+| Assert.cs:49:10:49:11 | M7 | Assert.cs:50:5:54:5 | {...} |
+| Assert.cs:56:10:56:11 | M8 | Assert.cs:57:5:61:5 | {...} |
+| Assert.cs:63:10:63:11 | M9 | Assert.cs:64:5:68:5 | {...} |
+| Assert.cs:70:10:70:12 | M10 | Assert.cs:71:5:75:5 | {...} |
+| Assert.cs:77:10:77:12 | M11 | Assert.cs:78:5:82:5 | {...} |
+| Assert.cs:84:10:84:12 | M12 | Assert.cs:85:5:129:5 | {...} |
 | Assignments.cs:3:10:3:10 | M | Assignments.cs:4:5:15:5 | {...} |
 | Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:33:14:35 | {...} |
 | Assignments.cs:17:40:17:40 | + | Assignments.cs:18:5:20:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/guards/AbstractValue.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/AbstractValue.expected
@@ -32,7 +32,7 @@ abstractValue
 | 0 | Guards.cs:322:18:322:18 | 0 |
 | 0 | Guards.cs:329:17:329:19 | access to constant A |
 | 0 | Guards.cs:334:20:334:20 | 0 |
-| 0 | Splitting.cs:136:20:136:20 | 0 |
+| 0 | Splitting.cs:137:20:137:20 | 0 |
 | 1 | Collections.cs:13:28:13:28 | 1 |
 | 1 | Collections.cs:15:28:15:28 | 1 |
 | 1 | Collections.cs:18:28:18:28 | 1 |
@@ -365,6 +365,9 @@ abstractValue
 | non-null | Guards.cs:281:17:281:17 | access to local variable a |
 | non-null | Guards.cs:283:17:283:17 | access to parameter o |
 | non-null | Guards.cs:287:17:287:17 | access to parameter o |
+| non-null | Guards.cs:341:31:341:32 | "" |
+| non-null | Guards.cs:343:13:343:19 | access to type Console |
+| non-null | Guards.cs:343:31:343:31 | access to local variable s |
 | non-null | Splitting.cs:13:17:13:17 | access to parameter o |
 | non-null | Splitting.cs:23:24:23:24 | access to parameter o |
 | non-null | Splitting.cs:33:24:33:25 | "" |
@@ -384,12 +387,13 @@ abstractValue
 | non-null | Splitting.cs:117:9:117:9 | access to parameter o |
 | non-null | Splitting.cs:119:13:119:13 | access to parameter o |
 | non-null | Splitting.cs:120:16:120:16 | access to parameter o |
-| non-null | Splitting.cs:132:17:132:17 | access to local variable o |
-| non-null | Splitting.cs:132:17:132:29 | ... = ... |
-| non-null | Splitting.cs:132:21:132:29 | call to method M11 |
-| non-null | Splitting.cs:132:21:132:29 | this access |
-| non-null | Splitting.cs:132:28:132:28 | access to local variable o |
+| non-null | Splitting.cs:129:17:129:17 | access to local variable o |
 | non-null | Splitting.cs:133:17:133:17 | access to local variable o |
+| non-null | Splitting.cs:133:17:133:29 | ... = ... |
+| non-null | Splitting.cs:133:21:133:29 | call to method M11 |
+| non-null | Splitting.cs:133:21:133:29 | this access |
+| non-null | Splitting.cs:133:28:133:28 | access to local variable o |
+| non-null | Splitting.cs:134:17:134:17 | access to local variable o |
 | null | Assert.cs:9:24:9:27 | null |
 | null | Assert.cs:10:27:10:30 | null |
 | null | Assert.cs:16:24:16:27 | null |
@@ -438,6 +442,8 @@ abstractValue
 | null | Guards.cs:181:39:181:42 | null |
 | null | Guards.cs:185:43:185:46 | null |
 | null | Guards.cs:203:18:203:21 | null |
+| null | Guards.cs:341:24:341:27 | null |
+| null | Guards.cs:342:18:342:21 | null |
 | null | Splitting.cs:12:22:12:25 | null |
 | null | Splitting.cs:22:22:22:25 | null |
 | null | Splitting.cs:32:22:32:25 | null |
@@ -450,7 +456,7 @@ abstractValue
 | null | Splitting.cs:105:27:105:30 | null |
 | null | Splitting.cs:116:27:116:30 | null |
 | null | Splitting.cs:125:21:125:24 | null |
-| null | Splitting.cs:128:22:128:25 | null |
+| null | Splitting.cs:129:22:129:25 | null |
 | true | Guards.cs:177:20:177:23 | true |
 | true | Guards.cs:181:46:181:49 | true |
 | true | Guards.cs:185:50:185:53 | true |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -75,6 +75,7 @@
 | Guards.cs:208:17:208:17 | access to parameter o | Guards.cs:203:13:203:21 | ... != ... | Guards.cs:203:13:203:13 | access to parameter o | true |
 | Guards.cs:269:13:269:14 | access to parameter o1 | Guards.cs:268:13:268:41 | call to operator == | Guards.cs:268:13:268:14 | access to parameter o1 | true |
 | Guards.cs:271:13:271:14 | access to parameter o1 | Guards.cs:270:13:270:42 | call to operator == | Guards.cs:270:13:270:14 | access to parameter o1 | true |
+| Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |
@@ -93,4 +94,4 @@
 | Splitting.cs:117:9:117:9 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
-| Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
+| Splitting.cs:133:25:133:25 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -4,9 +4,13 @@
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:24 | access to local variable s | false |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:54:13:54:16 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
@@ -68,6 +72,7 @@
 | Guards.cs:269:13:269:14 | access to parameter o1 | Guards.cs:268:13:268:41 | call to operator == | Guards.cs:268:13:268:14 | access to parameter o1 | true |
 | Guards.cs:271:13:271:14 | access to parameter o1 | Guards.cs:270:13:270:42 | call to operator == | Guards.cs:270:13:270:14 | access to parameter o1 | true |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | true |
 | Splitting.cs:25:13:25:13 | access to parameter o | Splitting.cs:22:17:22:25 | ... != ... | Splitting.cs:22:17:22:17 | access to parameter o | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/BooleanGuardedExpr.expected
@@ -4,17 +4,9 @@
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:24 | access to local variable s | false |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s | true |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s | false |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s | false |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:54:13:54:16 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
@@ -10,26 +10,26 @@
 | Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:24:45:24 | access to local variable s | false |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:24:52:24 | access to local variable s | non-null |
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s | false |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
-| Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | non-null |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s | true |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
-| Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | non-null |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s | false |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
-| Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | null |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s | true |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
-| Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | null |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s | false |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | true |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | true |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | false |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | false |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | non-empty |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
@@ -15,21 +15,29 @@
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | true |
 | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | non-null |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
 | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | true |
 | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | non-null |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | false |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
 | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
 | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | null |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | false |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
 | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
 | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | null |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | non-empty |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
@@ -197,6 +205,8 @@
 | Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | true |
 | Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | non-null |
+| Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | non-null |
+| Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:14:13:14:13 | [b (line 9): false] access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedControlFlowNode.expected
@@ -192,6 +192,11 @@
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-match access to type Action<Object> |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-match null |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-null |
+| Guards.cs:342:27:342:27 | [b (line 339): false] access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:342:27:342:27 | [b (line 339): false] access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | non-null |
+| Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | true |
+| Guards.cs:342:27:342:27 | [b (line 339): true] access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | non-null |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | [b (line 9): true] access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:14:13:14:13 | [b (line 9): false] access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | Splitting.cs:11:13:11:13 | access to parameter b | false |
@@ -256,5 +261,5 @@
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
-| Splitting.cs:130:21:130:21 | [b (line 123): false] access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
-| Splitting.cs:132:25:132:25 | [b (line 123): false] access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
+| Splitting.cs:131:21:131:21 | [b (line 123): false] access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | false |
+| Splitting.cs:133:25:133:25 | [b (line 123): false] access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -12,12 +12,20 @@
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | non-null |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | non-null |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | null |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | null |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | non-empty |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
@@ -182,6 +190,8 @@
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-null |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
 | Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | non-null |
+| Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | Guards.cs:342:13:342:13 | access to local variable s | non-null |
+| Guards.cs:343:31:343:31 | access to local variable s | Guards.cs:342:13:342:21 | ... != ... | Guards.cs:342:13:342:13 | access to local variable s | true |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | non-null |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -12,24 +12,12 @@
 | Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:24:52:24 | access to local variable s | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:20:58:20 | access to parameter b | false |
 | Assert.cs:59:36:59:36 | access to parameter b | Assert.cs:58:20:58:32 | ... ? ... : ... | Assert.cs:58:20:58:20 | access to parameter b | non-null |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | Assert.cs:59:23:59:23 | access to local variable s | non-null |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:31 | ... != ... | Assert.cs:59:23:59:23 | access to local variable s | true |
-| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:59:23:59:36 | ... && ... | Assert.cs:59:23:59:23 | access to local variable s | true |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:20:65:20 | access to parameter b | false |
 | Assert.cs:66:37:66:37 | access to parameter b | Assert.cs:65:20:65:32 | ... ? ... : ... | Assert.cs:65:20:65:20 | access to parameter b | non-null |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | Assert.cs:66:24:66:24 | access to local variable s | non-null |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:32 | ... == ... | Assert.cs:66:24:66:24 | access to local variable s | false |
-| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:66:24:66:37 | ... \|\| ... | Assert.cs:66:24:66:24 | access to local variable s | false |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:20:72:20 | access to parameter b | true |
 | Assert.cs:73:36:73:36 | access to parameter b | Assert.cs:72:20:72:32 | ... ? ... : ... | Assert.cs:72:20:72:20 | access to parameter b | null |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | Assert.cs:73:23:73:23 | access to local variable s | null |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:31 | ... == ... | Assert.cs:73:23:73:23 | access to local variable s | true |
-| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:73:23:73:36 | ... && ... | Assert.cs:73:23:73:23 | access to local variable s | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:20:79:20 | access to parameter b | true |
 | Assert.cs:80:37:80:37 | access to parameter b | Assert.cs:79:20:79:32 | ... ? ... : ... | Assert.cs:79:20:79:20 | access to parameter b | null |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | Assert.cs:80:24:80:24 | access to local variable s | null |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:32 | ... != ... | Assert.cs:80:24:80:24 | access to local variable s | false |
-| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:80:24:80:37 | ... \|\| ... | Assert.cs:80:24:80:24 | access to local variable s | false |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | Collections.cs:50:13:50:16 | access to parameter args | non-empty |
 | Collections.cs:52:17:52:20 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |
 | Collections.cs:53:9:53:12 | access to parameter args | Collections.cs:50:13:50:27 | ... == ... | Collections.cs:50:13:50:16 | access to parameter args | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/GuardedExpr.expected
@@ -192,6 +192,8 @@
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-match access to type Action<Object> |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-match null |
 | Guards.cs:287:17:287:17 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | Guards.cs:276:16:276:16 | access to parameter o | non-null |
+| Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:342:27:342:27 | access to parameter b | Guards.cs:341:20:341:32 | ... ? ... : ... | Guards.cs:341:20:341:20 | access to parameter b | non-null |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:13:17:13:17 | access to parameter o | Splitting.cs:12:17:12:25 | ... != ... | Splitting.cs:12:17:12:17 | access to parameter o | true |
 | Splitting.cs:23:24:23:24 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | Splitting.cs:22:17:22:17 | access to parameter o | non-null |
@@ -228,4 +230,4 @@
 | Splitting.cs:119:13:119:13 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
 | Splitting.cs:120:16:120:16 | access to parameter o | Splitting.cs:116:22:116:30 | ... != ... | Splitting.cs:116:22:116:22 | access to parameter o | true |
-| Splitting.cs:132:25:132:25 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | Splitting.cs:130:21:130:21 | access to parameter b | false |
+| Splitting.cs:133:25:133:25 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | Splitting.cs:131:21:131:21 | access to parameter b | false |

--- a/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
@@ -340,7 +340,7 @@ public class Guards
     {
         string s = b ? null : "";
         if (s != null && !b)
-            Console.WriteLine(s.Length); // null guarded [MISSING]
+            Console.WriteLine(s.Length); // null guarded
     }
 }
 

--- a/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Guards.cs
@@ -335,5 +335,12 @@ public class Guards
             _ => 1
         };
     }
+
+    void M28(bool b)
+    {
+        string s = b ? null : "";
+        if (s != null && !b)
+            Console.WriteLine(s.Length); // null guarded [MISSING]
+    }
 }
 

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -18,7 +18,9 @@
 | Assert.cs:16:20:16:32 | ... ? ... : ... | null | Assert.cs:16:24:16:27 | null | null |
 | Assert.cs:17:23:17:23 | access to local variable s | empty | Assert.cs:16:20:16:32 | ... ? ... : ... | empty |
 | Assert.cs:17:23:17:23 | access to local variable s | non-empty | Assert.cs:16:20:16:32 | ... ? ... : ... | non-empty |
+| Assert.cs:17:23:17:23 | access to local variable s | non-null | Assert.cs:16:20:16:20 | access to parameter b | false |
 | Assert.cs:17:23:17:23 | access to local variable s | non-null | Assert.cs:16:20:16:32 | ... ? ... : ... | non-null |
+| Assert.cs:17:23:17:23 | access to local variable s | null | Assert.cs:16:20:16:20 | access to parameter b | true |
 | Assert.cs:17:23:17:23 | access to local variable s | null | Assert.cs:16:20:16:32 | ... ? ... : ... | null |
 | Assert.cs:18:27:18:27 | access to local variable s | non-null | Assert.cs:16:20:16:32 | ... ? ... : ... | non-null |
 | Assert.cs:18:27:18:27 | access to local variable s | null | Assert.cs:16:20:16:32 | ... ? ... : ... | null |
@@ -28,7 +30,9 @@
 | Assert.cs:23:20:23:32 | ... ? ... : ... | null | Assert.cs:23:24:23:27 | null | null |
 | Assert.cs:24:26:24:26 | access to local variable s | empty | Assert.cs:23:20:23:32 | ... ? ... : ... | empty |
 | Assert.cs:24:26:24:26 | access to local variable s | non-empty | Assert.cs:23:20:23:32 | ... ? ... : ... | non-empty |
+| Assert.cs:24:26:24:26 | access to local variable s | non-null | Assert.cs:23:20:23:20 | access to parameter b | false |
 | Assert.cs:24:26:24:26 | access to local variable s | non-null | Assert.cs:23:20:23:32 | ... ? ... : ... | non-null |
+| Assert.cs:24:26:24:26 | access to local variable s | null | Assert.cs:23:20:23:20 | access to parameter b | true |
 | Assert.cs:24:26:24:26 | access to local variable s | null | Assert.cs:23:20:23:32 | ... ? ... : ... | null |
 | Assert.cs:25:27:25:27 | access to local variable s | non-null | Assert.cs:23:20:23:32 | ... ? ... : ... | non-null |
 | Assert.cs:25:27:25:27 | access to local variable s | null | Assert.cs:23:20:23:32 | ... ? ... : ... | null |

--- a/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/Implications.expected
@@ -416,6 +416,24 @@
 | Guards.cs:332:16:332:16 | access to local variable e | match access to constant B | Guards.cs:330:13:330:13 | access to parameter b | true |
 | Guards.cs:332:16:332:16 | access to local variable e | match access to constant B | Guards.cs:332:16:332:16 | access to local variable e | 1 |
 | Guards.cs:332:16:332:16 | access to local variable e | non-match access to constant B | Guards.cs:330:13:330:13 | access to parameter b | false |
+| Guards.cs:341:20:341:32 | ... ? ... : ... | non-null | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:341:20:341:32 | ... ? ... : ... | non-null | Guards.cs:341:31:341:32 | "" | non-null |
+| Guards.cs:341:20:341:32 | ... ? ... : ... | null | Guards.cs:341:20:341:20 | access to parameter b | true |
+| Guards.cs:341:20:341:32 | ... ? ... : ... | null | Guards.cs:341:24:341:27 | null | null |
+| Guards.cs:342:13:342:13 | access to local variable s | empty | Guards.cs:341:20:341:32 | ... ? ... : ... | empty |
+| Guards.cs:342:13:342:13 | access to local variable s | non-empty | Guards.cs:341:20:341:32 | ... ? ... : ... | non-empty |
+| Guards.cs:342:13:342:13 | access to local variable s | non-null | Guards.cs:341:20:341:32 | ... ? ... : ... | non-null |
+| Guards.cs:342:13:342:13 | access to local variable s | null | Guards.cs:341:20:341:32 | ... ? ... : ... | null |
+| Guards.cs:342:13:342:21 | ... != ... | false | Guards.cs:341:20:341:20 | access to parameter b | true |
+| Guards.cs:342:13:342:21 | ... != ... | false | Guards.cs:342:13:342:13 | access to local variable s | null |
+| Guards.cs:342:13:342:21 | ... != ... | true | Guards.cs:341:20:341:20 | access to parameter b | false |
+| Guards.cs:342:13:342:21 | ... != ... | true | Guards.cs:342:13:342:13 | access to local variable s | non-null |
+| Guards.cs:342:13:342:27 | ... && ... | true | Guards.cs:342:13:342:21 | ... != ... | true |
+| Guards.cs:342:13:342:27 | ... && ... | true | Guards.cs:342:26:342:27 | !... | true |
+| Guards.cs:342:26:342:27 | !... | false | Guards.cs:342:27:342:27 | access to parameter b | true |
+| Guards.cs:342:26:342:27 | !... | true | Guards.cs:342:27:342:27 | access to parameter b | false |
+| Guards.cs:343:31:343:31 | access to local variable s | non-null | Guards.cs:341:20:341:32 | ... ? ... : ... | non-null |
+| Guards.cs:343:31:343:31 | access to local variable s | null | Guards.cs:341:20:341:32 | ... ? ... : ... | null |
 | Splitting.cs:12:17:12:25 | ... != ... | false | Splitting.cs:12:17:12:17 | access to parameter o | null |
 | Splitting.cs:12:17:12:25 | ... != ... | true | Splitting.cs:12:17:12:17 | access to parameter o | non-null |
 | Splitting.cs:22:17:22:25 | ... != ... | false | Splitting.cs:22:17:22:17 | access to parameter o | null |
@@ -438,7 +456,8 @@
 | Splitting.cs:105:22:105:30 | ... != ... | true | Splitting.cs:105:22:105:22 | access to parameter o | non-null |
 | Splitting.cs:116:22:116:30 | ... != ... | false | Splitting.cs:116:22:116:22 | access to parameter o | null |
 | Splitting.cs:116:22:116:30 | ... != ... | true | Splitting.cs:116:22:116:22 | access to parameter o | non-null |
-| Splitting.cs:128:17:128:25 | ... != ... | false | Splitting.cs:128:17:128:17 | access to local variable o | null |
-| Splitting.cs:128:17:128:25 | ... != ... | true | Splitting.cs:128:17:128:17 | access to local variable o | non-null |
-| Splitting.cs:133:17:133:17 | access to local variable o | non-null | Splitting.cs:132:21:132:29 | call to method M11 | non-null |
-| Splitting.cs:133:17:133:17 | access to local variable o | null | Splitting.cs:132:21:132:29 | call to method M11 | null |
+| Splitting.cs:129:17:129:25 | ... != ... | false | Splitting.cs:129:17:129:17 | access to local variable o | null |
+| Splitting.cs:129:17:129:25 | ... != ... | false | Splitting.cs:129:22:129:25 | null | non-null |
+| Splitting.cs:129:17:129:25 | ... != ... | true | Splitting.cs:129:17:129:17 | access to local variable o | non-null |
+| Splitting.cs:134:17:134:17 | access to local variable o | non-null | Splitting.cs:133:21:133:29 | call to method M11 | non-null |
+| Splitting.cs:134:17:134:17 | access to local variable o | null | Splitting.cs:133:21:133:29 | call to method M11 | null |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -2,8 +2,6 @@
 | Assert.cs:25:27:25:27 | access to local variable s |
 | Assert.cs:39:27:39:27 | access to local variable s |
 | Assert.cs:53:27:53:27 | access to local variable s |
-| Assert.cs:60:27:60:27 | access to local variable s |
-| Assert.cs:67:27:67:27 | access to local variable s |
 | Guards.cs:12:13:12:13 | access to parameter s |
 | Guards.cs:14:31:14:31 | access to parameter s |
 | Guards.cs:26:31:26:31 | access to parameter s |

--- a/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
+++ b/csharp/ql/test/library-tests/controlflow/guards/NullGuardedExpr.expected
@@ -2,6 +2,8 @@
 | Assert.cs:25:27:25:27 | access to local variable s |
 | Assert.cs:39:27:39:27 | access to local variable s |
 | Assert.cs:53:27:53:27 | access to local variable s |
+| Assert.cs:60:27:60:27 | access to local variable s |
+| Assert.cs:67:27:67:27 | access to local variable s |
 | Guards.cs:12:13:12:13 | access to parameter s |
 | Guards.cs:14:31:14:31 | access to parameter s |
 | Guards.cs:26:31:26:31 | access to parameter s |
@@ -43,6 +45,7 @@
 | Guards.cs:279:17:279:17 | access to parameter o |
 | Guards.cs:283:17:283:17 | access to parameter o |
 | Guards.cs:287:17:287:17 | access to parameter o |
+| Guards.cs:343:31:343:31 | access to local variable s |
 | Splitting.cs:13:17:13:17 | access to parameter o |
 | Splitting.cs:23:24:23:24 | access to parameter o |
 | Splitting.cs:35:13:35:13 | access to parameter o |

--- a/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
+++ b/csharp/ql/test/library-tests/controlflow/guards/Splitting.cs
@@ -125,6 +125,7 @@ public class Splitting
         object? o = null;
         do
         {
+            o.GetHashCode(); // not null guarded
             if (o != null)
             {
                 if (b)

--- a/csharp/ql/test/library-tests/dataflow/signanalysis/SignAnalysis.cs
+++ b/csharp/ql/test/library-tests/dataflow/signanalysis/SignAnalysis.cs
@@ -289,7 +289,7 @@ class SignAnalysis
     void Assert(int i, bool b)
     {
         Debug.Assert(i > 0);
-        System.Console.WriteLine(i); // strictly positive [MISSING]
+        System.Console.WriteLine(i); // strictly positive
 
         if (b)
             System.Console.WriteLine(i); // strictly positive

--- a/csharp/ql/test/library-tests/dataflow/signanalysis/SignAnalysis.expected
+++ b/csharp/ql/test/library-tests/dataflow/signanalysis/SignAnalysis.expected
@@ -156,6 +156,7 @@
 | SignAnalysis.cs:278:42:278:42 | access to parameter k | positive |
 | SignAnalysis.cs:280:21:280:21 | access to parameter k | positive |
 | SignAnalysis.cs:280:26:280:26 | 5 | strictlyPositive |
+| SignAnalysis.cs:292:34:292:34 | access to parameter i | strictlyPositive |
 | SignAnalysis.cs:295:38:295:38 | access to parameter i | strictlyPositive |
 | SignAnalysis.cs:300:27:300:28 | -... | strictlyNegative |
 | SignAnalysis.cs:300:28:300:28 | 1 | strictlyPositive |

--- a/csharp/ql/test/query-tests/API Abuse/FormatInvalid/FormatInvalid.expected
+++ b/csharp/ql/test/query-tests/API Abuse/FormatInvalid/FormatInvalid.expected
@@ -48,7 +48,7 @@ nodes
 | FormatInvalid.cs:108:23:108:25 | "}" | semmle.label | "}" |
 | FormatInvalid.cs:109:23:109:25 | "}" | semmle.label | "}" |
 | FormatInvalid.cs:110:23:110:25 | "}" | semmle.label | "}" |
-| FormatInvalid.cs:115:56:115:58 | "}" | semmle.label | "}" |
+| FormatInvalid.cs:115:56:115:58 | [assertion success] "}" | semmle.label | [assertion success] "}" |
 | FormatInvalid.cs:116:18:116:20 | "}" | semmle.label | "}" |
 | FormatInvalid.cs:117:40:117:42 | "}" | semmle.label | "}" |
 | FormatInvalidBad.cs:7:30:7:44 | "class {0} { }" | semmle.label | "class {0} { }" |
@@ -93,7 +93,7 @@ edges
 | FormatInvalid.cs:108:24:108:25 | "}" | FormatInvalid.cs:108:23:108:25 | "}" | FormatInvalid.cs:108:23:108:25 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:108:9:108:32 | call to method Write | this |
 | FormatInvalid.cs:109:24:109:25 | "}" | FormatInvalid.cs:109:23:109:25 | "}" | FormatInvalid.cs:109:23:109:25 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:109:9:109:35 | call to method Write | this |
 | FormatInvalid.cs:110:24:110:25 | "}" | FormatInvalid.cs:110:23:110:25 | "}" | FormatInvalid.cs:110:23:110:25 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:110:9:110:38 | call to method Write | this |
-| FormatInvalid.cs:115:57:115:58 | "}" | FormatInvalid.cs:115:56:115:58 | "}" | FormatInvalid.cs:115:56:115:58 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:115:9:115:63 | call to method Assert | this |
+| FormatInvalid.cs:115:57:115:58 | "}" | FormatInvalid.cs:115:56:115:58 | [assertion success] "}" | FormatInvalid.cs:115:56:115:58 | [assertion success] "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:115:9:115:63 | call to method Assert | this |
 | FormatInvalid.cs:116:19:116:20 | "}" | FormatInvalid.cs:116:18:116:20 | "}" | FormatInvalid.cs:116:18:116:20 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:116:9:116:24 | call to method Write | this |
 | FormatInvalid.cs:117:41:117:42 | "}" | FormatInvalid.cs:117:40:117:42 | "}" | FormatInvalid.cs:117:40:117:42 | "}" | Invalid format string used in $@ formatting call. | FormatInvalid.cs:117:9:117:47 | call to method Print | this |
 | FormatInvalidBad.cs:7:41:7:44 | "class {0} { }" | FormatInvalidBad.cs:7:30:7:44 | "class {0} { }" | FormatInvalidBad.cs:7:30:7:44 | "class {0} { }" | Invalid format string used in $@ formatting call. | FormatInvalidBad.cs:7:16:7:45 | call to method Format | this |

--- a/csharp/ql/test/query-tests/Nullness/Assert.cs
+++ b/csharp/ql/test/query-tests/Nullness/Assert.cs
@@ -39,7 +39,7 @@ class AssertTests
         Console.WriteLine(s.Length); // GOOD
 
         s = b ? null : "";
-        Assert.IsFalse(s == null || b);
+        Assert.IsFalse(s == null || !b);
         Console.WriteLine(s.Length); // GOOD
 
         s = b ? null : "";
@@ -47,7 +47,7 @@ class AssertTests
         Console.WriteLine(s.Length); // BAD (always)
 
         s = b ? null : "";
-        Assert.IsFalse(s != null || b);
+        Assert.IsFalse(s != null || !b);
         Console.WriteLine(s.Length); // BAD (always)
     }
 }

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -164,8 +164,10 @@
 | Assert.cs:42:24:42:32 | ... == ... | false | Assert.cs:42:24:42:24 | access to local variable s | non-null |
 | Assert.cs:42:24:42:32 | ... == ... | true | Assert.cs:41:13:41:13 | access to parameter b | true |
 | Assert.cs:42:24:42:32 | ... == ... | true | Assert.cs:42:24:42:24 | access to local variable s | null |
-| Assert.cs:42:24:42:37 | ... \|\| ... | false | Assert.cs:42:24:42:32 | ... == ... | false |
-| Assert.cs:42:24:42:37 | ... \|\| ... | false | Assert.cs:42:37:42:37 | access to parameter b | false |
+| Assert.cs:42:24:42:38 | ... \|\| ... | false | Assert.cs:42:24:42:32 | ... == ... | false |
+| Assert.cs:42:24:42:38 | ... \|\| ... | false | Assert.cs:42:37:42:38 | !... | false |
+| Assert.cs:42:37:42:38 | !... | false | Assert.cs:42:38:42:38 | access to parameter b | true |
+| Assert.cs:42:37:42:38 | !... | true | Assert.cs:42:38:42:38 | access to parameter b | false |
 | Assert.cs:43:27:43:27 | access to local variable s | non-null | Assert.cs:41:13:41:25 | ... ? ... : ... | non-null |
 | Assert.cs:43:27:43:27 | access to local variable s | null | Assert.cs:41:13:41:25 | ... ? ... : ... | null |
 | Assert.cs:45:13:45:25 | ... ? ... : ... | non-null | Assert.cs:45:13:45:13 | access to parameter b | false |
@@ -196,8 +198,10 @@
 | Assert.cs:50:24:50:32 | ... != ... | false | Assert.cs:50:24:50:24 | access to local variable s | null |
 | Assert.cs:50:24:50:32 | ... != ... | true | Assert.cs:49:13:49:13 | access to parameter b | false |
 | Assert.cs:50:24:50:32 | ... != ... | true | Assert.cs:50:24:50:24 | access to local variable s | non-null |
-| Assert.cs:50:24:50:37 | ... \|\| ... | false | Assert.cs:50:24:50:32 | ... != ... | false |
-| Assert.cs:50:24:50:37 | ... \|\| ... | false | Assert.cs:50:37:50:37 | access to parameter b | false |
+| Assert.cs:50:24:50:38 | ... \|\| ... | false | Assert.cs:50:24:50:32 | ... != ... | false |
+| Assert.cs:50:24:50:38 | ... \|\| ... | false | Assert.cs:50:37:50:38 | !... | false |
+| Assert.cs:50:37:50:38 | !... | false | Assert.cs:50:38:50:38 | access to parameter b | true |
+| Assert.cs:50:37:50:38 | !... | true | Assert.cs:50:38:50:38 | access to parameter b | false |
 | Assert.cs:51:27:51:27 | access to local variable s | non-null | Assert.cs:49:13:49:25 | ... ? ... : ... | non-null |
 | Assert.cs:51:27:51:27 | access to local variable s | null | Assert.cs:49:13:49:25 | ... ? ... : ... | null |
 | B.cs:12:13:12:24 | access to local variable eqCallAlways | non-null | B.cs:7:26:7:29 | null | non-null |

--- a/csharp/ql/test/query-tests/Nullness/Implications.expected
+++ b/csharp/ql/test/query-tests/Nullness/Implications.expected
@@ -66,7 +66,9 @@
 | Assert.cs:13:13:13:25 | ... ? ... : ... | null | Assert.cs:13:17:13:20 | null | null |
 | Assert.cs:14:23:14:23 | access to local variable s | empty | Assert.cs:13:13:13:25 | ... ? ... : ... | empty |
 | Assert.cs:14:23:14:23 | access to local variable s | non-empty | Assert.cs:13:13:13:25 | ... ? ... : ... | non-empty |
+| Assert.cs:14:23:14:23 | access to local variable s | non-null | Assert.cs:13:13:13:13 | access to parameter b | false |
 | Assert.cs:14:23:14:23 | access to local variable s | non-null | Assert.cs:13:13:13:25 | ... ? ... : ... | non-null |
+| Assert.cs:14:23:14:23 | access to local variable s | null | Assert.cs:13:13:13:13 | access to parameter b | true |
 | Assert.cs:14:23:14:23 | access to local variable s | null | Assert.cs:13:13:13:25 | ... ? ... : ... | null |
 | Assert.cs:15:27:15:27 | access to local variable s | non-null | Assert.cs:13:13:13:25 | ... ? ... : ... | non-null |
 | Assert.cs:15:27:15:27 | access to local variable s | null | Assert.cs:13:13:13:25 | ... ? ... : ... | null |
@@ -76,7 +78,9 @@
 | Assert.cs:17:13:17:25 | ... ? ... : ... | null | Assert.cs:17:17:17:20 | null | null |
 | Assert.cs:18:26:18:26 | access to local variable s | empty | Assert.cs:17:13:17:25 | ... ? ... : ... | empty |
 | Assert.cs:18:26:18:26 | access to local variable s | non-empty | Assert.cs:17:13:17:25 | ... ? ... : ... | non-empty |
+| Assert.cs:18:26:18:26 | access to local variable s | non-null | Assert.cs:17:13:17:13 | access to parameter b | false |
 | Assert.cs:18:26:18:26 | access to local variable s | non-null | Assert.cs:17:13:17:25 | ... ? ... : ... | non-null |
+| Assert.cs:18:26:18:26 | access to local variable s | null | Assert.cs:17:13:17:13 | access to parameter b | true |
 | Assert.cs:18:26:18:26 | access to local variable s | null | Assert.cs:17:13:17:25 | ... ? ... : ... | null |
 | Assert.cs:19:27:19:27 | access to local variable s | non-null | Assert.cs:17:13:17:25 | ... ? ... : ... | non-null |
 | Assert.cs:19:27:19:27 | access to local variable s | null | Assert.cs:17:13:17:25 | ... ? ... : ... | null |
@@ -324,7 +328,9 @@
 | C.cs:55:18:55:36 | ... ? ... : ... | null | C.cs:55:28:55:31 | null | null |
 | C.cs:56:23:56:24 | access to local variable o2 | empty | C.cs:55:18:55:36 | ... ? ... : ... | empty |
 | C.cs:56:23:56:24 | access to local variable o2 | non-empty | C.cs:55:18:55:36 | ... ? ... : ... | non-empty |
+| C.cs:56:23:56:24 | access to local variable o2 | non-null | C.cs:55:18:55:24 | call to method Maybe | false |
 | C.cs:56:23:56:24 | access to local variable o2 | non-null | C.cs:55:18:55:36 | ... ? ... : ... | non-null |
+| C.cs:56:23:56:24 | access to local variable o2 | null | C.cs:55:18:55:24 | call to method Maybe | true |
 | C.cs:56:23:56:24 | access to local variable o2 | null | C.cs:55:18:55:36 | ... ? ... : ... | null |
 | C.cs:57:9:57:10 | access to local variable o2 | non-null | C.cs:55:18:55:36 | ... ? ... : ... | non-null |
 | C.cs:57:9:57:10 | access to local variable o2 | null | C.cs:55:18:55:36 | ... ? ... : ... | null |
@@ -348,7 +354,9 @@
 | C.cs:70:18:70:46 | ... ? ... : ... | non-null | C.cs:70:35:70:46 | object creation of type Object | non-null |
 | C.cs:70:18:70:46 | ... ? ... : ... | null | C.cs:70:18:70:24 | call to method Maybe | true |
 | C.cs:70:18:70:46 | ... ? ... : ... | null | C.cs:70:28:70:31 | null | null |
+| C.cs:71:26:71:27 | access to local variable o3 | non-null | C.cs:70:18:70:24 | call to method Maybe | false |
 | C.cs:71:26:71:27 | access to local variable o3 | non-null | C.cs:70:18:70:46 | ... ? ... : ... | non-null |
+| C.cs:71:26:71:27 | access to local variable o3 | null | C.cs:70:18:70:24 | call to method Maybe | true |
 | C.cs:71:26:71:27 | access to local variable o3 | null | C.cs:70:18:70:46 | ... ? ... : ... | null |
 | C.cs:72:9:72:10 | access to local variable o3 | non-null | C.cs:70:18:70:46 | ... ? ... : ... | non-null |
 | C.cs:72:9:72:10 | access to local variable o3 | null | C.cs:70:18:70:46 | ... ? ... : ... | null |

--- a/csharp/ql/test/query-tests/Nullness/NullCheck.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullCheck.expected
@@ -1,5 +1,9 @@
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:22 | access to local variable s | false | true |
 | Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:22:10:22 | access to local variable s | true | false |
+| Assert.cs:14:23:14:23 | access to local variable s | Assert.cs:14:23:14:23 | access to local variable s | non-null | false |
+| Assert.cs:14:23:14:23 | access to local variable s | Assert.cs:14:23:14:23 | access to local variable s | null | true |
+| Assert.cs:18:26:18:26 | access to local variable s | Assert.cs:18:26:18:26 | access to local variable s | non-null | false |
+| Assert.cs:18:26:18:26 | access to local variable s | Assert.cs:18:26:18:26 | access to local variable s | null | true |
 | Assert.cs:22:23:22:31 | ... == ... | Assert.cs:22:23:22:23 | access to local variable s | false | false |
 | Assert.cs:22:23:22:31 | ... == ... | Assert.cs:22:23:22:23 | access to local variable s | true | true |
 | Assert.cs:26:23:26:31 | ... != ... | Assert.cs:26:23:26:23 | access to local variable s | false | true |
@@ -60,6 +64,10 @@
 | C.cs:41:22:41:30 | ... == ... | C.cs:41:22:41:22 | access to local variable s | true | true |
 | C.cs:45:22:45:30 | ... != ... | C.cs:45:22:45:22 | access to local variable s | false | true |
 | C.cs:45:22:45:30 | ... != ... | C.cs:45:22:45:22 | access to local variable s | true | false |
+| C.cs:56:23:56:24 | access to local variable o2 | C.cs:56:23:56:24 | access to local variable o2 | non-null | false |
+| C.cs:56:23:56:24 | access to local variable o2 | C.cs:56:23:56:24 | access to local variable o2 | null | true |
+| C.cs:71:26:71:27 | access to local variable o3 | C.cs:71:26:71:27 | access to local variable o3 | non-null | false |
+| C.cs:71:26:71:27 | access to local variable o3 | C.cs:71:26:71:27 | access to local variable o3 | null | true |
 | C.cs:78:13:78:24 | call to method IsNotNull | C.cs:78:23:78:23 | access to local variable o | false | true |
 | C.cs:78:13:78:24 | call to method IsNotNull | C.cs:78:23:78:23 | access to local variable o | true | false |
 | C.cs:82:14:82:22 | call to method IsNull | C.cs:82:21:82:21 | access to local variable o | false | false |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -30,14 +30,9 @@ nodes
 | Assert.cs:29:9:29:25 | [b (line 7): true] SSA def(s) |
 | Assert.cs:31:27:31:27 | access to local variable s |
 | Assert.cs:31:27:31:27 | access to local variable s |
-| Assert.cs:45:9:45:25 | [b (line 7): false] SSA def(s) |
 | Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) |
-| Assert.cs:46:36:46:36 | [b (line 7): false] access to parameter b |
-| Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b |
 | Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:49:9:49:25 | SSA def(s) |
-| Assert.cs:50:37:50:38 | !... |
+| Assert.cs:49:9:49:25 | [b (line 7): true] SSA def(s) |
 | Assert.cs:51:27:51:27 | access to local variable s |
 | B.cs:7:11:7:29 | SSA def(eqCallAlways) |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) |
@@ -423,12 +418,8 @@ edges
 | Assert.cs:21:9:21:25 | [b (line 7): true] SSA def(s) | Assert.cs:23:27:23:27 | access to local variable s |
 | Assert.cs:29:9:29:25 | [b (line 7): false] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
 | Assert.cs:29:9:29:25 | [b (line 7): true] SSA def(s) | Assert.cs:31:27:31:27 | access to local variable s |
-| Assert.cs:45:9:45:25 | [b (line 7): false] SSA def(s) | Assert.cs:46:36:46:36 | [b (line 7): false] access to parameter b |
-| Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) | Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b |
-| Assert.cs:46:36:46:36 | [b (line 7): false] access to parameter b | Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b | Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:49:9:49:25 | SSA def(s) | Assert.cs:50:37:50:38 | !... |
-| Assert.cs:50:37:50:38 | !... | Assert.cs:51:27:51:27 | access to local variable s |
+| Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) | Assert.cs:47:27:47:27 | access to local variable s |
+| Assert.cs:49:9:49:25 | [b (line 7): true] SSA def(s) | Assert.cs:51:27:51:27 | access to local variable s |
 | B.cs:7:11:7:29 | SSA def(eqCallAlways) | B.cs:13:13:13:24 | access to local variable eqCallAlways |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:13:13:13:36 | ...; |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:15:9:16:26 | if (...) ... |

--- a/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
+++ b/csharp/ql/test/query-tests/Nullness/NullMaybe.expected
@@ -37,7 +37,7 @@ nodes
 | Assert.cs:47:27:47:27 | access to local variable s |
 | Assert.cs:47:27:47:27 | access to local variable s |
 | Assert.cs:49:9:49:25 | SSA def(s) |
-| Assert.cs:50:37:50:37 | access to parameter b |
+| Assert.cs:50:37:50:38 | !... |
 | Assert.cs:51:27:51:27 | access to local variable s |
 | B.cs:7:11:7:29 | SSA def(eqCallAlways) |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) |
@@ -427,8 +427,8 @@ edges
 | Assert.cs:45:9:45:25 | [b (line 7): true] SSA def(s) | Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b |
 | Assert.cs:46:36:46:36 | [b (line 7): false] access to parameter b | Assert.cs:47:27:47:27 | access to local variable s |
 | Assert.cs:46:36:46:36 | [b (line 7): true] access to parameter b | Assert.cs:47:27:47:27 | access to local variable s |
-| Assert.cs:49:9:49:25 | SSA def(s) | Assert.cs:50:37:50:37 | access to parameter b |
-| Assert.cs:50:37:50:37 | access to parameter b | Assert.cs:51:27:51:27 | access to local variable s |
+| Assert.cs:49:9:49:25 | SSA def(s) | Assert.cs:50:37:50:38 | !... |
+| Assert.cs:50:37:50:38 | !... | Assert.cs:51:27:51:27 | access to local variable s |
 | B.cs:7:11:7:29 | SSA def(eqCallAlways) | B.cs:13:13:13:24 | access to local variable eqCallAlways |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:13:13:13:36 | ...; |
 | B.cs:10:11:10:30 | SSA def(neqCallAlways) | B.cs:15:9:16:26 | if (...) ... |


### PR DESCRIPTION
### Overview

This PR models assertions directly in the CFG, which means that an assertion
```csharp
Assert(e);
```
gets roughly the same CFG as
```csharp
if (!e)
    throw new AssertionException();
```

This allows for simplifications to the guards/nullness libraries, as assertions are now just normal guards.

### Implementation

For an assertion
```csharp
Assert(e);
...
```
we want a CFG that looks like
```
              e
            /  \
           /    \
        true    false	 
         /        \
        /          \
       |            |   
call to Assert    call to Assert
       |            |
      ...          exit
```
which means that we need two copies of the `call to Assert` node. This is implemented using our CFG splitting framework.

### Commits

Commit-by-commit review is encouraged.

The implementation of assertions in the CFG (f1d6f7cd0c128092b0314a491ce585a910e20aa4) revealed an (unrelated) problem in the analysis of guards in the context of CFG splitting. This is witnessed by [a new test](https://github.com/github/codeql/pull/4293/commits/17f0ac4b208991ddbf4f04a0fe52b135ee1df043#diff-30ab0a2814437def50566a6f430c2502R343) added in the first commit:
```csharp
void M28(bool b)
{
    string s = b ? null : "";
    if (s != null && !b)
        Console.WriteLine(s.Length); // null guarded [MISSING]
}
```
The old analysis would require _all_ SSA variables for `s` in `s != null` to match an SSA variable for `s` in `s.Length`. However, we actually only need to check those SSA variables that are read in _any_ of the copies of `s != null` that guard `s.Length` (that is, only the copy for `b=false`). This change is implemented in the last commit, 1a93090778b05bb8914ad7d1b8051b9a3070af42.

### CSharp-Differences

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/499

I want to highlight one fixed false positive: the access to `usingBinderOpt._syntax.Statement` in https://github.com/dotnet/roslyn/blob/d2244950fab50c039b3cdfc65da1243f39c326b1/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs#L159 is no longer flagged as a potential NPE. This is because the statement is guarded by both [`Debug.Assert(isUsingDeclaration || usingBinderOpt != null)`](https://github.com/dotnet/roslyn/blob/d2244950fab50c039b3cdfc65da1243f39c326b1/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs#L92) and [`!isUsingDeclaration`](https://github.com/dotnet/roslyn/blob/d2244950fab50c039b3cdfc65da1243f39c326b1/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs#L153), and now that `isUsingDeclaration || usingBinderOpt != null` is modelled as a conditional expression, we get CFG splitting on the Boolean value `isUsingDeclaration`.