### PR TITLE
JS: Add model for needle in ClientRequests.qll

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -14,6 +14,7 @@
   - [json-stringify-safe](https://www.npmjs.com/package/json-stringify-safe)
   - [json3](https://www.npmjs.com/package/json3)
   - [lodash](https://www.npmjs.com/package/lodash)
+  - [needle](https://www.npmjs.com/package/needle)
   - [object-inspect](https://www.npmjs.com/package/object-inspect)
   - [pretty-format](https://www.npmjs.com/package/pretty-format)
   - [stringify-object](https://www.npmjs.com/package/stringify-object)

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -396,11 +396,11 @@ module ClientRequest {
 
       override DataFlow::Node getAResponseDataNode(string responseType, boolean promise) {
         promise = false and
-        result = this.getCallback(this.getNumArgument() - 1).getParameter(1) and
+        result = this.getABoundCallbackParameter(this.getNumArgument() - 1, 1) and
         responseType = "fetch.response"
         or
         promise = false and
-        result = this.getCallback(this.getNumArgument() - 1).getParameter(2) and
+        result = this.getABoundCallbackParameter(this.getNumArgument() - 1, 2) and
         responseType = "json"
       }
     }

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -328,6 +328,36 @@ module ClientRequest {
   }
 
   /**
+   * Classes for modelling the url request library `needle`.
+   */
+  private module Needle {
+    /**
+     * A model of a URL request made using `require("needle")(...)`.
+     */
+    class PromisedNeedleRequest extends ClientRequest::Range {
+      DataFlow::Node url;
+
+      PromisedNeedleRequest() { this = DataFlow::moduleImport("needle").getACall() }
+
+      override DataFlow::Node getUrl() { result = getArgument(1) }
+
+      override DataFlow::Node getHost() { none() }
+
+      override DataFlow::Node getADataNode() {
+        result = getOptionArgument([2, 3], "headers")
+        or
+        result = getArgument(2)
+      }
+
+      override DataFlow::Node getAResponseDataNode(string responseType, boolean promise) {
+        responseType = "fetch.response" and
+        promise = true and
+        result = this
+      }
+    }
+  }
+
+  /**
    * A model of a URL request made using the `got` library.
    */
   class GotUrlRequest extends ClientRequest::Range {

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -67,6 +67,7 @@ test_ClientRequest
 | tst.js:202:5:208:7 | $.ajax( ...     }}) |
 | tst.js:210:2:210:21 | $.get("example.php") |
 | tst.js:219:5:219:41 | data.so ... Host"}) |
+| tst.js:229:5:229:67 | needle( ... ptions) |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -97,6 +98,8 @@ test_getADataNode
 | tst.js:183:2:183:60 | $.post( ...  ) { }) | tst.js:183:28:183:37 | "PostData" |
 | tst.js:187:2:193:3 | $.ajax( ... on"\\n\\t}) | tst.js:190:11:190:20 | "AjaxData" |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:223:23:223:30 | "foobar" |
+| tst.js:229:5:229:67 | needle( ... ptions) | tst.js:228:32:228:70 | { 'X-Cu ... tuna' } |
+| tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:50:229:57 | "MyData" |
 test_getHost
 | tst.js:87:5:87:39 | http.ge ...  host}) | tst.js:87:34:87:37 | host |
 | tst.js:89:5:89:23 | axios({host: host}) | tst.js:89:18:89:21 | host |
@@ -177,6 +180,7 @@ test_getUrl
 | tst.js:202:5:208:7 | $.ajax( ...     }}) | tst.js:203:10:203:22 | "example.php" |
 | tst.js:210:2:210:21 | $.get("example.php") | tst.js:210:8:210:20 | "example.php" |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:219:25:219:40 | {host: "myHost"} |
+| tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:20:229:47 | "http:/ ... oo/bar" |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |
@@ -238,3 +242,4 @@ test_getAResponseDataNode
 | tst.js:202:5:208:7 | $.ajax( ...     }}) | tst.js:207:21:207:36 | err.responseText | json | false |
 | tst.js:210:2:210:21 | $.get("example.php") | tst.js:210:55:210:70 | xhr.responseText |  | false |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:221:29:221:32 | data | text | false |
+| tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:5:229:67 | needle( ... ptions) | fetch.response | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -68,6 +68,8 @@ test_ClientRequest
 | tst.js:210:2:210:21 | $.get("example.php") |
 | tst.js:219:5:219:41 | data.so ... Host"}) |
 | tst.js:229:5:229:67 | needle( ... ptions) |
+| tst.js:231:5:233:6 | needle. ... \\n    }) |
+| tst.js:235:5:237:6 | needle. ... \\n    }) |
 test_getADataNode
 | tst.js:53:5:53:23 | axios({data: data}) | tst.js:53:18:53:21 | data |
 | tst.js:57:5:57:39 | axios.p ... data2}) | tst.js:57:19:57:23 | data1 |
@@ -100,6 +102,8 @@ test_getADataNode
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:223:23:223:30 | "foobar" |
 | tst.js:229:5:229:67 | needle( ... ptions) | tst.js:228:32:228:70 | { 'X-Cu ... tuna' } |
 | tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:50:229:57 | "MyData" |
+| tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:228:32:228:70 | { 'X-Cu ... tuna' } |
+| tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:44:235:49 | "data" |
 test_getHost
 | tst.js:87:5:87:39 | http.ge ...  host}) | tst.js:87:34:87:37 | host |
 | tst.js:89:5:89:23 | axios({host: host}) | tst.js:89:18:89:21 | host |
@@ -181,6 +185,8 @@ test_getUrl
 | tst.js:210:2:210:21 | $.get("example.php") | tst.js:210:8:210:20 | "example.php" |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:219:25:219:40 | {host: "myHost"} |
 | tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:20:229:47 | "http:/ ... oo/bar" |
+| tst.js:231:5:233:6 | needle. ... \\n    }) | tst.js:231:16:231:35 | "http://example.org" |
+| tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:17:235:41 | "http:/ ... g/post" |
 test_getAResponseDataNode
 | tst.js:19:5:19:23 | requestPromise(url) | tst.js:19:5:19:23 | requestPromise(url) | text | true |
 | tst.js:21:5:21:23 | superagent.get(url) | tst.js:21:5:21:23 | superagent.get(url) | stream | true |
@@ -243,3 +249,7 @@ test_getAResponseDataNode
 | tst.js:210:2:210:21 | $.get("example.php") | tst.js:210:55:210:70 | xhr.responseText |  | false |
 | tst.js:219:5:219:41 | data.so ... Host"}) | tst.js:221:29:221:32 | data | text | false |
 | tst.js:229:5:229:67 | needle( ... ptions) | tst.js:229:5:229:67 | needle( ... ptions) | fetch.response | true |
+| tst.js:231:5:233:6 | needle. ... \\n    }) | tst.js:231:44:231:47 | resp | fetch.response | false |
+| tst.js:231:5:233:6 | needle. ... \\n    }) | tst.js:231:50:231:53 | body | json | false |
+| tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:67:235:70 | resp | fetch.response | false |
+| tst.js:235:5:237:6 | needle. ... \\n    }) | tst.js:235:73:235:76 | body | json | false |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -222,3 +222,9 @@ const net = require("net");
 
     data.socket.write("foobar");
 })();
+
+const needle = require("needle");
+(function () {
+    const options = { headers: { 'X-Custom-Header': 'Bumbaway atuna' } };
+    needle("POST", "http://example.org/foo/bar", "MyData", options).then(function(resp) { console.log(resp.body) });
+})();

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -227,4 +227,12 @@ const needle = require("needle");
 (function () {
     const options = { headers: { 'X-Custom-Header': 'Bumbaway atuna' } };
     needle("POST", "http://example.org/foo/bar", "MyData", options).then(function(resp) { console.log(resp.body) });
+
+    needle.get("http://example.org", (err, resp, body) => {
+
+    });
+
+    needle.post("http://example.org/post", "data", options, (err, resp, body) => {
+
+    });
 })();


### PR DESCRIPTION
Inspired by [this benchmark](https://github.com/OWASP/NodeGoat/blob/master/app/routes/research.js#L13). 

With this PR we get a TP for `js/request-forgery` in that benchmark. 