### PR TITLE
C#: Precise data-flow for `System.Threading.Tasks`

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -95,6 +95,10 @@ private class LocalTaintExprStepConfiguration extends ControlFlowReachabilityCon
           scope = e2 and
           isSuccessor = true
         )
+      or
+      e1 = e2.(AwaitExpr).getExpr() and
+      scope = e2 and
+      isSuccessor = true
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/runtime/CompilerServices.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/runtime/CompilerServices.qll
@@ -1,0 +1,30 @@
+/** Provides definitions related to the namespace `System.Runtime.CompilerServices`. */
+
+import csharp
+private import semmle.code.csharp.frameworks.system.Runtime
+
+/** The `System.Runtime.CompilerServices` namespace. */
+class SystemRuntimeCompilerServicesNamespace extends Namespace {
+  SystemRuntimeCompilerServicesNamespace() {
+    this.getParentNamespace() instanceof SystemRuntimeNamespace and
+    this.hasName("CompilerServices")
+  }
+}
+
+/** An unbound generic struct in the `System.Runtime.CompilerServices` namespace. */
+class SystemRuntimeCompilerServicesNamespaceUnboundGenericStruct extends UnboundGenericStruct {
+  SystemRuntimeCompilerServicesNamespaceUnboundGenericStruct() {
+    this = any(SystemRuntimeCompilerServicesNamespace n).getATypeDeclaration()
+  }
+}
+
+/** The `System.Runtime.CompilerServices.TaskAwaiter<>` struct. */
+class SystemRuntimeCompilerServicesTaskAwaiterStruct extends SystemRuntimeCompilerServicesNamespaceUnboundGenericStruct {
+  SystemRuntimeCompilerServicesTaskAwaiterStruct() { this.hasName("TaskAwaiter<>") }
+
+  /** Gets the `GetResult` method. */
+  Method getGetResultMethod() { result = this.getAMethod("GetResult") }
+
+  /** Gets the field that stores the underlying task. */
+  Field getUnderlyingTaskField() { result = this.getAField() and result.hasName("m_task") }
+}

--- a/csharp/ql/src/semmle/code/csharp/frameworks/system/threading/Tasks.qll
+++ b/csharp/ql/src/semmle/code/csharp/frameworks/system/threading/Tasks.qll
@@ -38,4 +38,7 @@ class SystemThreadingTasksTaskTClass extends SystemThreadingTasksUnboundGenericC
     result.hasName("Result") and
     result.getType() = this.getTypeParameter(0)
   }
+
+  /** Gets the `GetAwaiter` method. */
+  Method getGetAwaiterMethod() { result = this.getAMethod("GetAwaiter") }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -37,20 +37,20 @@
 | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
 | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -55,7 +55,7 @@ edges
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String |
@@ -64,7 +64,7 @@ edges
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String |
+| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String |
 | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
@@ -80,31 +80,31 @@ edges
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:377:41:377:41 | x : String |
+| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
 | GlobalDataFlow.cs:54:15:54:15 | x : String | GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String |
-| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String |
+| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:377:41:377:41 | x : String |
+| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:57:37:57:37 | x : String | GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String |
-| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String |
+| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:422:9:422:11 | value : String |
+| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:424:9:424:11 | value : String |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String |
 | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String |
@@ -129,7 +129,7 @@ edges
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 |
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:85:59:85:64 | access to local variable sink14 : String |
 | GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select [[]] : String |
-| GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String |
 | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [[]] : String | GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String |
 | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [[]] : String |
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip [[]] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First : String |
@@ -167,7 +167,7 @@ edges
 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [[]] : String |
 | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
 | GlobalDataFlow.cs:212:71:212:71 | x : String | GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String |
+| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String |
 | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String |
 | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:213:22:213:39 | call to method Select [[]] : String |
 | GlobalDataFlow.cs:213:22:213:39 | call to method Select [[]] : String | GlobalDataFlow.cs:213:22:213:47 | call to method First : String |
@@ -177,45 +177,45 @@ edges
 | GlobalDataFlow.cs:215:22:215:39 | call to method Select [[]] : String | GlobalDataFlow.cs:215:22:215:47 | call to method First : String |
 | GlobalDataFlow.cs:215:22:215:47 | call to method First : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
 | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String |
+| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String |
-| GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String | GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String | GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String | GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [Value] : String |
-| GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
-| GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
-| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [[]] : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String |
-| GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:422:9:422:11 | value : String | GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
+| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
+| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [[]] : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String |
+| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:424:9:424:11 | value : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -367,52 +367,52 @@ nodes
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | semmle.label | call to method Select [[]] : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
-| GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | semmle.label | tainted : String |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
-| GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
-| GlobalDataFlow.cs:422:9:422:11 | value : String | semmle.label | value : String |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
-| GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
+| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | semmle.label | tainted : String |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
+| GlobalDataFlow.cs:424:9:424:11 | value : String | semmle.label | value : String |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | semmle.label | [b (line 3): false] call to method Return : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return : String | semmle.label | [b (line 3): true] call to method Return : String |
@@ -441,17 +441,17 @@ nodes
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
 | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | access to local variable sink1 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
+| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
 | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:82:15:82:20 | access to local variable sink13 | access to local variable sink13 |
 | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:84:15:84:20 | access to local variable sink14 | access to local variable sink14 |
 | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:86:15:86:20 | access to local variable sink15 | access to local variable sink15 |
 | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:88:15:88:20 | access to local variable sink16 | access to local variable sink16 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
 | GlobalDataFlow.cs:77:15:77:19 | access to local variable sink2 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:77:15:77:19 | access to local variable sink2 | access to local variable sink2 |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | access to local variable sink20 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
 | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | access to local variable sink24 |
 | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | access to local variable sink25 |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | access to local variable sink26 |
@@ -470,27 +470,27 @@ nodes
 | Capture.cs:195:15:195:20 | access to local variable sink38 | Capture.cs:125:25:125:31 | tainted : String | Capture.cs:195:15:195:20 | access to local variable sink38 | access to local variable sink38 |
 | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | access to local variable sink4 |
 | Capture.cs:122:15:122:20 | access to local variable sink40 | Capture.cs:115:26:115:39 | "taint source" : String | Capture.cs:122:15:122:20 | access to local variable sink40 | access to local variable sink40 |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | access to local variable sink42 |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | access to local variable sink42 |
 | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
 | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | access to local variable sink9 |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
 | Capture.cs:57:27:57:32 | access to parameter sink39 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:57:27:57:32 | access to parameter sink39 | access to parameter sink39 |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
 | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
 | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 | access to parameter sinkParam2 |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
 | Splitting.cs:21:28:21:32 | access to parameter value | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:21:28:21:32 | access to parameter value | access to parameter value |
 | GlobalDataFlow.cs:27:15:27:32 | access to property SinkProperty0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:27:15:27:32 | access to property SinkProperty0 | access to property SinkProperty0 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -180,8 +180,13 @@ edges
 | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String |
+| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String | GlobalDataFlow.cs:239:22:239:32 | access to property Result : String |
+| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:241:22:241:31 | await ... : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String | GlobalDataFlow.cs:241:22:241:31 | await ... : String |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
 | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
@@ -367,8 +372,13 @@ nodes
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | semmle.label | call to method Select [[]] : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | semmle.label | call to method Run [Result] : String |
 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String | semmle.label | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | semmle.label | access to property Result : String |
 | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:241:22:241:31 | await ... : String | semmle.label | await ... : String |
+| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String | semmle.label | access to local variable task [Result] : String |
 | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
 | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |

--- a/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/GetAnOutNode.expected
@@ -186,13 +186,15 @@
 | GlobalDataFlow.cs:231:19:231:49 | call to method Select | yield return | GlobalDataFlow.cs:231:19:231:49 | call to method Select |
 | GlobalDataFlow.cs:231:19:231:57 | call to method First | return | GlobalDataFlow.cs:231:19:231:57 | call to method First |
 | GlobalDataFlow.cs:231:37:231:48 | [implicit call] delegate creation of type Func<String,String> | return | GlobalDataFlow.cs:231:37:231:48 | [output] delegate creation of type Func<String,String> |
