### PR TITLE
JavaScript: Minor improvements to API graph library

### DIFF
--- a/javascript/ql/src/meta/ApiGraphs/ApiGraphEdges.ql
+++ b/javascript/ql/src/meta/ApiGraphs/ApiGraphEdges.ql
@@ -1,0 +1,15 @@
+/**
+ * @name API-graph edges
+ * @description The number of edges (other than points-to edges) in the API graph.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/api-graph-edges
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(),
+  count(API::Node pred, string lbl, API::Node succ | succ = pred.getASuccessor(lbl))

--- a/javascript/ql/src/meta/ApiGraphs/ApiGraphNodes.ql
+++ b/javascript/ql/src/meta/ApiGraphs/ApiGraphNodes.ql
@@ -1,0 +1,14 @@
+/**
+ * @name API-graph nodes
+ * @description The number of nodes in the API graph.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/api-graph-nodes
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(), count(API::Node nd)

--- a/javascript/ql/src/meta/ApiGraphs/ApiGraphPointsToEdges.ql
+++ b/javascript/ql/src/meta/ApiGraphs/ApiGraphPointsToEdges.ql
@@ -1,0 +1,14 @@
+/**
+ * @name API-graph points-to edges
+ * @description The number of points-to edges in the API graph.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/api-graph-points-to-edges
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(), count(API::Node pred, API::Node succ | pred.refersTo(succ))

--- a/javascript/ql/src/meta/ApiGraphs/ApiGraphRhsNodes.ql
+++ b/javascript/ql/src/meta/ApiGraphs/ApiGraphRhsNodes.ql
@@ -1,0 +1,15 @@
+/**
+ * @name API-graph right-hand-side nodes
+ * @description The number of data-flow nodes corresponding to a right-hand side of
+ *              a definition of an API-graph node.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/api-graph-rhs-nodes
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(), count(any(API::Node nd).getARhs())

--- a/javascript/ql/src/meta/ApiGraphs/ApiGraphUseNodes.ql
+++ b/javascript/ql/src/meta/ApiGraphs/ApiGraphUseNodes.ql
@@ -1,0 +1,14 @@
+/**
+ * @name API-graph use nodes
+ * @description The number of data-flow nodes corresponding to a use of an API-graph node.
+ * @kind metric
+ * @metricType project
+ * @metricAggregate sum
+ * @tags meta
+ * @id js/meta/api-graph-use-nodes
+ */
+
+import javascript
+import meta.MetaMetrics
+
+select projectRoot(), count(any(API::Node nd).getAUse())

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -223,6 +223,9 @@ module API {
       ) and
       length in [1 .. Impl::distanceFromRoot(this)]
     }
+
+    /** Gets the shortest distance from the root to this node in the API graph. */
+    int getDepth() { result = Impl::distanceFromRoot(this) }
   }
 
   /** The root node of an API graph. */


### PR DESCRIPTION
Two independent improvements:

  - Expose a predicate `API::Node.getDepth()`.
    My main use case right now is to be able to define a sensible order on API-graph nodes for tests of `@kind graph`. (We don't have any in this repo, but I have some in another repo.)
  - Add a few metric queries for API graphs so we can measure the impact of future changes.