### PR TITLE
C++: Manual recursion in `skipCopyValueInstructions`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -355,14 +355,16 @@ private class ArrayToPointerConvertInstruction extends ConvertInstruction {
   }
 }
 
-private Instruction skipOneCopyValueInstruction(Instruction instr) {
-  not instr instanceof CopyValueInstruction and result = instr
+private Instruction skipOneCopyValueInstructionRec(CopyValueInstruction copy) {
+  copy.getUnary() = result and not result instanceof CopyValueInstruction
   or
-  result = instr.(CopyValueInstruction).getUnary()
+  result = skipOneCopyValueInstructionRec(copy.getUnary())
 }
 
 private Instruction skipCopyValueInstructions(Instruction instr) {
-  result = skipOneCopyValueInstruction*(instr) and not result instanceof CopyValueInstruction
+  not result instanceof CopyValueInstruction and result = instr
+  or
+  result = skipOneCopyValueInstructionRec(instr)
 }
 
 private predicate arrayReadStep(Node node1, ArrayContent a, Node node2) {


### PR DESCRIPTION
Before this PR we got the following clause timing report in the `DataFlowImplCommon` stage when running on `chakracore`:

```
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Cand::parameterValueFlowCand#fff ...................... 6.8s (executed 425 times)
	TaintedPath.ql-13:#DataFlowPrivate::skipOneCopyValueInstruction#ffPlus ........................................... 5.5s
	TaintedPath.ql-13:DataFlowPrivate::readStep#fff .................................................................. 4.2s
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Final::parameterValueFlow0#fff ........................ 1.8s (executed 849 times)
	TaintedPath.ql-13:SSAConstruction::Cached::getInstructionResultType#2#ff_10#join_rhs ............................. 1.3s

```
where `skipOneCopyValueInstruction#ffPlus` is the inlined version of `skipCopyValueInstructions`.

With this PR:
```
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Cand::parameterValueFlowCand#fff ...................... 6.6s (executed 425 times)
	TaintedPath.ql-13:DataFlowPrivate::readStep#fff .................................................................. 3.6s
	TaintedPath.ql-13:SSAConstruction::Cached::getInstructionResultType#2#ff_10#join_rhs ............................. 1.7s
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Final::parameterValueFlow0#fff ........................ 1.7s (executed 849 times)
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Cand::parameterValueFlowCand#fff_120#join_rhs ......... 1s
	TaintedPath.ql-13:Operand::Operand::getDef_dispred#3#ff_10#join_rhs .............................................. 995ms
	TaintedPath.ql-13:DataFlowPrivate::ArgumentNode#class#ff ......................................................... 890ms
	TaintedPath.ql-13:DataFlowPrivate::storeStep#fff ................................................................. 843ms
	TaintedPath.ql-13:Operand::RegisterOperand#3#ffff_20#join_rhs .................................................... 770ms
	TaintedPath.ql-13:DataFlowImplCommon::Cached::FlowThrough::Final::parameterValueFlow#fff ......................... 752ms (executed 507 times)
	TaintedPath.ql-13:DataFlowPrivate::skipCopyValueInstructions#ff .................................................. 741ms
```
CPP-difference: https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/1453/