-| GlobalDataFlow.cs:238:22:238:51 | call to method Run | return | GlobalDataFlow.cs:238:22:238:51 | call to method Run |
-| GlobalDataFlow.cs:238:31:238:50 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:238:31:238:50 | [output] (...) => ... |
-| GlobalDataFlow.cs:244:24:244:41 | call to method Run | return | GlobalDataFlow.cs:244:24:244:41 | call to method Run |
-| GlobalDataFlow.cs:244:33:244:40 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:244:33:244:40 | [output] (...) => ... |
-| GlobalDataFlow.cs:295:17:295:38 | call to method ApplyFunc | return | GlobalDataFlow.cs:295:17:295:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:384:16:384:19 | delegate call | return | GlobalDataFlow.cs:384:16:384:19 | delegate call |
-| GlobalDataFlow.cs:449:44:449:47 | delegate call | return | GlobalDataFlow.cs:449:44:449:47 | delegate call |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run | return | GlobalDataFlow.cs:238:20:238:49 | call to method Run |
+| GlobalDataFlow.cs:238:29:238:48 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:238:29:238:48 | [output] (...) => ... |
+| GlobalDataFlow.cs:239:22:239:32 | access to property Result | return | GlobalDataFlow.cs:239:22:239:32 | access to property Result |
+| GlobalDataFlow.cs:245:16:245:33 | call to method Run | return | GlobalDataFlow.cs:245:16:245:33 | call to method Run |
+| GlobalDataFlow.cs:245:25:245:32 | [implicit call] (...) => ... | return | GlobalDataFlow.cs:245:25:245:32 | [output] (...) => ... |
+| GlobalDataFlow.cs:246:24:246:34 | access to property Result | return | GlobalDataFlow.cs:246:24:246:34 | access to property Result |
+| GlobalDataFlow.cs:297:17:297:38 | call to method ApplyFunc | return | GlobalDataFlow.cs:297:17:297:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:386:16:386:19 | delegate call | return | GlobalDataFlow.cs:386:16:386:19 | delegate call |
+| GlobalDataFlow.cs:451:44:451:47 | delegate call | return | GlobalDataFlow.cs:451:44:451:47 | delegate call |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return | return | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return | return | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return |
 | Splitting.cs:20:22:20:30 | call to method Return | return | Splitting.cs:20:22:20:30 | call to method Return |

--- a/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/GlobalDataFlow.cs
@@ -235,15 +235,17 @@ public class DataFlow
     public async void M3()
     {
         // async await, tainted
-        var sink41 = Task.Run(() => "taint source");
+        var task = Task.Run(() => "taint source");
+        var sink41 = task.Result;
         Check(sink41);
-        var sink42 = await sink41;
+        var sink42 = await task;
         Check(sink42);
 
         // async await, not tainted
-        var nonSink0 = Task.Run(() => "");
+        task = Task.Run(() => "");
+        var nonSink0 = task.Result;
         Check(nonSink0);
-        var nonSink1 = await nonSink0;
+        var nonSink1 = await task;
         Check(nonSink1);
     }
 

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -41,20 +41,20 @@
 | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 |
 | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -55,7 +55,7 @@ edges
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:36:13:36:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String |
@@ -64,7 +64,7 @@ edges
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String |
+| GlobalDataFlow.cs:38:35:38:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String |
 | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String | GlobalDataFlow.cs:45:50:45:59 | access to parameter sinkParam2 |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:45:30:45:39 | sinkParam2 : String |
 | GlobalDataFlow.cs:46:13:46:30 | access to property SinkProperty0 : String | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String |
@@ -80,31 +80,31 @@ edges
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:377:41:377:41 | x : String |
+| GlobalDataFlow.cs:53:20:53:37 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
 | GlobalDataFlow.cs:54:15:54:15 | x : String | GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String |
-| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String |
+| GlobalDataFlow.cs:54:24:54:24 | access to parameter x : String | GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:377:41:377:41 | x : String |
+| GlobalDataFlow.cs:54:28:54:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:379:41:379:41 | x : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:55:44:55:61 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:56:28:56:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:57:37:57:37 | x : String | GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String |
-| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String |
+| GlobalDataFlow.cs:57:46:57:46 | access to parameter x : String | GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:391:52:391:52 | x : String |
+| GlobalDataFlow.cs:58:35:58:52 | access to property SinkProperty0 : String | GlobalDataFlow.cs:393:52:393:52 | x : String |
 | GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:422:9:422:11 | value : String |
