### PR TITLE
C++: Change note for several range-analysis PRs

### DIFF
--- a/cpp/change-notes/2020-09-29-range-analysis-rollup.md
+++ b/cpp/change-notes/2020-09-29-range-analysis-rollup.md
@@ -1,0 +1,14 @@
+lgtm,codescanning
+* The `SimpleRangeAnalysis` library has gained support for several language
+  constructs it did not support previously. These improvements primarily affect
+  the queries `cpp/constant-comparison`, `cpp/comparison-with-wider-type`, and
+  `cpp/integer-multiplication-cast-to-long`. The newly supported language
+  features are:
+    * Multiplication of unsigned numbers.
+    * Multiplication by a constant.
+    * Reference-typed function parameters.
+    * Comparing a variable not equal to an endpoint of its range, thus narrowing the range by one.
+    * Using `if (x)` or `if (!x)` or similar to test for equality to zero.
+* The `SimpleRangeAnalysis` library can now be extended with custom rules. See
+  examples in
+  `cpp/ql/src/experimental/semmle/code/cpp/rangeanalysis/extensions/`.


### PR DESCRIPTION
This is my first attempt at using the new format for change notes. It's been done in this repo before in https://github.com/github/codeql/pull/4325, and it's been used in https://github.com/github/codeql-go/tree/main/change-notes for a while.

@alexet, does the formatting and everything look correct for the tooling? Is that something we can/should verify for each PR?