### PR TITLE
JS: Fixing an API-graph gotcha in `SQL.qll`

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -39,27 +39,27 @@ module API {
     }
 
     /**
-     * Gets a reference to the API component represented by this node.
+     * Gets an immediate use of the API component represented by this node.
      *
-     * For example, `require('fs').readFileSync` is a reference to the `readFileSync` member from the
-     * `fs` module.
+     * For example, `require('fs').readFileSync` is a an immediate use of the `readFileSync` member
+     * from the `fs` module.
      *
      * Unlike `getAUse()`, this predicate only gets the immediate references, not the indirect uses
      * found via data flow. This means that in `const x = fs.readFile` only `fs.readFile` is a reference
      * to the `readFile` member of `fs`, neither `x` nor any node that `x` flows to is a reference to
      * this API component.
      */
-    DataFlow::SourceNode getAReference() { Impl::use(this, result) }
+    DataFlow::SourceNode getAnImmediateUse() { Impl::use(this, result) }
 
     /**
      * Gets a call to the function represented by this API component.
      */
-    DataFlow::CallNode getACall() { result = getReturn().getAReference() }
+    DataFlow::CallNode getACall() { result = getReturn().getAnImmediateUse() }
 
     /**
      * Gets a `new` call to the function represented by this API component.
      */
