### PR TITLE
JS: Extract XML with codeql when run with codeql

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1249,7 +1249,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
       cmd.addAll(xmlExtensions);
     } else {
       String command = Env.getOS() == OS.WINDOWS ? "codeql.cmd" : "codeql";
-      cmd.add(EnvironmentVariables.getCodeQLDist() + "/" + command);
+      cmd.add(Paths.get(EnvironmentVariables.getCodeQLDist(), command).toString());
       cmd.add("database");
       cmd.add("index-files");
       cmd.add("--language");

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -60,6 +60,7 @@ import com.semmle.util.io.WholeIO;
 import com.semmle.util.io.csv.CSVReader;
 import com.semmle.util.language.LegacyLanguage;
 import com.semmle.util.process.Env;
+import com.semmle.util.process.Env.OS;
 import com.semmle.util.projectstructure.ProjectLayout;
 import com.semmle.util.trap.TrapWriter;
 
@@ -1239,11 +1240,29 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
   protected void extractXml() throws IOException {
     if (xmlExtensions.isEmpty()) return;
     List<String> cmd = new ArrayList<>();
-    cmd.add("odasa");
-    cmd.add("index");
-    cmd.add("--xml");
-    cmd.add("--extensions");
-    cmd.addAll(xmlExtensions);
+    if (EnvironmentVariables.getCodeQLDist() == null) {
+      // Use the legacy odasa XML extractor
+      cmd.add("odasa");
+      cmd.add("index");
+      cmd.add("--xml");
+      cmd.add("--extensions");
+      cmd.addAll(xmlExtensions);
+    } else {
+      String command = Env.getOS() == OS.WINDOWS ? "codeql.cmd" : "codeql";
+      cmd.add(EnvironmentVariables.getCodeQLDist() + "/" + command);
+      cmd.add("database");
+      cmd.add("index-files");
+      cmd.add("--language");
+      cmd.add("xml");
+      cmd.add("--size-limit");
+      cmd.add("10m");
+      for (String extension : xmlExtensions) {
+        cmd.add("--include-extension");
+        cmd.add(extension);
+      }
+      cmd.add("--");
+      cmd.add(EnvironmentVariables.getWipDatabase());
+    }
     ProcessBuilder pb = new ProcessBuilder(cmd);
     try {
       pb.redirectError(Redirect.INHERIT);

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1248,7 +1248,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
       cmd.add("--extensions");
       cmd.addAll(xmlExtensions);
     } else {
-      String command = Env.getOS() == OS.WINDOWS ? "codeql.cmd" : "codeql";
+      String command = Env.getOS() == OS.WINDOWS ? "codeql.exe" : "codeql";
       cmd.add(Paths.get(EnvironmentVariables.getCodeQLDist(), command).toString());
       cmd.add("database");
       cmd.add("index-files");

--- a/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/EnvironmentVariables.java
@@ -14,6 +14,11 @@ public class EnvironmentVariables {
   public static final String LGTM_WORKSPACE_ENV_VAR =
       "LGTM_WORKSPACE";
 
+  public static final String CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE_ENV_VAR =
+      "CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE";
+
+  public static final String CODEQL_DIST_ENV_VAR = "CODEQL_DIST";
+
   /**
    * Gets the extractor root based on the <code>CODEQL_EXTRACTOR_JAVASCRIPT_ROOT</code> or <code>
    * SEMMLE_DIST</code> or environment variable, or <code>null</code> if neither is set.
@@ -48,5 +53,14 @@ public class EnvironmentVariables {
     if (env != null) return env;
 
     throw new UserError(CODEQL_EXTRACTOR_JAVASCRIPT_SCRATCH_DIR_ENV_VAR + " or " + LGTM_WORKSPACE_ENV_VAR + " must be set");
+  }
+
+  public static String getCodeQLDist() {
+    return Env.systemEnv().getNonEmpty(CODEQL_DIST_ENV_VAR);
+  }
+
+  /** Gets the output database directory. */
+  public static String getWipDatabase() {
+    return Env.systemEnv().getNonEmpty(CODEQL_EXTRACTOR_JAVASCRIPT_WIP_DATABASE_ENV_VAR);
   }
 }


### PR DESCRIPTION
XML extraction currently works by AutoBuild calling back to `odasa` to invoke the XML extractor. This now calls back to `codeql` when `CODEQL_DIST` is set.

It's questionable whether it _should_ be done like this, but given that our tests are blocked on this, I opted for the minimal change needed so we can get our tests running again.