### PR TITLE
JS: better join-order fix in HTTP

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -253,21 +253,20 @@ module HTTP {
   private predicate isDecoratedCall(DataFlow::CallNode call, DataFlow::FunctionNode decoratee) {
     // indirect route-handler `result` is given to function `outer`, which returns function `inner` which calls the function `pred`.
     exists(int i, DataFlow::FunctionNode outer, HTTP::RouteHandlerCandidate inner |
+      inner = outer.getAReturn().getALocalSource() and
       decoratee = call.getArgument(i).getALocalSource() and
       outer.getFunction() = call.getACallee() and
-      returnsRouteHandler(outer, inner) and
-      isAForwardingRouteHandlerCall(outer.getParameter(i), inner)
+      hasForwardingHandlerParameter(i, outer, inner)
     )
   }
 
   /**
-   * Holds if `fun` returns the route-handler-candidate `routeHandler`.
+   * Holds if the `i`th parameter of `outer` has a call that `inner` forwards its parameters to.
    */
-  pragma[noinline]
-  private predicate returnsRouteHandler(
-    DataFlow::FunctionNode fun, HTTP::RouteHandlerCandidate routeHandler
+  private predicate hasForwardingHandlerParameter(
+    int i, DataFlow::FunctionNode outer, HTTP::RouteHandlerCandidate inner
   ) {
-    routeHandler = fun.getAReturn().getALocalSource()
+    isAForwardingRouteHandlerCall(outer.getParameter(i), inner)
   }
 
   /**


### PR DESCRIPTION
My [recent join-order fix](https://github.com/github/codeql/pull/4311) did work, but not that well. 

In the benchmarks I ran the `returnsRouteHandler` predicate became empty, and thus it was easy for the runtime to deduce that `isDecoratedCall` was also empty.   
However, if I modified `react` to contain a single indirect route-handler, then the bad join-order in `isDecoratedCall` reappeared (because `returnsRouteHandler` was non-empty). 

Sorry for not investigating how my previous fix worked earlier.

This PR is a better fix, that also works when benchmarks contain indirect route-handlers, and there is no need for `pragma`.   

[Evaluation on security/nightly looks good](https://docs.google.com/spreadsheets/d/1vC4nu01jvBIQBuYdpkWC_vLc2S9ZELvX4czMbq29PUs/edit?usp=sharing).   
(It is clear that I should have run a larger evaluation earlier, to catch that slowdown in `nodejs`.) 