### PR TITLE
JavaScript: Improve API-graph support for function-style classes.

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -547,7 +547,11 @@ module API {
         ref = DataFlow::moduleImport(m)
       )
       or
-      exists(DataFlow::ClassNode cls | nd = MkClassInstance(cls) | ref = cls.getAReceiverNode())
+      exists(DataFlow::ClassNode cls | nd = MkClassInstance(cls) |
+        ref = cls.getAReceiverNode()
+        or
+        ref = cls.(DataFlow::ClassNode::FunctionStyleClass).getAPrototypeReference()
+      )
       or
       nd = MkUse(ref)
       or

--- a/javascript/ql/test/ApiGraphs/classes/classes.js
+++ b/javascript/ql/test/ApiGraphs/classes/classes.js
@@ -20,4 +20,8 @@ MyOtherStream.prototype.write = function (data) { /* use (instance (member MyOth
     return this;
 };
 
+MyOtherStream.prototype.instanceProp = 1; /* def (member instanceProp (instance (member MyOtherStream (member exports (module classes))))) */
+
+MyOtherStream.classProp = 1; /* def (member classProp (member MyOtherStream (member exports (module classes)))) */
+
 module.exports.MyOtherStream = MyOtherStream;


### PR DESCRIPTION
At [no discernible cost](https://github.com/max-schaefer/dist-compare-reports/blob/master/js/api-graph-classrefs/report.md) (internal link) to performance.