### PR TITLE
JS: type-track objects where the "$where" property has been written

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -13,10 +13,22 @@ module NoSQL {
 }
 
 /**
+ * Gets a reference to an object where the "$where" property has been assigned to`rhs`.
+ */
+DataFlow::SourceNode getADollarWherePropertyValueSource(DataFlow::TypeTracker t, DataFlow::Node rhs) {
+  t.start() and
+  rhs = result.getAPropertyWrite("$where").getRhs()
+  or
+  exists(DataFlow::TypeTracker t2 |
+    result = getADollarWherePropertyValueSource(t2, rhs).track(t2, t)
+  )
+}
+
+/**
  * Gets the value of a `$where` property of an object that flows to `n`.
  */
 private DataFlow::Node getADollarWherePropertyValue(DataFlow::Node n) {
-  result = n.getALocalSource().getAPropertyWrite("$where").getRhs()
+  getADollarWherePropertyValueSource(DataFlow::TypeTracker::end(), result).flowsTo(n)
 }
 
 /**

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -8,6 +8,11 @@ nodes
 | NoSQLCodeInjection.js:19:36:19:43 | req.body |
 | NoSQLCodeInjection.js:19:36:19:43 | req.body |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name |
+| NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
 | angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:36 | location.search |
@@ -152,6 +157,10 @@ edges
 | NoSQLCodeInjection.js:19:36:19:43 | req.body | NoSQLCodeInjection.js:19:36:19:48 | req.body.name |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
@@ -275,6 +284,7 @@ edges
 #select
 | NoSQLCodeInjection.js:18:24:18:37 | req.body.query | NoSQLCodeInjection.js:18:24:18:31 | req.body | NoSQLCodeInjection.js:18:24:18:37 | req.body.query | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:18:24:18:31 | req.body | User-provided value |
 | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name | NoSQLCodeInjection.js:19:36:19:43 | req.body | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:19:36:19:43 | req.body | User-provided value |
+| NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name | NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name | $@ flows to here and is interpreted as code. | NoSQLCodeInjection.js:22:36:22:43 | req.body | User-provided value |
 | angularjs.js:10:22:10:36 | location.search | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:10:22:10:29 | location | User-provided value |
 | angularjs.js:13:23:13:37 | location.search | angularjs.js:13:23:13:30 | location | angularjs.js:13:23:13:37 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:13:23:13:30 | location | User-provided value |
 | angularjs.js:16:28:16:42 | location.search | angularjs.js:16:28:16:35 | location | angularjs.js:16:28:16:42 | location.search | $@ flows to here and is interpreted as code. | angularjs.js:16:28:16:35 | location | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -8,6 +8,11 @@ nodes
 | NoSQLCodeInjection.js:19:36:19:43 | req.body |
 | NoSQLCodeInjection.js:19:36:19:43 | req.body |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name |
+| NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
 | angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:29 | location |
 | angularjs.js:10:22:10:36 | location.search |
@@ -156,6 +161,10 @@ edges
 | NoSQLCodeInjection.js:19:36:19:43 | req.body | NoSQLCodeInjection.js:19:36:19:48 | req.body.name |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name |
 | NoSQLCodeInjection.js:19:36:19:48 | req.body.name | NoSQLCodeInjection.js:19:24:19:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
+| NoSQLCodeInjection.js:22:36:22:43 | req.body | NoSQLCodeInjection.js:22:36:22:48 | req.body.name |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
+| NoSQLCodeInjection.js:22:36:22:48 | req.body.name | NoSQLCodeInjection.js:22:24:22:48 | "name = ... dy.name |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |
 | angularjs.js:10:22:10:29 | location | angularjs.js:10:22:10:36 | location.search |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/NoSQLCodeInjection.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/NoSQLCodeInjection.js
@@ -17,5 +17,11 @@ app.post("/documents/find", (req, res) => {
     doc.find(query); // NOT OK, but that is flagged by js/sql-injection [INCONSISTENCY]
     doc.find({ $where: req.body.query }); // NOT OK
     doc.find({ $where: "name = " + req.body.name }); // NOT OK
+
+    function mkWhereObj() {
+      return { $where: "name = " + req.body.name };  // NOT OK
+    }
+
+    doc.find(mkWhereObj()); // the alert location is in mkWhereObj.
   });
 });


### PR DESCRIPTION
Gets a TP for `js/code-injection` on [this synthetic benchmark](https://github.com/OWASP/NodeGoat/blob/58cbbe2da2062237c4cd38a19bff6323b58141f8/app/data/allocations-dao.js#L78). 

An alternative would be to add a `$where` step as an additional taint step (with flow-labels).   
But that requires a larger refactoring of the `$where` sink, and could end up costing performance.   

With this solution there can be a disconnect between a query-call and the alert location.    
But I don't see a good solution to this. 