### PR TITLE
C++: Add test demonstrating field conflation after merging #4230

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -101,3 +101,13 @@ void addressOfField() {
   int* px = &s_copy.m1;
   sink(*px); // $f-:ast $ir
 }
+
+void taint_a_ptr(int* pa) {
+  *pa = user_input();
+}
+
+void test_field_conflation_array_content() {
+  S s;
+  taint_a_ptr(&s.m1);
+  sink(s.m2); //$f+:ir
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
@@ -21,6 +21,7 @@
 | aliasing.cpp:79:11:79:20 | call to user_input | aliasing.cpp:80:12:80:13 | m1 | IR only |
 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | IR only |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | IR only |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:112:10:112:11 | m2 | IR only |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | AST only |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array | AST only |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:38:24:38:27 | data | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -64,6 +64,11 @@ edges
 | aliasing.cpp:98:3:98:21 | Store | aliasing.cpp:98:3:98:21 | Chi [m1] |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Store |
 | aliasing.cpp:100:14:100:14 | Store [m1] | aliasing.cpp:102:8:102:10 | * ... |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Store | aliasing.cpp:106:3:106:20 | Chi [array content] |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:3:106:20 | Store |
+| aliasing.cpp:111:15:111:19 | Chi [array content] | aliasing.cpp:112:10:112:11 | m2 |
+| aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] | aliasing.cpp:111:15:111:19 | Chi [array content] |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
@@ -280,6 +285,12 @@ nodes
 | aliasing.cpp:98:10:98:19 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:100:14:100:14 | Store [m1] | semmle.label | Store [m1] |
 | aliasing.cpp:102:8:102:10 | * ... | semmle.label | * ... |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:106:3:106:20 | Store | semmle.label | Store |
+| aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:111:15:111:19 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:112:10:112:11 | m2 | semmle.label | m2 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:9:8:9:11 | * ... | semmle.label | * ... |
@@ -449,6 +460,7 @@ nodes
 | aliasing.cpp:87:12:87:13 | m1 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | m1 flows from $@ | aliasing.cpp:86:10:86:19 | call to user_input | call to user_input |
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
 | aliasing.cpp:102:8:102:10 | * ... | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | * ... flows from $@ | aliasing.cpp:98:10:98:19 | call to user_input | call to user_input |
+| aliasing.cpp:112:10:112:11 | m2 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:112:10:112:11 | m2 | m2 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:10:8:10:15 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -158,6 +158,9 @@
 | aliasing.cpp:92:3:92:3 | w | AST only |
 | aliasing.cpp:92:7:92:8 | m1 | AST only |
 | aliasing.cpp:98:5:98:6 | m1 | AST only |
+| aliasing.cpp:106:3:106:5 | * ... | AST only |
+| aliasing.cpp:111:15:111:19 | & ... | AST only |
+| aliasing.cpp:111:16:111:16 | s | AST only |
 | arrays.cpp:6:3:6:8 | access to array | AST only |
 | arrays.cpp:6:3:6:23 | arr | IR only |
 | arrays.cpp:15:3:15:10 | * ... | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -187,6 +187,9 @@
 | aliasing.cpp:92:7:92:8 | m1 |
 | aliasing.cpp:98:3:98:3 | s |
 | aliasing.cpp:98:5:98:6 | m1 |
+| aliasing.cpp:106:3:106:5 | * ... |
+| aliasing.cpp:111:15:111:19 | & ... |
+| aliasing.cpp:111:16:111:16 | s |
 | arrays.cpp:6:3:6:8 | access to array |
 | arrays.cpp:15:3:15:10 | * ... |
 | arrays.cpp:36:3:36:3 | o |


### PR DESCRIPTION
#4230 added some support for dataflow through arrays, but unfortunately introduced a kind of field-conflation which wasn't present in our tests. This particular field-conflation arises because `*pa = user_input()` is seen as a store to an array, and the subsequent load of `s.m2` is then treated as a load from an array (i.e., roughly `*(&s + offset of m2)`).