### PR TITLE
Python: Attribute access API

### DIFF
--- a/python/ql/src/experimental/dataflow/TypeTracker.qll
+++ b/python/ql/src/experimental/dataflow/TypeTracker.qll
@@ -6,7 +6,7 @@ private import internal.DataFlowPrivate
 
 /** Any string that may appear as the name of an attribute or access path. */
 class AttributeName extends string {
-  AttributeName() { this = any(Attribute a).getName() }
+  AttributeName() { this = any(AttrRef a).getAttributeName() }
 }
 
 /** Either an attribute name, or the empty string (representing no attribute). */
@@ -115,11 +115,10 @@ predicate returnStep(ReturnNode nodeFrom, Node nodeTo) {
  * assignment to `z` inside `bar`, even though this attribute write happens _after_ `bar` is called.
  */
 predicate basicStoreStep(Node nodeFrom, Node nodeTo, string attr) {
-  exists(AttributeAssignment a, Node var |
-    a.getName() = attr and
-    simpleLocalFlowStep*(nodeTo, var) and
-    var.asVar() = a.getInput() and
-    nodeFrom.asCfgNode() = a.getValue()
+  exists(AttrWrite a |
+    a.getAttributeName() = attr and
+    nodeFrom = a.getValue() and
+    simpleLocalFlowStep*(nodeTo, a.getObject())
   )
 }
 
@@ -127,7 +126,11 @@ predicate basicStoreStep(Node nodeFrom, Node nodeTo, string attr) {
  * Holds if `nodeTo` is the result of accessing the `attr` attribute of `nodeFrom`.
  */
 predicate basicLoadStep(Node nodeFrom, Node nodeTo, string attr) {
-  exists(AttrNode s | nodeTo.asCfgNode() = s and s.getObject(attr) = nodeFrom.asCfgNode())
+  exists(AttrRead a |
+    attr = a.getAttributeName() and
+    nodeFrom = a.getObject() and
+    nodeTo = a
+  )
 }
 
 /**

--- a/python/ql/src/experimental/dataflow/TypeTracker.qll
+++ b/python/ql/src/experimental/dataflow/TypeTracker.qll
@@ -116,7 +116,7 @@ predicate returnStep(ReturnNode nodeFrom, Node nodeTo) {
  */
 predicate basicStoreStep(Node nodeFrom, Node nodeTo, string attr) {
   exists(AttrWrite a |
-    a.getAttributeName() = attr and
+    a.mayHaveAttributeName(attr) and
     nodeFrom = a.getValue() and
     simpleLocalFlowStep*(nodeTo, a.getObject())
   )
@@ -127,7 +127,7 @@ predicate basicStoreStep(Node nodeFrom, Node nodeTo, string attr) {
  */
 predicate basicLoadStep(Node nodeFrom, Node nodeTo, string attr) {
   exists(AttrRead a |
-    attr = a.getAttributeName() and
+    a.mayHaveAttributeName(attr) and
     nodeFrom = a.getObject() and
     nodeTo = a
   )

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -17,7 +17,7 @@ abstract class AttrRef extends Node {
   abstract Node getObject();
 
   /**
-   * Gets the expression control flow node that defines the attribute being accessed. This is
+   * Gets the expression node that defines the attribute being accessed, if any. This is
    * usually an identifier or literal.
    */
   abstract ExprNode getAttributeNameExpr();

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -218,3 +218,31 @@ private class GetAttrCallAsAttrRead extends AttrRead, CfgNode {
     result = this.getAttributeNameExpr().asExpr().(StrConst).getText()
   }
 }
+
+/**
+ * A convenience class for embedding `ImportMemberNode` into `DataFlowCfgNode`, as the former is not
+ * obviously a subtype of the latter.
+ */
+private class DataFlowImportMemberNode extends ImportMemberNode, DataFlowCfgNode { }
+
+/**
+ * Represents a named import as an attribute read. That is,
+ * ```python
+ * from module import attr as attr_ref
+ * ```
+ * is treated as if it is a read of the attribute `module.attr`, even if `module` is not imported directly.
+ */
+private class ModuleAttributeImportAsAttrRead extends AttrRead, CfgNode {
+  override DataFlowImportMemberNode node;
+
+  override Node getObject() { result.asCfgNode() = node.getModule(_) }
+
+  override ExprNode getAttributeNameExpr() {
+    // The name of an imported attribute doesn't exist as a `Node` in the control flow graph, as it
+    // can only ever be an identifier, and is therefore represented directly as a string.
+    // Use `getAttributeName` to access the name of the attribute.
+    none()
+  }
+
+  override string getAttributeName() { exists(node.getModule(result)) }
+}

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -1,5 +1,6 @@
 /** This module provides an API for attribute reads and writes. */
 
+import DataFlowUtil
 import DataFlowPublic
 private import DataFlowPrivate
 
@@ -22,7 +23,14 @@ abstract class AttrRef extends Node {
   abstract ExprNode getAttributeNameExpr();
 
   /** Holds if this attribute reference may access an attribute named `attrName`. */
-  predicate mayHaveAttributeName(string attrName) { none() }
+  predicate mayHaveAttributeName(string attrName) {
+    attrName = this.getAttributeName()
+    or
+    exists(Node nodeFrom |
+      localFlow(nodeFrom, this.getAttributeNameExpr()) and
+      attrName = nodeFrom.asExpr().(StrConst).getText()
+    )
+  }
 
   /** Gets the name of the attribute being read or written, if it can be determined statically. */
   abstract string getAttributeName();

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -1,0 +1,208 @@
+/** This module provides an API for attribute reads and writes. */
+
+import DataFlowPublic
+private import DataFlowPrivate
+
+/**
+ * A data flow node that reads or writes an attribute of an object.
+ *
+ * This abstract base class only knows about the base object on which the attribute is being
+ * accessed, and the attribute itself, if it is statically inferrable.
+ */
+abstract class AttrRef extends Node {
+  /**
+   * Gets the data flow node corresponding to the object whose attribute is being read or written.
+   */
+  abstract Node getObject();
+
+  /**
+   * Gets the expression control flow node that defines the attribute being accessed. This is
+   * usually an identifier or literal.
+   */
+  abstract ExprNode getAttributeNameExpr();
+
+  /** Holds if this attribute reference may access an attribute named `attrName`. */
+  predicate mayHaveAttributeName(string attrName) { none() }
+
+  /** Gets the name of the attribute being read or written, if it can be determined statically. */
+  abstract string getAttributeName();
+}
+
+/**
+ * A data flow node that writes an attribute of an object. This includes
+ * - Simple attribute writes: `object.attr = value`
+ * - Dynamic attribute writes: `setattr(object, attr, value)`
+ * - Fields written during class initialization: `class MyClass: attr = value`
+ */
+abstract class AttrWrite extends AttrRef {
+  /** Gets the data flow node corresponding to the value that is written to the attribute. */
+  abstract Node getValue();
+}
+
+/** A simple attribute assignment: `object.attr = value`. */
+private class AttributeAssignmentAsAttrWrite extends AttrWrite, CfgNode {
+  DefinitionNode attr_node;
+
+  AttributeAssignmentAsAttrWrite() { this = TCfgNode(attr_node) and attr_node instanceof AttrNode }
+
+  override Node getValue() { result = TCfgNode(attr_node.(DefinitionNode).getValue()) }
+
+  override Node getObject() { result = TCfgNode(attr_node.(AttrNode).getObject()) }
+
+  override ExprNode getAttributeNameExpr() {
+    // Attribute names don't exist as `Node`s in the control flow graph, as they can only ever be
+    // identifiers, and are therefore represented directly as strings.
+    // Use `getAttributeName` to access the name of the attribute.
+    none()
+  }
+
+  override string getAttributeName() { result = attr_node.(AttrNode).getName() }
+}
+
+import semmle.python.types.Builtins
+
+/** Represents `CallNode`s that may refer to calls to built-in functions or classes. */
+private class BuiltInCallNode extends CallNode {
+  string name;
+
+  BuiltInCallNode() {
+    // TODO disallow instances where `setattr` may refer to an in-scope variable of that name.
+    exists(NameNode id | this.getFunction() = id and id.getId() = name and id.isGlobal()) and
+    name = any(Builtin b).getName()
+  }
+
+  /** Gets the name of the built-in function that is called at this `CallNode` */
+  string getBuiltinName() { result = name }
+}
+
+/**
+ * Represents a call to the built-ins that handle dynamic inspection and modification of
+ * attributes: `getattr`, `setattr`, and `hasattr`.
+ */
+private class BuiltinAttrCallNode extends BuiltInCallNode {
+  BuiltinAttrCallNode() {
+    name = "setattr" or
+    name = "getattr" or
+    name = "hasattr"
+  }
+
+  /** Gets the control flow node for object on which the attribute is accessed. */
+  ControlFlowNode getObject() { result in [this.getArg(0), this.getArgByName("object")] }
+
+  /**
+   * Gets the control flow node for the value that is being written to the attribute.
+   * Only relevant for `setattr` calls.
+   */
+  ControlFlowNode getValue() {
+    // only valid for `setattr`
+    name = "setattr" and
+    result in [this.getArg(2), this.getArgByName("value")]
+  }
+
+  /** Gets the control flow node that defines the name of the attribute being accessed. */
+  ControlFlowNode getName() { result in [this.getArg(1), this.getArgByName("name")] }
+}
+
+/** Represents calls to the built-in `setattr`. */
+private class SetAttrCallNode extends BuiltinAttrCallNode {
+  SetAttrCallNode() { name = "setattr" }
+}
+
+/** Represents calls to the built-in `getattr`. */
+private class GetAttrCallNode extends BuiltinAttrCallNode {
+  GetAttrCallNode() { name = "getattr" }
+}
+
+/** An attribute assignment using `setattr`, e.g. `setattr(object, attr, value)` */
+private class SetAttrCallAsAttrWrite extends AttrWrite, CfgNode {
+  SetAttrCallNode setattr_call;
+
+  SetAttrCallAsAttrWrite() { this = TCfgNode(setattr_call) }
+
+  override Node getValue() { result = TCfgNode(setattr_call.getValue()) }
+
+  override Node getObject() { result = TCfgNode(setattr_call.getObject()) }
+
+  override ExprNode getAttributeNameExpr() { result = TCfgNode(setattr_call.getName()) }
+
+  override string getAttributeName() {
+    // TODO track this back using local flow
+    exists(StrConst s, Node nodeFrom |
+      s = nodeFrom.asExpr() and
+      simpleLocalFlowStep*(nodeFrom, this.getAttributeNameExpr()) and
+      result = s.getText()
+    )
+  }
+}
+
+/**
+ * An attribute assignment via a class field, e.g.
+ * ```python
+ * class MyClass:
+ *     attr = value
+ * ```
+ * is treated as equivalent to `MyClass.attr = value`.
+ */
+private class ClassDefinitionAsAttrWrite extends AttrWrite, Node {
+  ClassExpr cls;
+  DefinitionNode attr_node;
+
+  ClassDefinitionAsAttrWrite() {
+    attr_node instanceof NameNode and
+    this.asCfgNode() = attr_node and
+    attr_node.getScope() = cls.getInnerScope()
+  }
+
+  override Node getValue() { result = TCfgNode(attr_node.getValue()) }
+
+  override Node getObject() { result = TCfgNode(cls.getAFlowNode()) }
+
+  override ExprNode getAttributeNameExpr() { none() }
+
+  override string getAttributeName() { result = attr_node.(NameNode).getId() }
+}
+
+/**
+ * A read of an attribute on an object. This includes
+ * - Simple attribute reads: `object.attr`
+ * - Dynamic attribute reads using `getattr`: `getattr(object, attr)`
+ * - Qualified imports: `from module import attr as name`
+ */
+abstract class AttrRead extends AttrRef, Node { }
+
+/** A simple attribute read, e.g. `object.attr` */
+private class AttributeReadAsAttrRead extends AttrRead, CfgNode {
+  AttrNode attr_node;
+
+  AttributeReadAsAttrRead() { this = TCfgNode(attr_node) }
+
+  override Node getObject() { result = TCfgNode(attr_node.getObject()) }
+
+  override ExprNode getAttributeNameExpr() {
+    // Attribute names don't exist as `Node`s in the control flow graph, as they can only ever be
+    // identifiers, and are therefore represented directly as strings.
+    // Use `getAttributeName` to access the name of the attribute.
+    none()
+  }
+
+  override string getAttributeName() { result = attr_node.getName() }
+}
+
+/** An attribute read using `getattr`: `getattr(object, attr)` */
+private class GetAttrCallAsAttrRead extends AttrRead, CfgNode {
+  GetAttrCallNode getattr_call;
+
+  GetAttrCallAsAttrRead() { this.asCfgNode() = getattr_call }
+
+  override Node getObject() { result = TCfgNode(getattr_call.getObject()) }
+
+  override ExprNode getAttributeNameExpr() { result = TCfgNode(getattr_call.getName()) }
+
+  override string getAttributeName() {
+    exists(StrConst s, Node nodeFrom |
+      s = nodeFrom.asExpr() and
+      simpleLocalFlowStep*(nodeFrom, this.getAttributeNameExpr()) and
+      result = s.getText()
+    )
+  }
+}

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -137,12 +137,7 @@ private class SetAttrCallAsAttrWrite extends AttrWrite, CfgNode {
   override ExprNode getAttributeNameExpr() { result.asCfgNode() = node.getName() }
 
   override string getAttributeName() {
-    // TODO track this back using local flow
-    exists(StrConst s, Node nodeFrom |
-      s = nodeFrom.asExpr() and
-      simpleLocalFlowStep*(nodeFrom, this.getAttributeNameExpr()) and
-      result = s.getText()
-    )
+    result = this.getAttributeNameExpr().asExpr().(StrConst).getText()
   }
 }
 
@@ -220,10 +215,6 @@ private class GetAttrCallAsAttrRead extends AttrRead, CfgNode {
   override ExprNode getAttributeNameExpr() { result.asCfgNode() = node.getName() }
 
   override string getAttributeName() {
-    exists(StrConst s, Node nodeFrom |
-      s = nodeFrom.asExpr() and
-      simpleLocalFlowStep*(nodeFrom, this.getAttributeNameExpr()) and
-      result = s.getText()
-    )
+    result = this.getAttributeNameExpr().asExpr().(StrConst).getText()
   }
 }

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -37,9 +37,9 @@ abstract class AttrRef extends Node {
   }
 
   /**
-   * Gets the name of the attribute being read or written. Only holds if the attribute name has
-   * been uniquely determined statically. For attributes that are computed dynamically,
-   * consider using `mayHaveAttributeName` instead.
+   * Gets the name of the attribute being read or written. For dynamic attribute accesses, this
+   * method is not guaranteed to return a result. For such cases, using `mayHaveAttributeName` may yield
+   * better results.
    */
   abstract string getAttributeName();
 }

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -74,7 +74,7 @@ private class BuiltInCallNode extends CallNode {
   string name;
 
   BuiltInCallNode() {
-    // TODO disallow instances where `setattr` may refer to an in-scope variable of that name.
+    // TODO disallow instances where the name of the built-in may refer to an in-scope variable of that name.
     exists(NameNode id | this.getFunction() = id and id.getId() = name and id.isGlobal()) and
     name = any(Builtin b).getName()
   }
@@ -85,14 +85,10 @@ private class BuiltInCallNode extends CallNode {
 
 /**
  * Represents a call to the built-ins that handle dynamic inspection and modification of
- * attributes: `getattr`, `setattr`, and `hasattr`.
+ * attributes: `getattr`, `setattr`, `hasattr`, and `delattr`.
  */
 private class BuiltinAttrCallNode extends BuiltInCallNode {
-  BuiltinAttrCallNode() {
-    name = "setattr" or
-    name = "getattr" or
-    name = "hasattr"
-  }
+  BuiltinAttrCallNode() { name in ["setattr", "getattr", "hasattr", "delattr"] }
 
   /** Gets the control flow node for object on which the attribute is accessed. */
   ControlFlowNode getObject() { result in [this.getArg(0), this.getArgByName("object")] }

--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -22,7 +22,11 @@ abstract class AttrRef extends Node {
    */
   abstract ExprNode getAttributeNameExpr();
 
-  /** Holds if this attribute reference may access an attribute named `attrName`. */
+  /**
+   * Holds if this attribute reference may access an attribute named `attrName`.
+   * Uses local data flow to track potential attribute names, which may lead to imprecision. If more
+   * precision is needed, consider using `getAttributeName` instead.
+   */
   predicate mayHaveAttributeName(string attrName) {
     attrName = this.getAttributeName()
     or
@@ -32,7 +36,11 @@ abstract class AttrRef extends Node {
     )
   }
 
-  /** Gets the name of the attribute being read or written, if it can be determined statically. */
+  /**
+   * Gets the name of the attribute being read or written. Only holds if the attribute name has
+   * been uniquely determined statically. For attributes that are computed dynamically,
+   * consider using `mayHaveAttributeName` instead.
+   */
   abstract string getAttributeName();
 }
 

--- a/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
@@ -5,6 +5,7 @@
 private import python
 private import DataFlowPrivate
 import experimental.dataflow.TypeTracker
+import Attributes
 private import semmle.python.essa.SsaCompute
 
 /**

--- a/python/ql/test/experimental/dataflow/import-helper/ImportHelper.expected
+++ b/python/ql/test/experimental/dataflow/import-helper/ImportHelper.expected
@@ -1,16 +1,36 @@
 importModule
+| test1.py:1:8:1:12 | ControlFlowNode for ImportExpr | mypkg |
 | test1.py:1:8:1:12 | GSSA Variable mypkg | mypkg |
+| test2.py:1:6:1:10 | ControlFlowNode for ImportExpr | mypkg |
+| test2.py:1:6:1:10 | ControlFlowNode for ImportExpr | mypkg |
 | test2.py:1:19:1:21 | GSSA Variable foo | mypkg.foo |
 | test2.py:1:24:1:26 | GSSA Variable bar | mypkg.bar |
+| test3.py:1:8:1:16 | ControlFlowNode for ImportExpr | mypkg |
+| test3.py:1:8:1:16 | ControlFlowNode for ImportExpr | mypkg.foo |
+| test3.py:2:8:2:16 | ControlFlowNode for ImportExpr | mypkg |
+| test3.py:2:8:2:16 | ControlFlowNode for ImportExpr | mypkg.bar |
 | test3.py:2:8:2:16 | GSSA Variable mypkg | mypkg |
+| test4.py:1:8:1:16 | ControlFlowNode for ImportExpr | mypkg |
+| test4.py:1:8:1:16 | ControlFlowNode for ImportExpr | mypkg.foo |
 | test4.py:1:21:1:24 | GSSA Variable _foo | mypkg.foo |
+| test4.py:2:8:2:16 | ControlFlowNode for ImportExpr | mypkg |
+| test4.py:2:8:2:16 | ControlFlowNode for ImportExpr | mypkg.bar |
 | test4.py:2:21:2:24 | GSSA Variable _bar | mypkg.bar |
+| test5.py:1:8:1:12 | ControlFlowNode for ImportExpr | mypkg |
 | test5.py:1:8:1:12 | GSSA Variable mypkg | mypkg |
+| test5.py:9:6:9:10 | ControlFlowNode for ImportExpr | mypkg |
 | test5.py:9:26:9:29 | GSSA Variable _bar | mypkg.bar |
+| test6.py:1:8:1:12 | ControlFlowNode for ImportExpr | mypkg |
 | test6.py:1:8:1:12 | GSSA Variable mypkg | mypkg |
+| test6.py:5:8:5:16 | ControlFlowNode for ImportExpr | mypkg |
+| test6.py:5:8:5:16 | ControlFlowNode for ImportExpr | mypkg.foo |
 | test6.py:5:8:5:16 | GSSA Variable mypkg | mypkg |
+| test7.py:1:6:1:10 | ControlFlowNode for ImportExpr | mypkg |
 | test7.py:1:19:1:21 | GSSA Variable foo | mypkg.foo |
+| test7.py:5:8:5:16 | ControlFlowNode for ImportExpr | mypkg |
+| test7.py:5:8:5:16 | ControlFlowNode for ImportExpr | mypkg.foo |
 | test7.py:5:8:5:16 | GSSA Variable mypkg | mypkg |
+| test7.py:9:6:9:10 | ControlFlowNode for ImportExpr | mypkg |
 | test7.py:9:19:9:21 | GSSA Variable foo | mypkg.foo |
 importMember
 | test2.py:1:19:1:21 | GSSA Variable foo | mypkg | foo |

--- a/python/ql/test/experimental/dataflow/typetracking/attribute_tests.py
+++ b/python/ql/test/experimental/dataflow/typetracking/attribute_tests.py
@@ -29,3 +29,73 @@ def test_incompatible_types():
     expects_int(x) # $int=field $f+:str=field
     x.field = str("Hello") # $f+:int=field $str=field $f+:int $str
     expects_string(x) # $f+:int=field $str=field
+
+
+# Attributes assigned statically to a class
+
+class MyClass: # $tracked=field
+    field = tracked # $tracked
+
+lookup = MyClass.field # $tracked $tracked=field
+instance = MyClass() # $tracked=field
+lookup2 = instance.field # $f-:tracked
+
+## Dynamic attribute access
+
+# Via `getattr`/`setattr`
+
+def setattr_immediate_write():
+    x = SomeClass() # $tracked=foo
+    setattr(x,"foo", tracked) # $tracked $tracked=foo
+    y = x.foo # $tracked $tracked=foo
+    do_stuff(y) # $tracked
+
+def getattr_immediate_read():
+    x = SomeClass() # $tracked=foo
+    x.foo = tracked # $tracked $tracked=foo
+    y = getattr(x,"foo") # $tracked $tracked=foo
+    do_stuff(y) # $tracked
+
+def setattr_indirect_write():
+    attr = "foo"
+    x = SomeClass() # $tracked=foo
+    setattr(x, attr, tracked) # $tracked $tracked=foo
+    y = x.foo # $tracked $tracked=foo
+    do_stuff(y) # $tracked
+
+def getattr_indirect_read():
+    attr = "foo"
+    x = SomeClass() # $tracked=foo
+    x.foo = tracked # $tracked $tracked=foo
+    y = getattr(x, attr) #$tracked $tracked=foo
+    do_stuff(y) # $tracked
+
+# Via `__dict__` -- not currently implemented.
+
+def dunder_dict_immediate_write():
+    x = SomeClass() # $f-:tracked=foo
+    x.__dict__["foo"] = tracked # $tracked $f-:tracked=foo
+    y = x.foo # $f-:tracked $f-:tracked=foo
+    do_stuff(y) # $f-:tracked
+
+def dunder_dict_immediate_read():
+    x = SomeClass() # $tracked=foo
+    x.foo = tracked # $tracked $tracked=foo
+    y = x.__dict__["foo"] # $f-:tracked $tracked=foo
+    do_stuff(y) # $f-:tracked
+
+def dunder_dict_indirect_write():
+    attr = "foo"
+    x = SomeClass() # $f-:tracked=foo
+    x.__dict__[attr] = tracked # $tracked $f-:tracked=foo
+    y = x.foo # $f-:tracked $f-:tracked=foo
+    do_stuff(y) # $f-:tracked
+
+def dunder_dict_indirect_read():
+    attr = "foo"
+    x = SomeClass() # $tracked=foo
+    x.foo = tracked # $tracked $tracked=foo
+    y = x.__dict__[attr] # $f-:tracked $tracked=foo
+    do_stuff(y) # $f-:tracked
+
+

--- a/python/ql/test/experimental/dataflow/typetracking/import_as_attr.py
+++ b/python/ql/test/experimental/dataflow/typetracking/import_as_attr.py
@@ -1,0 +1,9 @@
+from module import attr as attr_ref
+
+x = attr_ref
+
+def fun():
+    y = attr_ref
+
+# The following should _not_ be a reference to the above module, since we don't actually import it.
+z = module

--- a/python/ql/test/experimental/dataflow/typetracking/moduleattr.expected
+++ b/python/ql/test/experimental/dataflow/typetracking/moduleattr.expected
@@ -1,0 +1,10 @@
+module_tracker
+| import_as_attr.py:1:6:1:11 | ControlFlowNode for ImportExpr |
+module_attr_tracker
+| import_as_attr.py:0:0:0:0 | ModuleVariableNode for Global Variable attr_ref in Module import_as_attr |
+| import_as_attr.py:1:20:1:35 | ControlFlowNode for ImportMember |
+| import_as_attr.py:1:28:1:35 | GSSA Variable attr_ref |
+| import_as_attr.py:3:1:3:1 | GSSA Variable x |
+| import_as_attr.py:3:5:3:12 | ControlFlowNode for attr_ref |
+| import_as_attr.py:6:5:6:5 | SSA variable y |
+| import_as_attr.py:6:9:6:16 | ControlFlowNode for attr_ref |

--- a/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
+++ b/python/ql/test/experimental/dataflow/typetracking/moduleattr.ql
@@ -1,0 +1,23 @@
+import python
+import experimental.dataflow.DataFlow
+import experimental.dataflow.TypeTracker
+
+DataFlow::Node module_tracker(TypeTracker t) {
+  t.start() and
+  result = DataFlow::importModule("module")
+  or
+  exists(TypeTracker t2 | result = module_tracker(t2).track(t2, t))
+}
+
+query DataFlow::Node module_tracker() { result = module_tracker(DataFlow::TypeTracker::end()) }
+
+DataFlow::Node module_attr_tracker(TypeTracker t) {
+  t.startInAttr("attr") and
+  result = module_tracker()
+  or
+  exists(TypeTracker t2 | result = module_attr_tracker(t2).track(t2, t))
+}
+
+query DataFlow::Node module_attr_tracker() {
+  result = module_attr_tracker(DataFlow::TypeTracker::end())
+}


### PR DESCRIPTION
This PR provides a unified interface for specifying attribute reads and writes. 

Currently not handled:
- Attribute access via the `__dict__` attribute. This should be fairly easy to add (and the tests are there already), but did not seem to be a pressing concern.
- ~Attribute reads for module imports (`from module import foo` acting as an access of `module.foo`). These turned out to be very awkward to get to work properly, and I think it would be better to simply handle them directly in the type tracker implementation.~ This now works as intended. `ImportMemberNode` turned out to be the magic ingredient I was missing.
- Class attributes should be propagated to instance attributes, but are currently not. I'm not sure how to fit this into the greater scheme of dataflow, as this will also need to be modelled correctly for field flow.

Other points:
- I'm not sure the way I implemented `getattr` etc. is the best way of doing so. Also, classes like `BuiltinCallNode` seem sort of out of place alongside the attributes. Maybe it would be better to move these into a file devoted entirely to modelling builtins?
- `getAttributeNameExpr` is supposed to return the data flow node that defines the name of the attribute. However, for simple attribute accesses, there is no underlying control flow node for `attr` in `object.attr` (in fact there isn't even an AST node for it!) and so for these kinds of attribute accesses, the aforementioned method has no return value. I tried synthesizing extra data flow nodes to avoid this, but this quickly got very involved, and so I opted to remove that part from this PR.  