-    DataFlow::NewNode getAnInstantiation() { result = getInstance().getAReference() }
+    DataFlow::NewNode getAnInstantiation() { result = getInstance().getAnImmediateUse() }
 
     /**
      * Gets an invocation (with our without `new`) to the function represented by this API component.

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -36,6 +36,17 @@ module API {
     }
 
     /**
+     * Gets a source-node corresponding to a use of the API component represented by this node.
+     *
+     * For example, `require('fs').readFileSync` is a use of the function `readFileSync` from the
+     * `fs` module, and `require('fs').readFileSync(file)` is a use of the result of that function.
+     *
+     * As another example, in the assignment `exports.plusOne = (x) => x+1` the two references to
+     * `x` are uses of the first parameter of `plusOne`.
+     */
+    DataFlow::SourceNode getASourceUse() { Impl::use(this, result) }
+
+    /**
      * Gets a data-flow node corresponding to the right-hand side of a definition of the API
      * component represented by this node.
      *

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -62,6 +62,11 @@ module API {
     DataFlow::NewNode getAnInstantiation() { result = getInstance().getAReference() }
 
     /**
+     * Gets an invocation (with our without `new`) to the function represented by this API component.
+     */
+    DataFlow::InvokeNode getAnInvocation() { result = getACall() or result = getAnInstantiation() }
+
+    /**
      * Gets a data-flow node corresponding to the right-hand side of a definition of the API
      * component represented by this node.
      *

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -21,13 +21,13 @@ module API {
    */
   class Node extends Impl::TApiNode {
     /**
-     * Gets a data-flow corresponding to a use of the API component represented by this node.
+     * Gets a data-flow node corresponding to a use of the API component represented by this node.
      *
      * For example, `require('fs').readFileSync` is a use of the function `readFileSync` from the
      * `fs` module, and `require('fs').readFileSync(file)` is a use of the return of that function.
      *
-     * The use is type-tracked, meaning that in `f(obj.foo); function f(x) {};` both `obj.foo` and
-     * `x` are uses of the `foo` member from `obj`.
+     * This includes indirect uses found via data flow, meaning that in
+     * `f(obj.foo); function f(x) {};` both `obj.foo` and `x` are uses of the `foo` member from `obj`.
      *
      * As another example, in the assignment `exports.plusOne = (x) => x+1` the two references to
      * `x` are uses of the first parameter of `plusOne`.
@@ -44,9 +44,10 @@ module API {
      * For example, `require('fs').readFileSync` is a reference to the `readFileSync` member from the
      * `fs` module.
      *
-     * No local data-flow or type-tracking happens on the result, which means that in
-     * `const x = fs.readFile` only `fs.readFile` is a reference to the `readFile` member of `fs`,
-     * neither `x` nor any node that `x` flows to is a reference to this API component.
+     * Unlike `getAUse()`, this predicate only gets the immediate references, not the indirect uses
+     * found via data flow. This means that in `const x = fs.readFile` only `fs.readFile` is a reference
+     * to the `readFile` member of `fs`, neither `x` nor any node that `x` flows to is a reference to
+     * this API component.
      */
     DataFlow::SourceNode getAReference() { Impl::use(this, result) }
 
@@ -56,7 +57,7 @@ module API {
     DataFlow::CallNode getACall() { result = getReturn().getAReference() }
 
     /**
-     * Gets an instantiation of the function represented by this API component.
+     * Gets a `new` call to the function represented by this API component.
      */
     DataFlow::NewNode getAnInstantiation() { result = getInstance().getAReference() }
 

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -46,6 +46,11 @@ module API {
     DataFlow::Node getAUse() { getAReference().flowsTo(result) }
 
     /**
+     * Gets a call to a use of the API component represented by this node.
+     */
+    DataFlow::CallNode getACall() { result = getAReference().getACall() }
+
+    /**
      * Gets a data-flow node corresponding to the right-hand side of a definition of the API
      * component represented by this node.
      *

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -21,30 +21,29 @@ module API {
    */
   class Node extends Impl::TApiNode {
     /**
-     * Gets a data-flow node corresponding to a use of the API component represented by this node.
+     * Gets a `SourceNode` corresponding to a use of the API component represented by this node.
      *
      * For example, `require('fs').readFileSync` is a use of the function `readFileSync` from the
      * `fs` module, and `require('fs').readFileSync(file)` is a use of the result of that function.
      *
      * As another example, in the assignment `exports.plusOne = (x) => x+1` the two references to
      * `x` are uses of the first parameter of `plusOne`.
+     *
+     * Note: The result from this predicate is always a `DataFlow::SourceǸode`, use `getAUse()` if
+     * you want to follow purely local data-flow and get all `DataFlow::Node`s that corrospond to a
+     * use of this API node.
      */
-    DataFlow::Node getAUse() {
-      exists(DataFlow::SourceNode src | Impl::use(this, src) |
-        Impl::trackUseNode(src).flowsTo(result)
-      )
+    DataFlow::SourceNode getAReference() {
+      exists(DataFlow::SourceNode src | Impl::use(this, src) | result = Impl::trackUseNode(src))
     }
 
     /**
-     * Gets a source-node corresponding to a use of the API component represented by this node.
+     * Gets a data-flow node corresponding to a use of the API component represented by this node.
      *
-     * For example, `require('fs').readFileSync` is a use of the function `readFileSync` from the
-     * `fs` module, and `require('fs').readFileSync(file)` is a use of the result of that function.
-     *
-     * As another example, in the assignment `exports.plusOne = (x) => x+1` the two references to
-     * `x` are uses of the first parameter of `plusOne`.
+     * This predicate is similar to `getAReference`, except this prediate also follows purely local
+     * data-flow.
      */
-    DataFlow::SourceNode getASourceUse() { Impl::use(this, result) }
+    DataFlow::Node getAUse() { getAReference().flowsTo(result) }
 
     /**
      * Gets a data-flow node corresponding to the right-hand side of a definition of the API

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -96,7 +96,7 @@ private module MySql {
  * Provides classes modelling the `pg` package.
  */
 private module Postgres {
-  /** Gets a reference to the `Client` constructor in the `pg` package. E.g: `require('pg').Client`. */
+  /** Gets a reference to the `Client` constructor in the `pg` package, for example `require('pg').Client`. */
   API::Node newClient() { result = API::moduleImport("pg").getMember("Client") }
 
   /** Gets a freshly created Postgres client instance. */

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -300,7 +300,7 @@ private module Sequelize {
 
     Credentials() {
       exists(NewExpr ne, string prop |
-        ne = sequelize().getAReference().getAnInstantiation().asExpr() and
+        ne = sequelize().getAnInstantiation().asExpr() and
         (
           this = ne.getArgument(1) and prop = "username"
           or

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -54,7 +54,7 @@ private module MySql {
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
     QueryCall() {
       exists(API::Node recv | recv = createPool() or recv = connection() |
-        this = recv.getMember("query").getASourceUse().getACall()
+        this = recv.getMember("query").getAReference().getACall()
       )
     }
 
@@ -72,7 +72,7 @@ private module MySql {
       this =
         [mysql(), createPool(), connection()]
             .getMember(["escape", "escapeId"])
-            .getASourceUse()
+            .getAReference()
             .getACall()
             .asExpr() and
       input = this.getArgument(0) and
@@ -132,7 +132,7 @@ private module Postgres {
 
   /** A call to the Postgres `query` method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = [client(), newPool()].getMember("query").getASourceUse().getACall() }
+    QueryCall() { this = [client(), newPool()].getMember("query").getAReference().getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -190,7 +190,7 @@ private module Sqlite {
         meth = "prepare" or
         meth = "run"
       |
-        this = newDb().getMember(meth).getASourceUse().getACall()
+        this = newDb().getMember(meth).getAReference().getACall()
       )
     }
 
@@ -234,7 +234,7 @@ private module MsSql {
 
   /** A call to a MsSql query method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = request().getMember(["query", "batch"]).getASourceUse().getACall() }
+    QueryCall() { this = request().getMember(["query", "batch"]).getAReference().getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -293,7 +293,7 @@ private module Sequelize {
 
   /** A call to `Sequelize.query`. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = newSequelize().getMember("query").getASourceUse().getACall() }
+    QueryCall() { this = newSequelize().getMember("query").getAReference().getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -312,7 +312,7 @@ private module Sequelize {
 
     Credentials() {
       exists(NewExpr ne, string prop |
-        ne = sequelize().getASourceUse().getAnInstantiation().asExpr() and
+        ne = sequelize().getAReference().getAnInstantiation().asExpr() and
         (
           this = ne.getArgument(1) and prop = "username"
           or
@@ -393,7 +393,7 @@ private module Spanner {
       this =
         database()
             .getMember(["run", "runPartitionedUpdate", "runStream"])
-            .getASourceUse()
+            .getAReference()
             .getACall()
     }
   }
@@ -403,7 +403,7 @@ private module Spanner {
    */
   class TransactionRunCall extends SqlExecution {
     TransactionRunCall() {
-      this = transaction().getMember(["run", "runStream", "runUpdate"]).getASourceUse().getACall()
+      this = transaction().getMember(["run", "runStream", "runUpdate"]).getAReference().getACall()
     }
   }
 
@@ -415,7 +415,7 @@ private module Spanner {
       this =
         v1SpannerClient()
             .getMember(["executeSql", "executeStreamingSql"])
-            .getASourceUse()
+            .getAReference()
             .getACall()
     }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SQL.qll
@@ -51,7 +51,7 @@ private module MySql {
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
     QueryCall() {
       exists(API::Node recv | recv = pool() or recv = connection() |
-        this = recv.getMember("query").getAReference().getACall()
+        this = recv.getMember("query").getACall()
       )
     }
 
@@ -69,7 +69,6 @@ private module MySql {
       this =
         [mysql(), pool(), connection()]
             .getMember(["escape", "escapeId"])
-            .getAReference()
             .getACall()
             .asExpr() and
       input = this.getArgument(0) and
@@ -129,7 +128,7 @@ private module Postgres {
 
   /** A call to the Postgres `query` method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = [client(), newPool()].getMember("query").getAReference().getACall() }
+    QueryCall() { this = [client(), newPool()].getMember("query").getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -187,7 +186,7 @@ private module Sqlite {
         meth = "prepare" or
         meth = "run"
       |
-        this = newDb().getMember(meth).getAReference().getACall()
+        this = newDb().getMember(meth).getACall()
       )
     }
 
@@ -231,7 +230,7 @@ private module MsSql {
 
   /** A call to a MsSql query method. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = request().getMember(["query", "batch"]).getAReference().getACall() }
+    QueryCall() { this = request().getMember(["query", "batch"]).getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -290,7 +289,7 @@ private module Sequelize {
 
   /** A call to `Sequelize.query`. */
   private class QueryCall extends DatabaseAccess, DataFlow::MethodCallNode {
-    QueryCall() { this = newSequelize().getMember("query").getAReference().getACall() }
+    QueryCall() { this = newSequelize().getMember("query").getACall() }
 
     override DataFlow::Node getAQueryArgument() { result = getArgument(0) }
   }
@@ -390,7 +389,6 @@ private module Spanner {
       this =
         database()
             .getMember(["run", "runPartitionedUpdate", "runStream"])
-            .getAReference()
             .getACall()
     }
   }
@@ -400,7 +398,7 @@ private module Spanner {
    */
   class TransactionRunCall extends SqlExecution {
     TransactionRunCall() {
-      this = transaction().getMember(["run", "runStream", "runUpdate"]).getAReference().getACall()
+      this = transaction().getMember(["run", "runStream", "runUpdate"]).getACall()
     }
   }
 
@@ -412,7 +410,6 @@ private module Spanner {
       this =
         v1SpannerClient()
             .getMember(["executeSql", "executeStreamingSql"])
-            .getAReference()
             .getACall()
     }
 

--- a/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
+++ b/javascript/ql/test/library-tests/frameworks/SQL/SqlString.expected
@@ -3,6 +3,7 @@
 | mssql2.js:5:15:5:34 | 'select 1 as number' |
 | mssql2.js:13:15:13:66 | 'create ...  table' |
 | mssql2.js:22:24:22:43 | 'select 1 as number' |
+| mssql2.js:29:30:29:81 | 'create ...  table' |
 | mysql1.js:13:18:13:43 | 'SELECT ... lution' |
 | mysql1.js:18:18:22:1 | {\\n    s ... vid']\\n} |
 | mysql1a.js:17:18:17:43 | 'SELECT ... lution' |

--- a/javascript/ql/test/library-tests/frameworks/SQL/mssql2.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mssql2.js
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/tediousjs/node-mssql#readme
 const sql = require('mssql')
- 
+
 const request = new sql.Request()
 request.query('select 1 as number', (err, result) => {
     // ... error checks
@@ -19,7 +19,16 @@ class C {
         this.req = req;
     }
     send() {
-        this.req.query('select 1 as number', (err, result) => {})
+        this.req.query('select 1 as number', (err, result) => { })
     }
 }
 new C(new sql.Request());
+
+var obj = {
+    foo: function () {
+        return request.batch('create procedure #temporary as select * from table', (err, result) => {
+            // ... error checks
+        })
+    }
+}
+obj.foo("foo", "bar", "baz"); // A API-graphs gotcha.

--- a/javascript/ql/test/library-tests/frameworks/SQL/mssql2.js
+++ b/javascript/ql/test/library-tests/frameworks/SQL/mssql2.js
@@ -31,4 +31,4 @@ var obj = {
         })
     }
 }
-obj.foo("foo", "bar", "baz"); // A API-graphs gotcha.
+obj.foo("foo", "bar", "baz"); // An API-graphs gotcha: "baz" should not be considered a `SqlString`


### PR DESCRIPTION
Consider an example where API-graphs are used to create a model for some call, like: 

```CodeQL
class QueryCall extends DataFlow::CallNode {
  QueryCall() {
    this = API::moduleImport("my-module").getReturn().getAUse()
  }
  DataFlow::Node getQueryArg() {...}
}
```

This will correctly match something like `var foo = require("my-module")(x)`.  
But it will also falsely match `bar(x)` in the below example (because the return is type-tracked). 

```JavaScript
function bar(x) {
  return require("my-module")("something");
}
bar(x);
```

For such models we want to flag just the call to `my-module`, and we do not want to type-track that call.   
So the model should instead look something like: 

```CodeQL
class QueryCall extends DataFlow::CallNode {
  QueryCall() {
    this.getCalleeNode() = API::moduleImport("my-module").getAUse()
  }
  DataFlow::Node getQueryArg() {...}
}
```

You can also look at the test-case I added in this PR. The `"baz"` in `obj.foo("foo", "bar", "baz");` was falsely flagged as an SQL-string before this fix. 

I've gone through `SQL.qll` and fixed all the offending code I found.  
I've also made some drive-by-changes to refactor `hasOptionArgument` to use API-graphs instead.

I've added a convenience method - `API::Node::getASourceUse()` - such that the model above can be implemented like: 

```CodeQL
class QueryCall extends DataFlow::CallNode {
  QueryCall() {
    this = API::moduleImport("my-module").getASourceUse().getACall()
  }
  DataFlow::Node getQueryArg() {...}
}
```

@max-schaefer I would like your thoughts here. 