### PR TITLE
JavaScript: Teach API graphs to recognise arguments supplied in partial function applications.

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -412,22 +412,39 @@ module API {
           rhs = f.getAReturn()
         )
         or
-        exists(DataFlow::SourceNode src, DataFlow::InvokeNode invk |
-          use(base, src) and invk = trackUseNode(src).getAnInvocation()
-        |
-          exists(int i |
-            lbl = Label::parameter(i) and
-            rhs = invk.getArgument(i)
-          )
-          or
-          lbl = Label::receiver() and
-          rhs = invk.(DataFlow::CallNode).getReceiver()
+        exists(int i |
+          lbl = Label::parameter(i) and
+          argumentPassing(base, i, rhs)
         )
         or
         exists(DataFlow::SourceNode src, DataFlow::PropWrite pw |
           use(base, src) and pw = trackUseNode(src).getAPropertyWrite() and rhs = pw.getRhs()
         |
           lbl = Label::memberFromRef(pw)
+        )
+      )
+    }
+
+    /**
+     * Holds if `arg` is passed as the `i`th argument to a use of `base`, either by means of a
+     * full invocation, or in a partial function application.
+     *
+     * The receiver is considered to be argument -1.
+     */
+    private predicate argumentPassing(TApiNode base, int i, DataFlow::Node arg) {
+      exists(DataFlow::SourceNode use, DataFlow::SourceNode pred |
+        use(base, use) and pred = trackUseNode(use)
+      |
+        arg = pred.getAnInvocation().getArgument(i)
+        or
+        arg = pred.getACall().getReceiver() and
+        i = -1
+        or
+        exists(DataFlow::PartialInvokeNode pin, DataFlow::Node callback | pred.flowsTo(callback) |
+          pin.isPartialArgument(callback, arg, i)
+          or
+          arg = pin.getBoundReceiver(callback) and
+          i = -1
         )
       )
     }
@@ -719,10 +736,14 @@ private module Label {
   bindingset[s]
   string parameterByStringIndex(string s) {
     result = "parameter " + s and
-    s.toInt() >= 0
+    s.toInt() >= -1
   }
 
-  /** Gets the `parameter` edge label for the `i`th parameter. */
+  /**
+   * Gets the `parameter` edge label for the `i`th parameter.
+   *
+   * The receiver is considered to be parameter -1.
+   */
   bindingset[i]
   string parameter(int i) { result = parameterByStringIndex(i.toString()) }
 

--- a/javascript/ql/test/ApiGraphs/partial-invoke/VerifyAssertions.ql
+++ b/javascript/ql/test/ApiGraphs/partial-invoke/VerifyAssertions.ql
@@ -1,0 +1,1 @@
+import ApiGraphs.VerifyAssertions

--- a/javascript/ql/test/ApiGraphs/partial-invoke/index.js
+++ b/javascript/ql/test/ApiGraphs/partial-invoke/index.js
@@ -1,0 +1,8 @@
+const cp = require('child_process');
+
+module.exports = function () {
+    return cp.spawn.bind(
+        cp,   // def (parameter -1 (member spawn (member exports (module child_process))))
+        "cat" // def (parameter 0 (member spawn (member exports (module child_process))))
+    );
+};

--- a/javascript/ql/test/ApiGraphs/partial-invoke/package.json
+++ b/javascript/ql/test/ApiGraphs/partial-invoke/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "partial-invoke"
+}


### PR DESCRIPTION
[Evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/0b151e73f1a4a3dbc80da462fd500c1270a29ef8/js/api-graph-partial-calls/report.md) (internal link) shows a few performance wobbles on the first run, which went away on rerunning. Also note the metrics towards the bottom of the report, which show no significant changes to API graph size or complexity.