### PR TITLE
CodeQL docs: mention `generate query-help` CLI command

### DIFF
--- a/docs/language/learn-ql/writing-queries/query-help.rst
+++ b/docs/language/learn-ql/writing-queries/query-help.rst
@@ -21,7 +21,7 @@ For more information about how to write useful query help in a style that is con
 Overview
 ========
 
-Each query help file provides detailed information about the purpose and use of a query. When you write your own queries, we recommend that you also write query help files so that other users know what the queries do, and how they work.
+Each query help file provides detailed information about the purpose and use of a query. When you write your own queries, we recommend that you also write query help files so that other users know what the queries do, and how they work. When writing query help, you can test the files to make sure they are valid and render a preview of the content in markdown using the CodeQL CLI. For more information, see "`Testing query help files <https://help.semmle.com/codeql/codeql-cli/procedures/testing-query-help-files.html>`__."
 
 Structure
 =========

--- a/docs/query-help-style-guide.md
+++ b/docs/query-help-style-guide.md
@@ -10,6 +10,8 @@ When you contribute a new [supported query](supported-queries.md) to this reposi
 *   [JavaScript queries](https://help.semmle.com/wiki/display/JS/)
 *   [Python queries](https://help.semmle.com/wiki/display/PYTHON/)
 
+When writing query help, you can test the files to make sure they are valid and render a preview of the content in markdown using the CodeQL CLI. For more information, see "`Testing query help files <https://help.semmle.com/codeql/codeql-cli/procedures/testing-query-help-files.html>`__."
+
 ### Location and file name
 
 Query help files must have the same base name as the query they describe and must be located in the same directory.  


### PR DESCRIPTION
Closes https://github.com/github/semmle-docs/issues/216.

Links articles about query help to new article about the `generate query-help` command. The new article is not available yet.