### PR TITLE
JS: Refactorization of NoSQL.qll to use API-graphs

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -301,6 +301,9 @@ module API {
 
     /** Gets a data-flow node that defines this entry point. */
     abstract DataFlow::Node getARhs();
+
+    /** Gets a API-node for this entry point. */
+    API::Node getNode() { result = root().getASuccessor(this) }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -302,7 +302,7 @@ module API {
     /** Gets a data-flow node that defines this entry point. */
     abstract DataFlow::Node getARhs();
 
-    /** Gets a API-node for this entry point. */
+    /** Gets an API-graph node for this entry point. */
     API::Node getNode() { result = root().getASuccessor(this) }
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -537,13 +537,13 @@ private module Mongoose {
             param = func.getLastParameter().getParameter(1)
           )
           or
-          exists(API::Node f, string executor, int paramIndex |
-            executor = "then" and paramIndex = 0
+          exists(API::Node f |
+            f = Query::getAMongooseQuery().getMember("then") and
+            param = f.getParameter(0).getParameter(0)
             or
-            executor = "exec" and paramIndex = 1
+            f = Query::getAMongooseQuery().getMember("exec") and
+            param = f.getParameter(0).getParameter(1)
           |
-            f = Query::getAMongooseQuery().getMember(executor) and
-            param = f.getParameter(0).getParameter(paramIndex) and
             exists(DataFlow::MethodCallNode pred |
               // limitation: look at the previous method call	
               Query::MethodSignatures::returnsDocumentQuery(pred.getMethodName(), asArray) and

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -29,8 +29,8 @@ private module MongoDB {
   private API::Node getAMongoClient() {
     result = API::moduleImport("mongodb").getMember("MongoClient")
     or
-    // slightly imprecise, is not supposed to have a result if the parameter name is "db" (that would be a mongodb v2 `Db`).
-    result = getAMongoDbCallback().getParameter(1)
+    result = getAMongoDbCallback().getParameter(1) and
+    not result.getAnImmediateUse().(DataFlow::ParameterNode).getName() = "db" // mongodb v2 provides a `Db` here
   }
 
   /** Gets an api node that refers to a `connect` callback. */
@@ -44,8 +44,8 @@ private module MongoDB {
   private API::Node getAMongoDb() {
     result = getAMongoClient().getMember("db").getReturn()
     or
-    // slightly imprecise, is not supposed to have a result if the parameter name is "client" (that would be a mongodb v3 `Mongoclient`).
-    result = getAMongoDbCallback().getParameter(1)
+    result = getAMongoDbCallback().getParameter(1) and
+    not result.getAnImmediateUse().(DataFlow::ParameterNode).getName() = "client" // mongodb v3 provides a `Mongoclient` here
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -33,13 +33,13 @@ private module MongoDB {
     not result.getAnImmediateUse().(DataFlow::ParameterNode).getName() = "db" // mongodb v2 provides a `Db` here
   }
 
-  /** Gets an api node that refers to a `connect` callback. */
+  /** Gets an API-graph node that refers to a `connect` callback. */
   private API::Node getAMongoDbCallback() {
     result = getAMongoClient().getMember("connect").getLastParameter()
   }
 
   /**
-   * Gets an API node that may refer to a MongoDB database connection.
+   * Gets an API-graph node that may refer to a MongoDB database connection.
    */
   private API::Node getAMongoDb() {
     result = getAMongoClient().getMember("db").getReturn()
@@ -183,7 +183,7 @@ private module Mongoose {
    */
   private class MongooseFunction extends API::Node {
     /**
-     * Gets the API node for the result from this function (if the function returns a Query).
+     * Gets the API-graph node for the result from this function (if the function returns a `Query`).
      */
     abstract API::Node getQueryReturn();
 
@@ -237,7 +237,7 @@ private module Mongoose {
     }
 
     /**
-     * Gets a API node referring to a Mongoose Model object.
+     * Gets a API-graph node referring to a Mongoose Model object.
      */
     private API::Node getModelObject() {
       result = getAMongooseInstance().getMember("model").getReturn()

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -136,6 +136,8 @@ nodes
 | mongoose.js:94:51:94:55 | query |
 | mongoose.js:96:46:96:50 | query |
 | mongoose.js:96:46:96:50 | query |
+| mongoose.js:111:14:111:18 | query |
+| mongoose.js:111:14:111:18 | query |
 | mongooseJsonParse.js:19:11:19:20 | query |
 | mongooseJsonParse.js:19:19:19:20 | {} |
 | mongooseJsonParse.js:20:19:20:44 | JSON.pa ... y.data) |
@@ -337,6 +339,8 @@ edges
 | mongoose.js:20:11:20:20 | query | mongoose.js:94:51:94:55 | query |
 | mongoose.js:20:11:20:20 | query | mongoose.js:96:46:96:50 | query |
 | mongoose.js:20:11:20:20 | query | mongoose.js:96:46:96:50 | query |
+| mongoose.js:20:11:20:20 | query | mongoose.js:111:14:111:18 | query |
+| mongoose.js:20:11:20:20 | query | mongoose.js:111:14:111:18 | query |
 | mongoose.js:20:19:20:20 | {} | mongoose.js:20:11:20:20 | query |
 | mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
 | mongoose.js:21:19:21:26 | req.body | mongoose.js:21:19:21:32 | req.body.title |
@@ -403,6 +407,8 @@ edges
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:94:51:94:55 | query |
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:96:46:96:50 | query |
 | mongoose.js:21:19:21:32 | req.body.title | mongoose.js:96:46:96:50 | query |
+| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:111:14:111:18 | query |
+| mongoose.js:21:19:21:32 | req.body.title | mongoose.js:111:14:111:18 | query |
 | mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
 | mongoose.js:24:25:24:29 | query | mongoose.js:24:24:24:30 | [query] |
 | mongooseJsonParse.js:19:11:19:20 | query | mongooseJsonParse.js:23:19:23:23 | query |
@@ -490,6 +496,7 @@ edges
 | mongoose.js:92:46:92:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:92:46:92:50 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:94:51:94:55 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:94:51:94:55 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:96:46:96:50 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:96:46:96:50 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
+| mongoose.js:111:14:111:18 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:111:14:111:18 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query depends on $@. | mongooseModelClient.js:10:22:10:29 | req.body | a user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query depends on $@. | mongooseModelClient.js:12:22:12:29 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongoose.js
@@ -97,4 +97,16 @@ app.post('/documents/find', (req, res) => {
 	Document.find(X).then(Y, (err) => err.count(query)); // OK
 
 	Document.count(X, (err, res) => res.count(query)); // OK (res is a number)
+    
+	function innocent(X, Y, query) { // To detect if API-graphs were used incorrectly.
+		return new Mongoose.Query("constant", "constant", "constant");
+	}
+	new innocent(X, Y, query);
+
+	function getQueryConstructor() {
+		return Mongoose.Query;
+	}
+
+	var C = getQueryConstructor();
+	new C(X, Y, query); // NOT OK
 });


### PR DESCRIPTION
~~A bit of precision has been lost compared to the previous implementation, due to limitations of the API-graphs API. 
But interestingly, no test case failed as a result.  
The imprecisions are in the top of NoSQL.qll (`getAMongoClient()` / `getAMongoDb()`).~~

I added a new convenience method to `API::EntryPoint`, which allows me to easily get an `API::Node` from an `EntryPoint`. 

I had to change the implementation in some places to avoid API-graph related gotchas.  
For example: instead of `Mongoose::InvokeNode` (modelling a call to a Mongoose function) I now have a `Mongoose::MongooseFunction` (modelling the Mongoose function itself). 