### PR TITLE
JS: detect uses of jsxFactory in js/unused-local-variable

### DIFF
--- a/javascript/ql/src/Declarations/UnusedVariable.ql
+++ b/javascript/ql/src/Declarations/UnusedVariable.ql
@@ -58,6 +58,16 @@ predicate isReactForJSX(UnusedLocal v) {
         plugin.getJsxFactoryVariableName() = v.getName()
       )
     )
+    or
+    exists(JSONObject tsconfig |
+      tsconfig.isTopLevel() and tsconfig.getFile().getBaseName() = "tsconfig.json"
+    |
+      v.getName() =
+        tsconfig
+            .getPropValue("compilerOptions")
+            .(JSONObject)
+            .getPropStringValue(["jsxFactory", "jsxFragmentFactory"])
+    )
   )
 }
 

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/ts/tsconfig.json
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/ts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "jsx": "react",
+        "jsxFactory": "m"
+    }
+}

--- a/javascript/ql/test/query-tests/Declarations/UnusedVariable/ts/usesreact.tsx
+++ b/javascript/ql/test/query-tests/Declarations/UnusedVariable/ts/usesreact.tsx
@@ -1,0 +1,5 @@
+import {m} from 'some-react-library';
+
+export default function doAThing() {
+    return <span>foo</span>;
+}


### PR DESCRIPTION
Fixes #4409

Defining custom `jsxFactory` and `jsxFragmentFactory` in tsconfig.json is a [new feature in TypeScript 4.0](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#custom-jsx-factories).   

I just assume that the variable is used if there exists any `tsconfig.json` file with a `jsxFactory` of the right name.   
I didn't do any "this file belongs to this `tsconfig.json`" check. 

I don't plan to do any evaluation. 