+| GlobalDataFlow.cs:65:22:65:39 | access to property SinkProperty0 : String | GlobalDataFlow.cs:424:9:424:11 | value : String |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 |
 | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String | GlobalDataFlow.cs:73:94:73:98 | access to local variable sink0 : String |
 | GlobalDataFlow.cs:71:28:71:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:71:21:71:46 | call to method Return : String |
@@ -133,7 +133,7 @@ edges
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:95:15:95:20 | access to local variable sink21 |
 | GlobalDataFlow.cs:83:22:83:95 | call to method First : String | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 |
 | GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:83:22:83:87 | call to method Select [[]] : String |
-| GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String |
+| GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String | GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String |
 | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [[]] : String | GlobalDataFlow.cs:83:23:83:66 | (...) ... [[]] : String |
 | GlobalDataFlow.cs:83:59:83:64 | access to local variable sink13 : String | GlobalDataFlow.cs:83:57:83:66 | { ..., ... } [[]] : String |
 | GlobalDataFlow.cs:85:22:85:128 | call to method Zip [[]] : String | GlobalDataFlow.cs:85:22:85:136 | call to method First : String |
@@ -174,7 +174,7 @@ edges
 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:208:44:208:61 | { ..., ... } [[]] : String |
 | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 |
 | GlobalDataFlow.cs:212:71:212:71 | x : String | GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String |
-| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String |
+| GlobalDataFlow.cs:212:89:212:89 | access to parameter x : String | GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String |
 | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:211:35:211:45 | sinkParam10 : String |
 | GlobalDataFlow.cs:213:22:213:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:213:22:213:39 | call to method Select [[]] : String |
 | GlobalDataFlow.cs:213:22:213:39 | call to method Select [[]] : String | GlobalDataFlow.cs:213:22:213:47 | call to method First : String |
@@ -184,45 +184,45 @@ edges
 | GlobalDataFlow.cs:215:22:215:39 | call to method Select [[]] : String | GlobalDataFlow.cs:215:22:215:47 | call to method First : String |
 | GlobalDataFlow.cs:215:22:215:47 | call to method First : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 |
 | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String |
-| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String |
+| GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String |
-| GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String | GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String | GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String | GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [Value] : String |
-| GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
-| GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
-| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String |
-| GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [[]] : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String |
-| GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:422:9:422:11 | value : String | GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 |
-| GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:154:21:154:25 | call to method Out : String |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:190:22:190:42 | object creation of type Lazy<String> [Value] : String |
+| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | GlobalDataFlow.cs:157:20:157:24 | SSA def(sink7) : String |
+| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | GlobalDataFlow.cs:160:20:160:24 | SSA def(sink8) : String |
+| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String |
+| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:162:22:162:31 | call to method OutYield [[]] : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:54:15:54:15 | x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:57:37:57:37 | x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String |
+| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | GlobalDataFlow.cs:164:22:164:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:424:9:424:11 | value : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 |
+| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:198:22:198:32 | access to property OutProperty : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): false] access to parameter tainted : String |
 | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:8:24:8:30 | [b (line 3): true] access to parameter tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x |
