### PR TITLE
Sign analysis cleanup

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/Sign.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/Sign.qll
@@ -3,6 +3,25 @@ newtype TSign =
   TZero() or
   TPos()
 
+newtype TUnarySignOperation =
+  TNegOp() or
+  TIncOp() or
+  TDecOp() or
+  TBitNotOp()
+
+newtype TBinarySignOperation =
+  TAddOp() or
+  TSubOp() or
+  TMulOp() or
+  TDivOp() or
+  TRemOp() or
+  TBitAndOp() or
+  TBitOrOp() or
+  TBitXorOp() or
+  TLShiftOp() or
+  TRShiftOp() or
+  TURShiftOp()
+
 /** Class representing expression signs (+, -, 0). */
 class Sign extends TSign {
   /** Gets the string representation of this sign. */
@@ -66,6 +85,12 @@ class Sign extends TSign {
     or
     this = TNeg() and s = TPos()
   }
+
+  /**
+   * Gets a possible sign after subtracting an expression with sign `s` from an expression
+   * that has this sign.
+   */
+  Sign sub(Sign s) { result = add(s.neg()) }
 
   /**
    * Gets a possible sign after multiplying an expression with sign `s` to an expression
@@ -215,5 +240,41 @@ class Sign extends TSign {
     result != TZero() and this = TNeg() and s != TZero()
     or
     result != TNeg() and this = TPos() and s != TZero()
+  }
+
+  /** Perform `op` on this sign. */
+  Sign applyUnaryOp(TUnarySignOperation op) {
+    op = TIncOp() and result = inc()
+    or
+    op = TDecOp() and result = dec()
+    or
+    op = TNegOp() and result = neg()
+    or
+    op = TBitNotOp() and result = bitnot()
+  }
+
+  /** Perform `op` on this sign and sign `s`. */
+  Sign applyBinaryOp(Sign s, TBinarySignOperation op) {
+    op = TAddOp() and result = add(s)
+    or
+    op = TSubOp() and result = sub(s)
+    or
+    op = TMulOp() and result = mul(s)
+    or
+    op = TDivOp() and result = div(s)
+    or
+    op = TRemOp() and result = rem(s)
+    or
+    op = TBitAndOp() and result = bitand(s)
+    or
+    op = TBitOrOp() and result = bitor(s)
+    or
+    op = TBitXorOp() and result = bitxor(s)
+    or
+    op = TLShiftOp() and result = lshift(s)
+    or
+    op = TRShiftOp() and result = rshift(s)
+    or
+    op = TURShiftOp() and result = urshift(s)
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -277,6 +277,20 @@ private Sign implicitSsaDefSign(SsaVariable v) {
   anySign(result) and nonFieldImplicitSsaDefinition(v)
 }
 
+/** Gets a possible sign for `f`. */
+Sign fieldSign(Field f) {
+  if not fieldWithUnknownSign(f)
+  then
+    result = exprSign(getAssignedValueToField(f))
+    or
+    fieldIncrementOperationOperand(f) and result = fieldSign(f).inc()
+    or
+    fieldDecrementOperationOperand(f) and result = fieldSign(f).dec()
+    or
+    result = specificFieldSign(f)
+  else anySign(result)
+}
+
 /** Gets a possible sign for `e`. */
 cached
 Sign exprSign(Expr e) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -245,6 +245,13 @@ private Sign ssaDefSign(SsaVariable v) {
   )
 }
 
+/** Returns the sign of implicit SSA definition `v`. */
+private Sign implicitSsaDefSign(SsaVariable v) {
+  result = fieldSign(getImplicitSsaDeclaration(v))
+  or
+  anySign(result) and nonFieldImplicitSsaDefinition(v)
+}
+
 /** Gets a possible sign for `e`. */
 cached
 Sign exprSign(Expr e) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -41,6 +41,18 @@ private Sign certainExprSign(Expr e) {
   )
 }
 
