### PR TITLE
JavaScript: Improve handling of re-exports in API graphs

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -645,6 +645,16 @@ module API {
       rhs(_, nd) and
       result = nd.getALocalSource()
       or
+      // additional backwards step from `require('m')` to `exports` or `module.exports` in m
+      exists(Import imp | imp.getImportedModuleNode() = trackDefNode(nd, t.continue()) |
+        result.(ExportsAsSourceNode).getModule() = imp.getImportedModule()
+        or
+        exists(ModuleAsSourceNode mod |
+          mod.getModule() = imp.getImportedModule() and
+          result = mod.(DataFlow::SourceNode).getAPropertyRead("exports")
+        )
+      )
+      or
       exists(DataFlow::TypeBackTracker t2 | result = trackDefNode(nd, t2).backtrack(t2, t))
     }
 

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -419,9 +419,18 @@ module API {
         exists(DataFlow::Node def, DataFlow::SourceNode pred |
           rhs(base, def) and pred = trackDefNode(def)
         |
+          // from `x` to a definition of `x.prop`
           exists(DataFlow::PropWrite pw | pw = pred.getAPropertyWrite() |
             lbl = Label::memberFromRef(pw) and
             rhs = pw.getRhs()
+          )
+          or
+          // special case: from `require('m')` to an export of `prop` in `m`
+          exists(Import imp, Module m, string prop |
+            pred = imp.getImportedModuleNode() and
+            m = imp.getImportedModule() and
+            lbl = Label::member(prop) and
+            rhs = m.getAnExportedValue(prop)
           )
           or
           exists(DataFlow::FunctionNode fn | fn = pred |

--- a/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
@@ -1,1 +1,2 @@
+| lib/stuff.js:1:19:1:103 | /* use  ... )))) */ | def (member other (member exports (module reexport))) has no outgoing edge labelled member bar; it has no outgoing edges at all. |
 | lib/utils.js:1:38:1:120 | /* use  ... )))) */ | def (member util (member exports (module reexport))) has no outgoing edge labelled member id; it has no outgoing edges at all. |

--- a/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
@@ -1,1 +1,0 @@
-| lib/utils.js:1:38:1:120 | /* use  ... )))) */ | def (member util (member exports (module reexport))) has no outgoing edge labelled member id; it has no outgoing edges at all. |

--- a/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/reexport/VerifyAssertions.expected
@@ -1,2 +1,1 @@
-| lib/stuff.js:1:19:1:103 | /* use  ... )))) */ | def (member other (member exports (module reexport))) has no outgoing edge labelled member bar; it has no outgoing edges at all. |
 | lib/utils.js:1:38:1:120 | /* use  ... )))) */ | def (member util (member exports (module reexport))) has no outgoing edge labelled member id; it has no outgoing edges at all. |

--- a/javascript/ql/test/ApiGraphs/reexport/index.js
+++ b/javascript/ql/test/ApiGraphs/reexport/index.js
@@ -2,5 +2,6 @@ const impl = require("./lib/impl.js");
 
 module.exports = {
     impl,
-    util: require("./lib/utils")
+    util: require("./lib/utils"),
+    other: require("./lib/stuff")
 };

--- a/javascript/ql/test/ApiGraphs/reexport/index.js
+++ b/javascript/ql/test/ApiGraphs/reexport/index.js
@@ -3,5 +3,6 @@ const impl = require("./lib/impl.js");
 module.exports = {
     impl,
     util: require("./lib/utils"),
-    other: require("./lib/stuff")
+    other: require("./lib/stuff"),
+    util2: require("./lib/utils2")
 };

--- a/javascript/ql/test/ApiGraphs/reexport/lib/stuff.js
+++ b/javascript/ql/test/ApiGraphs/reexport/lib/stuff.js
@@ -1,0 +1,5 @@
+function foo(x) { /* use (parameter 0 (member bar (member other (member exports (module reexport)))) */
+    return x + 1;
+}
+
+export const bar = foo;

--- a/javascript/ql/test/ApiGraphs/reexport/lib/utils2.js
+++ b/javascript/ql/test/ApiGraphs/reexport/lib/utils2.js
@@ -1,0 +1,5 @@
+module.exports = {
+    id: function id(x) { /* use (parameter 0 (member id (member util2 (member exports (module reexport)))) */
+	return x;
+    }
+};


### PR DESCRIPTION
Previously, API graphs didn't deal very well with re-exports. Specifically, if you had a package whose main `index.js` file was something like

```js
module.exports = require('./implementation.js')
```

and `implementation.js` had _individual_ exports (as opposed to a bulk export using `module.exports = ...`), those individual exports would not be reflected in the API graph of the package.

That's because we use type (back-)tracking to figure out where the value assigned to `module.exports` comes from, but if `implementation.js` doesn't use a bulk export then there isn't a node to step back to.

This would be fixed by introducing synthetic data-flow nodes representing the (initial) values of `exports` and `module`, as discussed previously, but it's a bit of a fiddly change, so this PR proposes to fix it at the API-graph level instead.

[Evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/52c948de5a2f5286ac009b4e6b05023e83f34081/js/api-graph-reexports/report.md) (internal link) shows no performance changes (after the customary initial wobbles). API-graph metrics show significant numbers of new edges for a few databases; `azure-sdk-node`, `amphtml`, and `node`, in particular, see an increase of 30%, and `cornerstoneWADOImageLoader` quadruples its number of edges. However, there are no corresponding increases in runtimes or tuple counts, and for many databases there are no changes at all.