### PR TITLE
C#: Fix extraction of library indexers with explicit interface implementations

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -240,7 +240,7 @@ namespace Semmle.Extraction.CSharp.Entities
                     return Destructor.Create(cx, methodDecl);
                 case MethodKind.PropertyGet:
                 case MethodKind.PropertySet:
-                    return methodDecl.AssociatedSymbol is null ? OrdinaryMethod.Create(cx, methodDecl) : (Method)Accessor.Create(cx, methodDecl);
+                    return Accessor.GetPropertySymbol(methodDecl) is null ? OrdinaryMethod.Create(cx, methodDecl) : (Method)Accessor.Create(cx, methodDecl);
                 case MethodKind.EventAdd:
                 case MethodKind.EventRemove:
                     return EventAccessor.Create(cx, methodDecl);

--- a/csharp/ql/test/library-tests/indexers/Indexers12.expected
+++ b/csharp/ql/test/library-tests/indexers/Indexers12.expected
@@ -1,0 +1,1 @@
+| Item[int] | get_Item(int) |

--- a/csharp/ql/test/library-tests/indexers/Indexers12.ql
+++ b/csharp/ql/test/library-tests/indexers/Indexers12.ql
@@ -1,0 +1,8 @@
+import csharp
+
+from Indexer i, Accessor a, string s
+where
+  i.getDeclaringType().hasQualifiedName("System", s) and
+  s.regexpMatch("Tuple<,*>") and
+  a = i.getAnAccessor()
+select i.toStringWithTypes(), a.toStringWithTypes()


### PR DESCRIPTION
Accessors belonging to indexers with explicit interface implementations in library code were incorrectly extracted as normal methods.