+/**
+ * Gets the value of the expression if it can't be converted to integer, but
+ * can be converted to float.
+ */
+float getNonIntegerValue(ExprWithPossibleValue e) {
+  exists(string s |
+    s = e.getValue() and
+    result = s.toFloat() and
+    not exists(s.toInt())
+  )
+}
+
 /** Holds if the sign of `e` is too complicated to determine. */
 predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
@@ -55,7 +67,7 @@ predicate unknownSign(Expr e) {
       not fromtyp instanceof NumericOrCharType
     )
     or
-    unknownIntegerAccess(e)
+    numericExprWithUnknownSign(e)
   )
 }
 
@@ -246,7 +258,7 @@ private Sign ssaDefSign(SsaVariable v) {
 }
 
 /** Returns the sign of explicit SSA definition `v`. */
-Sign explicitSsaDefSign(SsaVariable v) {
+private Sign explicitSsaDefSign(SsaVariable v) {
   exists(VariableUpdate def | def = getExplicitSsaAssignment(v) |
     result = exprSign(getExprFromSsaAssignment(def))
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -45,7 +45,7 @@ private Sign certainExprSign(Expr e) {
  * Gets the value of the expression if it can't be converted to integer, but
  * can be converted to float.
  */
-float getNonIntegerValue(ExprWithPossibleValue e) {
+private float getNonIntegerValue(ExprWithPossibleValue e) {
   exists(string s |
     s = e.getValue() and
     result = s.toFloat() and
@@ -54,7 +54,7 @@ float getNonIntegerValue(ExprWithPossibleValue e) {
 }
 
 /** Holds if the sign of `e` is too complicated to determine. */
-predicate unknownSign(Expr e) {
+private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
   (
     exists(IntegerLiteral lit | lit = e and not exists(lit.getValue().toInt()))
@@ -278,7 +278,7 @@ private Sign implicitSsaDefSign(SsaVariable v) {
 }
 
 /** Gets a possible sign for `f`. */
-Sign fieldSign(Field f) {
+private Sign fieldSign(Field f) {
   if not fieldWithUnknownSign(f)
   then
     result = exprSign(getAssignedValueToField(f))
@@ -327,7 +327,7 @@ Sign exprSign(Expr e) {
 }
 
 /** Gets a possible sign for `e` from the signs of its child nodes. */
-Sign specificSubExprSign(Expr e) {
+private Sign specificSubExprSign(Expr e) {
   result = exprSign(getASubExpr(e))
   or
   e =
@@ -352,9 +352,9 @@ private predicate binaryOpSigns(Expr e, Sign lhs, Sign rhs) {
   rhs = binaryOpRhsSign(e)
 }
 
-Sign binaryOpLhsSign(BinaryOperation e) { result = exprSign(e.getLeftOperand()) }
+private Sign binaryOpLhsSign(BinaryOperation e) { result = exprSign(e.getLeftOperand()) }
 
-Sign binaryOpRhsSign(BinaryOperation e) { result = exprSign(e.getRightOperand()) }
+private Sign binaryOpRhsSign(BinaryOperation e) { result = exprSign(e.getRightOperand()) }
 
 /**
  * Dummy predicate that holds for any sign. This is added to improve readability

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -245,6 +245,19 @@ private Sign ssaDefSign(SsaVariable v) {
   )
 }
 
+/** Returns the sign of explicit SSA definition `v`. */
+Sign explicitSsaDefSign(SsaVariable v) {
+  exists(VariableUpdate def | def = getExplicitSsaAssignment(v) |
+    result = exprSign(getExprFromSsaAssignment(def))
+    or
+    anySign(result) and explicitSsaDefWithAnySign(def)
+    or
+    result = exprSign(getIncrementOperand(def)).inc()
+    or
+    result = exprSign(getDecrementOperand(def)).dec()
+  )
+}
+
 /** Returns the sign of implicit SSA definition `v`. */
 private Sign implicitSsaDefSign(SsaVariable v) {
   result = fieldSign(getImplicitSsaDeclaration(v))

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -328,21 +328,20 @@ Sign exprSign(Expr e) {
 
 /** Gets a possible sign for `e` from the signs of its child nodes. */
 private Sign specificSubExprSign(Expr e) {
-  result = exprSign(getASubExpr(e))
+  result = exprSign(getASubExprWithSameSign(e))
   or
-  e =
-    any(DivExpr div |
-      result = exprSign(div.getLeftOperand()) and
-      result != TZero() and
-      div.getRightOperand().(RealLiteral).getValue().toFloat() = 0
-    )
+  exists(DivExpr div | div = e |
+    result = exprSign(div.getLeftOperand()) and
+    result != TZero() and
+    div.getRightOperand().(RealLiteral).getValue().toFloat() = 0
+  )
   or
-  exists(UnaryExpr unary | unary = e |
+  exists(UnaryOperation unary | unary = e |
     result = exprSign(unary.getOperand()).applyUnaryOp(unary.getOp())
   )
   or
   exists(Sign s1, Sign s2 | binaryOpSigns(e, s1, s2) |
-    result = s1.applyBinaryOp(s2, e.(BinaryExpr).getOp())
+    result = s1.applyBinaryOp(s2, e.(BinaryOperation).getOp())
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -41,18 +41,6 @@ private Sign certainExprSign(Expr e) {
   )
 }
 
-/**
- * Gets the value of the expression if it can't be converted to integer, but
- * can be converted to float.
- */
-private float getNonIntegerValue(ExprWithPossibleValue e) {
-  exists(string s |
-    s = e.getValue() and
-    result = s.toFloat() and
-    not exists(s.toInt())
-  )
-}
-
 /** Holds if the sign of `e` is too complicated to determine. */
 private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -32,6 +32,8 @@ module Private {
 
   class Expr = CS::Expr;
 
+  class VariableUpdate = CS::AssignableDefinition;
+
   predicate ssaRead = SU::ssaRead/2;
 }
 
@@ -107,19 +109,28 @@ private module Impl {
     }
   }
 
-  /** Returns the sign of explicit SSA definition `v`. */
-  Sign explicitSsaDefSign(Ssa::ExplicitDefinition v) {
-    exists(AssignableDefinition def | def = v.getADefinition() |
-      result = exprSign(def.getSource())
-      or
-      anySign(result) and
-      not exists(def.getSource()) and
-      not def.getElement() instanceof MutatorOperation
-      or
-      result = exprSign(def.getElement().(IncrementOperation).getOperand()).inc()
-      or
-      result = exprSign(def.getElement().(DecrementOperation).getOperand()).dec()
-    )
+  /** Returns the underlying variable update of the explicit SSA variable `v`. */
+  AssignableDefinition getExplicitSsaAssignment(Ssa::ExplicitDefinition v) {
+    result = v.getADefinition()
+  }
+
+  /** Returns the assignment of the variable update `def`. */
+  Expr getExprFromSsaAssignment(AssignableDefinition def) { result = def.getSource() }
+
+  /** Holds if `def` can have any sign. */
+  predicate explicitSsaDefWithAnySign(AssignableDefinition def) {
+    not exists(def.getSource()) and
+    not def.getElement() instanceof MutatorOperation
+  }
+
+  /** Returns the operand of the operation if `def` is a decrement. */
+  Expr getDecrementOperand(AssignableDefinition def) {
+    result = def.getElement().(DecrementOperation).getOperand()
+  }
+
+  /** Returns the operand of the operation if `def` is an increment. */
+  Expr getIncrementOperand(AssignableDefinition def) {
+    result = def.getElement().(IncrementOperation).getOperand()
   }
 
   /** Gets the variable underlying the implicit SSA variable `v`. */

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -34,6 +34,8 @@ module Private {
 
   class VariableUpdate = CS::AssignableDefinition;
 
+  class ExprWithPossibleValue = CS::Expr;
+
   predicate ssaRead = SU::ssaRead/2;
 }
 
@@ -49,18 +51,6 @@ private module Impl {
   private import semmle.code.csharp.commons.ComparisonTest
 
   private class BooleanValue = AbstractValues::BooleanValue;
-
-  /**
-   * Gets the value of the expression if it can't be converted to integer, but
-   * can be converted to float.
-   */
-  float getNonIntegerValue(Expr e) {
-    exists(string s |
-      s = e.getValue() and
-      result = s.toFloat() and
-      not exists(s.toInt())
-    )
-  }
 
   /** Gets the character value of expression `e`. */
   string getCharValue(Expr e) { result = e.getValue() and e.getType() instanceof CharType }
@@ -162,7 +152,7 @@ private module Impl {
   /**
    * Holds if `e` has type `NumericOrCharType`, but the sign of `e` is unknown.
    */
-  predicate unknownIntegerAccess(Expr e) {
+  predicate numericExprWithUnknownSign(Expr e) {
     e.getType() instanceof NumericOrCharType and
     not e = getARead(_) and
     not e instanceof FieldAccess and

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -122,11 +122,14 @@ private module Impl {
     )
   }
 
-  /** Returns the sign of implicit SSA definition `v`. */
-  Sign implicitSsaDefSign(Ssa::ImplicitDefinition v) {
-    result = fieldSign(v.getSourceVariable().getAssignable())
-    or
-    anySign(result) and not v.getSourceVariable().getAssignable() instanceof Field
+  /** Gets the variable underlying the implicit SSA variable `v`. */
+  Declaration getImplicitSsaDeclaration(Ssa::ImplicitDefinition v) {
+    result = v.getSourceVariable().getAssignable()
+  }
+
+  /** Holds if the variable underlying the implicit SSA variable `v` is not a field. */
+  predicate nonFieldImplicitSsaDefinition(Ssa::ImplicitDefinition v) {
+    not getImplicitSsaDeclaration(v) instanceof Field
   }
 
   /** Gets a possible sign for `f`. */

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -35,8 +35,6 @@ module Private {
 
   class VariableUpdate = CS::AssignableDefinition;
 
-  class ExprWithPossibleValue = CS::Expr;
-
   class Field = CS::Field;
 
   class RealLiteral = CS::RealLiteral;
@@ -129,6 +127,15 @@ private module Impl {
 
   /** Gets the character value of expression `e`. */
   string getCharValue(Expr e) { result = e.getValue() and e.getType() instanceof CharType }
+
+  /** Gets the constant `float` value of non-`ConstantIntegerExpr` expressions. */
+  float getNonIntegerValue(Expr e) {
+    exists(string s |
+      s = e.getValue() and
+      result = s.toFloat() and
+      not exists(s.toInt())
+    )
+  }
 
   /**
    * Holds if `e` is an access to the size of a container (`string`, `Array`,

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/Sign.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/Sign.qll
@@ -3,6 +3,25 @@ newtype TSign =
   TZero() or
   TPos()
 
+newtype TUnarySignOperation =
+  TNegOp() or
+  TIncOp() or
+  TDecOp() or
+  TBitNotOp()
+
+newtype TBinarySignOperation =
+  TAddOp() or
+  TSubOp() or
+  TMulOp() or
+  TDivOp() or
+  TRemOp() or
+  TBitAndOp() or
+  TBitOrOp() or
+  TBitXorOp() or
+  TLShiftOp() or
+  TRShiftOp() or
+  TURShiftOp()
+
 /** Class representing expression signs (+, -, 0). */
 class Sign extends TSign {
   /** Gets the string representation of this sign. */
@@ -66,6 +85,12 @@ class Sign extends TSign {
     or
     this = TNeg() and s = TPos()
   }
+
+  /**
+   * Gets a possible sign after subtracting an expression with sign `s` from an expression
+   * that has this sign.
+   */
+  Sign sub(Sign s) { result = add(s.neg()) }
 
   /**
    * Gets a possible sign after multiplying an expression with sign `s` to an expression
@@ -215,5 +240,41 @@ class Sign extends TSign {
     result != TZero() and this = TNeg() and s != TZero()
     or
     result != TNeg() and this = TPos() and s != TZero()
+  }
+
+  /** Perform `op` on this sign. */
+  Sign applyUnaryOp(TUnarySignOperation op) {
+    op = TIncOp() and result = inc()
+    or
+    op = TDecOp() and result = dec()
+    or
+    op = TNegOp() and result = neg()
+    or
+    op = TBitNotOp() and result = bitnot()
+  }
+
+  /** Perform `op` on this sign and sign `s`. */
+  Sign applyBinaryOp(Sign s, TBinarySignOperation op) {
+    op = TAddOp() and result = add(s)
+    or
+    op = TSubOp() and result = sub(s)
+    or
+    op = TMulOp() and result = mul(s)
+    or
+    op = TDivOp() and result = div(s)
+    or
+    op = TRemOp() and result = rem(s)
+    or
+    op = TBitAndOp() and result = bitand(s)
+    or
+    op = TBitOrOp() and result = bitor(s)
+    or
+    op = TBitXorOp() and result = bitxor(s)
+    or
+    op = TLShiftOp() and result = lshift(s)
+    or
+    op = TRShiftOp() and result = rshift(s)
+    or
+    op = TURShiftOp() and result = urshift(s)
   }
 }

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -277,6 +277,20 @@ private Sign implicitSsaDefSign(SsaVariable v) {
   anySign(result) and nonFieldImplicitSsaDefinition(v)
 }
 
+/** Gets a possible sign for `f`. */
+Sign fieldSign(Field f) {
+  if not fieldWithUnknownSign(f)
+  then
+    result = exprSign(getAssignedValueToField(f))
+    or
+    fieldIncrementOperationOperand(f) and result = fieldSign(f).inc()
+    or
+    fieldDecrementOperationOperand(f) and result = fieldSign(f).dec()
+    or
+    result = specificFieldSign(f)
+  else anySign(result)
+}
+
 /** Gets a possible sign for `e`. */
 cached
 Sign exprSign(Expr e) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -245,6 +245,13 @@ private Sign ssaDefSign(SsaVariable v) {
   )
 }
 
+/** Returns the sign of implicit SSA definition `v`. */
+private Sign implicitSsaDefSign(SsaVariable v) {
+  result = fieldSign(getImplicitSsaDeclaration(v))
+  or
+  anySign(result) and nonFieldImplicitSsaDefinition(v)
+}
+
 /** Gets a possible sign for `e`. */
 cached
 Sign exprSign(Expr e) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -41,6 +41,18 @@ private Sign certainExprSign(Expr e) {
   )
 }
 
+/**
+ * Gets the value of the expression if it can't be converted to integer, but
+ * can be converted to float.
+ */
+float getNonIntegerValue(ExprWithPossibleValue e) {
+  exists(string s |
+    s = e.getValue() and
+    result = s.toFloat() and
+    not exists(s.toInt())
+  )
+}
+
 /** Holds if the sign of `e` is too complicated to determine. */
 predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
@@ -55,7 +67,7 @@ predicate unknownSign(Expr e) {
       not fromtyp instanceof NumericOrCharType
     )
     or
-    unknownIntegerAccess(e)
+    numericExprWithUnknownSign(e)
   )
 }
 
@@ -246,7 +258,7 @@ private Sign ssaDefSign(SsaVariable v) {
 }
 
 /** Returns the sign of explicit SSA definition `v`. */
-Sign explicitSsaDefSign(SsaVariable v) {
+private Sign explicitSsaDefSign(SsaVariable v) {
   exists(VariableUpdate def | def = getExplicitSsaAssignment(v) |
     result = exprSign(getExprFromSsaAssignment(def))
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -45,7 +45,7 @@ private Sign certainExprSign(Expr e) {
  * Gets the value of the expression if it can't be converted to integer, but
  * can be converted to float.
  */
-float getNonIntegerValue(ExprWithPossibleValue e) {
+private float getNonIntegerValue(ExprWithPossibleValue e) {
   exists(string s |
     s = e.getValue() and
     result = s.toFloat() and
@@ -54,7 +54,7 @@ float getNonIntegerValue(ExprWithPossibleValue e) {
 }
 
 /** Holds if the sign of `e` is too complicated to determine. */
-predicate unknownSign(Expr e) {
+private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and
   (
     exists(IntegerLiteral lit | lit = e and not exists(lit.getValue().toInt()))
@@ -278,7 +278,7 @@ private Sign implicitSsaDefSign(SsaVariable v) {
 }
 
 /** Gets a possible sign for `f`. */
-Sign fieldSign(Field f) {
+private Sign fieldSign(Field f) {
   if not fieldWithUnknownSign(f)
   then
     result = exprSign(getAssignedValueToField(f))
@@ -327,7 +327,7 @@ Sign exprSign(Expr e) {
 }
 
 /** Gets a possible sign for `e` from the signs of its child nodes. */
-Sign specificSubExprSign(Expr e) {
+private Sign specificSubExprSign(Expr e) {
   result = exprSign(getASubExpr(e))
   or
   e =
@@ -352,9 +352,9 @@ private predicate binaryOpSigns(Expr e, Sign lhs, Sign rhs) {
   rhs = binaryOpRhsSign(e)
 }
 
-Sign binaryOpLhsSign(BinaryOperation e) { result = exprSign(e.getLeftOperand()) }
+private Sign binaryOpLhsSign(BinaryOperation e) { result = exprSign(e.getLeftOperand()) }
 
-Sign binaryOpRhsSign(BinaryOperation e) { result = exprSign(e.getRightOperand()) }
+private Sign binaryOpRhsSign(BinaryOperation e) { result = exprSign(e.getRightOperand()) }
 
 /**
  * Dummy predicate that holds for any sign. This is added to improve readability

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -245,6 +245,19 @@ private Sign ssaDefSign(SsaVariable v) {
   )
 }
 
+/** Returns the sign of explicit SSA definition `v`. */
+Sign explicitSsaDefSign(SsaVariable v) {
+  exists(VariableUpdate def | def = getExplicitSsaAssignment(v) |
+    result = exprSign(getExprFromSsaAssignment(def))
+    or
+    anySign(result) and explicitSsaDefWithAnySign(def)
+    or
+    result = exprSign(getIncrementOperand(def)).inc()
+    or
+    result = exprSign(getDecrementOperand(def)).dec()
+  )
+}
+
 /** Returns the sign of implicit SSA definition `v`. */
 private Sign implicitSsaDefSign(SsaVariable v) {
   result = fieldSign(getImplicitSsaDeclaration(v))

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -328,21 +328,20 @@ Sign exprSign(Expr e) {
 
 /** Gets a possible sign for `e` from the signs of its child nodes. */
 private Sign specificSubExprSign(Expr e) {
-  result = exprSign(getASubExpr(e))
+  result = exprSign(getASubExprWithSameSign(e))
   or
-  e =
-    any(DivExpr div |
-      result = exprSign(div.getLeftOperand()) and
-      result != TZero() and
-      div.getRightOperand().(RealLiteral).getValue().toFloat() = 0
-    )
+  exists(DivExpr div | div = e |
+    result = exprSign(div.getLeftOperand()) and
+    result != TZero() and
+    div.getRightOperand().(RealLiteral).getValue().toFloat() = 0
+  )
   or
-  exists(UnaryExpr unary | unary = e |
+  exists(UnaryOperation unary | unary = e |
     result = exprSign(unary.getOperand()).applyUnaryOp(unary.getOp())
   )
   or
   exists(Sign s1, Sign s2 | binaryOpSigns(e, s1, s2) |
-    result = s1.applyBinaryOp(s2, e.(BinaryExpr).getOp())
+    result = s1.applyBinaryOp(s2, e.(BinaryOperation).getOp())
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisCommon.qll
@@ -41,18 +41,6 @@ private Sign certainExprSign(Expr e) {
   )
 }
 
-/**
- * Gets the value of the expression if it can't be converted to integer, but
- * can be converted to float.
- */
-private float getNonIntegerValue(ExprWithPossibleValue e) {
-  exists(string s |
-    s = e.getValue() and
-    result = s.toFloat() and
-    not exists(s.toInt())
-  )
-}
-
 /** Holds if the sign of `e` is too complicated to determine. */
 private predicate unknownSign(Expr e) {
   not exists(certainExprSign(e)) and

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -115,13 +115,15 @@ private module Impl {
     )
   }
 
-  /** Returns the sign of implicit SSA definition `v`. */
-  Sign implicitSsaDefSign(SsaVariable v) {
-    result = fieldSign(v.(SsaImplicitUpdate).getSourceVariable().getVariable())
-    or
-    result = fieldSign(v.(SsaImplicitInit).getSourceVariable().getVariable())
-    or
-    anySign(result) and exists(Parameter p | v.(SsaImplicitInit).isParameterDefinition(p))
+  /** Gets the variable underlying the implicit SSA variable `v`. */
+  Variable getImplicitSsaDeclaration(SsaVariable v) {
+    result = v.(SsaImplicitUpdate).getSourceVariable().getVariable() or
+    result = v.(SsaImplicitInit).getSourceVariable().getVariable()
+  }
+
+  /** Holds if the variable underlying the implicit SSA variable `v` is not a field. */
+  predicate nonFieldImplicitSsaDefinition(SsaImplicitInit v) {
+    exists(Parameter p | v.isParameterDefinition(p))
   }
 
   /** Gets a possible sign for `f`. */

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -38,6 +38,8 @@ module Private {
 
   class VariableUpdate = J::VariableUpdate;
 
+  class ExprWithPossibleValue = J::Literal;
+
   predicate ssaRead = RU::ssaRead/2;
 
   predicate guardControlsSsaRead = RU::guardControlsSsaRead/3;
@@ -56,15 +58,6 @@ private module Impl {
   private import SsaReadPositionCommon
 
   class UnsignedNumericType = CharacterType;
-
-  /**
-   * Gets the `float` value of expression `e` where `e` has no `int` value.
-   */
-  float getNonIntegerValue(Expr e) {
-    result = e.(LongLiteral).getValue().toFloat() or
-    result = e.(FloatingPointLiteral).getValue().toFloat() or
-    result = e.(DoubleLiteral).getValue().toFloat()
-  }
 
   /** Gets the character value of expression `e`. */
   string getCharValue(Expr e) { result = e.(CharacterLiteral).getValue() }
@@ -86,11 +79,10 @@ private module Impl {
 
   /**
    * Holds if `e` has type `NumericOrCharType`, but the sign of `e` is unknown.
-   *
-   * The expression types handled in the predicate complements the expression
-   * types handled in `specificSubExprSign`.
    */
-  predicate unknownIntegerAccess(Expr e) {
+  predicate numericExprWithUnknownSign(Expr e) {
+    // The expression types handled in the predicate complements the expression
+    // types handled in `specificSubExprSign`.
     e instanceof ArrayAccess and e.getType() instanceof NumericOrCharType
     or
     e instanceof MethodAccess and e.getType() instanceof NumericOrCharType

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -45,21 +45,6 @@ module Private {
 
   class DivExpr = J::DivExpr;
 
-  class BinaryOperation extends J::Expr {
-    BinaryOperation() {
-      this instanceof J::BinaryExpr or
-      this instanceof J::AssignOp
-    }
-
-    Expr getLeftOperand() {
-      result = this.(J::BinaryExpr).getLeftOperand() or result = this.(J::AssignOp).getDest()
-    }
-
-    Expr getRightOperand() {
-      result = this.(J::BinaryExpr).getRightOperand() or result = this.(J::AssignOp).getRhs()
-    }
-  }
-
   /** Class to represent float and double literals. */
   class RealLiteral extends J::Literal {
     RealLiteral() {
@@ -68,9 +53,9 @@ module Private {
     }
   }
 
-  /** Class to represent unary expressions. */
-  class UnaryExpr extends J::Expr {
-    UnaryExpr() {
+  /** Class to represent unary operation. */
+  class UnaryOperation extends J::Expr {
+    UnaryOperation() {
       this instanceof J::PreIncExpr or
       this instanceof J::PreDecExpr or
       this instanceof J::MinusExpr or
@@ -97,9 +82,9 @@ module Private {
     }
   }
 
-  /** Class to represent binary expressions. */
-  class BinaryExpr extends J::Expr {
-    BinaryExpr() {
+  /** Class to represent binary operation. */
+  class BinaryOperation extends J::Expr {
+    BinaryOperation() {
       this instanceof J::AddExpr or
       this instanceof J::AssignAddExpr or
       this instanceof J::SubExpr or
@@ -169,6 +154,14 @@ module Private {
       this instanceof J::URShiftExpr and result = TURShiftOp()
       or
       this instanceof J::AssignURShiftExpr and result = TURShiftOp()
+    }
+
+    Expr getLeftOperand() {
+      result = this.(J::BinaryExpr).getLeftOperand() or result = this.(J::AssignOp).getDest()
+    }
+
+    Expr getRightOperand() {
+      result = this.(J::BinaryExpr).getRightOperand() or result = this.(J::AssignOp).getRhs()
     }
   }
 
@@ -300,7 +293,7 @@ private module Impl {
   }
 
   /** Returns a sub expression of `e` for expression types where the sign depends on the child. */
-  Expr getASubExpr(Expr e) {
+  Expr getASubExprWithSameSign(Expr e) {
     result = e.(AssignExpr).getSource() or
     result = e.(PlusExpr).getExpr() or
     result = e.(PostIncExpr).getExpr() or

--- a/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/rangeanalysis/SignAnalysisSpecific.qll
@@ -39,8 +39,6 @@ module Private {
 
   class VariableUpdate = J::VariableUpdate;
 
-  class ExprWithPossibleValue = J::Literal;
-
   class Field = J::Field;
 
   class DivExpr = J::DivExpr;
@@ -186,6 +184,13 @@ private module Impl {
 
   /** Gets the character value of expression `e`. */
   string getCharValue(Expr e) { result = e.(CharacterLiteral).getValue() }
+
+  /** Gets the constant `float` value of non-`ConstantIntegerExpr` expressions. */
+  float getNonIntegerValue(Expr e) {
+    result = e.(LongLiteral).getValue().toFloat() or
+    result = e.(FloatingPointLiteral).getValue().toFloat() or
+    result = e.(DoubleLiteral).getValue().toFloat()
+  }
 
   /**
    * Holds if `e` is an access to the size of a container (`string`, `Map`, or

--- a/java/ql/test/library-tests/dataflow/sign-analysis/SignAnalysis.ql
+++ b/java/ql/test/library-tests/dataflow/sign-analysis/SignAnalysis.ql
@@ -18,4 +18,5 @@ string getASignString(Expr e) {
 }
 
 from Expr e
+where not e instanceof Element or e.(Element).fromSource()
 select e, strictconcat(string s | s = getASignString(e) | s, " ")

--- a/java/ql/test/library-tests/dataflow/sign-analysis/SignAnalysis.ql
+++ b/java/ql/test/library-tests/dataflow/sign-analysis/SignAnalysis.ql
@@ -18,5 +18,5 @@ string getASignString(Expr e) {
 }
 
 from Expr e
-where not e instanceof Element or e.(Element).fromSource()
+where e.getEnclosingCallable().fromSource()
 select e, strictconcat(string s | s = getASignString(e) | s, " ")


### PR DESCRIPTION
This PR 
* cleans up sign analysis a bit,
* removes recursive calls between `SignAnalysisCommon` and `SignAnalysisSpecific.`
