### PR TITLE
Adds check for Server Side Template Injection vulnerabilities in RazorEngine

### DIFF
--- a/csharp/ql/src/experimental/CWE-095/razor_parse.ql
+++ b/csharp/ql/src/experimental/CWE-095/razor_parse.ql
@@ -1,0 +1,71 @@
+/**
+ * @name Server-Side Template Injection in RazorEngine
+ * @description User-controlled data may be evaluated, leading to arbitrary code execution.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id csharp/razor-injection
+ * @tags security
+ */
+
+import csharp
+import semmle.code.csharp.dataflow.TaintTracking
+import DataFlow::PathGraph
+
+/*
+ * The offending method is Parse from RazorEngine.Razor.
+ */
+
+class RazorEngineClass extends Class {
+  RazorEngineClass() { this.hasQualifiedName("RazorEngine.Razor") }
+
+  Method getIsValidMethod() {
+    result.getDeclaringType() = this and
+    result.hasName("Parse")
+  }
+}
+
+/*
+ * We are only interested in ASP.NET MVC Controller classes
+ */
+
+class ControllerMVC extends Class {
+  ControllerMVC() { this.hasQualifiedName("System.Web.Mvc", "Controller") }
+}
+
+/*
+ * We filter by the ActionResult. I think this might not be needed.
+ */
+
+class ActionResultCall extends Call {
+  ActionResultCall() {
+    this.getEnclosingCallable().getAnnotatedReturnType().toString() = "ActionResult"
+  }
+}
+
+/*
+ * TaintTracking configuration that will track any public method in MVC controllers that takes arguments that are parsed later by RazorEngine.Parse.
+ */
+
+class RazorEngineInjection extends TaintTracking::Configuration {
+  RazorEngineInjection() { this = "RazorEngineInjection" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(ActionResultCall ar |
+      ar.getEnclosingCallable().getDeclaringType().getABaseType() instanceof ControllerMVC and
+      source.asParameter() = ar.getEnclosingCallable().getAParameter()
+    )
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(RazorEngineClass rec, MethodCall mc |
+      mc.getQualifiedDeclaration() = rec.getIsValidMethod() and
+      sink.asExpr() = mc.getArgument(0)
+    )
+  }
+}
+
+from RazorEngineInjection cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink, source, sink,
+  "Server-Side Template Injection in RazorEngine leads to Remote Code Execution"

--- a/csharp/ql/src/experimental/CWE-095/razor_parse.qlhelp
+++ b/csharp/ql/src/experimental/CWE-095/razor_parse.qlhelp
@@ -1,0 +1,19 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>This rule finds public <code>ActualResults</code> methods that have user controlled parameters that could contain malicious code that
+is parsed by <code>RazorEngine.Parse()</code> leading to a Server-Side Template Injection vulnerability.
+
+</overview>
+<recommendation>
+<p>Do not use the class RazorEngine. If not possible, do not parse user input into the template.</p>
+
+</recommendation>
+<references>
+  <li><a href="https://docs.microsoft.com/en-us/dotnet/api/system.web.razor.parser.razorparser.parse?view=aspnet-webpages-3.2">RazorParser</a>.</li>
+  <li><a href="https://clement.notin.org/blog/2020/04/15/Server-Side-Template-Injection-(SSTI)-in-ASP.NET-Razor/">RazorEngine Injection ASP.NET</a>.</li>
+
+</references>
+</qhelp>


### PR DESCRIPTION
Adds check for Server Side Template Injection that leads to Remote Code Execution vulnerabilities in MVC ASP.NET applications using the RazorEngine class. MVC controller methods that receive user input that is parsed by the template engine is flagged with this rule. 

[ASP.NET Razor templates is listed as supported](https://help.semmle.com/codeql/supported-languages-and-frameworks.html) by CodeQL, yet only XSS is detected and we are missing this old yet critical vulnerability.

More info: [Server Side Template Injection (SSTI) in ASP.NET Razor](https://clement.notin.org/blog/2020/04/15/Server-Side-Template-Injection-(SSTI)-in-ASP.NET-Razor/)
 