### PR TITLE
Update expected results for `constint' support

### DIFF
--- a/cpp/ql/test/library-tests/clang_ms/element.expected
+++ b/cpp/ql/test/library-tests/clang_ms/element.expected
@@ -76,6 +76,7 @@
 | file://:0:0:0:0 | declaration of 1st parameter |
 | file://:0:0:0:0 | declaration of 1st parameter |
 | file://:0:0:0:0 | declared_constexpr |
+| file://:0:0:0:0 | declared_constinit |
 | file://:0:0:0:0 | decltype(nullptr) |
 | file://:0:0:0:0 | definition of fp_offset |
 | file://:0:0:0:0 | definition of gp_offset |

--- a/cpp/ql/test/library-tests/conditions/elements.expected
+++ b/cpp/ql/test/library-tests/conditions/elements.expected
@@ -46,6 +46,7 @@
 | file://:0:0:0:0 | const __va_list_tag |
 | file://:0:0:0:0 | const __va_list_tag & |
 | file://:0:0:0:0 | declared_constexpr |
+| file://:0:0:0:0 | declared_constinit |
 | file://:0:0:0:0 | decltype(nullptr) |
 | file://:0:0:0:0 | definition of <error> |
 | file://:0:0:0:0 | definition of fp_offset |

--- a/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
+++ b/cpp/ql/test/library-tests/templates/instantiations_functions/elements.expected
@@ -106,6 +106,7 @@
 | file://:0:0:0:0 | declaration of 1st parameter |
 | file://:0:0:0:0 | declaration of 1st parameter |
 | file://:0:0:0:0 | declared_constexpr |
+| file://:0:0:0:0 | declared_constinit |
 | file://:0:0:0:0 | decltype(nullptr) |
 | file://:0:0:0:0 | definition of fp_offset |
 | file://:0:0:0:0 | definition of gp_offset |

--- a/cpp/ql/test/library-tests/unnamed/elements.expected
+++ b/cpp/ql/test/library-tests/unnamed/elements.expected
@@ -38,6 +38,7 @@
 | file://:0:0:0:0 | char32_t | Other |
 | file://:0:0:0:0 | const | Other |
 | file://:0:0:0:0 | declared_constexpr | Other |
+| file://:0:0:0:0 | declared_constinit | Other |
 | file://:0:0:0:0 | decltype(nullptr) | Other |
 | file://:0:0:0:0 | definition of fp_offset | Other |
 | file://:0:0:0:0 | definition of gp_offset | Other |


### PR DESCRIPTION
Updates tests whose results change by adding `constinit` support.

This will fail testing as it depends on an internal C++ Extractor change.