### PR TITLE
C++: Merge StdSequenceContainerBeginEnd into the general BeginOrEndFunction

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Iterator.qll
@@ -280,7 +280,9 @@ class IteratorArrayMemberOperator extends MemberFunction, TaintFunction, Iterato
  */
 class BeginOrEndFunction extends MemberFunction, TaintFunction {
   BeginOrEndFunction() {
-    this.hasName(["begin", "cbegin", "rbegin", "crbegin", "end", "cend", "rend", "crend"]) and
+    this
+        .hasName(["begin", "cbegin", "rbegin", "crbegin", "end", "cend", "rend", "crend",
+              "before_begin", "cbefore_begin"]) and
     this.getType().getUnspecifiedType() instanceof Iterator
   }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -171,22 +171,6 @@ class StdSequenceContainerAssign extends TaintFunction {
 }
 
 /**
- * The standard container `before_begin` and `cbefore_begin` functions.
- */
-class StdSequenceContainerBeginEnd extends TaintFunction {
-  StdSequenceContainerBeginEnd() {
-    this
-        .hasQualifiedName("std", "forward_list",
-          ["before_begin", "cbefore_begin"])
-  }
-
-  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    input.isQualifierObject() and
-    output.isReturnValue()
-  }
-}
-
-/**
  * The standard container `swap` functions.
  */
 class StdSequenceContainerSwap extends TaintFunction {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdContainer.qll
@@ -171,17 +171,13 @@ class StdSequenceContainerAssign extends TaintFunction {
 }
 
 /**
- * The standard container `begin` and `end` functions and their
- * variants.
+ * The standard container `before_begin` and `cbefore_begin` functions.
  */
 class StdSequenceContainerBeginEnd extends TaintFunction {
   StdSequenceContainerBeginEnd() {
     this
-        .hasQualifiedName("std", ["array", "vector", "deque", "list"],
-          ["begin", "cbegin", "rbegin", "crbegin", "end", "cend", "rend", "crend"]) or
-    this
         .hasQualifiedName("std", "forward_list",
-          ["before_begin", "begin", "end", "cbefore_begin", "cbegin", "cend"])
+          ["before_begin", "cbefore_begin"])
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {


### PR DESCRIPTION
Remove `StdSequenceContainerBeginEnd` in favour of the general `BeginOrEndFunction` model from https://github.com/github/codeql/pull/4135 .  Expand the latter slightly so that everything's still covered.

@rdmarsh2 this might be a good one for you to review?