### PR TITLE
C#: Avoid bad magic in `RuntimeChecksBypass.ql`

### DIFF
--- a/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
@@ -27,6 +27,7 @@ GuardedExpr checkedWrite(Field f, Variable v, IfStmt check) {
  * The result is an unsafe write to the field `f`, where
  * there is no check performed within the (calling) scope of the method.
  */
+pragma[nomagic]
 Expr uncheckedWrite(Callable callable, Field f) {
   result = f.getAnAssignedValue() and
   result.getEnclosingCallable() = callable and


### PR DESCRIPTION
(See also https://github.com/github/codeql/pull/4296.)

Before:

```
[2020-09-18 14:03:57] (2587s) Tuple counts for RuntimeChecksBypass::uncheckedWrite#bbf#antijoin_rhs#1:
                      1270       ~8%     {2} r1 = SCAN RuntimeChecksBypass::uncheckedWrite#bbf#shared AS I OUTPUT I.<1>, I.<0>
                      188197390  ~0%     {3} r2 = JOIN r1 WITH #Callable::Callable::calls_dispred#bfPlus AS R ON FIRST 1 OUTPUT R.<1>, r1.<1>, r1.<0>
                      2425784042 ~1%     {3} r3 = JOIN r2 WITH Expr::Expr::getEnclosingCallable_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r2.<1>, R.<1>, r2.<2>
                      58         ~9%     {2} r4 = JOIN r3 WITH project#RuntimeChecksBypass::checkedWrite#bfff AS R ON FIRST 2 OUTPUT r3.<0>, r3.<2>
                                         return r4
```

After:

```
[2020-09-18 14:08:48] (5s) Tuple counts for RuntimeChecksBypass::uncheckedWrite#fff#antijoin_rhs:
                      24704473 ~2%      {2} r1 = SCAN DataFlowPublic::localExprFlow#ff AS I OUTPUT I.<1>, I.<0>
                      23784154 ~6%      {4} r2 = JOIN r1 WITH Expr::Expr::getEnclosingCallable_dispred#ff AS R ON FIRST 1 OUTPUT r1.<1>, 28, R.<0>, R.<1>
                      201391   ~2%      {2} r3 = JOIN r2 WITH expressions AS R ON FIRST 2 OUTPUT r2.<2>, r2.<3>
                      23784154 ~0%      {3} r4 = JOIN r1 WITH Expr::Expr::getEnclosingCallable_dispred#ff AS R ON FIRST 1 OUTPUT r1.<1>, R.<0>, R.<1>
                      1065242  ~20%     {2} r5 = JOIN r4 WITH expr_value AS R ON FIRST 1 OUTPUT r4.<1>, r4.<2>
                      1266633  ~16%     {2} r6 = r3 \/ r5
                                        return r6
```