### PR TITLE
JS: Some preparation for Angular2 model

### DIFF
--- a/javascript/ql/src/semmle/javascript/DOM.qll
+++ b/javascript/ql/src/semmle/javascript/DOM.qll
@@ -347,7 +347,11 @@ module DOM {
   }
 
   /** Gets a data flow node that may refer to a value from the DOM. */
-  DataFlow::SourceNode domValueRef() { result = domValueRef(DataFlow::TypeTracker::end()) }
+  DataFlow::SourceNode domValueRef() {
+    result = domValueRef(DataFlow::TypeTracker::end())
+    or
+    result.hasUnderlyingType("Element")
+  }
 
   module LocationSource {
     /**
@@ -419,5 +423,9 @@ module DOM {
   /**
    * Gets a reference to the 'document' object.
    */
-  DataFlow::SourceNode documentRef() { result = documentRef(DataFlow::TypeTracker::end()) }
+  DataFlow::SourceNode documentRef() {
+    result = documentRef(DataFlow::TypeTracker::end())
+    or
+    result.hasUnderlyingType("Document")
+  }
 }

--- a/javascript/ql/src/semmle/javascript/Extend.qll
+++ b/javascript/ql/src/semmle/javascript/Extend.qll
@@ -34,6 +34,13 @@ abstract class ExtendCall extends DataFlow::CallNode {
   }
 }
 
+/** A version of `JQuery::dollarSource()` with fewer dependencies. */
+private DataFlow::SourceNode localDollar() {
+  result.accessesGlobal(["$", "jQuery"])
+  or
+  result = DataFlow::moduleImport("jquery")
+}
+
 /**
  * An extend call of form `extend(true/false, dst, src1, src2, ...)`, where the true/false
  * argument is possibly omitted.
@@ -47,9 +54,7 @@ private class ExtendCallWithFlag extends ExtendCall {
       name = "node.extend"
     )
     or
-    // Match $.extend using the source of `$` only, as ExtendCall should not
-    // depend on type tracking.
-    this = JQuery::dollarSource().getAMemberCall("extend")
+    this = localDollar().getAMemberCall("extend")
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -426,7 +426,9 @@ private predicate barrierGuardBlocksSsaRefinement(
  * `outcome` is bound to the outcome of `cond` for join-ordering purposes.
  */
 pragma[noinline]
