### PR TITLE
Java: Update some CWE claims

### DIFF
--- a/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
+++ b/java/ql/src/Likely Bugs/Collections/ArrayIndexOutOfBounds.ql
@@ -9,6 +9,7 @@
  * @tags reliability
  *       correctness
  *       exceptions
+ *       external/cwe/cwe-193
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTainted.ql
@@ -8,6 +8,7 @@
  * @id java/sql-injection
  * @tags security
  *       external/cwe/cwe-089
+ *       external/cwe/cwe-564
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlTaintedLocal.ql
@@ -8,6 +8,7 @@
  * @id java/sql-injection-local
  * @tags security
  *       external/cwe/cwe-089
+ *       external/cwe/cwe-564
  */
 
 import semmle.code.java.Expr

--- a/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
+++ b/java/ql/src/Security/CWE/CWE-089/SqlUnescaped.ql
@@ -8,6 +8,7 @@
  * @id java/concatenated-sql-query
  * @tags security
  *       external/cwe/cwe-089
+ *       external/cwe/cwe-564
  */
 
 import java

--- a/java/ql/src/Security/CWE/CWE-611/XXE.ql
+++ b/java/ql/src/Security/CWE/CWE-611/XXE.ql
@@ -8,6 +8,8 @@
  * @id java/xxe
  * @tags security
  *       external/cwe/cwe-611
+ *       external/cwe/cwe-776
+ *       external/cwe/cwe-827
  */
 
 import java


### PR DESCRIPTION
I noticed a couple of missing CWE tags on existing Java queries:
 - The SQL injection queries cover Hibernate sinks, so I've added a claim for [CWE 564: SQL Injection: Hibernate](https://cwe.mitre.org/data/definitions/564.html).
 - I've updated the XXE query to claim the same coverage as the [C# equivalent](https://github.com/github/codeql/blob/main/csharp/ql/src/Security%20Features/CWE-611/UntrustedDataInsecureXml.ql), specifically adding:
   - [CWE-776: Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')](https://cwe.mitre.org/data/definitions/776.html)
   - [CWE-827: Improper Control of Document Type Definition](https://cwe.mitre.org/data/definitions/827.html).
 - The ArrayIndexOutOfBounds query identifies potential off-by-one errors, so I've updated it to claim [CWE-193: Off-by-one Error](https://cwe.mitre.org/data/definitions/193.html)