### PR TITLE
JS: improve join-order for HTTP::isDecoratedCall

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -240,12 +240,20 @@ module HTTP {
    */
   private predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
     // indirect route-handler `result` is given to function `outer`, which returns function `inner` which calls the function `pred`.
-    exists(int i, Function outer, Function inner |
+    exists(int i, DataFlow::FunctionNode outer, HTTP::RouteHandlerCandidate inner |
       decoratee = call.getArgument(i).getALocalSource() and
-      outer = call.getACallee() and
-      inner = outer.getAReturnedExpr() and
-      isAForwardingRouteHandlerCall(DataFlow::parameterNode(outer.getParameter(i)), inner.flow())
+      outer.getFunction() = call.getACallee() and
+      outer = returnsARouteHandler(inner) and
+      isAForwardingRouteHandlerCall(outer.getParameter(i), inner)
     )
+  }
+
+  /**
+   * Gets a function that returns the route-handler-candidate `routeHandler`.
+   */
+  pragma[noinline]
+  private DataFlow::FunctionNode returnsARouteHandler(HTTP::RouteHandlerCandidate routeHandler) {
+    routeHandler = result.getAReturn().getALocalSource()
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -237,6 +237,18 @@ module HTTP {
    * Holds if `call` decorates the function `pred`.
    * This means that `call` returns a function that forwards its arguments to `pred`.
    * Only holds when the decorator looks like it is decorating a route-handler.
+   *
+   * Below is a code example relating `call`, `decoratee`, `outer`, `inner`.
+   * ```
+   * function outer(method) {
+   *    return function inner(req, res) {
+   *      return method.call(this, req, res);
+   *    };
+   *  }
+   *  var route = outer(function decoratee(req, res) { // <- call
+   *    res.end("foo");
+   *  });
+   * ```
    */
   private predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
     // indirect route-handler `result` is given to function `outer`, which returns function `inner` which calls the function `pred`.

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -243,17 +243,19 @@ module HTTP {
     exists(int i, DataFlow::FunctionNode outer, HTTP::RouteHandlerCandidate inner |
       decoratee = call.getArgument(i).getALocalSource() and
       outer.getFunction() = call.getACallee() and
-      outer = returnsARouteHandler(inner) and
+      returnsRouteHandler(outer, inner) and
       isAForwardingRouteHandlerCall(outer.getParameter(i), inner)
     )
   }
 
   /**
-   * Gets a function that returns the route-handler-candidate `routeHandler`.
+   * Holds if `fun` returns the route-handler-candidate `routeHandler`.
    */
   pragma[noinline]
-  private DataFlow::FunctionNode returnsARouteHandler(HTTP::RouteHandlerCandidate routeHandler) {
-    routeHandler = result.getAReturn().getALocalSource()
+  private predicate returnsRouteHandler(
+    DataFlow::FunctionNode fun, HTTP::RouteHandlerCandidate routeHandler
+  ) {
+    routeHandler = fun.getAReturn().getALocalSource()
   }
 
   /**


### PR DESCRIPTION
My [recent PR](https://github.com/github/codeql/pull/4275) apparently got a bad join-order in some of the minor edits made towards the end. 

This PR fixes that join-order (and uses `DataFlow::FunctionNode` instead of `Function`). 