### PR TITLE
C#: Handle population of error types

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -80,6 +80,7 @@ namespace Semmle.Extraction.CSharp.Entities
                         case TypeKind.Enum: return Kinds.TypeKind.ENUM;
                         case TypeKind.Delegate: return Kinds.TypeKind.DELEGATE;
                         case TypeKind.Pointer: return Kinds.TypeKind.POINTER;
+                        case TypeKind.Error: return Kinds.TypeKind.UNKNOWN;
                         default:
                             cx.ModelError(t, $"Unhandled type kind '{t.TypeKind}'");
                             return Kinds.TypeKind.UNKNOWN;


### PR DESCRIPTION
`cx.ModelError` throws an exception, so `PopulateType` would fail after having written `types(#ID,` to the TRAP file, which resulted in invalid TRAP.