### PR TITLE
JS: add req.files as a RequestInputAccess in the Express model

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -505,6 +505,10 @@ module Express {
         // `req.cookies`
         kind = "cookie" and
         this = request.getAPropertyRead("cookies")
+        or
+        // `req.files`, treated the same as `req.body`.
+        kind = "body" and
+        this = request.getAPropertyRead("files")
       )
       or
       kind = "body" and

--- a/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
@@ -16,12 +16,12 @@ nodes
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
-| libxml.noent.js:16:26:16:34 | req.files |
-| libxml.noent.js:16:26:16:34 | req.files |
-| libxml.noent.js:16:26:16:43 | req.files.products |
-| libxml.noent.js:16:26:16:48 | req.fil ... ts.data |
-| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
-| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
+| libxml.noent.js:16:27:16:35 | req.files |
+| libxml.noent.js:16:27:16:35 | req.files |
+| libxml.noent.js:16:27:16:44 | req.files.products |
+| libxml.noent.js:16:27:16:49 | req.fil ... ts.data |
+| libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') |
+| libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
@@ -39,11 +39,11 @@ edges
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
-| libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:43 | req.files.products |
-| libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:43 | req.files.products |
-| libxml.noent.js:16:26:16:43 | req.files.products | libxml.noent.js:16:26:16:48 | req.fil ... ts.data |
-| libxml.noent.js:16:26:16:48 | req.fil ... ts.data | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
-| libxml.noent.js:16:26:16:48 | req.fil ... ts.data | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
+| libxml.noent.js:16:27:16:35 | req.files | libxml.noent.js:16:27:16:44 | req.files.products |
+| libxml.noent.js:16:27:16:35 | req.files | libxml.noent.js:16:27:16:44 | req.files.products |
+| libxml.noent.js:16:27:16:44 | req.files.products | libxml.noent.js:16:27:16:49 | req.fil ... ts.data |
+| libxml.noent.js:16:27:16:49 | req.fil ... ts.data | libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') |
+| libxml.noent.js:16:27:16:49 | req.fil ... ts.data | libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") |
 #select
@@ -52,6 +52,6 @@ edges
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | user-provided value |
 | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | user-provided value |
 | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | user-provided value |
-| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') | libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:16:26:16:34 | req.files | user-provided value |
+| libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') | libxml.noent.js:16:27:16:35 | req.files | libxml.noent.js:16:27:16:66 | req.fil ... 'utf8') | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:16:27:16:35 | req.files | user-provided value |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | user-provided value |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-611/Xxe.expected
@@ -10,6 +10,18 @@ nodes
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
+| libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
+| libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
+| libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
+| libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
+| libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
+| libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
+| libxml.noent.js:16:26:16:34 | req.files |
+| libxml.noent.js:16:26:16:34 | req.files |
+| libxml.noent.js:16:26:16:43 | req.files.products |
+| libxml.noent.js:16:26:16:48 | req.fil ... ts.data |
+| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
+| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
@@ -25,11 +37,21 @@ edges
 | domparser.js:2:13:2:29 | document.location | domparser.js:2:13:2:36 | documen ... .search |
 | domparser.js:2:13:2:36 | documen ... .search | domparser.js:2:7:2:36 | src |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") |
+| libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") |
+| libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") |
+| libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:43 | req.files.products |
+| libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:43 | req.files.products |
+| libxml.noent.js:16:26:16:43 | req.files.products | libxml.noent.js:16:26:16:48 | req.fil ... ts.data |
+| libxml.noent.js:16:26:16:48 | req.fil ... ts.data | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
+| libxml.noent.js:16:26:16:48 | req.fil ... ts.data | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") |
 #select
 | domparser.js:11:55:11:57 | src | domparser.js:2:13:2:29 | document.location | domparser.js:11:55:11:57 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
 | domparser.js:14:57:14:59 | src | domparser.js:2:13:2:29 | document.location | domparser.js:14:57:14:59 | src | A $@ is parsed as XML without guarding against external entity expansion. | domparser.js:2:13:2:29 | document.location | user-provided value |
 | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:6:21:6:41 | req.par ... e-xml") | user-provided value |
+| libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:11:21:11:41 | req.par ... e-xml") | user-provided value |
+| libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:14:27:14:47 | req.par ... e-xml") | user-provided value |
+| libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') | libxml.noent.js:16:26:16:34 | req.files | libxml.noent.js:16:26:16:65 | req.fil ... 'utf8') | A $@ is parsed as XML without guarding against external entity expansion. | libxml.noent.js:16:26:16:34 | req.files | user-provided value |
 | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.sax.js:6:22:6:42 | req.par ... e-xml") | user-provided value |
 | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | A $@ is parsed as XML without guarding against external entity expansion. | libxml.saxpush.js:6:15:6:35 | req.par ... e-xml") | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-611/libxml.noent.js
+++ b/javascript/ql/test/query-tests/Security/CWE-611/libxml.noent.js
@@ -5,3 +5,13 @@ express().get('/some/path', function(req) {
   // NOT OK: unguarded entity expansion
   libxmljs.parseXml(req.param("some-xml"), { noent: true });
 });
+
+express().post('/some/path', function(req, res) {
+  // NOT OK: unguarded entity expansion
+  libxmljs.parseXml(req.param("some-xml"), { noent: true });
+
+  // NOT OK: unguarded entity expansion
+  libxmljs.parseXmlString(req.param("some-xml"), {noent:true,noblanks:true})
+  // NOT OK: unguarded entity expansion
+	libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true,noblanks:true})
+});

--- a/javascript/ql/test/query-tests/Security/CWE-611/libxml.noent.js
+++ b/javascript/ql/test/query-tests/Security/CWE-611/libxml.noent.js
@@ -11,7 +11,10 @@ express().post('/some/path', function(req, res) {
   libxmljs.parseXml(req.param("some-xml"), { noent: true });
 
   // NOT OK: unguarded entity expansion
-  libxmljs.parseXmlString(req.param("some-xml"), {noent:true,noblanks:true})
+  libxmljs.parseXmlString(req.param("some-xml"), {noent:true})
   // NOT OK: unguarded entity expansion
-	libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true,noblanks:true})
+  libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:true})
+  
+  // OK - no entity expansion
+  libxmljs.parseXmlString(req.files.products.data.toString('utf8'), {noent:false})
 });


### PR DESCRIPTION
Gets is a TP/TN for [this example vulnerability](https://appsecco.com/books/dvna-developers-security-guide/solution/a4-xxe.html) from [Damn Vulnerable NodeJS Application](https://github.com/appsecco/dvna). 

For most intents and purposes `req.files` behaves the same as `reg.body` (it is completely user controllable).   
So I just reused the `kind = "body"`. 