### PR TITLE
Python: Make import of DataFlowPrivate private

### DIFF
--- a/python/ql/src/experimental/dataflow/internal/DataFlowUtil.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowUtil.qll
@@ -2,7 +2,7 @@
  * Contains utility functions for writing data flow queries
  */
 
-import DataFlowPrivate
+private import DataFlowPrivate
 import DataFlowPublic
 
 /**

--- a/python/ql/test/experimental/dataflow/basic/maximalFlowsConfig.qll
+++ b/python/ql/test/experimental/dataflow/basic/maximalFlowsConfig.qll
@@ -1,4 +1,5 @@
 import experimental.dataflow.DataFlow
+private import experimental.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /**
  * A configuration to find all "maximal" flows.
@@ -15,7 +16,7 @@ class MaximalFlowsConfig extends DataFlow::Configuration {
   }
 
   override predicate isSink(DataFlow::Node node) {
-    node instanceof DataFlow::ReturnNode
+    node instanceof DataFlowPrivate::ReturnNode
     or
     node instanceof DataFlow::EssaNode and
     not exists(node.(DataFlow::EssaNode).getVar().getASourceUse())

--- a/python/ql/test/experimental/dataflow/callGraphConfig.qll
+++ b/python/ql/test/experimental/dataflow/callGraphConfig.qll
@@ -1,5 +1,6 @@
 private import python
 import experimental.dataflow.DataFlow
+private import experimental.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /**
  * A configuration to find the call graph edges.
@@ -8,13 +9,13 @@ class CallGraphConfig extends DataFlow::Configuration {
   CallGraphConfig() { this = "CallGraphConfig" }
 
   override predicate isSource(DataFlow::Node node) {
-    node instanceof DataFlow::ReturnNode
+    node instanceof DataFlowPrivate::ReturnNode
     or
-    node instanceof DataFlow::ArgumentNode
+    node instanceof DataFlowPrivate::ArgumentNode
   }
 
   override predicate isSink(DataFlow::Node node) {
-    node instanceof DataFlow::OutNode
+    node instanceof DataFlowPrivate::OutNode
     or
     node instanceof DataFlow::ParameterNode
   }

--- a/python/ql/test/experimental/dataflow/coverage/argumentRouting1.ql
+++ b/python/ql/test/experimental/dataflow/coverage/argumentRouting1.ql
@@ -1,5 +1,6 @@
 import python
 import experimental.dataflow.DataFlow
+private import experimental.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /**
  * A configuration to check routing of arguments through magic methods.
@@ -8,7 +9,7 @@ class ArgumentRoutingConfig extends DataFlow::Configuration {
   ArgumentRoutingConfig() { this = "ArgumentRoutingConfig" }
 
   override predicate isSource(DataFlow::Node node) {
-    exists(AssignmentDefinition def, DataFlow::DataFlowCall call |
+    exists(AssignmentDefinition def, DataFlowPrivate::DataFlowCall call |
       def.getVariable() = node.(DataFlow::EssaNode).getVar() and
       def.getValue() = call.getNode() and
       call.getCallable().getName().matches("With\\_%")

--- a/python/ql/test/experimental/dataflow/coverage/classesCallGraph.ql
+++ b/python/ql/test/experimental/dataflow/coverage/classesCallGraph.ql
@@ -1,4 +1,5 @@
 import experimental.dataflow.DataFlow
+private import experimental.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /**
  * A configuration to find the call graph edges.
@@ -7,18 +8,18 @@ class CallGraphConfig extends DataFlow::Configuration {
   CallGraphConfig() { this = "CallGraphConfig" }
 
   override predicate isSource(DataFlow::Node node) {
-    node instanceof DataFlow::ReturnNode
+    node instanceof DataFlowPrivate::ReturnNode
     or
     // These sources should allow for the non-standard call syntax
-    node instanceof DataFlow::ArgumentNode
+    node instanceof DataFlowPrivate::ArgumentNode
   }
 
   override predicate isSink(DataFlow::Node node) {
-    node instanceof DataFlow::OutNode
+    node instanceof DataFlowPrivate::OutNode
     or
     node instanceof DataFlow::ParameterNode and
     // exclude parameters to the SINK-functions
-    not exists(DataFlow::DataFlowCallable c |
+    not exists(DataFlowPrivate::DataFlowCallable c |
       node.(DataFlow::ParameterNode).isParameterOf(c, _) and
       c.getName().matches("SINK_")
     )

--- a/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.ql
+++ b/python/ql/test/experimental/dataflow/strange-essaflow/testFlow.ql
@@ -1,5 +1,6 @@
 import python
 import experimental.dataflow.DataFlow
+private import experimental.dataflow.internal.DataFlowPrivate as DataFlowPrivate
 
 /** Gets the EssaNode that holds the module imported by the fully qualified module name `name` */
 DataFlow::EssaNode module_import(string name) {
@@ -27,10 +28,10 @@ query predicate flowstep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
 
 query predicate jumpStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
   os_import(nodeFrom) and
-  DataFlow::jumpStep(nodeFrom, nodeTo)
+  DataFlowPrivate::jumpStep(nodeFrom, nodeTo)
 }
 
 query predicate essaFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
   os_import(nodeFrom) and
-  DataFlow::EssaFlow::essaFlowStep(nodeFrom, nodeTo)
+  DataFlowPrivate::EssaFlow::essaFlowStep(nodeFrom, nodeTo)
 }


### PR DESCRIPTION
Otherwise you are able to use `DataFlow::isExpressionNode` where `isExpressionNode` is defined in `DataFlowPrivate.qll`.