@@ -381,52 +381,52 @@ nodes
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | semmle.label | call to method Select [[]] : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
-| GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
-| GlobalDataFlow.cs:252:26:252:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
-| GlobalDataFlow.cs:254:16:254:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:258:26:258:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:263:26:263:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:268:26:268:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:273:26:273:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:278:26:278:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:283:26:283:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:310:31:310:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:316:32:316:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:322:32:322:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:341:9:341:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:346:9:346:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
-| GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | semmle.label | "taint source" : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:377:41:377:41 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:379:11:379:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:391:52:391:52 | x : String | semmle.label | x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:393:11:393:11 | access to parameter x : String | semmle.label | access to parameter x : String |
-| GlobalDataFlow.cs:396:39:396:45 | tainted : String | semmle.label | tainted : String |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
-| GlobalDataFlow.cs:400:16:400:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
-| GlobalDataFlow.cs:422:9:422:11 | value : String | semmle.label | value : String |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
-| GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
+| GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
+| GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | semmle.label | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:260:26:260:35 | sinkParam1 : String | semmle.label | sinkParam1 : String |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | semmle.label | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:265:26:265:35 | sinkParam3 : String | semmle.label | sinkParam3 : String |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | semmle.label | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:270:26:270:35 | sinkParam4 : String | semmle.label | sinkParam4 : String |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | semmle.label | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:275:26:275:35 | sinkParam5 : String | semmle.label | sinkParam5 : String |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | semmle.label | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:280:26:280:35 | sinkParam6 : String | semmle.label | sinkParam6 : String |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | semmle.label | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:285:26:285:35 | sinkParam7 : String | semmle.label | sinkParam7 : String |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | semmle.label | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:312:31:312:40 | sinkParam8 : String | semmle.label | sinkParam8 : String |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | semmle.label | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:318:32:318:41 | sinkParam9 : String | semmle.label | sinkParam9 : String |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | semmle.label | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String | semmle.label | sinkParam11 : String |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | semmle.label | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:343:9:343:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:348:9:348:26 | SSA def(x) : String | semmle.label | SSA def(x) : String |
+| GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:379:41:379:41 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:381:11:381:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:393:52:393:52 | x : String | semmle.label | x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:395:11:395:11 | access to parameter x : String | semmle.label | access to parameter x : String |
+| GlobalDataFlow.cs:398:39:398:45 | tainted : String | semmle.label | tainted : String |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | semmle.label | access to local variable sink11 |
+| GlobalDataFlow.cs:402:16:402:21 | access to local variable sink11 : String | semmle.label | access to local variable sink11 : String |
+| GlobalDataFlow.cs:424:9:424:11 | value : String | semmle.label | value : String |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | semmle.label | access to local variable sink20 |
+| GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | semmle.label | "taint source" : String |
 | Splitting.cs:3:28:3:34 | tainted : String | semmle.label | tainted : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): false] call to method Return : String | semmle.label | [b (line 3): false] call to method Return : String |
 | Splitting.cs:8:17:8:31 | [b (line 3): true] call to method Return : String | semmle.label | [b (line 3): true] call to method Return : String |
@@ -479,32 +479,32 @@ nodes
 | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:98:15:98:20 | access to local variable sink22 | access to local variable sink22 |
 | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:137:15:137:19 | access to local variable sink4 | access to local variable sink4 |
 | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:145:15:145:19 | access to local variable sink5 | access to local variable sink5 |
-| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
-| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:341:13:341:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
-| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:346:13:346:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
-| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:352:22:352:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
-| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
+| GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:155:15:155:19 | access to local variable sink6 | access to local variable sink6 |
+| GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | GlobalDataFlow.cs:343:13:343:26 | "taint source" : String | GlobalDataFlow.cs:158:15:158:19 | access to local variable sink7 | access to local variable sink7 |
+| GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | GlobalDataFlow.cs:348:13:348:26 | "taint source" : String | GlobalDataFlow.cs:161:15:161:19 | access to local variable sink8 | access to local variable sink8 |
+| GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | GlobalDataFlow.cs:354:22:354:35 | "taint source" : String | GlobalDataFlow.cs:163:15:163:20 | access to local variable sink12 | access to local variable sink12 |
+| GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:165:15:165:20 | access to local variable sink23 | access to local variable sink23 |
 | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | GlobalDataFlow.cs:180:35:180:48 | "taint source" : String | GlobalDataFlow.cs:182:15:182:19 | access to local variable sink9 | access to local variable sink9 |
-| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:336:16:336:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
-| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:433:22:433:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
+| GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |
+| GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | GlobalDataFlow.cs:435:22:435:35 | "taint source" : String | GlobalDataFlow.cs:199:15:199:20 | access to local variable sink19 | access to local variable sink19 |
 | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:211:58:211:68 | access to parameter sinkParam10 | access to parameter sinkParam10 |
 | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:214:15:214:20 | access to local variable sink24 | access to local variable sink24 |
 | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:216:15:216:20 | access to local variable sink25 | access to local variable sink25 |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | access to local variable sink26 |
-| GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:239:15:239:20 | access to local variable sink41 | access to local variable sink41 |
-| GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | GlobalDataFlow.cs:238:37:238:50 | "taint source" : String | GlobalDataFlow.cs:241:15:241:20 | access to local variable sink42 | access to local variable sink42 |
-| GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:255:15:255:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
-| GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:260:15:260:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
-| GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:265:15:265:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
-| GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:270:15:270:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
-| GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:275:15:275:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
-| GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:280:15:280:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
-| GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:285:15:285:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
-| GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:312:15:312:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:318:15:318:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
-| GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:324:15:324:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
-| GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | GlobalDataFlow.cs:396:39:396:45 | tainted : String | GlobalDataFlow.cs:399:15:399:20 | access to local variable sink11 | access to local variable sink11 |
-| GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:422:41:422:46 | access to local variable sink20 | access to local variable sink20 |
+| GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | access to local variable sink41 |
+| GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | access to local variable sink42 |
+| GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 | access to parameter sinkParam0 |
+| GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:262:15:262:24 | access to parameter sinkParam1 | access to parameter sinkParam1 |
+| GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:267:15:267:24 | access to parameter sinkParam3 | access to parameter sinkParam3 |
+| GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:272:15:272:24 | access to parameter sinkParam4 | access to parameter sinkParam4 |
+| GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:277:15:277:24 | access to parameter sinkParam5 | access to parameter sinkParam5 |
+| GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:282:15:282:24 | access to parameter sinkParam6 | access to parameter sinkParam6 |
+| GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:287:15:287:24 | access to parameter sinkParam7 | access to parameter sinkParam7 |
+| GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:314:15:314:24 | access to parameter sinkParam8 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:320:15:320:24 | access to parameter sinkParam9 | access to parameter sinkParam9 |
+| GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | GlobalDataFlow.cs:208:46:208:59 | "taint source" : String | GlobalDataFlow.cs:326:15:326:25 | access to parameter sinkParam11 | access to parameter sinkParam11 |
+| GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | GlobalDataFlow.cs:398:39:398:45 | tainted : String | GlobalDataFlow.cs:401:15:401:20 | access to local variable sink11 | access to local variable sink11 |
+| GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:424:41:424:46 | access to local variable sink20 | access to local variable sink20 |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | Splitting.cs:11:19:11:19 | access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:11:19:11:19 | access to local variable x | access to local variable x |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -187,8 +187,13 @@ edges
 | GlobalDataFlow.cs:217:22:217:28 | access to local variable tainted [[]] : String | GlobalDataFlow.cs:324:32:324:42 | sinkParam11 : String |
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | GlobalDataFlow.cs:217:22:217:57 | call to method First : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
-| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String |
+| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String | GlobalDataFlow.cs:239:22:239:32 | access to property Result : String |
+| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 |
+| GlobalDataFlow.cs:241:22:241:31 | await ... : String | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 |
+| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String | GlobalDataFlow.cs:241:22:241:31 | await ... : String |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | GlobalDataFlow.cs:257:15:257:24 | access to parameter sinkParam0 |
 | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String |
@@ -381,8 +386,13 @@ nodes
 | GlobalDataFlow.cs:217:22:217:49 | call to method Select [[]] : String | semmle.label | call to method Select [[]] : String |
 | GlobalDataFlow.cs:217:22:217:57 | call to method First : String | semmle.label | call to method First : String |
 | GlobalDataFlow.cs:218:15:218:20 | access to local variable sink26 | semmle.label | access to local variable sink26 |
+| GlobalDataFlow.cs:238:20:238:49 | call to method Run [Result] : String | semmle.label | call to method Run [Result] : String |
 | GlobalDataFlow.cs:238:35:238:48 | "taint source" : String | semmle.label | "taint source" : String |
+| GlobalDataFlow.cs:239:22:239:25 | access to local variable task [Result] : String | semmle.label | access to local variable task [Result] : String |
+| GlobalDataFlow.cs:239:22:239:32 | access to property Result : String | semmle.label | access to property Result : String |
 | GlobalDataFlow.cs:240:15:240:20 | access to local variable sink41 | semmle.label | access to local variable sink41 |
+| GlobalDataFlow.cs:241:22:241:31 | await ... : String | semmle.label | await ... : String |
+| GlobalDataFlow.cs:241:28:241:31 | access to local variable task [Result] : String | semmle.label | access to local variable task [Result] : String |
 | GlobalDataFlow.cs:242:15:242:20 | access to local variable sink42 | semmle.label | access to local variable sink42 |
 | GlobalDataFlow.cs:254:26:254:35 | sinkParam0 : String | semmle.label | sinkParam0 : String |
 | GlobalDataFlow.cs:256:16:256:25 | access to parameter sinkParam0 : String | semmle.label | access to parameter sinkParam0 : String |

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.cs
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.cs
@@ -85,7 +85,7 @@ public class LibraryTypeDataFlow
         HttpContextBase context = null;
         string name = context.Request.QueryString["name"];
 