-private predicate barrierGuardUsedInCondition(BarrierGuardNode guard, ConditionGuardNode cond, boolean outcome) {
+private predicate barrierGuardUsedInCondition(
+  BarrierGuardNode guard, ConditionGuardNode cond, boolean outcome
+) {
   barrierGuardIsRelevant(guard) and
   outcome = cond.getOutcome() and
   (

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -228,7 +228,7 @@ module DataFlow {
      *
      * Doesn't take field types and function return types into account.
      */
-    private JSDocTypeExpr getFallbackTypeAnnotation() {
+    private TypeAnnotation getFallbackTypeAnnotation() {
       exists(BindingPattern pattern |
         this = valueNode(pattern) and
         not ast_node_type(pattern, _) and
@@ -236,6 +236,11 @@ module DataFlow {
       )
       or
       result = getAPredecessor().getFallbackTypeAnnotation()
+      or
+      exists(DataFlow::ClassNode cls, string fieldName |
+        this = cls.getAReceiverNode().getAPropertyRead(fieldName) and
+        result = cls.getFieldTypeAnnotation(fieldName)
+      )
     }
 
     /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -709,7 +709,9 @@ module DataFlow {
       result = thisNode(prop.getDeclaringClass().getConstructor().getBody())
     }
 
-    override Expr getPropertyNameExpr() { result = prop.getNameExpr() }
+    override Expr getPropertyNameExpr() {
+      none() // The parameter value is not the name of the field
+    }
 
     override string getPropertyName() { result = prop.getName() }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -995,6 +995,13 @@ class ClassNode extends DataFlow::SourceNode {
   predicate hasQualifiedName(string name) {
     getAClassReference().flowsTo(AccessPath::getAnAssignmentTo(name))
   }
+
+  /**
+   * Gets the type annotation for the field `fieldName`, if any.
+   */
+  TypeAnnotation getFieldTypeAnnotation(string fieldName) {
+    result = impl.getFieldTypeAnnotation(fieldName)
+  }
 }
 
 module ClassNode {
@@ -1047,6 +1054,11 @@ module ClassNode {
      * of this node.
      */
     abstract DataFlow::Node getASuperClassNode();
+
+    /**
+     * Gets the type annotation for the field `fieldName`, if any.
+     */
+    TypeAnnotation getFieldTypeAnnotation(string fieldName) { none() }
   }
 
   /**
@@ -1106,6 +1118,14 @@ module ClassNode {
     }
 
     override DataFlow::Node getASuperClassNode() { result = astNode.getSuperClass().flow() }
+
+    override TypeAnnotation getFieldTypeAnnotation(string fieldName) {
+      exists(FieldDeclaration field |
+        field.getDeclaringClass() = astNode and
+        fieldName = field.getName() and
+        result = field.getTypeAnnotation()
+      )
+    }
   }
 
   private DataFlow::PropRef getAPrototypeReferenceInFile(string name, File f) {

--- a/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
@@ -1,4 +1,4 @@
-| fields.ts:2:16:2:32 | (x: string) => {} | Foo.m | method |
+| fields.ts:12:16:12:32 | (x: string) => {} | Foo.m | method |
 | namespace.js:5:32:5:44 | function() {} | Baz.method | method |
 | tst2.js:6:9:9:3 | () {\\n   ... .x;\\n  } | C.method | method |
 | tst2.js:11:13:13:3 | () {\\n   ... .x;\\n  } | C.getter | getter |

--- a/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
@@ -1,4 +1,4 @@
-| fields.ts:2:16:2:32 | (x: string) => {} | Foo.m |
+| fields.ts:12:16:12:32 | (x: string) => {} | Foo.m |
 | namespace.js:5:32:5:44 | function() {} | Baz.method |
 | tst2.js:6:9:9:3 | () {\\n   ... .x;\\n  } | C.method |
 | tst2.js:18:14:18:22 | (x) => {} | D.f |

--- a/javascript/ql/test/library-tests/ClassNode/SuperClass.expected
+++ b/javascript/ql/test/library-tests/ClassNode/SuperClass.expected
@@ -1,3 +1,4 @@
+| fields.ts:5:1:13:1 | class F ... > {};\\n} | Foo | fields.ts:1:1:3:1 | class B ... mber;\\n} | Base |
 | tst.js:13:1:13:21 | class A ... ds A {} | A2 | tst.js:3:1:10:1 | class A ... () {}\\n} | A |
 | tst.js:15:1:15:15 | function B() {} | B | tst.js:3:1:10:1 | class A ... () {}\\n} | A |
 | tst.js:19:1:19:15 | function C() {} | C | tst.js:15:1:15:15 | function B() {} | B |

--- a/javascript/ql/test/library-tests/ClassNode/fields.ts
+++ b/javascript/ql/test/library-tests/ClassNode/fields.ts
@@ -1,3 +1,13 @@
-class Foo {
+class Base {
+    baseField: number;
+}
+
+class Foo extends Base {
+    constructor(public x: number, private y: string) {
+        super();
+    }
+
+    z: string[];
+
     public m = (x: string) => {};
 }

--- a/javascript/ql/test/library-tests/ClassNode/getAReceiverNode.expected
+++ b/javascript/ql/test/library-tests/ClassNode/getAReceiverNode.expected
@@ -1,4 +1,5 @@
-| fields.ts:1:1:3:1 | class F ... > {};\\n} | fields.ts:1:11:1:10 | this |
+| fields.ts:1:1:3:1 | class B ... mber;\\n} | fields.ts:1:12:1:11 | this |
+| fields.ts:5:1:13:1 | class F ... > {};\\n} | fields.ts:6:5:6:4 | this |
 | namespace.js:3:15:3:31 | function Baz() {} | namespace.js:3:15:3:14 | this |
 | namespace.js:3:15:3:31 | function Baz() {} | namespace.js:5:32:5:31 | this |
 | tst2.js:1:1:14:1 | class C ... ;\\n  }\\n} | tst2.js:2:14:2:13 | this |

--- a/javascript/ql/test/library-tests/ClassNode/getFieldTypeAnnotation.expected
+++ b/javascript/ql/test/library-tests/ClassNode/getFieldTypeAnnotation.expected
@@ -1,0 +1,4 @@
+| fields.ts:1:1:3:1 | class B ... mber;\\n} | baseField | fields.ts:2:16:2:21 | number |
+| fields.ts:5:1:13:1 | class F ... > {};\\n} | x | fields.ts:6:27:6:32 | number |
+| fields.ts:5:1:13:1 | class F ... > {};\\n} | y | fields.ts:6:46:6:51 | string |
+| fields.ts:5:1:13:1 | class F ... > {};\\n} | z | fields.ts:10:8:10:15 | string[] |

--- a/javascript/ql/test/library-tests/ClassNode/getFieldTypeAnnotation.ql
+++ b/javascript/ql/test/library-tests/ClassNode/getFieldTypeAnnotation.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from DataFlow::ClassNode cls, string name
+select cls, name, cls.getFieldTypeAnnotation(name)


### PR DESCRIPTION
Contains a few things that are needed for the Angular2 model, but make sense to evaluate and merge independently.

- Makes `SourceNode.hasUnderlyingType` more robust in absence of static type information. Specifically, `getFallbackTypeAnnotation` is no longer restricted to JSDoc type annotations, and expressions like `this.f` will be associated with the type of a field in the enclosing class. Inheritance is not accounted for.
- DOM elements are now recognized by type.
- The `ExtendCall` case for `$.extend` no longer depends on `JQuerySource::Range` in order to break a circular dependency between `hasUnderlyingType` and `ExtendCall`.
- Fixes a subtle bug in the handling of parameter fields introduced by https://github.com/github/codeql/pull/3508: For a parameter field like `foo` in `constructor(public foo: string)` the `getPropertyNameExpr` would return the identifier `foo`, but that is now associated with the value of the parameter, making the analysis think the value of the parameter was the name of the property being assigned to 😱 . Gave some dubious results from our good friend `js/remote-property-injection` 😅 
- Fixes a bad join ordering in `barrierGuardBlocksNode`.

Evaluations:
- [Security suite on angular2.slugs](https://github.com/github/asgerf-dist-compare-reports/tree/js/angular-prerequisites_1601873880029): fixes two failures. The apparent slowdown on ag-grid is because it failed in the baseline.
- [Security suite on smoke-test.slugs](https://github.com/github/asgerf-dist-compare-reports/tree/js/angular-prerequisites_1601818142973): looks fine

