### PR TITLE
JS: Add source and sink for DVSA

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -3,6 +3,8 @@
 ## General improvements
 
 * Support for the following frameworks and libraries has been improved:
+  - [AWS Serverless](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html)
+  - [Alibaba Serverless](https://www.alibabacloud.com/help/doc-detail/156876.htm)
   - [bluebird](https://www.npmjs.com/package/bluebird)
   - [express](https://www.npmjs.com/package/express)
   - [fast-json-stable-stringify](https://www.npmjs.com/package/fast-json-stable-stringify)

--- a/javascript/ql/src/javascript.qll
+++ b/javascript/ql/src/javascript.qll
@@ -94,6 +94,7 @@ import semmle.javascript.frameworks.PropertyProjection
 import semmle.javascript.frameworks.React
 import semmle.javascript.frameworks.ReactNative
 import semmle.javascript.frameworks.Request
+import semmle.javascript.frameworks.ServerLess
 import semmle.javascript.frameworks.ShellJS
 import semmle.javascript.frameworks.SystemCommandExecutors
 import semmle.javascript.frameworks.SQL

--- a/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
@@ -1,0 +1,91 @@
+/**
+ * Provides classes and predicates for working with serverless handlers.
+ * E.g. AWS: https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html
+ */
+
+import javascript
+private import semmle.javascript.PackageExports as Exports
+
+/**
+ * Provides classes and predicates for working with serverless handlers.
+ */
+private module ServerLess {
+  /**
+   * Holds if the `.yml` file `ymlFile` contains a serverless configuration with `handler` and `codeURI` properties.
+   * `codeURI` defaults to the empty string if no explicit value is set in the configuration.
+   */
+  private predicate hasServerlessHandler(File ymlFile, string handler, string codeURI) {
+    exists(YAMLMapping resource | ymlFile = resource.getFile() |
+      // There exists at least "AWS::Serverless::Function" and "Aliyun::Serverless::Function"
+      resource.lookup("Type").(YAMLScalar).getValue().regexpMatch(".*::Serverless::Function") and
+      exists(YAMLMapping properties | properties = resource.lookup("Properties") |
+        handler = properties.lookup("Handler").(YAMLScalar).getValue() and
+        if exists(properties.lookup("CodeUri"))
+        then codeURI = properties.lookup("CodeUri").(YAMLScalar).getValue()
+        else codeURI = ""
+      )
+    )
+  }
+
+  /**
+   * Gets a string where an ending "/." is simplified to "/" (if it exists).
+   */
+  bindingset[base]
+  private string removeTrailingDot(string base) {
+    if base.regexpMatch(".*/\\.")
+    then result = base.substring(0, base.length() - 1)
+    else result = base
+  }
+
+  /**
+   * Gets a string where a leading "./" is simplified to "" (if it exists).
+   */
+  bindingset[base]
+  private string removeLeadingDotSlash(string base) {
+    if base.regexpMatch("\\./.*") then result = base.substring(2, base.length()) else result = base
+  }
+
+  /**
+   * Gets a path to a file from a `codeURI` property and a file name from a serverless configuration.
+   */
+  bindingset[codeURI, file]
+  private string getPathFromHandlerProperties(string codeURI, string file) {
+    exists(string folder | folder = removeLeadingDotSlash(removeTrailingDot(codeURI)) |
+      if folder.regexpMatch(".*\\..+") then result = folder else result = folder + file + ".js"
+    )
+  }
+
+  /**
+   * Holds if `file` has a serverless handler function with name `func`.
+   */
+  private predicate hasServerlessHandler(File file, string func) {
+    exists(File ymlFile, string handler, string codeURI, string fileName |
+      hasServerlessHandler(ymlFile, handler, codeURI) and
+      func = handler.regexpCapture(".*\\.(.*)", 1) and
+      fileName = handler.regexpCapture("([^.]+).*", 1)
+    |
+      file.getAbsolutePath() =
+        ymlFile.getParentContainer().getAbsolutePath() + "/" +
+          getPathFromHandlerProperties(codeURI, fileName)
+    )
+  }
+
+  /**
+   * Gets a function that is a serverless request handler.
+   */
+  private DataFlow::FunctionNode getAServerlessHandler() {
+    exists(File file, string handler, Module mod | hasServerlessHandler(file, handler) |
+      mod.getFile() = file and
+      result = mod.getAnExportedValue(handler).getAFunctionValue()
+    )
+  }
+
+  /**
+   * A serverless request handler event, seen as a RemoteFlowSource.
+   */
+  private class ServerlessHandlerEventAsRemoteFlow extends RemoteFlowSource {
+    ServerlessHandlerEventAsRemoteFlow() { this = getAServerlessHandler().getParameter(0) }
+
+    override string getSourceType() { result = "Serverless event" }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
@@ -63,10 +63,12 @@ private module ServerLess {
   private predicate hasServerlessHandler(File file, string func) {
     exists(File ymlFile, string handler, string codeURI, string fileName |
       hasServerlessHandler(ymlFile, handler, codeURI) and
-      // Captures everything right of the dot in `handler`. E.g. if `handler` is "index.foo" then `func` is "foo".
-      func = handler.regexpCapture(".*\\.(.*)", 1) and
-      // Captures everything left of the dot in `handler`. E.g. if `handler` is "index.foo" then `fileName` is "index".
-      fileName = handler.regexpCapture("([^.]+).*", 1)
+      // Splits a `handler` into two components. The `fileName` to the left of the dot, and the `func` to the right.
+      // E.g. if `handler` is "index.foo", then `fileName` is "index" and `func` is "foo".
+      exists(string pattern | pattern = "(.*)\\.(.*)" |
+        fileName = handler.regexpCapture(pattern, 1) and
+        func = handler.regexpCapture(pattern, 2)
+      )
     |
       file.getAbsolutePath() =
         ymlFile.getParentContainer().getAbsolutePath() + "/" +

--- a/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ServerLess.qll
@@ -78,7 +78,7 @@ private module ServerLess {
    * Gets a function that is a serverless request handler.
    *
    * For example: if an AWS serverless resource contains the following properties (in the "template.yml" file):
-   * ```
+   * ```yaml
    * Handler: mylibrary.handler
    * Runtime: nodejs12.x
    * CodeUri: backend/src/

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -87,6 +87,7 @@ module CodeInjection {
         this = c.getArgument(index)
       )
       or
+      // node-serialize is not intended to be safe for untrusted inputs
       this = DataFlow::moduleMember("node-serialize", "unserialize").getACall().getArgument(0)
     }
   }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -86,6 +86,8 @@ module CodeInjection {
       |
         this = c.getArgument(index)
       )
+      or
+      this = DataFlow::moduleMember("node-serialize", "unserialize").getACall().getArgument(0)
     }
   }
 

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/test.expected
@@ -1,0 +1,5 @@
+| tst1/backend/src/mylibrary.js:1:36:1:40 | event |
+| tst2/nodejs/index.js:1:36:1:40 | event |
+| tst3/function/index.js:1:36:1:40 | event |
+| tst4/app.js:1:36:1:40 | event |
+| tst5/app.js:1:36:1:40 | event |

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/test.ql
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/test.ql
@@ -1,0 +1,3 @@
+import javascript
+
+query RemoteFlowSource remoteFlow() { any() }

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst1/backend/src/mylibrary.js
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst1/backend/src/mylibrary.js
@@ -1,0 +1,3 @@
+module.exports.handler = function (event) {
+    console.log(event);
+}

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst1/template.yml
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst1/template.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: 'Serverless thing'
+
+Globals:
+  Api:
+    Cors:
+      AllowMethods: "'*'"
+      AllowHeaders: "'*'"
+      AllowOrigin: "'*'"
+
+Resources:
+  OrderManagerJsFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      FunctionName: MY-SERVERLESS-THING
+      Handler: mylibrary.handler
+      Runtime: nodejs12.x
+      CodeUri: backend/src/

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst2/nodejs/index.js
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst2/nodejs/index.js
@@ -1,0 +1,3 @@
+module.exports.handler = function (event) {
+    console.log(event);
+}

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst2/template.yml
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst2/template.yml
@@ -1,0 +1,18 @@
+Transform: 'Aliyun::Serverless-2018-04-03'
+Resources:
+  fc-mongo:
+    Type: 'Aliyun::Serverless::Service'
+    Properties:
+      Description: MyServiceThing
+    nodejs:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: index.handler
+        Runtime: nodejs10
+        CodeUri: nodejs/
+    python:
+      Type: 'Aliyun::Serverless::Function'
+      Properties:
+        Handler: 'index.handler'
+        Runtime: python3
+        CodeUri: python/

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst3/function/index.js
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst3/function/index.js
@@ -1,0 +1,3 @@
+module.exports.handler = function (event) {
+    console.log(event);
+}

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst3/template.yml
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst3/template.yml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: An AWS Lambda application.
+Resources:
+  function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      CodeUri: function/.

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst4/app.js
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst4/app.js
@@ -1,0 +1,3 @@
+module.exports.handler = function (event) {
+    console.log(event);
+}

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst4/template.yml
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst4/template.yml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: A AWS Lambda function.
+
+Resources:
+  helloworld:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: app.handler
+      Runtime: nodejs6.10
+      CodeUri: ./
+      Description: A AWS Lambda function.

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst5/app.js
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst5/app.js
@@ -1,0 +1,3 @@
+module.exports.handler = function (event) {
+    console.log(event);
+}

--- a/javascript/ql/test/library-tests/frameworks/ServerLess/tst5/template.yml
+++ b/javascript/ql/test/library-tests/frameworks/ServerLess/tst5/template.yml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: A AWS Lambda function.
+
+Resources:
+  helloworld:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: app.handler
+      Runtime: nodejs6.10
+      Description: A AWS Lambda function.


### PR DESCRIPTION
With this PR we get a TP/TN for [Lesson 1](https://github.com/OWASP/DVSA/blob/master/AWS/LESSONS/LESSON_01.md) from A [Damn Vulnerable Serverless Application](https://github.com/OWASP/DVSA) (DVSA). 
(And as a bonus we recognize the sink for [Insecure Deserialization from DVNA](https://appsecco.com/books/dvna-developers-security-guide/solution/a8-insecure-deserialization.html).)

---

DVSA uses serverless handlers, and we didn't have any support for those previously.   
It doesn't [look like Serverless applications are all that common](https://github.com/search?q=filename%3Atemplate.yml+Handler+nodejs&type=Code&ref=advsearch&l=&l=), but it is a nice addition to have none the less. 
A serverless handler is specified using a special `.yml` configuration, which we now recognize (see the tests).   

I've added the `event` parameter of any serverless handler as a `RemoteFlowSource`.   

Our support for serverless application is somewhat coarse with this implementation (e.g. nothing tries to recognize if a handler is visible to the public or not).  
But I haven't found any reliable method with which we can do better.

---

I've also added `require("node-serialize").unserialize(..)` as a `js/code-injection` sink (to get the full flow). 

`node-serialize` has a trivial `eval(..)` sink that has been flagged as `wont-fix`.   
Therefore it seems OK to add is as a `js/code-injection` sink. 