-        var dict = new Dictionary<string, int>() { {"abc", 0 } };
+        var dict = new Dictionary<string, int>() { { "abc", 0 } };
     }
 
     [DataContract]

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
@@ -598,25 +598,10 @@ callableFlow
 | System.Threading.Tasks.Task.ContinueWith(Action<Task, Object>, object, TaskContinuationOptions) | argument 1 -> parameter 1 of argument 0 | true |
 | System.Threading.Tasks.Task.ContinueWith(Action<Task, Object>, object, TaskScheduler) | argument 1 -> parameter 1 of argument 0 | true |
 | System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskContinuationOptions) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskContinuationOptions) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskScheduler) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskScheduler) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, CancellationToken) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, TaskContinuationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, TaskScheduler) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.FromResult<TResult>(TResult) | argument 0 -> return | true |
-| System.Threading.Tasks.Task.Run<TResult>(Func<TResult>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.Run<TResult>(Func<TResult>, CancellationToken) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.Run<TResult>(Func<Task<TResult>>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task.Run<TResult>(Func<Task<TResult>>, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task.Task(Action<Object>, object) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task.Task(Action<Object>, object, CancellationToken) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task.Task(Action<Object>, object, CancellationToken, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
@@ -637,127 +622,61 @@ callableFlow
 | System.Threading.Tasks.Task<>.ContinueWith(Action<Task<>>, TaskContinuationOptions) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith(Action<Task<>>, TaskScheduler) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskContinuationOptions) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskContinuationOptions) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskContinuationOptions) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskScheduler) | argument 1 -> parameter 1 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskScheduler) | qualifier -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>) | qualifier -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken) | qualifier -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | qualifier -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskContinuationOptions) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskContinuationOptions) | qualifier -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskScheduler) | qualifier -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions) | output from argument 0 -> return | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task<>.Task(Func<TResult>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task<>.Task(Func<TResult>, CancellationToken) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task<>.Task(Func<TResult>, CancellationToken, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task<>.Task(Func<TResult>, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.Task<>.get_Result() | qualifier -> return | true |
+| System.Threading.Tasks.Task<>.get_Result() | qualifier -> return | false |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task>) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, CancellationToken) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task<TAntecedentResult>>) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task<TAntecedentResult>>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task<TAntecedentResult>>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
 | System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Action<Task<TAntecedentResult>>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, CancellationToken) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory.StartNew(Action<Object>, object) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.TaskFactory.StartNew(Action<Object>, object, CancellationToken) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.TaskFactory.StartNew(Action<Object>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.TaskFactory.StartNew(Action<Object>, object, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
 | System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, CancellationToken) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, CancellationToken) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, CancellationToken) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | argument 0 -> parameter 0 of argument 1 | true |
-| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | output from argument 1 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 -> return | true |
 | System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, TaskCreationOptions) | argument 1 -> parameter 0 of argument 0 | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, CancellationToken) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 -> return | true |
-| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, TaskCreationOptions) | output from argument 0 -> return | true |
 | System.Uri.ToString() | qualifier -> return | false |
 | System.Uri.Uri(string) | argument 0 -> return | false |
 | System.Uri.Uri(string, UriKind) | argument 0 -> return | false |
@@ -1981,10 +1900,91 @@ callableFlowAccessPath
 | System.Text.StringBuilder.StringBuilder(string, int, int, int) | argument 0 [<empty>] -> return [[]] | true |
 | System.Text.StringBuilder.ToString() | qualifier [[]] -> return [<empty>] | false |
 | System.Text.StringBuilder.ToString(int, int) | qualifier [[]] -> return [<empty>] | false |
