### PR TITLE
Java: Add taint steps through string formatting methods

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -772,7 +772,7 @@ private predicate formatStep(Expr tracked, Expr sink) {
 /**
  * A local variable that is assigned a `Formatter`.
  * Writing tainted data to such a formatter causes the underlying
- * `OutputStream` or `Appenable` to be tainted.
+ * `OutputStream` or `Appendable` to be tainted.
  */
 private class FormatterVar extends LocalVariableDecl {
   FormatterVar() {

--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -456,7 +456,8 @@ private predicate taintPreservingArgumentToMethod(Method method) {
   method.getDeclaringType() instanceof TypeString and
   method.hasName("join")
   or
-  method instanceof StringFormatMethod
+  method instanceof StringFormatMethod and
+  not method.getDeclaringType().hasQualifiedName("java.io", "Console")
 }
 
 /**
@@ -649,7 +650,8 @@ private predicate argToQualifierStep(Expr tracked, Expr sink) {
  */
 private predicate taintPreservingArgumentToQualifier(Method method) {
   method instanceof StringFormatMethod and
-  not method.getDeclaringType() instanceof TypeString
+  not method.getDeclaringType() instanceof TypeString and
+  not method.getDeclaringType().hasQualifiedName("java.io", "Console")
 }
 
 /**

--- a/java/ql/test/library-tests/dataflow/taint-format/A.java
+++ b/java/ql/test/library-tests/dataflow/taint-format/A.java
@@ -1,0 +1,34 @@
+import java.util.Formatter;
+import java.lang.StringBuilder;
+
+class A {
+    public static String taint() { return "tainted"; }
+
+    public static void test1() {
+        String bad = taint();
+        String good = "hi";
+
+        bad.formatted(good);
+        good.formatted("a", bad, "b", good);
+        String.format("%s%s", bad, good);
+    }
+
+    public static void test2() {
+        String bad = taint();
+        Formatter f = new Formatter();
+
+        f.toString();
+        f.format("%s", bad);
+        f.toString();
+    }
+
+    public static void test3() {
+        String bad = taint();
+        StringBuilder sb = new StringBuilder();
+        Formatter f = new Formatter(sb);
+
+        sb.toString(); // false positive
+        f.format("%s", bad);
+        sb.toString();
+    }
+}

--- a/java/ql/test/library-tests/dataflow/taint-format/A.java
+++ b/java/ql/test/library-tests/dataflow/taint-format/A.java
@@ -1,5 +1,7 @@
 import java.util.Formatter;
 import java.lang.StringBuilder;
+import java.lang.System;
+import java.io.Console;
 
 class A {
     public static String taint() { return "tainted"; }
@@ -11,6 +13,7 @@ class A {
         bad.formatted(good);
         good.formatted("a", bad, "b", good);
         String.format("%s%s", bad, good);
+        String.format("%s", good);
     }
 
     public static void test2() {
@@ -30,5 +33,13 @@ class A {
         sb.toString(); // false positive
         f.format("%s", bad);
         sb.toString();
+    }
+
+    public static void test4() {
+        String bad = taint();
+        Console c = System.console();
+
+        c.format(bad);
+        c.readLine("Enter something: %s", bad);
     }
 }

--- a/java/ql/test/library-tests/dataflow/taint-format/options
+++ b/java/ql/test/library-tests/dataflow/taint-format/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args --enable-preview -source 14 -target 14

--- a/java/ql/test/library-tests/dataflow/taint-format/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint-format/test.expected
@@ -1,0 +1,24 @@
+| A.java:8:22:8:28 | taint(...) | A.java:8:22:8:28 | taint(...) |
+| A.java:8:22:8:28 | taint(...) | A.java:11:9:11:11 | bad |
+| A.java:8:22:8:28 | taint(...) | A.java:11:9:11:27 | formatted(...) |
+| A.java:8:22:8:28 | taint(...) | A.java:12:9:12:43 | formatted(...) |
+| A.java:8:22:8:28 | taint(...) | A.java:12:9:12:43 | new ..[] { .. } |
+| A.java:8:22:8:28 | taint(...) | A.java:12:29:12:31 | bad |
+| A.java:8:22:8:28 | taint(...) | A.java:13:9:13:40 | format(...) |
+| A.java:8:22:8:28 | taint(...) | A.java:13:9:13:40 | new ..[] { .. } |
+| A.java:8:22:8:28 | taint(...) | A.java:13:31:13:33 | bad |
+| A.java:17:22:17:28 | taint(...) | A.java:17:22:17:28 | taint(...) |
+| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:9 | f [post update] |
+| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:27 | format(...) |
+| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:27 | new ..[] { .. } |
+| A.java:17:22:17:28 | taint(...) | A.java:21:24:21:26 | bad |
+| A.java:17:22:17:28 | taint(...) | A.java:22:9:22:9 | f |
+| A.java:26:22:26:28 | taint(...) | A.java:26:22:26:28 | taint(...) |
+| A.java:26:22:26:28 | taint(...) | A.java:30:9:30:10 | sb |
+| A.java:26:22:26:28 | taint(...) | A.java:30:9:30:21 | toString(...) |
+| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:9 | f [post update] |
+| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:27 | format(...) |
+| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:27 | new ..[] { .. } |
+| A.java:26:22:26:28 | taint(...) | A.java:31:24:31:26 | bad |
+| A.java:26:22:26:28 | taint(...) | A.java:32:9:32:10 | sb |
+| A.java:26:22:26:28 | taint(...) | A.java:32:9:32:21 | toString(...) |

--- a/java/ql/test/library-tests/dataflow/taint-format/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint-format/test.expected
@@ -1,24 +1,28 @@
-| A.java:8:22:8:28 | taint(...) | A.java:8:22:8:28 | taint(...) |
-| A.java:8:22:8:28 | taint(...) | A.java:11:9:11:11 | bad |
-| A.java:8:22:8:28 | taint(...) | A.java:11:9:11:27 | formatted(...) |
-| A.java:8:22:8:28 | taint(...) | A.java:12:9:12:43 | formatted(...) |
-| A.java:8:22:8:28 | taint(...) | A.java:12:9:12:43 | new ..[] { .. } |
-| A.java:8:22:8:28 | taint(...) | A.java:12:29:12:31 | bad |
-| A.java:8:22:8:28 | taint(...) | A.java:13:9:13:40 | format(...) |
-| A.java:8:22:8:28 | taint(...) | A.java:13:9:13:40 | new ..[] { .. } |
-| A.java:8:22:8:28 | taint(...) | A.java:13:31:13:33 | bad |
-| A.java:17:22:17:28 | taint(...) | A.java:17:22:17:28 | taint(...) |
-| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:9 | f [post update] |
-| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:27 | format(...) |
-| A.java:17:22:17:28 | taint(...) | A.java:21:9:21:27 | new ..[] { .. } |
-| A.java:17:22:17:28 | taint(...) | A.java:21:24:21:26 | bad |
-| A.java:17:22:17:28 | taint(...) | A.java:22:9:22:9 | f |
-| A.java:26:22:26:28 | taint(...) | A.java:26:22:26:28 | taint(...) |
-| A.java:26:22:26:28 | taint(...) | A.java:30:9:30:10 | sb |
-| A.java:26:22:26:28 | taint(...) | A.java:30:9:30:21 | toString(...) |
-| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:9 | f [post update] |
-| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:27 | format(...) |
-| A.java:26:22:26:28 | taint(...) | A.java:31:9:31:27 | new ..[] { .. } |
-| A.java:26:22:26:28 | taint(...) | A.java:31:24:31:26 | bad |
-| A.java:26:22:26:28 | taint(...) | A.java:32:9:32:10 | sb |
-| A.java:26:22:26:28 | taint(...) | A.java:32:9:32:21 | toString(...) |
+| A.java:10:22:10:28 | taint(...) | A.java:10:22:10:28 | taint(...) |
+| A.java:10:22:10:28 | taint(...) | A.java:13:9:13:11 | bad |
+| A.java:10:22:10:28 | taint(...) | A.java:13:9:13:27 | formatted(...) |
+| A.java:10:22:10:28 | taint(...) | A.java:14:9:14:43 | formatted(...) |
+| A.java:10:22:10:28 | taint(...) | A.java:14:9:14:43 | new ..[] { .. } |
+| A.java:10:22:10:28 | taint(...) | A.java:14:29:14:31 | bad |
+| A.java:10:22:10:28 | taint(...) | A.java:15:9:15:40 | format(...) |
+| A.java:10:22:10:28 | taint(...) | A.java:15:9:15:40 | new ..[] { .. } |
+| A.java:10:22:10:28 | taint(...) | A.java:15:31:15:33 | bad |
+| A.java:20:22:20:28 | taint(...) | A.java:20:22:20:28 | taint(...) |
+| A.java:20:22:20:28 | taint(...) | A.java:24:9:24:9 | f [post update] |
+| A.java:20:22:20:28 | taint(...) | A.java:24:9:24:27 | format(...) |
+| A.java:20:22:20:28 | taint(...) | A.java:24:9:24:27 | new ..[] { .. } |
+| A.java:20:22:20:28 | taint(...) | A.java:24:24:24:26 | bad |
+| A.java:20:22:20:28 | taint(...) | A.java:25:9:25:9 | f |
+| A.java:29:22:29:28 | taint(...) | A.java:29:22:29:28 | taint(...) |
+| A.java:29:22:29:28 | taint(...) | A.java:33:9:33:10 | sb |
+| A.java:29:22:29:28 | taint(...) | A.java:33:9:33:21 | toString(...) |
+| A.java:29:22:29:28 | taint(...) | A.java:34:9:34:9 | f [post update] |
+| A.java:29:22:29:28 | taint(...) | A.java:34:9:34:27 | format(...) |
+| A.java:29:22:29:28 | taint(...) | A.java:34:9:34:27 | new ..[] { .. } |
+| A.java:29:22:29:28 | taint(...) | A.java:34:24:34:26 | bad |
+| A.java:29:22:29:28 | taint(...) | A.java:35:9:35:10 | sb |
+| A.java:29:22:29:28 | taint(...) | A.java:35:9:35:21 | toString(...) |
+| A.java:39:22:39:28 | taint(...) | A.java:39:22:39:28 | taint(...) |
+| A.java:39:22:39:28 | taint(...) | A.java:42:18:42:20 | bad |
+| A.java:39:22:39:28 | taint(...) | A.java:43:9:43:46 | new ..[] { .. } |
+| A.java:39:22:39:28 | taint(...) | A.java:43:43:43:45 | bad |

--- a/java/ql/test/library-tests/dataflow/taint-format/test.ql
+++ b/java/ql/test/library-tests/dataflow/taint-format/test.ql
@@ -1,0 +1,16 @@
+import java
+import semmle.code.java.dataflow.TaintTracking
+
+class Conf extends TaintTracking::Configuration {
+  Conf() { this = "qltest:dataflow:format" }
+
+  override predicate isSource(DataFlow::Node n) {
+    n.asExpr().(MethodAccess).getMethod().hasName("taint")
+  }
+
+  override predicate isSink(DataFlow::Node n) { any() }
+}
+
+from DataFlow::Node src, DataFlow::Node sink, Conf conf
+where conf.hasFlow(src, sink)
+select src, sink


### PR DESCRIPTION
Part of https://github.com/github/codeql-java-team/issues/5.

Taint tracking through `StringFormatMethod`s as well as from the arguments of `Formatter.format` to the `Appendable` or `OutputStream` that formatter is constucted with. 