### PR TITLE
Add support for Variable.is_constinit()

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -145,6 +145,11 @@ class Variable extends Declaration, @variable {
   predicate isConstexpr() { this.hasSpecifier("is_constexpr") }
 
   /**
+   * Holds if this variable is declared `constinit`.
+   */
+  predicate isConstinit() { this.hasSpecifier("declared_constinit") }
+
+  /**
    * Holds if this variable is `thread_local`.
    */
   predicate isThreadLocal() { this.hasSpecifier("is_thread_local") }


### PR DESCRIPTION
This adds a predicate to check whether a variable has been declared with C++20's `constinit` specifier.

Currently this does not check whether any of the various `constexpr` checks in the library and standard queries need to be extended to support `constinit`

Whilst this depends on extractor support, it doesn't depend on a Schema upgrade and so this change can be made independently of the extractor.