### PR TITLE
JavaScript: Fix and improve indirect command-argument tracking

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
@@ -64,6 +64,26 @@ private DataFlow::SourceNode argumentList(SystemCommandExecution sys) {
 }
 
 /**
+ * Gets a data-flow node whose value ends up being interpreted as an element of the argument list
+ * `args` after a flow summarised by `t`.
+ */
+private DataFlow::Node argumentListElement(DataFlow::SourceNode args, DataFlow::TypeBackTracker t) {
+  t.start() and
+  args = argumentList(_) and
+  result = args.getAPropertyWrite().getRhs()
+  or
+  exists(DataFlow::TypeBackTracker t2 | t2 = t.smallstep(result, argumentListElement(args, t2)))
+}
+
+/**
+ * Gets a data-flow node whose value ends up being interpreted as an element of the argument list
+ * `args`.
+ */
+private DataFlow::Node argumentListElement(DataFlow::SourceNode args) {
+  result = argumentListElement(args, DataFlow::TypeBackTracker::end())
+}
+
+/**
  * Holds if `source` contributes to the arguments of an indirect command execution `sys`.
  *
  * An indirect command execution is a system execution command that starts with `sh -c`, `cmd.exe /c`, or similar.
@@ -86,8 +106,8 @@ predicate isIndirectCommandArgument(DataFlow::Node source, SystemCommandExecutio
   exists(DataFlow::ArrayCreationNode args, DataFlow::Node shell, string dashC |
     shellCmd(shell.asExpr(), dashC) and
     shell = commandArgument(sys) and
-    args.getAPropertyWrite().getRhs().mayHaveStringValue(dashC) and
     args = argumentList(sys) and
+    argumentListElement(args).mayHaveStringValue(dashC) and
     (
       source = argumentList(sys)
       or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
@@ -108,10 +108,10 @@ predicate isIndirectCommandArgument(DataFlow::Node source, SystemCommandExecutio
     shell = commandArgument(sys) and
     args = argumentList(sys) and
     argumentListElement(args).mayHaveStringValue(dashC) and
-    (
-      source = argumentList(sys)
-      or
-      source = argumentList(sys).getAPropertyWrite().getRhs()
+    exists(DataFlow::SourceNode argsSource | argsSource = argumentList(sys) |
+      if exists(argsSource.getAPropertyWrite())
+      then source = argsSource.getAPropertyWrite().getRhs()
+      else source = argsSource
     )
   )
 }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IndirectCommandArgument.qll
@@ -30,7 +30,7 @@ private DataFlow::Node commandArgument(SystemCommandExecution sys, DataFlow::Typ
   t.start() and
   result = sys.getACommandArgument()
   or
-  exists(DataFlow::TypeBackTracker t2 | t = t2.smallstep(result, commandArgument(sys, t2)))
+  exists(DataFlow::TypeBackTracker t2 | t2 = t.smallstep(result, commandArgument(sys, t2)))
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -55,6 +55,18 @@ nodes
 | child_process-test.js:83:19:83:36 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName |
+| exec-sh2.js:9:17:9:23 | command |
+| exec-sh2.js:10:33:10:47 | ["-c", command] |
+| exec-sh2.js:10:33:10:47 | ["-c", command] |
+| exec-sh2.js:10:40:10:46 | command |
+| exec-sh2.js:10:40:10:46 | command |
+| exec-sh2.js:14:9:14:49 | cmd |
+| exec-sh2.js:14:15:14:38 | url.par ... , true) |
+| exec-sh2.js:14:15:14:44 | url.par ... ).query |
+| exec-sh2.js:14:15:14:49 | url.par ... ry.path |
+| exec-sh2.js:14:25:14:31 | req.url |
+| exec-sh2.js:14:25:14:31 | req.url |
+| exec-sh2.js:15:12:15:14 | cmd |
 | execSeries.js:3:20:3:22 | arr |
 | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:21 | arr[i++] |
@@ -174,6 +186,17 @@ edges
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:7:32:7:35 | name |
 | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:7:32:7:35 | name |
+| exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
+| exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
+| exec-sh2.js:10:40:10:46 | command | exec-sh2.js:10:33:10:47 | ["-c", command] |
+| exec-sh2.js:10:40:10:46 | command | exec-sh2.js:10:33:10:47 | ["-c", command] |
+| exec-sh2.js:14:9:14:49 | cmd | exec-sh2.js:15:12:15:14 | cmd |
+| exec-sh2.js:14:15:14:38 | url.par ... , true) | exec-sh2.js:14:15:14:44 | url.par ... ).query |
+| exec-sh2.js:14:15:14:44 | url.par ... ).query | exec-sh2.js:14:15:14:49 | url.par ... ry.path |
+| exec-sh2.js:14:15:14:49 | url.par ... ry.path | exec-sh2.js:14:9:14:49 | cmd |
+| exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:14:15:14:38 | url.par ... , true) |
+| exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:14:15:14:38 | url.par ... , true) |
+| exec-sh2.js:15:12:15:14 | cmd | exec-sh2.js:9:17:9:23 | command |
 | execSeries.js:3:20:3:22 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:16 | arr | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:6:14:6:21 | arr[i++] | execSeries.js:14:24:14:30 | command |
@@ -260,6 +283,8 @@ edges
 | child_process-test.js:67:3:67:21 | cp.spawn(cmd, args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:48:15:48:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:75:29:75:31 | cmd | child_process-test.js:73:25:73:31 | req.url | child_process-test.js:75:29:75:31 | cmd | This command depends on $@. | child_process-test.js:73:25:73:31 | req.url | a user-provided value |
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | This command depends on $@. | child_process-test.js:83:19:83:36 | req.query.fileName | a user-provided value |
+| exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:33:10:47 | ["-c", command] | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
+| exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:40:10:46 | command | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -67,6 +67,18 @@ nodes
 | exec-sh2.js:14:25:14:31 | req.url |
 | exec-sh2.js:14:25:14:31 | req.url |
 | exec-sh2.js:15:12:15:14 | cmd |
+| exec-sh.js:13:17:13:23 | command |
+| exec-sh.js:15:32:15:51 | [shell.arg, command] |
+| exec-sh.js:15:32:15:51 | [shell.arg, command] |
+| exec-sh.js:15:44:15:50 | command |
+| exec-sh.js:15:44:15:50 | command |
+| exec-sh.js:19:9:19:49 | cmd |
+| exec-sh.js:19:15:19:38 | url.par ... , true) |
+| exec-sh.js:19:15:19:44 | url.par ... ).query |
+| exec-sh.js:19:15:19:49 | url.par ... ry.path |
+| exec-sh.js:19:25:19:31 | req.url |
+| exec-sh.js:19:25:19:31 | req.url |
+| exec-sh.js:20:12:20:14 | cmd |
 | execSeries.js:3:20:3:22 | arr |
 | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:21 | arr[i++] |
@@ -197,6 +209,17 @@ edges
 | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:14:15:14:38 | url.par ... , true) |
 | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:14:15:14:38 | url.par ... , true) |
 | exec-sh2.js:15:12:15:14 | cmd | exec-sh2.js:9:17:9:23 | command |
+| exec-sh.js:13:17:13:23 | command | exec-sh.js:15:44:15:50 | command |
+| exec-sh.js:13:17:13:23 | command | exec-sh.js:15:44:15:50 | command |
+| exec-sh.js:15:44:15:50 | command | exec-sh.js:15:32:15:51 | [shell.arg, command] |
+| exec-sh.js:15:44:15:50 | command | exec-sh.js:15:32:15:51 | [shell.arg, command] |
+| exec-sh.js:19:9:19:49 | cmd | exec-sh.js:20:12:20:14 | cmd |
+| exec-sh.js:19:15:19:38 | url.par ... , true) | exec-sh.js:19:15:19:44 | url.par ... ).query |
+| exec-sh.js:19:15:19:44 | url.par ... ).query | exec-sh.js:19:15:19:49 | url.par ... ry.path |
+| exec-sh.js:19:15:19:49 | url.par ... ry.path | exec-sh.js:19:9:19:49 | cmd |
+| exec-sh.js:19:25:19:31 | req.url | exec-sh.js:19:15:19:38 | url.par ... , true) |
+| exec-sh.js:19:25:19:31 | req.url | exec-sh.js:19:15:19:38 | url.par ... , true) |
+| exec-sh.js:20:12:20:14 | cmd | exec-sh.js:13:17:13:23 | command |
 | execSeries.js:3:20:3:22 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:16 | arr | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:6:14:6:21 | arr[i++] | execSeries.js:14:24:14:30 | command |
@@ -285,6 +308,8 @@ edges
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | This command depends on $@. | child_process-test.js:83:19:83:36 | req.query.fileName | a user-provided value |
 | exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:33:10:47 | ["-c", command] | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
 | exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:40:10:46 | command | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
+| exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:32:15:51 | [shell.arg, command] | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
+| exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:44:15:50 | command | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -23,8 +23,6 @@ nodes
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:18:39:30 | [ flag, cmd ] |
 | child_process-test.js:39:26:39:28 | cmd |
 | child_process-test.js:39:26:39:28 | cmd |
 | child_process-test.js:43:15:43:17 | cmd |
@@ -35,7 +33,6 @@ nodes
 | child_process-test.js:53:15:53:17 | cmd |
 | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) |
 | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) |
-| child_process-test.js:56:46:56:57 | ["bar", cmd] |
 | child_process-test.js:56:46:56:57 | ["bar", cmd] |
 | child_process-test.js:56:54:56:56 | cmd |
 | child_process-test.js:56:54:56:56 | cmd |
@@ -56,8 +53,6 @@ nodes
 | child_process-test.js:85:37:85:54 | req.query.fileName |
 | child_process-test.js:85:37:85:54 | req.query.fileName |
 | exec-sh2.js:9:17:9:23 | command |
-| exec-sh2.js:10:33:10:47 | ["-c", command] |
-| exec-sh2.js:10:33:10:47 | ["-c", command] |
 | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:14:9:14:49 | cmd |
@@ -68,8 +63,6 @@ nodes
 | exec-sh2.js:14:25:14:31 | req.url |
 | exec-sh2.js:15:12:15:14 | cmd |
 | exec-sh.js:13:17:13:23 | command |
-| exec-sh.js:15:32:15:51 | [shell.arg, command] |
-| exec-sh.js:15:32:15:51 | [shell.arg, command] |
 | exec-sh.js:15:44:15:50 | command |
 | exec-sh.js:15:44:15:50 | command |
 | exec-sh.js:19:9:19:49 | cmd |
@@ -180,11 +173,8 @@ edges
 | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:6:15:6:38 | url.par ... , true) |
 | child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
 | child_process-test.js:25:21:25:23 | cmd | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" |
-| child_process-test.js:39:26:39:28 | cmd | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
-| child_process-test.js:39:26:39:28 | cmd | child_process-test.js:39:18:39:30 | [ flag, cmd ] |
 | child_process-test.js:56:46:56:57 | ["bar", cmd] | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) |
 | child_process-test.js:56:46:56:57 | ["bar", cmd] | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) |
-| child_process-test.js:56:54:56:56 | cmd | child_process-test.js:56:46:56:57 | ["bar", cmd] |
 | child_process-test.js:56:54:56:56 | cmd | child_process-test.js:56:46:56:57 | ["bar", cmd] |
 | child_process-test.js:57:46:57:48 | cmd | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) |
 | child_process-test.js:57:46:57:48 | cmd | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) |
@@ -200,8 +190,6 @@ edges
 | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:7:32:7:35 | name |
 | exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
 | exec-sh2.js:9:17:9:23 | command | exec-sh2.js:10:40:10:46 | command |
-| exec-sh2.js:10:40:10:46 | command | exec-sh2.js:10:33:10:47 | ["-c", command] |
-| exec-sh2.js:10:40:10:46 | command | exec-sh2.js:10:33:10:47 | ["-c", command] |
 | exec-sh2.js:14:9:14:49 | cmd | exec-sh2.js:15:12:15:14 | cmd |
 | exec-sh2.js:14:15:14:38 | url.par ... , true) | exec-sh2.js:14:15:14:44 | url.par ... ).query |
 | exec-sh2.js:14:15:14:44 | url.par ... ).query | exec-sh2.js:14:15:14:49 | url.par ... ry.path |
@@ -211,8 +199,6 @@ edges
 | exec-sh2.js:15:12:15:14 | cmd | exec-sh2.js:9:17:9:23 | command |
 | exec-sh.js:13:17:13:23 | command | exec-sh.js:15:44:15:50 | command |
 | exec-sh.js:13:17:13:23 | command | exec-sh.js:15:44:15:50 | command |
-| exec-sh.js:15:44:15:50 | command | exec-sh.js:15:32:15:51 | [shell.arg, command] |
-| exec-sh.js:15:44:15:50 | command | exec-sh.js:15:32:15:51 | [shell.arg, command] |
 | exec-sh.js:19:9:19:49 | cmd | exec-sh.js:20:12:20:14 | cmd |
 | exec-sh.js:19:15:19:38 | url.par ... , true) | exec-sh.js:19:15:19:44 | url.par ... ).query |
 | exec-sh.js:19:15:19:44 | url.par ... ).query | exec-sh.js:19:15:19:49 | url.par ... ry.path |
@@ -293,12 +279,10 @@ edges
 | child_process-test.js:22:18:22:20 | cmd | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:22:18:22:20 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:23:13:23:15 | cmd | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:23:13:23:15 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:25:13:25:31 | "foo" + cmd + "bar" | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
-| child_process-test.js:39:5:39:31 | cp.spaw ...  cmd ]) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:39:18:39:30 | [ flag, cmd ] | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:39:5:39:31 | cp.spaw ...  cmd ]) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:39:26:39:28 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:44:5:44:34 | cp.exec ... , args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:43:15:43:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:54:5:54:39 | cp.exec ... , args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:53:15:53:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:56:5:56:59 | cp.spaw ...  cmd])) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
-| child_process-test.js:56:5:56:59 | cp.spaw ...  cmd])) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:56:46:56:57 | ["bar", cmd] | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:56:5:56:59 | cp.spaw ...  cmd])) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:56:54:56:56 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:57:5:57:50 | cp.spaw ... t(cmd)) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:6:15:6:49 | url.par ... ry.path | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:57:5:57:50 | cp.spaw ... t(cmd)) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
@@ -306,9 +290,7 @@ edges
 | child_process-test.js:67:3:67:21 | cp.spawn(cmd, args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:48:15:48:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:75:29:75:31 | cmd | child_process-test.js:73:25:73:31 | req.url | child_process-test.js:75:29:75:31 | cmd | This command depends on $@. | child_process-test.js:73:25:73:31 | req.url | a user-provided value |
 | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | child_process-test.js:83:19:83:36 | req.query.fileName | This command depends on $@. | child_process-test.js:83:19:83:36 | req.query.fileName | a user-provided value |
-| exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:33:10:47 | ["-c", command] | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
 | exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:14:25:14:31 | req.url | exec-sh2.js:10:40:10:46 | command | This command depends on $@. | exec-sh2.js:14:25:14:31 | req.url | a user-provided value |
-| exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:32:15:51 | [shell.arg, command] | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
 | exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:19:25:19:31 | req.url | exec-sh.js:15:44:15:50 | command | This command depends on $@. | exec-sh.js:19:25:19:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
 | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | child_process-test.js:85:37:85:54 | req.query.fileName | lib/subLib/index.js:8:10:8:25 | "rm -rf " + name | This command depends on $@. | child_process-test.js:85:37:85:54 | req.query.fileName | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
@@ -1,2 +1,1 @@
-| query-tests/Security/CWE-078/exec-sh2.js:10 | expected an alert, but found none | BAD | ComandInjection |
 | query-tests/Security/CWE-078/exec-sh.js:15 | expected an alert, but found none | BAD | ComandInjection |

--- a/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
@@ -1,1 +1,0 @@
-| query-tests/Security/CWE-078/exec-sh.js:15 | expected an alert, but found none | BAD | ComandInjection |

--- a/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/Consistency.expected
@@ -1,0 +1,2 @@
+| query-tests/Security/CWE-078/exec-sh2.js:10 | expected an alert, but found none | BAD | ComandInjection |
+| query-tests/Security/CWE-078/exec-sh.js:15 | expected an alert, but found none | BAD | ComandInjection |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UselessUseOfCat.expected
@@ -94,6 +94,8 @@ options
 | child_process-test.js:56:5:56:59 | cp.spaw ...  cmd])) | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) |
 | child_process-test.js:57:5:57:50 | cp.spaw ... t(cmd)) | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) |
 | child_process-test.js:67:3:67:21 | cp.spawn(cmd, args) | child_process-test.js:67:17:67:20 | args |
+| exec-sh2.js:10:12:10:57 | cp.spaw ... ptions) | exec-sh2.js:10:50:10:56 | options |
+| exec-sh.js:15:12:15:61 | cp.spaw ... ptions) | exec-sh.js:15:54:15:60 | options |
 | lib/lib.js:152:2:152:23 | cp.spaw ... gs, cb) | lib/lib.js:152:21:152:22 | cb |
 | lib/lib.js:159:2:159:23 | cp.spaw ... gs, cb) | lib/lib.js:159:21:159:22 | cb |
 | lib/lib.js:163:2:167:2 | cp.spaw ... t' }\\n\\t) | lib/lib.js:166:3:166:22 | { stdio: 'inherit' } |

--- a/javascript/ql/test/query-tests/Security/CWE-078/exec-sh.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/exec-sh.js
@@ -1,0 +1,21 @@
+const cp = require('child_process'),
+    http = require('http'),
+    url = require('url');
+
+function getShell() {
+    if (process.platform === 'win32') {
+        return { cmd: 'cmd', arg: '/C' }
+    } else {
+        return { cmd: 'sh', arg: '-c' }
+    }
+}
+
+function execSh(command, options) {
+    var shell = getShell()
+    return cp.spawn(shell.cmd, [shell.arg, command], options) // BAD
+}
+
+http.createServer(function (req, res) {
+    let cmd = url.parse(req.url, true).query.path;
+    execSh(cmd);
+});

--- a/javascript/ql/test/query-tests/Security/CWE-078/exec-sh2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/exec-sh2.js
@@ -1,0 +1,16 @@
+const cp = require('child_process'),
+    http = require('http'),
+    url = require('url');
+
+function getShell() {
+    return "sh";
+}
+
+function execSh(command, options) {
+    return cp.spawn(getShell(), ["-c", command], options) // BAD
+};
+
+http.createServer(function (req, res) {
+    let cmd = url.parse(req.url, true).query.path;
+    execSh(cmd);
+});


### PR DESCRIPTION
The first two commits are a simple correctness fix: `commandArgument` was using type backtrackers wrongly, and hence was unable to backtrack into function calls.

The third commit introduces an extra bit of type tracking: we previously already type-tracked the `'sh'` string (or similar) in an indirect command, now we also track the corresponding `-c` (or similar). With this improvement, we can derive a reasonable summary for https://github.com/tsertkov/exec-sh.

The final commit is an unrelated bit of clean-up to reduce the number of alert locations for the command-injection query.