### PR TITLE
Fix OWASP broken links

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.qhelp
+++ b/cpp/ql/src/Security/CWE/CWE-022/TaintedPath.qhelp
@@ -39,7 +39,7 @@ access all the system's passwords.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Security Features/CWE-022/TaintedPath.qhelp
+++ b/csharp/ql/src/Security Features/CWE-022/TaintedPath.qhelp
@@ -41,7 +41,7 @@ sent back to the user, giving them access to all the system's passwords.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
+++ b/csharp/ql/src/Security Features/CWE-022/ZipSlip.qhelp
@@ -71,7 +71,7 @@ Snyk:
 </li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/csharp/ql/src/Security Features/CWE-643/XPathInjection.qhelp
+++ b/csharp/ql/src/Security Features/CWE-643/XPathInjection.qhelp
@@ -42,7 +42,7 @@ variables in an <code>XsltArgumentList</code>.
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php?title=Testing_for_XPath_Injection_(OTG-INPVAL-010)">Testing for XPath Injection</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection">Testing for XPath Injection</a>.</li>
 <li>OWASP: <a href="https://www.owasp.org/index.php/XPATH_Injection">XPath Injection</a>.</li>
 <li>MSDN: <a href="https://msdn.microsoft.com/en-us/library/dd567715.aspx">User Defined Functions and Variables</a>.</li>
 </references>

--- a/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
+++ b/csharp/ql/src/experimental/CWE-099/TaintedWebClient.qhelp
@@ -51,7 +51,7 @@ system's passwords.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/java/ql/src/Security/CWE/CWE-022/TaintedPath.qhelp
+++ b/java/ql/src/Security/CWE/CWE-022/TaintedPath.qhelp
@@ -39,7 +39,7 @@ giving them access to all the system's passwords.</p>
 
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
+++ b/java/ql/src/Security/CWE/CWE-022/ZipSlip.qhelp
@@ -63,7 +63,7 @@ Snyk:
 </li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.qhelp
+++ b/java/ql/src/Security/CWE/CWE-209/StackTraceExposure.qhelp
@@ -38,7 +38,7 @@ information.</p>
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Information_Leak_(information_disclosure)">Information Leak</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/Improper_Error_Handling">Improper Error Handling</a>.</li>
 
 <li>CERT Java Coding Standard:
 <a href="https://www.securecoding.cert.org/confluence/display/java/ERR01-J.+Do+not+allow+exceptions+to+expose+sensitive+information">ERR01-J.

--- a/java/ql/src/experimental/Security/CWE/CWE-643/XPathInjection.qhelp
+++ b/java/ql/src/experimental/Security/CWE/CWE-643/XPathInjection.qhelp
@@ -38,7 +38,7 @@ The fifth example is a dom4j XPath injection example.
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php?title=Testing_for_XPath_Injection_(OTG-INPVAL-010)">Testing for XPath Injection</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection">Testing for XPath Injection</a>.</li>
 <li>OWASP: <a href="https://www.owasp.org/index.php/XPATH_Injection">XPath Injection</a>.</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-022/TaintedPath.qhelp
+++ b/javascript/ql/src/Security/CWE-022/TaintedPath.qhelp
@@ -50,7 +50,7 @@ system's passwords.
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.</li>
 <li>npm: <a href="https://www.npmjs.com/package/sanitize-filename">sanitize-filename</a> package.</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
+++ b/javascript/ql/src/Security/CWE-022/ZipSlip.qhelp
@@ -60,7 +60,7 @@ Snyk:
 </li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 
 </references>

--- a/javascript/ql/src/Security/CWE-209/StackTraceExposure.qhelp
+++ b/javascript/ql/src/Security/CWE-209/StackTraceExposure.qhelp
@@ -52,6 +52,6 @@ will not see the information:
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Information_Leak_(information_disclosure)">Information Leak</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/Improper_Error_Handling">Improper Error Handling</a>.</li>
 </references>
 </qhelp>

--- a/javascript/ql/src/Security/CWE-643/XpathInjection.qhelp
+++ b/javascript/ql/src/Security/CWE-643/XpathInjection.qhelp
@@ -33,7 +33,7 @@ by <code>xpath</code>:
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php?title=Testing_for_XPath_Injection_(OTG-INPVAL-010)">Testing for XPath Injection</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/07-Input_Validation_Testing/09-Testing_for_XPath_Injection">Testing for XPath Injection</a>.</li>
 <li>OWASP: <a href="https://www.owasp.org/index.php/XPATH_Injection">XPath Injection</a>.</li>
 <li>npm: <a href="https://www.npmjs.com/package/xpath">xpath</a>.</li>
 </references>

--- a/python/ql/src/Security/CWE-022/PathInjection.qhelp
+++ b/python/ql/src/Security/CWE-022/PathInjection.qhelp
@@ -55,7 +55,7 @@ known prefix. This ensures that regardless of the user input, the resulting path
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.</li>
 <li>npm: <a href="http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename">werkzeug.utils.secure_filename</a>.</li>
 </references>
 </qhelp>

--- a/python/ql/src/Security/CWE-022/TarSlip.qhelp
+++ b/python/ql/src/Security/CWE-022/TarSlip.qhelp
@@ -60,7 +60,7 @@ Snyk:
 </li>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Path_traversal">Path Traversal</a>.
+<a href="https://owasp.org/www-community/attacks/Path_Traversal">Path Traversal</a>.
 </li>
 <li>
 Python Library Reference:

--- a/python/ql/src/Security/CWE-209/StackTraceExposure.qhelp
+++ b/python/ql/src/Security/CWE-209/StackTraceExposure.qhelp
@@ -47,6 +47,6 @@ log, but remote users will not see the information.
 </example>
 
 <references>
-<li>OWASP: <a href="https://www.owasp.org/index.php/Information_Leak_(information_disclosure)">Information Leak</a>.</li>
+<li>OWASP: <a href="https://owasp.org/www-community/Improper_Error_Handling">Improper Error Handling</a>.</li>
 </references>
 </qhelp>


### PR DESCRIPTION
Fixes those broken links mentioned in https://github.com/github/codeql/issues/4379 that are also linked from the Go repository. The exact doc linked from the stack-trace exposure query didn't seem to exist any longer, so I found another doc that talked about stack dumps.