### PR TITLE
Java/Python: Reduce size of `blockPrecedesVar`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/SSA.qll
@@ -706,9 +706,9 @@ module Ssa {
 
     /**
      * Holds if `def` is accessed in basic block `bb1` (either a read or a write),
-     * `bb2` is a transitive successor of `bb1`, and `def` is *maybe* read in `bb2`
-     * or one of its transitive successors, but not in any block on the path between
-     * `bb1` and `bb2`.
+     * `bb2` is a transitive successor of `bb1`, `def` is live at the end of `bb1`,
+     * and the underlying variable for `def` is neither read nor written in any block
+     * on the path between `bb1` and `bb2`.
      */
     private predicate varBlockReaches(TrackedDefinition def, BasicBlock bb1, BasicBlock bb2) {
       varOccursInBlock(def, bb1, _) and

--- a/java/ql/src/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SSA.qll
@@ -770,7 +770,9 @@ private module SsaImpl {
 
     /** Holds if `v` occurs in `b` or one of `b`'s transitive successors. */
     private predicate blockPrecedesVar(TrackedVar v, BasicBlock b) {
-      varOccursInBlock(v, b.getABBSuccessor*())
+      varOccursInBlock(v, b)
+      or
+      ssaDefReachesEndOfBlock(v, _, b)
     }
 
     /**

--- a/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/BaseSSA.qll
@@ -321,7 +321,9 @@ private module SsaImpl {
 
     /** Holds if `v` occurs in `b` or one of `b`'s transitive successors. */
     private predicate blockPrecedesVar(BaseSsaSourceVariable v, BasicBlock b) {
-      varOccursInBlock(v, b.getABBSuccessor*())
+      varOccursInBlock(v, b)
+      or
+      ssaDefReachesEndOfBlock(v, _, b)
     }
 
     /**

--- a/python/ql/src/semmle/python/essa/SsaCompute.qll
+++ b/python/ql/src/semmle/python/essa/SsaCompute.qll
@@ -382,7 +382,9 @@ private module SsaComputeImpl {
 
     /** Holds if `v` occurs in `b` or one of `b`'s transitive successors. */
     private predicate blockPrecedesVar(SsaSourceVariable v, BasicBlock b) {
-      varOccursInBlock(v, b.getASuccessor*())
+      varOccursInBlock(v, b)
+      or
+      SsaDefinitionsImpl::reachesEndOfBlock(v, _, _, b)
     }
 
     /**


### PR DESCRIPTION
@RasmusWL 's https://github.com/github/codeql/pull/4246 got me looking at `varBlockReaches` for C#, to see if a similar optimization was relevant. The C# logic is, however, structured a bit different, because `varBlockReaches` is also used to compute last-reads (that is, reads that can reach a write, or a basic block in which the variable is neither accessed nor live).

Another thing that C# does differently is to compute (the equivalent of) `blockPrecedesVar` without explicit transitive closure, which this PR ports to Python and Java. This means that `blockPrecedesVar` computes a smaller set, which is safe because `varBlockReaches` is only used to compute def-use and use-use pairs.

The new predicate is reduced from 5594835 tuples to 3796144 on JDK.