### PR TITLE
JS: allow flask url_for in TargetBlank.ql

### DIFF
--- a/javascript/ql/src/DOM/TargetBlank.ql
+++ b/javascript/ql/src/DOM/TargetBlank.ql
@@ -31,7 +31,9 @@ predicate hasDynamicHrefHostAttributeValue(DOM::ElementDefinition elem) {
       // fixed string with templating
       url.regexpMatch(Templating::getDelimiterMatchingRegexpWithPrefix("[^?#]*")) and
       // ... that does not start with a fixed host or a relative path (common formats)
-      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*")
+      not url.regexpMatch("(?i)((https?:)?//)?[-a-z0-9.]*/.*") and
+      // .. that is not a call to `url_for` in a Flask application
+      not url.regexpMatch("\\{\\{\\s*url_for.*")
     )
   )
 }

--- a/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
+++ b/javascript/ql/test/query-tests/DOM/TargetBlank/tst.js
@@ -58,3 +58,8 @@ function f() {
 <a href="index.html/{{X}}" target="_blank">Example</a>;
 <a href="../index.html/{{X}}" target="_blank">Example</a>;
 <a href="/{{X}}" target="_blank">Example</a>;
+
+// OK, Flask application with internal links
+<a href="{{url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
+<a href="{{ url_for('foo.html', 'foo')}}" target="_blank">Example</a>;
+<a href="{{ 	url_for('foo.html', 'foo')}}" target="_blank">Example</a>;


### PR DESCRIPTION
[\<a href="{{url_for(...)}}" target="_blank">..\</a>](https://lgtm.com/projects/g/indico/indico/snapshot/6644fcefc7e4f3246091ae037234b15b7c281f31/files/indico/modules/events/abstracts/templates/reviewing/public.html?sort=name&dir=ASC&mode=heatmap#x615eaec2d2786aa5:1) is an FP for `js/unsafe-external-link` as the [`url_for(..)` method](https://flask.palletsprojects.com/en/1.1.x/api/?highlight=url_for#flask.url_for) is only used to create links for internal pages (in Flask). 

[The pattern is used somewhat often](https://github.com/search?q=%3Ca+href%3D%22%7B%7B+url_for+extension%3Ahtml&ref=simplesearch). 

Fixes #4387. 