### PR TITLE
C#: Avoid bad magic in `UselessUpcast.ql`

### DIFF
--- a/csharp/ql/src/Language Abuse/UselessUpcast.ql
+++ b/csharp/ql/src/Language Abuse/UselessUpcast.ql
@@ -38,7 +38,7 @@ predicate hasInstanceCallable(ValueOrRefType t, InstanceCallable c, string name)
 }
 
 /** Holds if extension method `m` is a method on `t` with name `name`. */
-pragma[noinline]
+pragma[nomagic]
 predicate hasExtensionMethod(ValueOrRefType t, ExtensionMethod m, string name) {
   t.isImplicitlyConvertibleTo(m.getExtendedType()) and
   name = m.getName()


### PR DESCRIPTION
Fallout from https://github.com/github/semmle-code/pull/37722. Detected by the nightly CSharp-Differences job.