### PR TITLE
Java: add Spring::MultipartRequest as taint source

### DIFF
--- a/java/change-notes/2020-09-23-spring-multipart-request-sources.md
+++ b/java/change-notes/2020-09-23-spring-multipart-request-sources.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The methods of the [Spring Web MultipartRequest](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/multipart/MultipartRequest.html)
+  class have been added as sources of remote user input, which may lead to more results from the security queries.

--- a/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
+++ b/java/ql/src/semmle/code/java/dataflow/FlowSources.qll
@@ -106,12 +106,31 @@ private class MessageBodyReaderParameterSource extends RemoteFlowSource {
   override string getSourceType() { result = "MessageBodyReader parameter" }
 }
 
+private class SpringMultipartRequestSource extends RemoteFlowSource {
+  SpringMultipartRequestSource() {
+    exists(MethodAccess ma, Method m |
+      ma = this.asExpr() and
+      m = ma.getMethod() and
+      m
+          .getDeclaringType()
+          .getASourceSupertype*()
+          .hasQualifiedName("org.springframework.web.multipart", "MultipartRequest") and
+      m.getName().matches("get%")
+    )
+  }
+
+  override string getSourceType() { result = "Spring MultipartRequest getter" }
+}
+
 private class SpringMultipartFileSource extends RemoteFlowSource {
   SpringMultipartFileSource() {
     exists(MethodAccess ma, Method m |
       ma = this.asExpr() and
       m = ma.getMethod() and
-      m.getDeclaringType().hasQualifiedName("org.springframework.web.multipart", "MultipartFile") and
+      m
+          .getDeclaringType()
+          .getASourceSupertype*()
+          .hasQualifiedName("org.springframework.web.multipart", "MultipartFile") and
       m.getName().matches("get%")
     )
   }

--- a/java/ql/test/library-tests/dataflow/taintsources/SpringMultiPart.java
+++ b/java/ql/test/library-tests/dataflow/taintsources/SpringMultiPart.java
@@ -1,4 +1,5 @@
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartRequest;
 
 public class SpringMultiPart {
 	MultipartFile file;
@@ -11,5 +12,14 @@ public class SpringMultiPart {
 		file.getName();
 		file.getContentType();
 		file.getOriginalFilename();
+	}
+	
+	public void test(MultipartRequest request) {
+		request.getFile("name");
+		request.getFileMap();
+		request.getFileNames();
+		request.getFiles("name");
+		request.getMultiFileMap();
+		request.getMultipartContentType("name");
 	}
 }

--- a/java/ql/test/library-tests/dataflow/taintsources/remote.expected
+++ b/java/ql/test/library-tests/dataflow/taintsources/remote.expected
@@ -9,9 +9,15 @@
 | RmiFlowImpl.java:4:30:4:40 | path | RmiFlowImpl.java:5:20:5:31 | ... + ... |
 | RmiFlowImpl.java:4:30:4:40 | path | RmiFlowImpl.java:5:28:5:31 | path |
 | RmiFlowImpl.java:4:30:4:40 | path | RmiFlowImpl.java:6:29:6:35 | command |
-| SpringMultiPart.java:7:3:7:17 | getBytes(...) | SpringMultiPart.java:7:3:7:17 | getBytes(...) |
-| SpringMultiPart.java:9:3:9:23 | getInputStream(...) | SpringMultiPart.java:9:3:9:23 | getInputStream(...) |
-| SpringMultiPart.java:10:3:10:20 | getResource(...) | SpringMultiPart.java:10:3:10:20 | getResource(...) |
-| SpringMultiPart.java:11:3:11:16 | getName(...) | SpringMultiPart.java:11:3:11:16 | getName(...) |
-| SpringMultiPart.java:12:3:12:23 | getContentType(...) | SpringMultiPart.java:12:3:12:23 | getContentType(...) |
-| SpringMultiPart.java:13:3:13:28 | getOriginalFilename(...) | SpringMultiPart.java:13:3:13:28 | getOriginalFilename(...) |
+| SpringMultiPart.java:8:3:8:17 | getBytes(...) | SpringMultiPart.java:8:3:8:17 | getBytes(...) |
+| SpringMultiPart.java:10:3:10:23 | getInputStream(...) | SpringMultiPart.java:10:3:10:23 | getInputStream(...) |
+| SpringMultiPart.java:11:3:11:20 | getResource(...) | SpringMultiPart.java:11:3:11:20 | getResource(...) |
+| SpringMultiPart.java:12:3:12:16 | getName(...) | SpringMultiPart.java:12:3:12:16 | getName(...) |
+| SpringMultiPart.java:13:3:13:23 | getContentType(...) | SpringMultiPart.java:13:3:13:23 | getContentType(...) |
+| SpringMultiPart.java:14:3:14:28 | getOriginalFilename(...) | SpringMultiPart.java:14:3:14:28 | getOriginalFilename(...) |
+| SpringMultiPart.java:18:3:18:25 | getFile(...) | SpringMultiPart.java:18:3:18:25 | getFile(...) |
+| SpringMultiPart.java:19:3:19:22 | getFileMap(...) | SpringMultiPart.java:19:3:19:22 | getFileMap(...) |
+| SpringMultiPart.java:20:3:20:24 | getFileNames(...) | SpringMultiPart.java:20:3:20:24 | getFileNames(...) |
+| SpringMultiPart.java:21:3:21:26 | getFiles(...) | SpringMultiPart.java:21:3:21:26 | getFiles(...) |
+| SpringMultiPart.java:22:3:22:27 | getMultiFileMap(...) | SpringMultiPart.java:22:3:22:27 | getMultiFileMap(...) |
+| SpringMultiPart.java:23:3:23:41 | getMultipartContentType(...) | SpringMultiPart.java:23:3:23:41 | getMultipartContentType(...) |


### PR DESCRIPTION
All getters of [`MultipartRequest`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/multipart/MultipartRequest.html) should be marked as `RemoteFlowSource`s.