### PR TITLE
C++: Fix field conflation after #4230

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -211,10 +211,17 @@ private predicate fieldStoreStepNoChi(Node node1, FieldContent f, PostUpdateNode
   )
 }
 
+private FieldAddressInstruction getFieldInstruction(Instruction instr) {
+  result = instr or
+  result = instr.(CopyValueInstruction).getUnary()
+}
+
 pragma[noinline]
-private predicate getWrittenField(StoreInstruction store, Field f, Class c) {
+private predicate getWrittenField(Instruction instr, Field f, Class c) {
   exists(FieldAddressInstruction fa |
-    fa = store.getDestinationAddress() and
+    fa =
+      getFieldInstruction([any(StoreInstruction store | instr = store).getDestinationAddress(),
+            any(WriteSideEffectInstruction write | instr = write).getDestinationAddress()]) and
     f = fa.getField() and
     c = f.getDeclaringType()
   )
@@ -265,7 +272,23 @@ private predicate arrayStoreStepChi(Node node1, ArrayContent a, PostUpdateNode n
 predicate storeStep(Node node1, Content f, PostUpdateNode node2) {
   fieldStoreStepNoChi(node1, f, node2) or
   fieldStoreStepChi(node1, f, node2) or
-  arrayStoreStepChi(node1, f, node2)
+  arrayStoreStepChi(node1, f, node2) or
+  fieldStoreStepAfterArraySuppression(node1, f, node2)
+}
+
+// This predicate pushes the correct `FieldContent` onto the access path when the
+// `suppressArrayRead` predicate has popped off an `ArrayContent`.
+private predicate fieldStoreStepAfterArraySuppression(
+  Node node1, FieldContent f, PostUpdateNode node2
+) {
+  exists(BufferMayWriteSideEffectInstruction write, ChiInstruction chi, Class c |
+    not chi.isResultConflated() and
+    node1.asInstruction() = chi and
+    node2.asInstruction() = chi and
+    chi.getPartial() = write and
+    getWrittenField(write, f.getAField(), c) and
+    f.hasOffset(c, _, _)
+  )
 }
 
 bindingset[result, i]
@@ -302,11 +325,53 @@ private predicate fieldReadStep(Node node1, FieldContent f, Node node2) {
   )
 }
 
+predicate suppressArrayRead(Node node1, ArrayContent a, Node node2) {
+  a = TArrayContent() and
+  exists(BufferMayWriteSideEffectInstruction write, ChiInstruction chi |
+    node1.asInstruction() = write and
+    node2.asInstruction() = chi and
+    chi.getPartial() = write and
+    getWrittenField(write, _, _)
+  )
+}
+
+private class ArrayToPointerConvertInstruction extends ConvertInstruction {
+  ArrayToPointerConvertInstruction() {
+    this.getUnary().getResultType() instanceof ArrayType and
+    this.getResultType() instanceof PointerType
+  }
+}
+
 private predicate arrayReadStep(Node node1, ArrayContent a, Node node2) {
   a = TArrayContent() and
-  exists(LoadInstruction load |
-    node1.asInstruction() = load.getSourceValueOperand().getAnyDef() and
-    load = node2.asInstruction()
+  (
+    // In cases such as:
+    // ```cpp
+    // void f(int* pa) {
+    //   *pa = source();
+    // }
+    // ...
+    // int x;
+    // f(&x);
+    // use(x);
+    // ```
+    // the load on `x` in `use(x)` will exactly overlap with its definition (in this case the definition
+    // is a `BufferMayWriteSideEffect`).
+    exists(LoadInstruction load |
+      node1.asInstruction() = load.getSourceValue() and
+      load = node2.asInstruction()
+    )
+    or
+    // Explicit dereferences such as `*p` or `p[i]` where `p` is a pointer or array.
+    exists(LoadInstruction load |
+      node1.asInstruction() = load.getSourceValueOperand().getAnyDef() and
+      load = node2.asInstruction() and
+      (
+        load.getSourceAddress() instanceof LoadInstruction or
+        load.getSourceAddress() instanceof ArrayToPointerConvertInstruction or
+        load.getSourceAddress() instanceof PointerAddInstruction
+      )
+    )
   )
 }
 
@@ -317,7 +382,19 @@ private predicate arrayReadStep(Node node1, ArrayContent a, Node node2) {
  */
 predicate readStep(Node node1, Content f, Node node2) {
   fieldReadStep(node1, f, node2) or
-  arrayReadStep(node1, f, node2)
+  arrayReadStep(node1, f, node2) or
+  // When a store step happens in a function that looks like an array write such as:
+  // ```cpp
+  // void f(int* pa) {
+  //   *pa = source();
+  // }
+  // ```
+  // it can be a write to an array, but it can also happen that `f` is called as `f(&a.x)`. If that is
+  // the case, the `ArrayContent` that was written by the call to `f` should be popped off the access
+  // path, and a `FieldContent` containing `x` should be pushed instead.
+  // So this case pops `ArrayContent` off the access path, and the `fieldStoreStepAfterArraySuppression`
+  // predicate in `storeStep` ensures that we push the right `FieldContent` onto the access path.
+  suppressArrayRead(node1, f, node2)
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -220,8 +220,8 @@ pragma[noinline]
 private predicate getWrittenField(Instruction instr, Field f, Class c) {
   exists(FieldAddressInstruction fa |
     fa =
-      getFieldInstruction([any(StoreInstruction store | instr = store).getDestinationAddress(),
-            any(WriteSideEffectInstruction write | instr = write).getDestinationAddress()]) and
+      getFieldInstruction([instr.(StoreInstruction).getDestinationAddress(),
+            instr.(WriteSideEffectInstruction).getDestinationAddress()]) and
     f = fa.getField() and
     c = f.getDeclaringType()
   )

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -394,6 +394,12 @@ private FieldAddressInstruction getFieldInstruction(Instruction instr) {
   result = instr.(CopyValueInstruction).getUnary()
 }
 
+/**
+ * The target of a `fieldStoreStepAfterArraySuppression` store step, which is used to convert
+ * an `ArrayContent` to a `FieldContent` when the `BufferMayWriteSideEffect` instruction stores
+ * into a field. See the QLDoc for `suppressArrayRead` for an example of where such a conversion
+ * is inserted.
+ */
 private class BufferMayWriteSideEffectFieldStoreQualifierNode extends PartialDefinitionNode {
   override ChiInstruction instr;
   BufferMayWriteSideEffectInstruction write;

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -389,6 +389,29 @@ private class ExplicitSingleFieldStoreQualifierNode extends PartialDefinitionNod
   }
 }
 
+private FieldAddressInstruction getFieldInstruction(Instruction instr) {
+  result = instr or
+  result = instr.(CopyValueInstruction).getUnary()
+}
+
+private class BufferMayWriteSideEffectFieldStoreQualifierNode extends PartialDefinitionNode {
+  override ChiInstruction instr;
+  BufferMayWriteSideEffectInstruction write;
+  FieldAddressInstruction field;
+
+  BufferMayWriteSideEffectFieldStoreQualifierNode() {
+    not instr.isResultConflated() and
+    instr.getPartial() = write and
+    field = getFieldInstruction(write.getDestinationAddress())
+  }
+
+  override Node getPreUpdateNode() { result.asOperand() = instr.getTotalOperand() }
+
+  override Expr getDefinedExpr() {
+    result = field.getObjectAddress().getUnconvertedResultExpression()
+  }
+}
+
 /**
  * The `PostUpdateNode` that is the target of a `arrayStoreStepChi` store step. The overriden
  * `ChiInstruction` corresponds to the instruction represented by `node2` in `arrayStoreStepChi`.

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
@@ -93,6 +93,7 @@
 | defaulttainttracking.cpp:88:18:88:23 | call to getenv | shared.h:5:23:5:31 | sinkparam |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:91:42:91:44 | arg |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:92:12:92:14 | arg |
+| defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:96:11:96:12 | p2 |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:97:27:97:32 | call to getenv |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | (const char *)... |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 |

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
@@ -16,6 +16,7 @@
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:91:31:91:33 | ret | AST only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:92:5:92:8 | * ... | AST only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:92:6:92:8 | ret | AST only |
+| defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:96:11:96:12 | p2 | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | (const char *)... | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | defaulttainttracking.cpp:98:10:98:11 | p2 | IR only |
 | defaulttainttracking.cpp:97:27:97:32 | call to getenv | shared.h:5:23:5:31 | sinkparam | IR only |

--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -109,5 +109,5 @@ void taint_a_ptr(int* pa) {
 void test_field_conflation_array_content() {
   S s;
   taint_a_ptr(&s.m1);
-  sink(s.m2); //$f+:ir
+  sink(s.m2);
 }

--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -111,3 +111,82 @@ void test_field_conflation_array_content() {
   taint_a_ptr(&s.m1);
   sink(s.m2);
 }
+
+struct S_with_pointer {
+  int m1, m2;
+  int* data;
+};
+
+void pointer_deref(int* xs) {
+  taint_a_ptr(xs);
+  sink(xs[0]); // $f-:ast $ir
+}
+
+void pointer_member_index(S_with_pointer s) {
+  taint_a_ptr(s.data);
+  // `s.data` is points to all-aliased-memory
+  sink(s.data[0]); // $f-:ast,ir
+}
+
+void member_array_different_field(S_with_pointer* s) {
+  taint_a_ptr(&s[0].m1);
+  sink(s[0].m2);
+}
+
+struct S_with_array {
+  int m1, m2;
+  int data[10];
+};
+
+void pointer_member_deref() {
+  S_with_array s;
+  taint_a_ptr(s.data);
+  sink(*s.data); // $ir,ast
+}
+
+void array_member_deref() {
+  S_with_array s;
+  taint_a_ptr(s.data);
+  sink(s.data[0]); // $ir,ast
+}
+
+struct S2 {
+  S s;
+  int m3;
+};
+
+void deep_member_field_dot() {
+  S2 s2;
+  taint_a_ptr(&s2.s.m1);
+  sink(s2.s.m1); // $ir,ast
+}
+
+void deep_member_field_dot_different_fields() {
+  S2 s2;
+  taint_a_ptr(&s2.s.m1);
+  sink(s2.s.m2);
+}
+
+void deep_member_field_dot_2() {
+  S2 s2;
+  taint_a_ptr(&s2.s.m1);
+  S2 s2_2 = s2;
+  sink(s2_2.s.m1); // $ir,ast
+}
+
+void deep_member_field_dot_different_fields_2() {
+  S2 s2;
+  taint_a_ptr(&s2.s.m1);
+  S2 s2_2 = s2;
+  sink(s2_2.s.m2);
+}
+
+void deep_member_field_arrow(S2 *ps2) {
+  taint_a_ptr(&ps2->s.m1);
+  sink(ps2->s.m1); // $ir,ast
+}
+
+void deep_member_field_arrow_different_fields(S2 *ps2) {
+  taint_a_ptr(&ps2->s.m1);
+  sink(ps2->s.m2);
+}

--- a/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/aliasing.cpp
@@ -122,6 +122,21 @@ void pointer_deref(int* xs) {
   sink(xs[0]); // $f-:ast $ir
 }
 
+void pointer_deref_sub(int* xs) {
+  taint_a_ptr(xs - 2);
+  sink(*(xs - 2)); // $f-:ast $ir
+}
+
+void pointer_many_addrof_and_deref(int* xs) {
+  taint_a_ptr(xs);
+  sink(*&*&*xs); // $f-:ast $ir
+}
+
+void pointer_unary_plus(int* xs) {
+  taint_a_ptr(+xs);
+  sink(*+xs); // $f-:ast $ir
+}
+
 void pointer_member_index(S_with_pointer s) {
   taint_a_ptr(s.data);
   // `s.data` is points to all-aliased-memory

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
@@ -21,7 +21,6 @@
 | aliasing.cpp:79:11:79:20 | call to user_input | aliasing.cpp:80:12:80:13 | m1 | IR only |
 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | IR only |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | IR only |
-| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:112:10:112:11 | m2 | IR only |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | AST only |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array | AST only |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:38:24:38:27 | data | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
@@ -21,6 +21,7 @@
 | aliasing.cpp:79:11:79:20 | call to user_input | aliasing.cpp:80:12:80:13 | m1 | IR only |
 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | IR only |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | IR only |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:122:8:122:12 | access to array | IR only |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | AST only |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array | AST only |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:38:24:38:27 | data | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow-diff.expected
@@ -22,6 +22,9 @@
 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | IR only |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | IR only |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:122:8:122:12 | access to array | IR only |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:127:8:127:16 | * ... | IR only |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:132:8:132:14 | * ... | IR only |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:137:8:137:11 | * ... | IR only |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | AST only |
 | arrays.cpp:15:14:15:23 | call to user_input | arrays.cpp:17:8:17:13 | access to array | AST only |
 | arrays.cpp:36:26:36:35 | call to user_input | arrays.cpp:38:24:38:27 | data | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -65,29 +65,38 @@ edges
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Store |
 | aliasing.cpp:100:14:100:14 | Store [m1] | aliasing.cpp:102:8:102:10 | * ... |
 | aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:187:15:187:22 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:200:15:200:24 | taint_a_ptr output argument [array content] |
 | aliasing.cpp:106:3:106:20 | Store | aliasing.cpp:106:3:106:20 | Chi [array content] |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:3:106:20 | Store |
 | aliasing.cpp:121:15:121:16 | Chi [array content] | aliasing.cpp:122:8:122:12 | access to array |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | aliasing.cpp:121:15:121:16 | Chi [array content] |
-| aliasing.cpp:143:15:143:20 | Chi [array content] | aliasing.cpp:144:8:144:14 | * ... |
-| aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] | aliasing.cpp:143:15:143:20 | Chi [array content] |
-| aliasing.cpp:149:15:149:20 | Chi [array content] | aliasing.cpp:150:8:150:16 | access to array |
-| aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] | aliasing.cpp:149:15:149:20 | Chi [array content] |
-| aliasing.cpp:160:15:160:22 | Chi | aliasing.cpp:160:15:160:22 | Chi [m1] |
-| aliasing.cpp:160:15:160:22 | Chi [m1] | aliasing.cpp:161:13:161:14 | m1 |
-| aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] | aliasing.cpp:160:15:160:22 | Chi |
-| aliasing.cpp:172:15:172:22 | Chi | aliasing.cpp:172:15:172:22 | Chi [m1] |
-| aliasing.cpp:172:15:172:22 | Chi [m1] | aliasing.cpp:173:13:173:14 | Store [m1] |
-| aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] | aliasing.cpp:172:15:172:22 | Chi |
-| aliasing.cpp:173:13:173:14 | Store [m1] | aliasing.cpp:174:15:174:16 | m1 |
-| aliasing.cpp:185:15:185:24 | Chi | aliasing.cpp:185:15:185:24 | Chi [m1] |
-| aliasing.cpp:185:15:185:24 | Chi [m1] | aliasing.cpp:186:15:186:16 | m1 |
-| aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] | aliasing.cpp:185:15:185:24 | Chi |
+| aliasing.cpp:126:15:126:20 | Chi [array content] | aliasing.cpp:127:8:127:16 | * ... |
+| aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] | aliasing.cpp:126:15:126:20 | Chi [array content] |
+| aliasing.cpp:131:15:131:16 | Chi [array content] | aliasing.cpp:132:8:132:14 | * ... |
+| aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] | aliasing.cpp:131:15:131:16 | Chi [array content] |
+| aliasing.cpp:136:15:136:17 | Chi [array content] | aliasing.cpp:137:8:137:11 | * ... |
+| aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] | aliasing.cpp:136:15:136:17 | Chi [array content] |
+| aliasing.cpp:158:15:158:20 | Chi [array content] | aliasing.cpp:159:8:159:14 | * ... |
+| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] | aliasing.cpp:158:15:158:20 | Chi [array content] |
+| aliasing.cpp:164:15:164:20 | Chi [array content] | aliasing.cpp:165:8:165:16 | access to array |
+| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] | aliasing.cpp:164:15:164:20 | Chi [array content] |
+| aliasing.cpp:175:15:175:22 | Chi | aliasing.cpp:175:15:175:22 | Chi [m1] |
+| aliasing.cpp:175:15:175:22 | Chi [m1] | aliasing.cpp:176:13:176:14 | m1 |
+| aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] | aliasing.cpp:175:15:175:22 | Chi |
+| aliasing.cpp:187:15:187:22 | Chi | aliasing.cpp:187:15:187:22 | Chi [m1] |
+| aliasing.cpp:187:15:187:22 | Chi [m1] | aliasing.cpp:188:13:188:14 | Store [m1] |
+| aliasing.cpp:187:15:187:22 | taint_a_ptr output argument [array content] | aliasing.cpp:187:15:187:22 | Chi |
+| aliasing.cpp:188:13:188:14 | Store [m1] | aliasing.cpp:189:15:189:16 | m1 |
+| aliasing.cpp:200:15:200:24 | Chi | aliasing.cpp:200:15:200:24 | Chi [m1] |
+| aliasing.cpp:200:15:200:24 | Chi [m1] | aliasing.cpp:201:15:201:16 | m1 |
+| aliasing.cpp:200:15:200:24 | taint_a_ptr output argument [array content] | aliasing.cpp:200:15:200:24 | Chi |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
@@ -314,25 +323,34 @@ nodes
 | aliasing.cpp:121:15:121:16 | Chi [array content] | semmle.label | Chi [array content] |
 | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | aliasing.cpp:122:8:122:12 | access to array | semmle.label | access to array |
-| aliasing.cpp:143:15:143:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:144:8:144:14 | * ... | semmle.label | * ... |
-| aliasing.cpp:149:15:149:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:150:8:150:16 | access to array | semmle.label | access to array |
-| aliasing.cpp:160:15:160:22 | Chi | semmle.label | Chi |
-| aliasing.cpp:160:15:160:22 | Chi [m1] | semmle.label | Chi [m1] |
-| aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:161:13:161:14 | m1 | semmle.label | m1 |
-| aliasing.cpp:172:15:172:22 | Chi | semmle.label | Chi |
-| aliasing.cpp:172:15:172:22 | Chi [m1] | semmle.label | Chi [m1] |
-| aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:173:13:173:14 | Store [m1] | semmle.label | Store [m1] |
-| aliasing.cpp:174:15:174:16 | m1 | semmle.label | m1 |
-| aliasing.cpp:185:15:185:24 | Chi | semmle.label | Chi |
-| aliasing.cpp:185:15:185:24 | Chi [m1] | semmle.label | Chi [m1] |
-| aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:186:15:186:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:126:15:126:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:126:15:126:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:127:8:127:16 | * ... | semmle.label | * ... |
+| aliasing.cpp:131:15:131:16 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:131:15:131:16 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:132:8:132:14 | * ... | semmle.label | * ... |
+| aliasing.cpp:136:15:136:17 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:136:15:136:17 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:137:8:137:11 | * ... | semmle.label | * ... |
+| aliasing.cpp:158:15:158:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:158:15:158:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:159:8:159:14 | * ... | semmle.label | * ... |
+| aliasing.cpp:164:15:164:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:164:15:164:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:165:8:165:16 | access to array | semmle.label | access to array |
+| aliasing.cpp:175:15:175:22 | Chi | semmle.label | Chi |
+| aliasing.cpp:175:15:175:22 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:175:15:175:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:176:13:176:14 | m1 | semmle.label | m1 |
+| aliasing.cpp:187:15:187:22 | Chi | semmle.label | Chi |
+| aliasing.cpp:187:15:187:22 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:187:15:187:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:188:13:188:14 | Store [m1] | semmle.label | Store [m1] |
+| aliasing.cpp:189:15:189:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:200:15:200:24 | Chi | semmle.label | Chi |
+| aliasing.cpp:200:15:200:24 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:200:15:200:24 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:201:15:201:16 | m1 | semmle.label | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:9:8:9:11 | * ... | semmle.label | * ... |
@@ -507,11 +525,14 @@ nodes
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
 | aliasing.cpp:102:8:102:10 | * ... | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | * ... flows from $@ | aliasing.cpp:98:10:98:19 | call to user_input | call to user_input |
 | aliasing.cpp:122:8:122:12 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:122:8:122:12 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:144:8:144:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:144:8:144:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:150:8:150:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:150:8:150:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:161:13:161:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:161:13:161:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:174:15:174:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:174:15:174:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:186:15:186:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:186:15:186:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:127:8:127:16 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:127:8:127:16 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:132:8:132:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:132:8:132:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:137:8:137:11 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:137:8:137:11 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:159:8:159:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:159:8:159:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:165:8:165:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:165:8:165:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:176:13:176:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:176:13:176:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:189:15:189:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:189:15:189:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:201:15:201:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:201:15:201:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:10:8:10:15 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -64,11 +64,6 @@ edges
 | aliasing.cpp:98:3:98:21 | Store | aliasing.cpp:98:3:98:21 | Chi [m1] |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Store |
 | aliasing.cpp:100:14:100:14 | Store [m1] | aliasing.cpp:102:8:102:10 | * ... |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] |
-| aliasing.cpp:106:3:106:20 | Store | aliasing.cpp:106:3:106:20 | Chi [array content] |
-| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:3:106:20 | Store |
-| aliasing.cpp:111:15:111:19 | Chi [array content] | aliasing.cpp:112:10:112:11 | m2 |
-| aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] | aliasing.cpp:111:15:111:19 | Chi [array content] |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
@@ -104,20 +99,24 @@ edges
 | by_reference.cpp:96:8:96:17 | call to user_input | by_reference.cpp:96:3:96:19 | Store |
 | by_reference.cpp:102:21:102:39 | Chi [a] | by_reference.cpp:110:27:110:27 | a |
 | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | by_reference.cpp:102:21:102:39 | Chi [a] |
-| by_reference.cpp:104:15:104:22 | Chi [array content] | by_reference.cpp:112:14:112:14 | a |
-| by_reference.cpp:104:15:104:22 | taint_a_ptr output argument [array content] | by_reference.cpp:104:15:104:22 | Chi [array content] |
+| by_reference.cpp:104:15:104:22 | Chi | by_reference.cpp:104:15:104:22 | Chi [a] |
+| by_reference.cpp:104:15:104:22 | Chi [a] | by_reference.cpp:112:14:112:14 | a |
+| by_reference.cpp:104:15:104:22 | taint_a_ptr output argument [array content] | by_reference.cpp:104:15:104:22 | Chi |
 | by_reference.cpp:106:21:106:41 | Chi [a] | by_reference.cpp:114:29:114:29 | a |
 | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | by_reference.cpp:106:21:106:41 | Chi [a] |
-| by_reference.cpp:108:15:108:24 | Chi [array content] | by_reference.cpp:116:16:116:16 | a |
-| by_reference.cpp:108:15:108:24 | taint_a_ptr output argument [array content] | by_reference.cpp:108:15:108:24 | Chi [array content] |
+| by_reference.cpp:108:15:108:24 | Chi | by_reference.cpp:108:15:108:24 | Chi [a] |
+| by_reference.cpp:108:15:108:24 | Chi [a] | by_reference.cpp:116:16:116:16 | a |
+| by_reference.cpp:108:15:108:24 | taint_a_ptr output argument [array content] | by_reference.cpp:108:15:108:24 | Chi |
 | by_reference.cpp:122:21:122:38 | Chi [a] | by_reference.cpp:130:27:130:27 | a |
 | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | by_reference.cpp:122:21:122:38 | Chi [a] |
-| by_reference.cpp:124:15:124:21 | Chi [array content] | by_reference.cpp:132:14:132:14 | a |
-| by_reference.cpp:124:15:124:21 | taint_a_ref output argument [array content] | by_reference.cpp:124:15:124:21 | Chi [array content] |
+| by_reference.cpp:124:15:124:21 | Chi | by_reference.cpp:124:15:124:21 | Chi [a] |
+| by_reference.cpp:124:15:124:21 | Chi [a] | by_reference.cpp:132:14:132:14 | a |
+| by_reference.cpp:124:15:124:21 | taint_a_ref output argument [array content] | by_reference.cpp:124:15:124:21 | Chi |
 | by_reference.cpp:126:21:126:40 | Chi [a] | by_reference.cpp:134:29:134:29 | a |
 | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | by_reference.cpp:126:21:126:40 | Chi [a] |
-| by_reference.cpp:128:15:128:23 | Chi [array content] | by_reference.cpp:136:16:136:16 | a |
-| by_reference.cpp:128:15:128:23 | taint_a_ref output argument [array content] | by_reference.cpp:128:15:128:23 | Chi [array content] |
+| by_reference.cpp:128:15:128:23 | Chi | by_reference.cpp:128:15:128:23 | Chi [a] |
+| by_reference.cpp:128:15:128:23 | Chi [a] | by_reference.cpp:136:16:136:16 | a |
+| by_reference.cpp:128:15:128:23 | taint_a_ref output argument [array content] | by_reference.cpp:128:15:128:23 | Chi |
 | complex.cpp:40:17:40:17 | *b [a_] | complex.cpp:51:16:51:16 | Argument -1 indirection [a_] |
 | complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:51:16:51:16 | Argument -1 indirection [b_] |
 | complex.cpp:40:17:40:17 | *b [b_] | complex.cpp:52:16:52:16 | Argument -1 indirection [b_] |
@@ -285,12 +284,6 @@ nodes
 | aliasing.cpp:98:10:98:19 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:100:14:100:14 | Store [m1] | semmle.label | Store [m1] |
 | aliasing.cpp:102:8:102:10 | * ... | semmle.label | * ... |
-| aliasing.cpp:106:3:106:20 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:106:3:106:20 | Store | semmle.label | Store |
-| aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:111:15:111:19 | Chi [array content] | semmle.label | Chi [array content] |
-| aliasing.cpp:111:15:111:19 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
-| aliasing.cpp:112:10:112:11 | m2 | semmle.label | m2 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:9:8:9:11 | * ... | semmle.label | * ... |
@@ -329,11 +322,13 @@ nodes
 | by_reference.cpp:96:8:96:17 | call to user_input | semmle.label | call to user_input |
 | by_reference.cpp:102:21:102:39 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:102:21:102:39 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:104:15:104:22 | Chi [array content] | semmle.label | Chi [array content] |
+| by_reference.cpp:104:15:104:22 | Chi | semmle.label | Chi |
+| by_reference.cpp:104:15:104:22 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:104:15:104:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | by_reference.cpp:106:21:106:41 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:106:21:106:41 | taint_inner_a_ptr output argument [a] | semmle.label | taint_inner_a_ptr output argument [a] |
-| by_reference.cpp:108:15:108:24 | Chi [array content] | semmle.label | Chi [array content] |
+| by_reference.cpp:108:15:108:24 | Chi | semmle.label | Chi |
+| by_reference.cpp:108:15:108:24 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:108:15:108:24 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
 | by_reference.cpp:110:27:110:27 | a | semmle.label | a |
 | by_reference.cpp:112:14:112:14 | a | semmle.label | a |
@@ -341,11 +336,13 @@ nodes
 | by_reference.cpp:116:16:116:16 | a | semmle.label | a |
 | by_reference.cpp:122:21:122:38 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:122:21:122:38 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:124:15:124:21 | Chi [array content] | semmle.label | Chi [array content] |
+| by_reference.cpp:124:15:124:21 | Chi | semmle.label | Chi |
+| by_reference.cpp:124:15:124:21 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:124:15:124:21 | taint_a_ref output argument [array content] | semmle.label | taint_a_ref output argument [array content] |
 | by_reference.cpp:126:21:126:40 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:126:21:126:40 | taint_inner_a_ref output argument [a] | semmle.label | taint_inner_a_ref output argument [a] |
-| by_reference.cpp:128:15:128:23 | Chi [array content] | semmle.label | Chi [array content] |
+| by_reference.cpp:128:15:128:23 | Chi | semmle.label | Chi |
+| by_reference.cpp:128:15:128:23 | Chi [a] | semmle.label | Chi [a] |
 | by_reference.cpp:128:15:128:23 | taint_a_ref output argument [array content] | semmle.label | taint_a_ref output argument [array content] |
 | by_reference.cpp:130:27:130:27 | a | semmle.label | a |
 | by_reference.cpp:132:14:132:14 | a | semmle.label | a |
@@ -460,7 +457,6 @@ nodes
 | aliasing.cpp:87:12:87:13 | m1 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | m1 flows from $@ | aliasing.cpp:86:10:86:19 | call to user_input | call to user_input |
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
 | aliasing.cpp:102:8:102:10 | * ... | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | * ... flows from $@ | aliasing.cpp:98:10:98:19 | call to user_input | call to user_input |
-| aliasing.cpp:112:10:112:11 | m2 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:112:10:112:11 | m2 | m2 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:10:8:10:15 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/ir-path-flow.expected
@@ -64,6 +64,30 @@ edges
 | aliasing.cpp:98:3:98:21 | Store | aliasing.cpp:98:3:98:21 | Chi [m1] |
 | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:98:3:98:21 | Store |
 | aliasing.cpp:100:14:100:14 | Store [m1] | aliasing.cpp:102:8:102:10 | * ... |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] |
+| aliasing.cpp:106:3:106:20 | Store | aliasing.cpp:106:3:106:20 | Chi [array content] |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:3:106:20 | Store |
+| aliasing.cpp:121:15:121:16 | Chi [array content] | aliasing.cpp:122:8:122:12 | access to array |
+| aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | aliasing.cpp:121:15:121:16 | Chi [array content] |
+| aliasing.cpp:143:15:143:20 | Chi [array content] | aliasing.cpp:144:8:144:14 | * ... |
+| aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] | aliasing.cpp:143:15:143:20 | Chi [array content] |
+| aliasing.cpp:149:15:149:20 | Chi [array content] | aliasing.cpp:150:8:150:16 | access to array |
+| aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] | aliasing.cpp:149:15:149:20 | Chi [array content] |
+| aliasing.cpp:160:15:160:22 | Chi | aliasing.cpp:160:15:160:22 | Chi [m1] |
+| aliasing.cpp:160:15:160:22 | Chi [m1] | aliasing.cpp:161:13:161:14 | m1 |
+| aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] | aliasing.cpp:160:15:160:22 | Chi |
+| aliasing.cpp:172:15:172:22 | Chi | aliasing.cpp:172:15:172:22 | Chi [m1] |
+| aliasing.cpp:172:15:172:22 | Chi [m1] | aliasing.cpp:173:13:173:14 | Store [m1] |
+| aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] | aliasing.cpp:172:15:172:22 | Chi |
+| aliasing.cpp:173:13:173:14 | Store [m1] | aliasing.cpp:174:15:174:16 | m1 |
+| aliasing.cpp:185:15:185:24 | Chi | aliasing.cpp:185:15:185:24 | Chi [m1] |
+| aliasing.cpp:185:15:185:24 | Chi [m1] | aliasing.cpp:186:15:186:16 | m1 |
+| aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] | aliasing.cpp:185:15:185:24 | Chi |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... |
@@ -284,6 +308,31 @@ nodes
 | aliasing.cpp:98:10:98:19 | call to user_input | semmle.label | call to user_input |
 | aliasing.cpp:100:14:100:14 | Store [m1] | semmle.label | Store [m1] |
 | aliasing.cpp:102:8:102:10 | * ... | semmle.label | * ... |
+| aliasing.cpp:106:3:106:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:106:3:106:20 | Store | semmle.label | Store |
+| aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:121:15:121:16 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:121:15:121:16 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:122:8:122:12 | access to array | semmle.label | access to array |
+| aliasing.cpp:143:15:143:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:143:15:143:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:144:8:144:14 | * ... | semmle.label | * ... |
+| aliasing.cpp:149:15:149:20 | Chi [array content] | semmle.label | Chi [array content] |
+| aliasing.cpp:149:15:149:20 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:150:8:150:16 | access to array | semmle.label | access to array |
+| aliasing.cpp:160:15:160:22 | Chi | semmle.label | Chi |
+| aliasing.cpp:160:15:160:22 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:160:15:160:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:161:13:161:14 | m1 | semmle.label | m1 |
+| aliasing.cpp:172:15:172:22 | Chi | semmle.label | Chi |
+| aliasing.cpp:172:15:172:22 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:172:15:172:22 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:173:13:173:14 | Store [m1] | semmle.label | Store [m1] |
+| aliasing.cpp:174:15:174:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:185:15:185:24 | Chi | semmle.label | Chi |
+| aliasing.cpp:185:15:185:24 | Chi [m1] | semmle.label | Chi [m1] |
+| aliasing.cpp:185:15:185:24 | taint_a_ptr output argument [array content] | semmle.label | taint_a_ptr output argument [array content] |
+| aliasing.cpp:186:15:186:16 | m1 | semmle.label | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:9:8:9:11 | * ... | semmle.label | * ... |
@@ -457,6 +506,12 @@ nodes
 | aliasing.cpp:87:12:87:13 | m1 | aliasing.cpp:86:10:86:19 | call to user_input | aliasing.cpp:87:12:87:13 | m1 | m1 flows from $@ | aliasing.cpp:86:10:86:19 | call to user_input | call to user_input |
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
 | aliasing.cpp:102:8:102:10 | * ... | aliasing.cpp:98:10:98:19 | call to user_input | aliasing.cpp:102:8:102:10 | * ... | * ... flows from $@ | aliasing.cpp:98:10:98:19 | call to user_input | call to user_input |
+| aliasing.cpp:122:8:122:12 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:122:8:122:12 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:144:8:144:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:144:8:144:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:150:8:150:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:150:8:150:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:161:13:161:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:161:13:161:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:174:15:174:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:174:15:174:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:186:15:186:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:186:15:186:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:10:8:10:15 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:10:8:10:15 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -160,6 +160,26 @@
 | aliasing.cpp:98:5:98:6 | m1 | AST only |
 | aliasing.cpp:106:3:106:5 | * ... | AST only |
 | aliasing.cpp:111:15:111:19 | & ... | AST only |
+| aliasing.cpp:121:15:121:16 | xs | AST only |
+| aliasing.cpp:126:15:126:15 | s | AST only |
+| aliasing.cpp:126:17:126:20 | data | AST only |
+| aliasing.cpp:132:15:132:22 | & ... | AST only |
+| aliasing.cpp:143:15:143:15 | s | AST only |
+| aliasing.cpp:143:17:143:20 | data | AST only |
+| aliasing.cpp:149:15:149:15 | s | AST only |
+| aliasing.cpp:149:17:149:20 | data | AST only |
+| aliasing.cpp:160:15:160:22 | & ... | AST only |
+| aliasing.cpp:160:16:160:17 | s2 | AST only |
+| aliasing.cpp:166:15:166:22 | & ... | AST only |
+| aliasing.cpp:166:16:166:17 | s2 | AST only |
+| aliasing.cpp:172:15:172:22 | & ... | AST only |
+| aliasing.cpp:172:16:172:17 | s2 | AST only |
+| aliasing.cpp:179:15:179:22 | & ... | AST only |
+| aliasing.cpp:179:16:179:17 | s2 | AST only |
+| aliasing.cpp:185:15:185:24 | & ... | AST only |
+| aliasing.cpp:185:16:185:18 | ps2 | AST only |
+| aliasing.cpp:190:15:190:24 | & ... | AST only |
+| aliasing.cpp:190:16:190:18 | ps2 | AST only |
 | arrays.cpp:6:3:6:8 | access to array | AST only |
 | arrays.cpp:6:3:6:23 | arr | IR only |
 | arrays.cpp:15:3:15:10 | * ... | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -161,25 +161,28 @@
 | aliasing.cpp:106:3:106:5 | * ... | AST only |
 | aliasing.cpp:111:15:111:19 | & ... | AST only |
 | aliasing.cpp:121:15:121:16 | xs | AST only |
-| aliasing.cpp:126:15:126:15 | s | AST only |
-| aliasing.cpp:126:17:126:20 | data | AST only |
-| aliasing.cpp:132:15:132:22 | & ... | AST only |
-| aliasing.cpp:143:15:143:15 | s | AST only |
-| aliasing.cpp:143:17:143:20 | data | AST only |
-| aliasing.cpp:149:15:149:15 | s | AST only |
-| aliasing.cpp:149:17:149:20 | data | AST only |
-| aliasing.cpp:160:15:160:22 | & ... | AST only |
-| aliasing.cpp:160:16:160:17 | s2 | AST only |
-| aliasing.cpp:166:15:166:22 | & ... | AST only |
-| aliasing.cpp:166:16:166:17 | s2 | AST only |
-| aliasing.cpp:172:15:172:22 | & ... | AST only |
-| aliasing.cpp:172:16:172:17 | s2 | AST only |
-| aliasing.cpp:179:15:179:22 | & ... | AST only |
-| aliasing.cpp:179:16:179:17 | s2 | AST only |
-| aliasing.cpp:185:15:185:24 | & ... | AST only |
-| aliasing.cpp:185:16:185:18 | ps2 | AST only |
-| aliasing.cpp:190:15:190:24 | & ... | AST only |
-| aliasing.cpp:190:16:190:18 | ps2 | AST only |
+| aliasing.cpp:126:15:126:20 | ... - ... | AST only |
+| aliasing.cpp:131:15:131:16 | xs | AST only |
+| aliasing.cpp:136:15:136:17 | + ... | AST only |
+| aliasing.cpp:141:15:141:15 | s | AST only |
+| aliasing.cpp:141:17:141:20 | data | AST only |
+| aliasing.cpp:147:15:147:22 | & ... | AST only |
+| aliasing.cpp:158:15:158:15 | s | AST only |
+| aliasing.cpp:158:17:158:20 | data | AST only |
+| aliasing.cpp:164:15:164:15 | s | AST only |
+| aliasing.cpp:164:17:164:20 | data | AST only |
+| aliasing.cpp:175:15:175:22 | & ... | AST only |
+| aliasing.cpp:175:16:175:17 | s2 | AST only |
+| aliasing.cpp:181:15:181:22 | & ... | AST only |
+| aliasing.cpp:181:16:181:17 | s2 | AST only |
+| aliasing.cpp:187:15:187:22 | & ... | AST only |
+| aliasing.cpp:187:16:187:17 | s2 | AST only |
+| aliasing.cpp:194:15:194:22 | & ... | AST only |
+| aliasing.cpp:194:16:194:17 | s2 | AST only |
+| aliasing.cpp:200:15:200:24 | & ... | AST only |
+| aliasing.cpp:200:16:200:18 | ps2 | AST only |
+| aliasing.cpp:205:15:205:24 | & ... | AST only |
+| aliasing.cpp:205:16:205:18 | ps2 | AST only |
 | arrays.cpp:6:3:6:8 | access to array | AST only |
 | arrays.cpp:6:3:6:23 | arr | IR only |
 | arrays.cpp:15:3:15:10 | * ... | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -160,7 +160,6 @@
 | aliasing.cpp:98:5:98:6 | m1 | AST only |
 | aliasing.cpp:106:3:106:5 | * ... | AST only |
 | aliasing.cpp:111:15:111:19 | & ... | AST only |
-| aliasing.cpp:111:16:111:16 | s | AST only |
 | arrays.cpp:6:3:6:8 | access to array | AST only |
 | arrays.cpp:6:3:6:23 | arr | IR only |
 | arrays.cpp:15:3:15:10 | * ... | AST only |
@@ -222,17 +221,13 @@
 | by_reference.cpp:92:3:92:5 | * ... | AST only |
 | by_reference.cpp:96:3:96:4 | pa | AST only |
 | by_reference.cpp:102:21:102:39 | & ... | AST only |
-| by_reference.cpp:102:22:102:26 | outer | AST only |
 | by_reference.cpp:103:21:103:25 | outer | AST only |
 | by_reference.cpp:103:27:103:35 | inner_ptr | AST only |
 | by_reference.cpp:104:15:104:22 | & ... | AST only |
-| by_reference.cpp:104:16:104:20 | outer | AST only |
 | by_reference.cpp:106:21:106:41 | & ... | AST only |
-| by_reference.cpp:106:22:106:27 | pouter | AST only |
 | by_reference.cpp:107:21:107:26 | pouter | AST only |
 | by_reference.cpp:107:29:107:37 | inner_ptr | AST only |
 | by_reference.cpp:108:15:108:24 | & ... | AST only |
-| by_reference.cpp:108:16:108:21 | pouter | AST only |
 | by_reference.cpp:110:8:110:12 | outer | AST only |
 | by_reference.cpp:110:14:110:25 | inner_nested | AST only |
 | by_reference.cpp:110:27:110:27 | a | AST only |
@@ -249,17 +244,13 @@
 | by_reference.cpp:115:27:115:27 | a | AST only |
 | by_reference.cpp:116:8:116:13 | pouter | AST only |
 | by_reference.cpp:116:16:116:16 | a | AST only |
-| by_reference.cpp:122:21:122:25 | outer | AST only |
 | by_reference.cpp:122:27:122:38 | inner_nested | AST only |
 | by_reference.cpp:123:21:123:36 | * ... | AST only |
 | by_reference.cpp:123:22:123:26 | outer | AST only |
-| by_reference.cpp:124:15:124:19 | outer | AST only |
 | by_reference.cpp:124:21:124:21 | a | AST only |
-| by_reference.cpp:126:21:126:26 | pouter | AST only |
 | by_reference.cpp:126:29:126:40 | inner_nested | AST only |
 | by_reference.cpp:127:21:127:38 | * ... | AST only |
 | by_reference.cpp:127:22:127:27 | pouter | AST only |
-| by_reference.cpp:128:15:128:20 | pouter | AST only |
 | by_reference.cpp:128:23:128:23 | a | AST only |
 | by_reference.cpp:130:8:130:12 | outer | AST only |
 | by_reference.cpp:130:14:130:25 | inner_nested | AST only |
@@ -413,6 +404,5 @@
 | struct_init.c:34:14:34:22 | pointerAB | AST only |
 | struct_init.c:34:25:34:25 | b | AST only |
 | struct_init.c:36:10:36:24 | & ... | AST only |
-| struct_init.c:36:11:36:15 | outer | AST only |
 | struct_init.c:46:10:46:14 | outer | AST only |
 | struct_init.c:46:16:46:24 | pointerAB | AST only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -28,6 +28,13 @@
 | aliasing.cpp:92:5:92:5 | s |
 | aliasing.cpp:98:3:98:3 | s |
 | aliasing.cpp:111:16:111:16 | s |
+| aliasing.cpp:132:16:132:19 | access to array |
+| aliasing.cpp:160:19:160:19 | s |
+| aliasing.cpp:166:19:166:19 | s |
+| aliasing.cpp:172:19:172:19 | s |
+| aliasing.cpp:179:19:179:19 | s |
+| aliasing.cpp:185:21:185:21 | s |
+| aliasing.cpp:190:21:190:21 | s |
 | arrays.cpp:6:3:6:5 | arr |
 | arrays.cpp:36:3:36:17 | access to array |
 | by_reference.cpp:12:5:12:5 | s |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -28,13 +28,13 @@
 | aliasing.cpp:92:5:92:5 | s |
 | aliasing.cpp:98:3:98:3 | s |
 | aliasing.cpp:111:16:111:16 | s |
-| aliasing.cpp:132:16:132:19 | access to array |
-| aliasing.cpp:160:19:160:19 | s |
-| aliasing.cpp:166:19:166:19 | s |
-| aliasing.cpp:172:19:172:19 | s |
-| aliasing.cpp:179:19:179:19 | s |
-| aliasing.cpp:185:21:185:21 | s |
-| aliasing.cpp:190:21:190:21 | s |
+| aliasing.cpp:147:16:147:19 | access to array |
+| aliasing.cpp:175:19:175:19 | s |
+| aliasing.cpp:181:19:181:19 | s |
+| aliasing.cpp:187:19:187:19 | s |
+| aliasing.cpp:194:19:194:19 | s |
+| aliasing.cpp:200:21:200:21 | s |
+| aliasing.cpp:205:21:205:21 | s |
 | arrays.cpp:6:3:6:5 | arr |
 | arrays.cpp:36:3:36:17 | access to array |
 | by_reference.cpp:12:5:12:5 | s |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -27,12 +27,21 @@
 | aliasing.cpp:86:3:86:3 | s |
 | aliasing.cpp:92:5:92:5 | s |
 | aliasing.cpp:98:3:98:3 | s |
+| aliasing.cpp:111:16:111:16 | s |
 | arrays.cpp:6:3:6:5 | arr |
 | arrays.cpp:36:3:36:17 | access to array |
 | by_reference.cpp:12:5:12:5 | s |
 | by_reference.cpp:16:5:16:8 | this |
 | by_reference.cpp:84:3:84:7 | inner |
 | by_reference.cpp:88:3:88:7 | inner |
+| by_reference.cpp:102:22:102:26 | outer |
+| by_reference.cpp:104:16:104:20 | outer |
+| by_reference.cpp:106:22:106:27 | pouter |
+| by_reference.cpp:108:16:108:21 | pouter |
+| by_reference.cpp:122:21:122:25 | outer |
+| by_reference.cpp:124:15:124:19 | outer |
+| by_reference.cpp:126:21:126:26 | pouter |
+| by_reference.cpp:128:15:128:20 | pouter |
 | complex.cpp:11:22:11:23 | this |
 | complex.cpp:12:22:12:23 | this |
 | constructors.cpp:20:24:20:25 | this |
@@ -46,3 +55,4 @@
 | simple.cpp:65:5:65:5 | a |
 | simple.cpp:83:9:83:10 | f2 |
 | simple.cpp:92:5:92:5 | a |
+| struct_init.c:36:11:36:15 | outer |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -190,6 +190,33 @@
 | aliasing.cpp:106:3:106:5 | * ... |
 | aliasing.cpp:111:15:111:19 | & ... |
 | aliasing.cpp:111:16:111:16 | s |
+| aliasing.cpp:121:15:121:16 | xs |
+| aliasing.cpp:126:15:126:15 | s |
+| aliasing.cpp:126:17:126:20 | data |
+| aliasing.cpp:132:15:132:22 | & ... |
+| aliasing.cpp:132:16:132:19 | access to array |
+| aliasing.cpp:143:15:143:15 | s |
+| aliasing.cpp:143:17:143:20 | data |
+| aliasing.cpp:149:15:149:15 | s |
+| aliasing.cpp:149:17:149:20 | data |
+| aliasing.cpp:160:15:160:22 | & ... |
+| aliasing.cpp:160:16:160:17 | s2 |
+| aliasing.cpp:160:19:160:19 | s |
+| aliasing.cpp:166:15:166:22 | & ... |
+| aliasing.cpp:166:16:166:17 | s2 |
+| aliasing.cpp:166:19:166:19 | s |
+| aliasing.cpp:172:15:172:22 | & ... |
+| aliasing.cpp:172:16:172:17 | s2 |
+| aliasing.cpp:172:19:172:19 | s |
+| aliasing.cpp:179:15:179:22 | & ... |
+| aliasing.cpp:179:16:179:17 | s2 |
+| aliasing.cpp:179:19:179:19 | s |
+| aliasing.cpp:185:15:185:24 | & ... |
+| aliasing.cpp:185:16:185:18 | ps2 |
+| aliasing.cpp:185:21:185:21 | s |
+| aliasing.cpp:190:15:190:24 | & ... |
+| aliasing.cpp:190:16:190:18 | ps2 |
+| aliasing.cpp:190:21:190:21 | s |
 | arrays.cpp:6:3:6:8 | access to array |
 | arrays.cpp:15:3:15:10 | * ... |
 | arrays.cpp:36:3:36:3 | o |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -191,32 +191,35 @@
 | aliasing.cpp:111:15:111:19 | & ... |
 | aliasing.cpp:111:16:111:16 | s |
 | aliasing.cpp:121:15:121:16 | xs |
-| aliasing.cpp:126:15:126:15 | s |
-| aliasing.cpp:126:17:126:20 | data |
-| aliasing.cpp:132:15:132:22 | & ... |
-| aliasing.cpp:132:16:132:19 | access to array |
-| aliasing.cpp:143:15:143:15 | s |
-| aliasing.cpp:143:17:143:20 | data |
-| aliasing.cpp:149:15:149:15 | s |
-| aliasing.cpp:149:17:149:20 | data |
-| aliasing.cpp:160:15:160:22 | & ... |
-| aliasing.cpp:160:16:160:17 | s2 |
-| aliasing.cpp:160:19:160:19 | s |
-| aliasing.cpp:166:15:166:22 | & ... |
-| aliasing.cpp:166:16:166:17 | s2 |
-| aliasing.cpp:166:19:166:19 | s |
-| aliasing.cpp:172:15:172:22 | & ... |
-| aliasing.cpp:172:16:172:17 | s2 |
-| aliasing.cpp:172:19:172:19 | s |
-| aliasing.cpp:179:15:179:22 | & ... |
-| aliasing.cpp:179:16:179:17 | s2 |
-| aliasing.cpp:179:19:179:19 | s |
-| aliasing.cpp:185:15:185:24 | & ... |
-| aliasing.cpp:185:16:185:18 | ps2 |
-| aliasing.cpp:185:21:185:21 | s |
-| aliasing.cpp:190:15:190:24 | & ... |
-| aliasing.cpp:190:16:190:18 | ps2 |
-| aliasing.cpp:190:21:190:21 | s |
+| aliasing.cpp:126:15:126:20 | ... - ... |
+| aliasing.cpp:131:15:131:16 | xs |
+| aliasing.cpp:136:15:136:17 | + ... |
+| aliasing.cpp:141:15:141:15 | s |
+| aliasing.cpp:141:17:141:20 | data |
+| aliasing.cpp:147:15:147:22 | & ... |
+| aliasing.cpp:147:16:147:19 | access to array |
+| aliasing.cpp:158:15:158:15 | s |
+| aliasing.cpp:158:17:158:20 | data |
+| aliasing.cpp:164:15:164:15 | s |
+| aliasing.cpp:164:17:164:20 | data |
+| aliasing.cpp:175:15:175:22 | & ... |
+| aliasing.cpp:175:16:175:17 | s2 |
+| aliasing.cpp:175:19:175:19 | s |
+| aliasing.cpp:181:15:181:22 | & ... |
+| aliasing.cpp:181:16:181:17 | s2 |
+| aliasing.cpp:181:19:181:19 | s |
+| aliasing.cpp:187:15:187:22 | & ... |
+| aliasing.cpp:187:16:187:17 | s2 |
+| aliasing.cpp:187:19:187:19 | s |
+| aliasing.cpp:194:15:194:22 | & ... |
+| aliasing.cpp:194:16:194:17 | s2 |
+| aliasing.cpp:194:19:194:19 | s |
+| aliasing.cpp:200:15:200:24 | & ... |
+| aliasing.cpp:200:16:200:18 | ps2 |
+| aliasing.cpp:200:21:200:21 | s |
+| aliasing.cpp:205:15:205:24 | & ... |
+| aliasing.cpp:205:16:205:18 | ps2 |
+| aliasing.cpp:205:21:205:21 | s |
 | arrays.cpp:6:3:6:8 | access to array |
 | arrays.cpp:15:3:15:10 | * ... |
 | arrays.cpp:36:3:36:3 | o |

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -155,6 +155,38 @@ edges
 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:92:3:92:23 | ... = ... |
 | aliasing.cpp:93:8:93:8 | w [s, m1] | aliasing.cpp:93:10:93:10 | s [m1] |
 | aliasing.cpp:93:10:93:10 | s [m1] | aliasing.cpp:93:12:93:13 | m1 |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:143:17:143:20 | ref arg data |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:149:17:149:20 | ref arg data |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:160:15:160:22 | ref arg & ... |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:172:15:172:22 | ref arg & ... |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:185:15:185:24 | ref arg & ... |
+| aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:4:106:5 | pa [inner post update] |
+| aliasing.cpp:143:15:143:15 | s [post update] [data] | aliasing.cpp:144:9:144:9 | s [data] |
+| aliasing.cpp:143:17:143:20 | ref arg data | aliasing.cpp:143:15:143:15 | s [post update] [data] |
+| aliasing.cpp:144:9:144:9 | s [data] | aliasing.cpp:144:11:144:14 | data |
+| aliasing.cpp:144:11:144:14 | data | aliasing.cpp:144:8:144:14 | * ... |
+| aliasing.cpp:149:15:149:15 | s [post update] [data] | aliasing.cpp:150:8:150:8 | s [data] |
+| aliasing.cpp:149:17:149:20 | ref arg data | aliasing.cpp:149:15:149:15 | s [post update] [data] |
+| aliasing.cpp:150:8:150:8 | s [data] | aliasing.cpp:150:10:150:13 | data |
+| aliasing.cpp:150:10:150:13 | data | aliasing.cpp:150:8:150:16 | access to array |
+| aliasing.cpp:160:15:160:22 | ref arg & ... | aliasing.cpp:160:21:160:22 | m1 [inner post update] |
+| aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] | aliasing.cpp:161:8:161:9 | s2 [s, m1] |
+| aliasing.cpp:160:19:160:19 | s [post update] [m1] | aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] |
+| aliasing.cpp:160:21:160:22 | m1 [inner post update] | aliasing.cpp:160:19:160:19 | s [post update] [m1] |
+| aliasing.cpp:161:8:161:9 | s2 [s, m1] | aliasing.cpp:161:11:161:11 | s [m1] |
+| aliasing.cpp:161:11:161:11 | s [m1] | aliasing.cpp:161:13:161:14 | m1 |
+| aliasing.cpp:172:15:172:22 | ref arg & ... | aliasing.cpp:172:21:172:22 | m1 [inner post update] |
+| aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] | aliasing.cpp:174:8:174:11 | s2_2 [s, m1] |
+| aliasing.cpp:172:19:172:19 | s [post update] [m1] | aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] |
+| aliasing.cpp:172:21:172:22 | m1 [inner post update] | aliasing.cpp:172:19:172:19 | s [post update] [m1] |
+| aliasing.cpp:174:8:174:11 | s2_2 [s, m1] | aliasing.cpp:174:13:174:13 | s [m1] |
+| aliasing.cpp:174:13:174:13 | s [m1] | aliasing.cpp:174:15:174:16 | m1 |
+| aliasing.cpp:185:15:185:24 | ref arg & ... | aliasing.cpp:185:23:185:24 | m1 [inner post update] |
+| aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] | aliasing.cpp:186:8:186:10 | ps2 [s, m1] |
+| aliasing.cpp:185:21:185:21 | s [post update] [m1] | aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] |
+| aliasing.cpp:185:23:185:24 | m1 [inner post update] | aliasing.cpp:185:21:185:21 | s [post update] [m1] |
+| aliasing.cpp:186:8:186:10 | ps2 [s, m1] | aliasing.cpp:186:13:186:13 | s [m1] |
+| aliasing.cpp:186:13:186:13 | s [m1] | aliasing.cpp:186:15:186:16 | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
@@ -602,6 +634,39 @@ nodes
 | aliasing.cpp:93:8:93:8 | w [s, m1] | semmle.label | w [s, m1] |
 | aliasing.cpp:93:10:93:10 | s [m1] | semmle.label | s [m1] |
 | aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | semmle.label | pa [inner post update] |
+| aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
+| aliasing.cpp:143:15:143:15 | s [post update] [data] | semmle.label | s [post update] [data] |
+| aliasing.cpp:143:17:143:20 | ref arg data | semmle.label | ref arg data |
+| aliasing.cpp:144:8:144:14 | * ... | semmle.label | * ... |
+| aliasing.cpp:144:9:144:9 | s [data] | semmle.label | s [data] |
+| aliasing.cpp:144:11:144:14 | data | semmle.label | data |
+| aliasing.cpp:149:15:149:15 | s [post update] [data] | semmle.label | s [post update] [data] |
+| aliasing.cpp:149:17:149:20 | ref arg data | semmle.label | ref arg data |
+| aliasing.cpp:150:8:150:8 | s [data] | semmle.label | s [data] |
+| aliasing.cpp:150:8:150:16 | access to array | semmle.label | access to array |
+| aliasing.cpp:150:10:150:13 | data | semmle.label | data |
+| aliasing.cpp:160:15:160:22 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
+| aliasing.cpp:160:19:160:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:160:21:160:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:161:8:161:9 | s2 [s, m1] | semmle.label | s2 [s, m1] |
+| aliasing.cpp:161:11:161:11 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:161:13:161:14 | m1 | semmle.label | m1 |
+| aliasing.cpp:172:15:172:22 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
+| aliasing.cpp:172:19:172:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:172:21:172:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:174:8:174:11 | s2_2 [s, m1] | semmle.label | s2_2 [s, m1] |
+| aliasing.cpp:174:13:174:13 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:174:15:174:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:185:15:185:24 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] | semmle.label | ps2 [post update] [s, m1] |
+| aliasing.cpp:185:21:185:21 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:185:23:185:24 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:186:8:186:10 | ps2 [s, m1] | semmle.label | ps2 [s, m1] |
+| aliasing.cpp:186:13:186:13 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:186:15:186:16 | m1 | semmle.label | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:8:8:8:13 | access to array | semmle.label | access to array |
@@ -925,6 +990,11 @@ nodes
 | aliasing.cpp:30:11:30:12 | m1 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:30:11:30:12 | m1 | m1 flows from $@ | aliasing.cpp:13:10:13:19 | call to user_input | call to user_input |
 | aliasing.cpp:62:14:62:15 | m1 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:62:14:62:15 | m1 | m1 flows from $@ | aliasing.cpp:60:11:60:20 | call to user_input | call to user_input |
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
+| aliasing.cpp:144:8:144:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:144:8:144:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:150:8:150:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:150:8:150:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:161:13:161:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:161:13:161:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:174:15:174:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:174:15:174:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:186:15:186:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:186:15:186:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:8:8:8:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/path-flow.expected
@@ -155,38 +155,38 @@ edges
 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:92:3:92:23 | ... = ... |
 | aliasing.cpp:93:8:93:8 | w [s, m1] | aliasing.cpp:93:10:93:10 | s [m1] |
 | aliasing.cpp:93:10:93:10 | s [m1] | aliasing.cpp:93:12:93:13 | m1 |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:143:17:143:20 | ref arg data |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:149:17:149:20 | ref arg data |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:160:15:160:22 | ref arg & ... |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:172:15:172:22 | ref arg & ... |
-| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:185:15:185:24 | ref arg & ... |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:158:17:158:20 | ref arg data |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:164:17:164:20 | ref arg data |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:175:15:175:22 | ref arg & ... |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:187:15:187:22 | ref arg & ... |
+| aliasing.cpp:106:4:106:5 | pa [inner post update] | aliasing.cpp:200:15:200:24 | ref arg & ... |
 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:106:4:106:5 | pa [inner post update] |
-| aliasing.cpp:143:15:143:15 | s [post update] [data] | aliasing.cpp:144:9:144:9 | s [data] |
-| aliasing.cpp:143:17:143:20 | ref arg data | aliasing.cpp:143:15:143:15 | s [post update] [data] |
-| aliasing.cpp:144:9:144:9 | s [data] | aliasing.cpp:144:11:144:14 | data |
-| aliasing.cpp:144:11:144:14 | data | aliasing.cpp:144:8:144:14 | * ... |
-| aliasing.cpp:149:15:149:15 | s [post update] [data] | aliasing.cpp:150:8:150:8 | s [data] |
-| aliasing.cpp:149:17:149:20 | ref arg data | aliasing.cpp:149:15:149:15 | s [post update] [data] |
-| aliasing.cpp:150:8:150:8 | s [data] | aliasing.cpp:150:10:150:13 | data |
-| aliasing.cpp:150:10:150:13 | data | aliasing.cpp:150:8:150:16 | access to array |
-| aliasing.cpp:160:15:160:22 | ref arg & ... | aliasing.cpp:160:21:160:22 | m1 [inner post update] |
-| aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] | aliasing.cpp:161:8:161:9 | s2 [s, m1] |
-| aliasing.cpp:160:19:160:19 | s [post update] [m1] | aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] |
-| aliasing.cpp:160:21:160:22 | m1 [inner post update] | aliasing.cpp:160:19:160:19 | s [post update] [m1] |
-| aliasing.cpp:161:8:161:9 | s2 [s, m1] | aliasing.cpp:161:11:161:11 | s [m1] |
-| aliasing.cpp:161:11:161:11 | s [m1] | aliasing.cpp:161:13:161:14 | m1 |
-| aliasing.cpp:172:15:172:22 | ref arg & ... | aliasing.cpp:172:21:172:22 | m1 [inner post update] |
-| aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] | aliasing.cpp:174:8:174:11 | s2_2 [s, m1] |
-| aliasing.cpp:172:19:172:19 | s [post update] [m1] | aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] |
-| aliasing.cpp:172:21:172:22 | m1 [inner post update] | aliasing.cpp:172:19:172:19 | s [post update] [m1] |
-| aliasing.cpp:174:8:174:11 | s2_2 [s, m1] | aliasing.cpp:174:13:174:13 | s [m1] |
-| aliasing.cpp:174:13:174:13 | s [m1] | aliasing.cpp:174:15:174:16 | m1 |
-| aliasing.cpp:185:15:185:24 | ref arg & ... | aliasing.cpp:185:23:185:24 | m1 [inner post update] |
-| aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] | aliasing.cpp:186:8:186:10 | ps2 [s, m1] |
-| aliasing.cpp:185:21:185:21 | s [post update] [m1] | aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] |
-| aliasing.cpp:185:23:185:24 | m1 [inner post update] | aliasing.cpp:185:21:185:21 | s [post update] [m1] |
-| aliasing.cpp:186:8:186:10 | ps2 [s, m1] | aliasing.cpp:186:13:186:13 | s [m1] |
-| aliasing.cpp:186:13:186:13 | s [m1] | aliasing.cpp:186:15:186:16 | m1 |
+| aliasing.cpp:158:15:158:15 | s [post update] [data] | aliasing.cpp:159:9:159:9 | s [data] |
+| aliasing.cpp:158:17:158:20 | ref arg data | aliasing.cpp:158:15:158:15 | s [post update] [data] |
+| aliasing.cpp:159:9:159:9 | s [data] | aliasing.cpp:159:11:159:14 | data |
+| aliasing.cpp:159:11:159:14 | data | aliasing.cpp:159:8:159:14 | * ... |
+| aliasing.cpp:164:15:164:15 | s [post update] [data] | aliasing.cpp:165:8:165:8 | s [data] |
+| aliasing.cpp:164:17:164:20 | ref arg data | aliasing.cpp:164:15:164:15 | s [post update] [data] |
+| aliasing.cpp:165:8:165:8 | s [data] | aliasing.cpp:165:10:165:13 | data |
+| aliasing.cpp:165:10:165:13 | data | aliasing.cpp:165:8:165:16 | access to array |
+| aliasing.cpp:175:15:175:22 | ref arg & ... | aliasing.cpp:175:21:175:22 | m1 [inner post update] |
+| aliasing.cpp:175:16:175:17 | s2 [post update] [s, m1] | aliasing.cpp:176:8:176:9 | s2 [s, m1] |
+| aliasing.cpp:175:19:175:19 | s [post update] [m1] | aliasing.cpp:175:16:175:17 | s2 [post update] [s, m1] |
+| aliasing.cpp:175:21:175:22 | m1 [inner post update] | aliasing.cpp:175:19:175:19 | s [post update] [m1] |
+| aliasing.cpp:176:8:176:9 | s2 [s, m1] | aliasing.cpp:176:11:176:11 | s [m1] |
+| aliasing.cpp:176:11:176:11 | s [m1] | aliasing.cpp:176:13:176:14 | m1 |
+| aliasing.cpp:187:15:187:22 | ref arg & ... | aliasing.cpp:187:21:187:22 | m1 [inner post update] |
+| aliasing.cpp:187:16:187:17 | s2 [post update] [s, m1] | aliasing.cpp:189:8:189:11 | s2_2 [s, m1] |
+| aliasing.cpp:187:19:187:19 | s [post update] [m1] | aliasing.cpp:187:16:187:17 | s2 [post update] [s, m1] |
+| aliasing.cpp:187:21:187:22 | m1 [inner post update] | aliasing.cpp:187:19:187:19 | s [post update] [m1] |
+| aliasing.cpp:189:8:189:11 | s2_2 [s, m1] | aliasing.cpp:189:13:189:13 | s [m1] |
+| aliasing.cpp:189:13:189:13 | s [m1] | aliasing.cpp:189:15:189:16 | m1 |
+| aliasing.cpp:200:15:200:24 | ref arg & ... | aliasing.cpp:200:23:200:24 | m1 [inner post update] |
+| aliasing.cpp:200:16:200:18 | ps2 [post update] [s, m1] | aliasing.cpp:201:8:201:10 | ps2 [s, m1] |
+| aliasing.cpp:200:21:200:21 | s [post update] [m1] | aliasing.cpp:200:16:200:18 | ps2 [post update] [s, m1] |
+| aliasing.cpp:200:23:200:24 | m1 [inner post update] | aliasing.cpp:200:21:200:21 | s [post update] [m1] |
+| aliasing.cpp:201:8:201:10 | ps2 [s, m1] | aliasing.cpp:201:13:201:13 | s [m1] |
+| aliasing.cpp:201:13:201:13 | s [m1] | aliasing.cpp:201:15:201:16 | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array |
 | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... |
@@ -636,37 +636,37 @@ nodes
 | aliasing.cpp:93:12:93:13 | m1 | semmle.label | m1 |
 | aliasing.cpp:106:4:106:5 | pa [inner post update] | semmle.label | pa [inner post update] |
 | aliasing.cpp:106:9:106:18 | call to user_input | semmle.label | call to user_input |
-| aliasing.cpp:143:15:143:15 | s [post update] [data] | semmle.label | s [post update] [data] |
-| aliasing.cpp:143:17:143:20 | ref arg data | semmle.label | ref arg data |
-| aliasing.cpp:144:8:144:14 | * ... | semmle.label | * ... |
-| aliasing.cpp:144:9:144:9 | s [data] | semmle.label | s [data] |
-| aliasing.cpp:144:11:144:14 | data | semmle.label | data |
-| aliasing.cpp:149:15:149:15 | s [post update] [data] | semmle.label | s [post update] [data] |
-| aliasing.cpp:149:17:149:20 | ref arg data | semmle.label | ref arg data |
-| aliasing.cpp:150:8:150:8 | s [data] | semmle.label | s [data] |
-| aliasing.cpp:150:8:150:16 | access to array | semmle.label | access to array |
-| aliasing.cpp:150:10:150:13 | data | semmle.label | data |
-| aliasing.cpp:160:15:160:22 | ref arg & ... | semmle.label | ref arg & ... |
-| aliasing.cpp:160:16:160:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
-| aliasing.cpp:160:19:160:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
-| aliasing.cpp:160:21:160:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
-| aliasing.cpp:161:8:161:9 | s2 [s, m1] | semmle.label | s2 [s, m1] |
-| aliasing.cpp:161:11:161:11 | s [m1] | semmle.label | s [m1] |
-| aliasing.cpp:161:13:161:14 | m1 | semmle.label | m1 |
-| aliasing.cpp:172:15:172:22 | ref arg & ... | semmle.label | ref arg & ... |
-| aliasing.cpp:172:16:172:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
-| aliasing.cpp:172:19:172:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
-| aliasing.cpp:172:21:172:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
-| aliasing.cpp:174:8:174:11 | s2_2 [s, m1] | semmle.label | s2_2 [s, m1] |
-| aliasing.cpp:174:13:174:13 | s [m1] | semmle.label | s [m1] |
-| aliasing.cpp:174:15:174:16 | m1 | semmle.label | m1 |
-| aliasing.cpp:185:15:185:24 | ref arg & ... | semmle.label | ref arg & ... |
-| aliasing.cpp:185:16:185:18 | ps2 [post update] [s, m1] | semmle.label | ps2 [post update] [s, m1] |
-| aliasing.cpp:185:21:185:21 | s [post update] [m1] | semmle.label | s [post update] [m1] |
-| aliasing.cpp:185:23:185:24 | m1 [inner post update] | semmle.label | m1 [inner post update] |
-| aliasing.cpp:186:8:186:10 | ps2 [s, m1] | semmle.label | ps2 [s, m1] |
-| aliasing.cpp:186:13:186:13 | s [m1] | semmle.label | s [m1] |
-| aliasing.cpp:186:15:186:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:158:15:158:15 | s [post update] [data] | semmle.label | s [post update] [data] |
+| aliasing.cpp:158:17:158:20 | ref arg data | semmle.label | ref arg data |
+| aliasing.cpp:159:8:159:14 | * ... | semmle.label | * ... |
+| aliasing.cpp:159:9:159:9 | s [data] | semmle.label | s [data] |
+| aliasing.cpp:159:11:159:14 | data | semmle.label | data |
+| aliasing.cpp:164:15:164:15 | s [post update] [data] | semmle.label | s [post update] [data] |
+| aliasing.cpp:164:17:164:20 | ref arg data | semmle.label | ref arg data |
+| aliasing.cpp:165:8:165:8 | s [data] | semmle.label | s [data] |
+| aliasing.cpp:165:8:165:16 | access to array | semmle.label | access to array |
+| aliasing.cpp:165:10:165:13 | data | semmle.label | data |
+| aliasing.cpp:175:15:175:22 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:175:16:175:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
+| aliasing.cpp:175:19:175:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:175:21:175:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:176:8:176:9 | s2 [s, m1] | semmle.label | s2 [s, m1] |
+| aliasing.cpp:176:11:176:11 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:176:13:176:14 | m1 | semmle.label | m1 |
+| aliasing.cpp:187:15:187:22 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:187:16:187:17 | s2 [post update] [s, m1] | semmle.label | s2 [post update] [s, m1] |
+| aliasing.cpp:187:19:187:19 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:187:21:187:22 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:189:8:189:11 | s2_2 [s, m1] | semmle.label | s2_2 [s, m1] |
+| aliasing.cpp:189:13:189:13 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:189:15:189:16 | m1 | semmle.label | m1 |
+| aliasing.cpp:200:15:200:24 | ref arg & ... | semmle.label | ref arg & ... |
+| aliasing.cpp:200:16:200:18 | ps2 [post update] [s, m1] | semmle.label | ps2 [post update] [s, m1] |
+| aliasing.cpp:200:21:200:21 | s [post update] [m1] | semmle.label | s [post update] [m1] |
+| aliasing.cpp:200:23:200:24 | m1 [inner post update] | semmle.label | m1 [inner post update] |
+| aliasing.cpp:201:8:201:10 | ps2 [s, m1] | semmle.label | ps2 [s, m1] |
+| aliasing.cpp:201:13:201:13 | s [m1] | semmle.label | s [m1] |
+| aliasing.cpp:201:15:201:16 | m1 | semmle.label | m1 |
 | arrays.cpp:6:12:6:21 | call to user_input | semmle.label | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | semmle.label | access to array |
 | arrays.cpp:8:8:8:13 | access to array | semmle.label | access to array |
@@ -990,11 +990,11 @@ nodes
 | aliasing.cpp:30:11:30:12 | m1 | aliasing.cpp:13:10:13:19 | call to user_input | aliasing.cpp:30:11:30:12 | m1 | m1 flows from $@ | aliasing.cpp:13:10:13:19 | call to user_input | call to user_input |
 | aliasing.cpp:62:14:62:15 | m1 | aliasing.cpp:60:11:60:20 | call to user_input | aliasing.cpp:62:14:62:15 | m1 | m1 flows from $@ | aliasing.cpp:60:11:60:20 | call to user_input | call to user_input |
 | aliasing.cpp:93:12:93:13 | m1 | aliasing.cpp:92:12:92:21 | call to user_input | aliasing.cpp:93:12:93:13 | m1 | m1 flows from $@ | aliasing.cpp:92:12:92:21 | call to user_input | call to user_input |
-| aliasing.cpp:144:8:144:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:144:8:144:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:150:8:150:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:150:8:150:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:161:13:161:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:161:13:161:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:174:15:174:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:174:15:174:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
-| aliasing.cpp:186:15:186:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:186:15:186:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:159:8:159:14 | * ... | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:159:8:159:14 | * ... | * ... flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:165:8:165:16 | access to array | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:165:8:165:16 | access to array | access to array flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:176:13:176:14 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:176:13:176:14 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:189:15:189:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:189:15:189:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
+| aliasing.cpp:201:15:201:16 | m1 | aliasing.cpp:106:9:106:18 | call to user_input | aliasing.cpp:201:15:201:16 | m1 | m1 flows from $@ | aliasing.cpp:106:9:106:18 | call to user_input | call to user_input |
 | arrays.cpp:7:8:7:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:7:8:7:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:8:8:8:13 | access to array | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:8:8:8:13 | access to array | access to array flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |
 | arrays.cpp:9:8:9:11 | * ... | arrays.cpp:6:12:6:21 | call to user_input | arrays.cpp:9:8:9:11 | * ... | * ... flows from $@ | arrays.cpp:6:12:6:21 | call to user_input | call to user_input |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-079/semmle/CgiXss/CgiXss.expected
@@ -2,9 +2,6 @@ edges
 | search.c:14:24:14:28 | query | search.c:17:8:17:12 | (const char *)... |
 | search.c:14:24:14:28 | query | search.c:17:8:17:12 | query |
 | search.c:14:24:14:28 | query | search.c:17:8:17:12 | query |
-| search.c:14:24:14:28 | query | search.c:17:8:17:12 | query |
-| search.c:17:8:17:12 | query | search.c:17:8:17:12 | (const char *)... |
-| search.c:17:8:17:12 | query | search.c:17:8:17:12 | query |
 | search.c:22:24:22:28 | query | search.c:23:39:23:43 | query |
 | search.c:22:24:22:28 | query | search.c:23:39:23:43 | query |
 | search.c:41:21:41:26 | call to getenv | search.c:45:17:45:25 | raw_query |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -19,8 +19,6 @@ edges
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:101:9:101:10 | i1 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:102:15:102:16 | i1 |
@@ -31,14 +29,10 @@ edges
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
-| argvLocal.c:100:7:100:10 | argv | argvLocal.c:144:9:144:10 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
 | argvLocal.c:100:7:100:10 | argv | argvLocal.c:145:15:145:16 | i7 |
-| argvLocal.c:101:9:101:10 | i1 | argvLocal.c:101:9:101:10 | (const char *)... |
-| argvLocal.c:101:9:101:10 | i1 | argvLocal.c:101:9:101:10 | i1 |
 | argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | (const char *)... |
 | argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | (const char *)... |
 | argvLocal.c:105:14:105:17 | argv | argvLocal.c:106:9:106:13 | access to array |
@@ -143,22 +137,16 @@ edges
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:131:9:131:14 | ... + ... |
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:132:15:132:20 | ... + ... |
 | argvLocal.c:128:15:128:16 | printWrapper output argument | argvLocal.c:132:15:132:20 | ... + ... |
-| argvLocal.c:144:9:144:10 | i7 | argvLocal.c:144:9:144:10 | (const char *)... |
-| argvLocal.c:144:9:144:10 | i7 | argvLocal.c:144:9:144:10 | i7 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | (const char *)... |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | (const char *)... |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
-| argvLocal.c:149:11:149:14 | argv | argvLocal.c:150:9:150:10 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
 | argvLocal.c:149:11:149:14 | argv | argvLocal.c:151:15:151:16 | i8 |
-| argvLocal.c:150:9:150:10 | i8 | argvLocal.c:150:9:150:10 | (const char *)... |
-| argvLocal.c:150:9:150:10 | i8 | argvLocal.c:150:9:150:10 | i8 |
 | argvLocal.c:156:23:156:26 | argv | argvLocal.c:157:9:157:10 | (const char *)... |
 | argvLocal.c:156:23:156:26 | argv | argvLocal.c:157:9:157:10 | (const char *)... |
 | argvLocal.c:156:23:156:26 | argv | argvLocal.c:157:9:157:10 | i9 |
@@ -183,21 +171,12 @@ edges
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:169:18:169:20 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:15:170:26 | (char *)... |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:15:170:26 | (char *)... |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
 | argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
-| argvLocal.c:168:18:168:21 | argv | argvLocal.c:170:24:170:26 | i10 |
-| argvLocal.c:169:18:169:20 | i10 | argvLocal.c:169:9:169:20 | (char *)... |
-| argvLocal.c:169:18:169:20 | i10 | argvLocal.c:169:9:169:20 | (const char *)... |
-| argvLocal.c:169:18:169:20 | i10 | argvLocal.c:169:18:169:20 | i10 |
-| argvLocal.c:170:24:170:26 | i10 | argvLocal.c:170:15:170:26 | (char *)... |
-| argvLocal.c:170:24:170:26 | i10 | argvLocal.c:170:24:170:26 | i10 |
 nodes
 | argvLocal.c:9:25:9:31 | *correct | semmle.label | *correct |
 | argvLocal.c:9:25:9:31 | correct | semmle.label | correct |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/funcs/funcsLocal.expected
@@ -17,14 +17,10 @@ edges
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:31:13:31:17 | call to fgets | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:19:31:21 | fgets output argument | funcsLocal.c:32:9:32:10 | (const char *)... |
 | funcsLocal.c:31:19:31:21 | fgets output argument | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | (const char *)... |
 | funcsLocal.c:31:19:31:21 | i41 | funcsLocal.c:32:9:32:10 | i4 |
-| funcsLocal.c:32:9:32:10 | i4 | funcsLocal.c:32:9:32:10 | (const char *)... |
-| funcsLocal.c:32:9:32:10 | i4 | funcsLocal.c:32:9:32:10 | i4 |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | (const char *)... |
 | funcsLocal.c:36:7:36:8 | gets output argument | funcsLocal.c:37:9:37:10 | i5 |
 | funcsLocal.c:36:7:36:8 | i5 | funcsLocal.c:37:9:37:10 | (const char *)... |
@@ -35,14 +31,10 @@ edges
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:41:13:41:16 | call to gets | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:18:41:20 | gets output argument | funcsLocal.c:42:9:42:10 | (const char *)... |
 | funcsLocal.c:41:18:41:20 | gets output argument | funcsLocal.c:42:9:42:10 | i6 |
 | funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | (const char *)... |
 | funcsLocal.c:41:18:41:20 | i61 | funcsLocal.c:42:9:42:10 | i6 |
-| funcsLocal.c:42:9:42:10 | i6 | funcsLocal.c:42:9:42:10 | (const char *)... |
-| funcsLocal.c:42:9:42:10 | i6 | funcsLocal.c:42:9:42:10 | i6 |
 nodes
 | funcsLocal.c:16:8:16:9 | fread output argument | semmle.label | fread output argument |
 | funcsLocal.c:16:8:16:9 | i1 | semmle.label | i1 |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/ifs/ifs.expected
@@ -5,110 +5,66 @@ edges
 | ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
 | ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
 | ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:61:8:61:11 | argv | ifs.c:62:9:62:10 | c7 |
-| ifs.c:62:9:62:10 | c7 | ifs.c:62:9:62:10 | (const char *)... |
-| ifs.c:62:9:62:10 | c7 | ifs.c:62:9:62:10 | c7 |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | (const char *)... |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | (const char *)... |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
 | ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:68:8:68:11 | argv | ifs.c:69:9:69:10 | c8 |
-| ifs.c:69:9:69:10 | c8 | ifs.c:69:9:69:10 | (const char *)... |
-| ifs.c:69:9:69:10 | c8 | ifs.c:69:9:69:10 | c8 |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | (const char *)... |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | (const char *)... |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
 | ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:74:8:74:11 | argv | ifs.c:75:9:75:10 | i1 |
-| ifs.c:75:9:75:10 | i1 | ifs.c:75:9:75:10 | (const char *)... |
-| ifs.c:75:9:75:10 | i1 | ifs.c:75:9:75:10 | i1 |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | (const char *)... |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | (const char *)... |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
 | ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:80:8:80:11 | argv | ifs.c:81:9:81:10 | i2 |
-| ifs.c:81:9:81:10 | i2 | ifs.c:81:9:81:10 | (const char *)... |
-| ifs.c:81:9:81:10 | i2 | ifs.c:81:9:81:10 | i2 |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | (const char *)... |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | (const char *)... |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
 | ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:86:8:86:11 | argv | ifs.c:87:9:87:10 | i3 |
-| ifs.c:87:9:87:10 | i3 | ifs.c:87:9:87:10 | (const char *)... |
-| ifs.c:87:9:87:10 | i3 | ifs.c:87:9:87:10 | i3 |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | (const char *)... |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | (const char *)... |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
 | ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:92:8:92:11 | argv | ifs.c:93:9:93:10 | i4 |
-| ifs.c:93:9:93:10 | i4 | ifs.c:93:9:93:10 | (const char *)... |
-| ifs.c:93:9:93:10 | i4 | ifs.c:93:9:93:10 | i4 |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | (const char *)... |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | (const char *)... |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
 | ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:98:8:98:11 | argv | ifs.c:99:9:99:10 | i5 |
-| ifs.c:99:9:99:10 | i5 | ifs.c:99:9:99:10 | (const char *)... |
-| ifs.c:99:9:99:10 | i5 | ifs.c:99:9:99:10 | i5 |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | (const char *)... |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | (const char *)... |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
 | ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:105:8:105:11 | argv | ifs.c:106:9:106:10 | i6 |
-| ifs.c:106:9:106:10 | i6 | ifs.c:106:9:106:10 | (const char *)... |
-| ifs.c:106:9:106:10 | i6 | ifs.c:106:9:106:10 | i6 |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | (const char *)... |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | (const char *)... |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
 | ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:111:8:111:11 | argv | ifs.c:112:9:112:10 | i7 |
-| ifs.c:112:9:112:10 | i7 | ifs.c:112:9:112:10 | (const char *)... |
-| ifs.c:112:9:112:10 | i7 | ifs.c:112:9:112:10 | i7 |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | (const char *)... |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | (const char *)... |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
 | ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:117:8:117:11 | argv | ifs.c:118:9:118:10 | i8 |
-| ifs.c:118:9:118:10 | i8 | ifs.c:118:9:118:10 | (const char *)... |
-| ifs.c:118:9:118:10 | i8 | ifs.c:118:9:118:10 | i8 |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | (const char *)... |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | (const char *)... |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
 | ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:123:8:123:11 | argv | ifs.c:124:9:124:10 | i9 |
-| ifs.c:124:9:124:10 | i9 | ifs.c:124:9:124:10 | (const char *)... |
-| ifs.c:124:9:124:10 | i9 | ifs.c:124:9:124:10 | i9 |
 nodes
 | ifs.c:61:8:61:11 | argv | semmle.label | argv |
 | ifs.c:61:8:61:11 | argv | semmle.label | argv |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -5,8 +5,6 @@ edges
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
 | test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
-| test.cpp:39:21:39:24 | argv | test.cpp:42:38:42:44 | tainted |
 | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:43:38:43:63 | ... * ... |
@@ -21,8 +19,6 @@ edges
 | test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
 | test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
 | test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
-| test.cpp:39:21:39:24 | argv | test.cpp:48:32:48:35 | size |
 | test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
 | test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
 | test.cpp:39:21:39:24 | argv | test.cpp:49:26:49:29 | size |
@@ -31,10 +27,6 @@ edges
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
 | test.cpp:39:21:39:24 | argv | test.cpp:52:35:52:60 | ... * ... |
-| test.cpp:42:38:42:44 | tainted | test.cpp:42:38:42:44 | (size_t)... |
-| test.cpp:42:38:42:44 | tainted | test.cpp:42:38:42:44 | tainted |
-| test.cpp:48:32:48:35 | size | test.cpp:48:32:48:35 | (size_t)... |
-| test.cpp:48:32:48:35 | size | test.cpp:48:32:48:35 | size |
 | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
 | test.cpp:123:18:123:23 | call to getenv | test.cpp:127:24:127:41 | ... * ... |
 | test.cpp:123:18:123:31 | (const char *)... | test.cpp:127:24:127:41 | ... * ... |
@@ -58,17 +50,13 @@ edges
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | (size_t)... |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:29 | call to getenv | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:235:11:235:20 | (size_t)... |
 | test.cpp:227:24:227:29 | call to getenv | test.cpp:237:10:237:19 | (size_t)... |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | (size_t)... |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
-| test.cpp:227:24:227:37 | (const char *)... | test.cpp:229:9:229:18 | local_size |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:235:11:235:20 | (size_t)... |
 | test.cpp:227:24:227:37 | (const char *)... | test.cpp:237:10:237:19 | (size_t)... |
-| test.cpp:229:9:229:18 | local_size | test.cpp:229:9:229:18 | (size_t)... |
-| test.cpp:229:9:229:18 | local_size | test.cpp:229:9:229:18 | local_size |
 | test.cpp:235:11:235:20 | (size_t)... | test.cpp:214:23:214:23 | s |
 | test.cpp:237:10:237:19 | (size_t)... | test.cpp:220:21:220:21 | s |
 | test.cpp:241:2:241:32 | Chi [array content] | test.cpp:279:17:279:20 | get_size output argument [array content] |
@@ -80,14 +68,12 @@ edges
 | test.cpp:249:20:249:25 | call to getenv | test.cpp:253:11:253:29 | ... * ... |
 | test.cpp:249:20:249:33 | (const char *)... | test.cpp:253:11:253:29 | ... * ... |
 | test.cpp:249:20:249:33 | (const char *)... | test.cpp:253:11:253:29 | ... * ... |
-| test.cpp:279:17:279:20 | Chi [array content] | test.cpp:281:11:281:14 | size |
-| test.cpp:279:17:279:20 | get_size output argument [array content] | test.cpp:279:17:279:20 | Chi [array content] |
-| test.cpp:281:11:281:14 | size | test.cpp:281:11:281:28 | ... * ... |
-| test.cpp:281:11:281:14 | size | test.cpp:281:11:281:28 | ... * ... |
-| test.cpp:295:18:295:21 | Chi [array content] | test.cpp:298:10:298:13 | size |
-| test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi [array content] |
-| test.cpp:298:10:298:13 | size | test.cpp:298:10:298:27 | ... * ... |
-| test.cpp:298:10:298:13 | size | test.cpp:298:10:298:27 | ... * ... |
+| test.cpp:279:17:279:20 | Chi | test.cpp:281:11:281:28 | ... * ... |
+| test.cpp:279:17:279:20 | Chi | test.cpp:281:11:281:28 | ... * ... |
+| test.cpp:279:17:279:20 | get_size output argument [array content] | test.cpp:279:17:279:20 | Chi |
+| test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
+| test.cpp:295:18:295:21 | Chi | test.cpp:298:10:298:27 | ... * ... |
+| test.cpp:295:18:295:21 | get_size output argument [array content] | test.cpp:295:18:295:21 | Chi |
 | test.cpp:301:19:301:24 | call to getenv | test.cpp:305:11:305:28 | ... * ... |
 | test.cpp:301:19:301:24 | call to getenv | test.cpp:305:11:305:28 | ... * ... |
 | test.cpp:301:19:301:32 | (const char *)... | test.cpp:305:11:305:28 | ... * ... |
@@ -168,15 +154,13 @@ nodes
 | test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
 | test.cpp:253:11:253:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:279:17:279:20 | Chi [array content] | semmle.label | Chi [array content] |
+| test.cpp:279:17:279:20 | Chi | semmle.label | Chi |
 | test.cpp:279:17:279:20 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
-| test.cpp:281:11:281:14 | size | semmle.label | size |
 | test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
 | test.cpp:281:11:281:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:295:18:295:21 | Chi [array content] | semmle.label | Chi [array content] |
+| test.cpp:295:18:295:21 | Chi | semmle.label | Chi |
 | test.cpp:295:18:295:21 | get_size output argument [array content] | semmle.label | get_size output argument [array content] |
-| test.cpp:298:10:298:13 | size | semmle.label | size |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |
 | test.cpp:298:10:298:27 | ... * ... | semmle.label | ... * ... |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/uncontrolled/ArithmeticUncontrolled.expected
@@ -23,14 +23,10 @@ edges
 | test.c:60:13:60:16 | call to rand | test.c:61:5:61:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:61:5:61:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:61:5:61:5 | r |
-| test.c:60:13:60:16 | call to rand | test.c:61:5:61:5 | r |
-| test.c:60:13:60:16 | call to rand | test.c:61:5:61:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:62:5:62:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:62:5:62:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:62:5:62:5 | r |
 | test.c:60:13:60:16 | call to rand | test.c:62:5:62:5 | r |
-| test.c:61:5:61:5 | r | test.c:62:5:62:5 | r |
-| test.c:61:5:61:5 | r | test.c:62:5:62:5 | r |
 | test.c:66:13:66:16 | call to rand | test.c:67:5:67:5 | r |
 | test.c:66:13:66:16 | call to rand | test.c:67:5:67:5 | r |
 | test.c:66:13:66:16 | call to rand | test.c:67:5:67:5 | r |
@@ -56,12 +52,12 @@ edges
 | test.cpp:18:9:18:12 | call to rand | test.cpp:18:2:18:14 | Store |
 | test.cpp:24:11:24:18 | call to get_rand | test.cpp:25:7:25:7 | r |
 | test.cpp:24:11:24:18 | call to get_rand | test.cpp:25:7:25:7 | r |
-| test.cpp:30:13:30:14 | Chi [array content] | test.cpp:31:7:31:7 | r |
-| test.cpp:30:13:30:14 | Chi [array content] | test.cpp:31:7:31:7 | r |
-| test.cpp:30:13:30:14 | get_rand2 output argument [array content] | test.cpp:30:13:30:14 | Chi [array content] |
-| test.cpp:36:13:36:13 | Chi [array content] | test.cpp:37:7:37:7 | r |
-| test.cpp:36:13:36:13 | Chi [array content] | test.cpp:37:7:37:7 | r |
-| test.cpp:36:13:36:13 | get_rand3 output argument [array content] | test.cpp:36:13:36:13 | Chi [array content] |
+| test.cpp:30:13:30:14 | Chi | test.cpp:31:7:31:7 | r |
+| test.cpp:30:13:30:14 | Chi | test.cpp:31:7:31:7 | r |
+| test.cpp:30:13:30:14 | get_rand2 output argument [array content] | test.cpp:30:13:30:14 | Chi |
+| test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
+| test.cpp:36:13:36:13 | Chi | test.cpp:37:7:37:7 | r |
+| test.cpp:36:13:36:13 | get_rand3 output argument [array content] | test.cpp:36:13:36:13 | Chi |
 nodes
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
 | test.c:18:13:18:16 | call to rand | semmle.label | call to rand |
@@ -126,12 +122,12 @@ nodes
 | test.cpp:25:7:25:7 | r | semmle.label | r |
 | test.cpp:25:7:25:7 | r | semmle.label | r |
 | test.cpp:25:7:25:7 | r | semmle.label | r |
-| test.cpp:30:13:30:14 | Chi [array content] | semmle.label | Chi [array content] |
+| test.cpp:30:13:30:14 | Chi | semmle.label | Chi |
 | test.cpp:30:13:30:14 | get_rand2 output argument [array content] | semmle.label | get_rand2 output argument [array content] |
 | test.cpp:31:7:31:7 | r | semmle.label | r |
 | test.cpp:31:7:31:7 | r | semmle.label | r |
 | test.cpp:31:7:31:7 | r | semmle.label | r |
-| test.cpp:36:13:36:13 | Chi [array content] | semmle.label | Chi [array content] |
+| test.cpp:36:13:36:13 | Chi | semmle.label | Chi |
 | test.cpp:36:13:36:13 | get_rand3 output argument [array content] | semmle.label | get_rand3 output argument [array content] |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
 | test.cpp:37:7:37:7 | r | semmle.label | r |


### PR DESCRIPTION
This PR fixes the field conflation identified in https://github.com/github/codeql/pull/4298.

Specifically, we add a pair of read and store steps when dataflow leaves a function. The read step pops an `ArrayContent` off the access path when we figure out that the argument passed to the function is a field (and not an array), and the store step inserts the correct `FieldContent` onto the access path.

In practice, for the following example:
```cpp
void taint_a_ptr(int* pa) {
  *pa = source();
}

void test_field1() {
  A a;
  taint_a_ptr(&a.x);
  sink(a.x);
}
```
we get the following path explanation:
```cpp
#    2| call to source
#-----|  -> Store

#    2| Store
#-----|  -> Chi [array content]

#    2| Chi [array content]
#-----|  -> taint_a_ptr output argument [array content]

// Conversion from ArrayContent to FieldContent starts here.
// First we pop the incorrect ArrayContent.
#    7| taint_a_ptr output argument [array content]
#-----|  -> Chi

// And then we insert the correct FieldContent here.
#    7| Chi
#-----|  -> Chi [x]

#    7| Chi [x]
#-----|  -> x

#    8| x
```

CPP-difference: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1439/