-| System.Threading.Tasks.Task.WhenAll<TResult>(IEnumerable<Task<TResult>>) | argument 0 [[]] -> return [<empty>] | true |
-| System.Threading.Tasks.Task.WhenAll<TResult>(params Task<TResult>[]) | argument 0 [[]] -> return [<empty>] | true |
-| System.Threading.Tasks.Task.WhenAny<TResult>(IEnumerable<Task<TResult>>) | argument 0 [[]] -> return [<empty>] | true |
-| System.Threading.Tasks.Task.WhenAny<TResult>(params Task<TResult>[]) | argument 0 [[]] -> return [<empty>] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskContinuationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, Object, TResult>, object, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, TaskContinuationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.ContinueWith<TResult>(Func<Task, TResult>, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.FromResult<TResult>(TResult) | argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.Run<TResult>(Func<TResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.Run<TResult>(Func<TResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.Run<TResult>(Func<Task<TResult>>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.Run<TResult>(Func<Task<TResult>>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task.WhenAll<TResult>(IEnumerable<Task<TResult>>) | argument 0 [[], Result] -> return [Result, []] | true |
+| System.Threading.Tasks.Task.WhenAll<TResult>(params Task<TResult>[]) | argument 0 [[], Result] -> return [Result, []] | true |
+| System.Threading.Tasks.Task.WhenAny<TResult>(IEnumerable<Task<TResult>>) | argument 0 [[], Result] -> return [Result, []] | true |
+| System.Threading.Tasks.Task.WhenAny<TResult>(params Task<TResult>[]) | argument 0 [[], Result] -> return [Result, []] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskContinuationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, Object, TNewResult>, object, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskContinuationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<TResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<TResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<TResult>, CancellationToken, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.Task(Func<TResult>, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAll<TResult>(Task[], Func<Task[], TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TAntecedentResult, TResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.ContinueWhenAny<TResult>(Task[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory.StartNew<TResult>(Func<TResult>, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll(Task[], Func<Task[], TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAll<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny(Task[], Func<Task, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.ContinueWhenAny<TAntecedentResult>(Task<TAntecedentResult>[], Func<Task<TAntecedentResult>, TResult>, TaskContinuationOptions) | output from argument 1 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<Object, TResult>, object, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, CancellationToken, TaskCreationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.TaskFactory<>.StartNew(Func<TResult>, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
 clearsContent
 | System.Array.Clear() | qualifier | [] |
 | System.Array.Clear(Array, int, int) | qualifier | [] |

--- a/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/LibraryTypeDataFlow.expected
@@ -1780,6 +1780,7 @@ callableFlowAccessPath
 | System.Runtime.CompilerServices.ReadOnlyCollectionBuilder<>.Reverse(int, int) | argument 0 [[]] -> return [[]] | true |
 | System.Runtime.CompilerServices.ReadOnlyCollectionBuilder<>.get_Item(int) | qualifier [[]] -> return [<empty>] | true |
 | System.Runtime.CompilerServices.ReadOnlyCollectionBuilder<>.set_Item(int, T) | argument 1 [<empty>] -> qualifier [[]] | true |
+| System.Runtime.CompilerServices.TaskAwaiter<>.GetResult() | qualifier [m_task, Result] -> return [<empty>] | true |
 | System.Security.PermissionSet.CopyTo(Array, int) | qualifier [[]] -> argument 0 [[]] | true |
 | System.Security.PermissionSet.GetEnumerator() | qualifier [[]] -> return [Current] | true |
 | System.String.Concat(IEnumerable<String>) | argument 0 [[]] -> return [<empty>] | false |
@@ -1929,6 +1930,7 @@ callableFlowAccessPath
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, CancellationToken, TaskContinuationOptions, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskContinuationOptions) | output from argument 0 [<empty>] -> return [Result] | true |
 | System.Threading.Tasks.Task<>.ContinueWith<TNewResult>(Func<Task<>, TNewResult>, TaskScheduler) | output from argument 0 [<empty>] -> return [Result] | true |
+| System.Threading.Tasks.Task<>.GetAwaiter() | qualifier [<empty>] -> return [m_task] | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object) | output from argument 0 [<empty>] -> return [Result] | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken) | output from argument 0 [<empty>] -> return [Result] | true |
 | System.Threading.Tasks.Task<>.Task(Func<Object, TResult>, object, CancellationToken, TaskCreationOptions) | output from argument 0 [<empty>] -> return [Result] | true |


### PR DESCRIPTION
This PR models data-flow through `Task`s precisely, in the same way that we model flow through `Lazy<T>`. When a `Task` is created, we model flow as a store into the `Result` property, and the value can be retrieved by either directly reading the `Result` property, or by using `await` (which is now modelled as a read of `Result`).

CSharp-Differences: https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/498 (the result differences appears to all be wobbliness).