### PR TITLE
Java: Add support for FastJson in unsafe deserialization.

### DIFF
--- a/java/change-notes/2020-10-07-fastjson-deserialization-sink.md
+++ b/java/change-notes/2020-10-07-fastjson-deserialization-sink.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The "Deserialization of user-controlled data" (`java/unsafe-deserialization`) query
+  now recognizes `FastJson` deserialization.

--- a/java/ql/src/semmle/code/java/frameworks/FastJson.qll
+++ b/java/ql/src/semmle/code/java/frameworks/FastJson.qll
@@ -5,18 +5,14 @@
 import java
 
 /**
- * The class `com.alibaba.fastjson.JSON` or `com.alibaba.fastjson.JSONObject`.
+ * The class `com.alibaba.fastjson.JSON`.
  */
 class FastJson extends RefType {
-  FastJson() {
-    this.hasQualifiedName("com.alibaba.fastjson", "JSON") or
-    this.hasQualifiedName("com.alibaba.fastjson", "JSONObject")
-  }
+  FastJson() { this.hasQualifiedName("com.alibaba.fastjson", "JSON") }
 }
 
 /**
- * A FastJson parse method. This is either `parse` or `parseObject` on either
- * `com.alibaba.fastjson.JSON` or `com.alibaba.fastjson.JSONObject`.
+ * A FastJson parse method. This is either `JSON.parse` or `JSON.parseObject`.
  */
 class FastJsonParseMethod extends Method {
   FastJsonParseMethod() {

--- a/java/ql/src/semmle/code/java/frameworks/FastJson.qll
+++ b/java/ql/src/semmle/code/java/frameworks/FastJson.qll
@@ -1,0 +1,50 @@
+/**
+ * Provides classes and predicates for working with the FastJson framework.
+ */
+
+import java
+
+/**
+ * The class `com.alibaba.fastjson.JSON` or `com.alibaba.fastjson.JSONObject`.
+ */
+class FastJson extends RefType {
+  FastJson() {
+    this.hasQualifiedName("com.alibaba.fastjson", "JSON") or
+    this.hasQualifiedName("com.alibaba.fastjson", "JSONObject")
+  }
+}
+
+/**
+ * A FastJson parse method. This is either `parse` or `parseObject` on either
+ * `com.alibaba.fastjson.JSON` or `com.alibaba.fastjson.JSONObject`.
+ */
+class FastJsonParseMethod extends Method {
+  FastJsonParseMethod() {
+    this.getDeclaringType() instanceof FastJson and
+    this.hasName(["parse", "parseObject"])
+  }
+}
+
+/**
+ * A call to `ParserConfig.setSafeMode`.
+ */
+class FastJsonSetSafeMode extends MethodAccess {
+  FastJsonSetSafeMode() {
+    exists(Method m |
+      this.getMethod() = m and
+      m.hasName("setSafeMode") and
+      m.getDeclaringType().hasQualifiedName("com.alibaba.fastjson.parser", "ParserConfig")
+    )
+  }
+
+  /** Gets the constant value passed to this call, if any. */
+  boolean getMode() { result = this.getArgument(0).(CompileTimeConstantExpr).getBooleanValue() }
+}
+
+/**
+ * Holds if there is some call to `ParserConfig.setSafeMode` that does not
+ * explicitly disable safe mode.
+ */
+predicate fastJsonLooksSafe() {
+  exists(FastJsonSetSafeMode setsafe | not setsafe.getMode() = false)
+}

--- a/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
+++ b/java/ql/src/semmle/code/java/security/UnsafeDeserialization.qll
@@ -1,6 +1,7 @@
 import semmle.code.java.frameworks.Kryo
 import semmle.code.java.frameworks.XStream
 import semmle.code.java.frameworks.SnakeYaml
+import semmle.code.java.frameworks.FastJson
 import semmle.code.java.frameworks.apache.Lang
 
 class ObjectInputStreamReadObjectMethod extends Method {
@@ -76,6 +77,10 @@ predicate unsafeDeserialization(MethodAccess ma, Expr sink) {
     sink = ma.getArgument(0)
     or
     ma instanceof UnsafeSnakeYamlParse and
+    sink = ma.getArgument(0)
+    or
+    ma.getMethod() instanceof FastJsonParseMethod and
+    not fastJsonLooksSafe() and
     sink = ma.getArgument(0)
   )
 }

--- a/java/ql/test/query-tests/security/CWE-502/B.java
+++ b/java/ql/test/query-tests/security/CWE-502/B.java
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.net.Socket;
+import com.alibaba.fastjson.JSON;
+
+public class B {
+  public Object deserializeJson1(Socket sock) {
+    InputStream inputStream = sock.getInputStream();
+    return JSON.parseObject(inputStream, null); // unsafe
+  }
+
+  public Object deserializeJson2(Socket sock) {
+    InputStream inputStream = sock.getInputStream();
+    byte[] bytes = new byte[100];
+    inputStream.read(bytes);
+    return JSON.parse(bytes); // unsafe
+  }
+
+  public Object deserializeJson3(Socket sock) {
+    InputStream inputStream = sock.getInputStream();
+    byte[] bytes = new byte[100];
+    inputStream.read(bytes);
+    String s = new String(bytes);
+    return JSON.parseObject(s); // unsafe
+  }
+
+  public Object deserializeJson4(Socket sock) {
+    InputStream inputStream = sock.getInputStream();
+    byte[] bytes = new byte[100];
+    inputStream.read(bytes);
+    String s = new String(bytes);
+    return JSON.parse(s); // unsafe
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -16,6 +16,10 @@ edges
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input |
 | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) |
+| B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream |
+| B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes |
+| B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s |
+| B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:31:23:31:23 | s |
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) |
 nodes
 | A.java:13:31:13:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
@@ -42,6 +46,14 @@ nodes
 | A.java:73:28:73:55 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
 | A.java:74:24:74:28 | input | semmle.label | input |
 | A.java:75:24:75:51 | new InputStreamReader(...) | semmle.label | new InputStreamReader(...) |
+| B.java:7:31:7:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:8:29:8:39 | inputStream | semmle.label | inputStream |
+| B.java:12:31:12:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:15:23:15:27 | bytes | semmle.label | bytes |
+| B.java:19:31:19:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:23:29:23:29 | s | semmle.label | s |
+| B.java:27:31:27:51 | getInputStream(...) : InputStream | semmle.label | getInputStream(...) : InputStream |
+| B.java:31:23:31:23 | s | semmle.label | s |
 | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | semmle.label | entityStream : InputStream |
 | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | semmle.label | new ObjectInputStream(...) |
 #select
@@ -62,4 +74,8 @@ nodes
 | A.java:73:17:73:56 | parse(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:73:28:73:55 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
 | A.java:74:12:74:38 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:74:24:74:28 | input | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
 | A.java:75:12:75:61 | loadAs(...) | A.java:70:25:70:45 | getInputStream(...) : InputStream | A.java:75:24:75:51 | new InputStreamReader(...) | Unsafe deserialization of $@. | A.java:70:25:70:45 | getInputStream(...) | user input |
+| B.java:8:12:8:46 | parseObject(...) | B.java:7:31:7:51 | getInputStream(...) : InputStream | B.java:8:29:8:39 | inputStream | Unsafe deserialization of $@. | B.java:7:31:7:51 | getInputStream(...) | user input |
+| B.java:15:12:15:28 | parse(...) | B.java:12:31:12:51 | getInputStream(...) : InputStream | B.java:15:23:15:27 | bytes | Unsafe deserialization of $@. | B.java:12:31:12:51 | getInputStream(...) | user input |
+| B.java:23:12:23:30 | parseObject(...) | B.java:19:31:19:51 | getInputStream(...) : InputStream | B.java:23:29:23:29 | s | Unsafe deserialization of $@. | B.java:19:31:19:51 | getInputStream(...) | user input |
+| B.java:31:12:31:24 | parse(...) | B.java:27:31:27:51 | getInputStream(...) : InputStream | B.java:31:23:31:23 | s | Unsafe deserialization of $@. | B.java:27:31:27:51 | getInputStream(...) | user input |
 | TestMessageBodyReader.java:22:18:22:65 | readObject(...) | TestMessageBodyReader.java:20:55:20:78 | entityStream : InputStream | TestMessageBodyReader.java:22:18:22:52 | new ObjectInputStream(...) | Unsafe deserialization of $@. | TestMessageBodyReader.java:20:55:20:78 | entityStream | user input |

--- a/java/ql/test/query-tests/security/CWE-502/options
+++ b/java/ql/test/query-tests/security/CWE-502/options
@@ -1,1 +1,1 @@
-//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/snakeyaml-1.21:${testdir}/../../../stubs/xstream-1.4.10:${testdir}/../../../stubs/kryo-4.0.2:${testdir}/../../../stubs/jsr311-api-1.1.1:${testdir}/../../../stubs/fastjson-1.2.74

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSON.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSON.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastjson;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.util.*;
+
+import com.alibaba.fastjson.parser.*;
+import com.alibaba.fastjson.parser.deserializer.ParseProcess;
+
+public abstract class JSON {
+    public static Object parse(String text) {
+        return null;
+    }
+
+    public static Object parse(String text, ParserConfig config) {
+        return null;
+    }
+
+    public static Object parse(String text, ParserConfig config, Feature... features) {
+        return null;
+    }
+
+    public static Object parse(String text, ParserConfig config, int features) {
+        return null;
+    }
+
+    public static Object parse(String text, int features) {
+        return null;
+    }
+
+    public static Object parse(byte[] input, Feature... features) {
+        return null;
+    }
+
+    public static Object parse(byte[] input, int off, int len, CharsetDecoder charsetDecoder, Feature... features) {
+        return null;
+    }
+
+    public static Object parse(byte[] input, int off, int len, CharsetDecoder charsetDecoder, int features) {
+        return null;
+    }
+
+    public static Object parse(String text, Feature... features) {
+        return null;
+    }
+
+    public static JSONObject parseObject(String text, Feature... features) {
+        return null;
+    }
+
+    public static JSONObject parseObject(String text) {
+        return null;
+    }
+
+    public static <T> T parseObject(String text, TypeReference<T> type, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String json, Class<T> clazz, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String text, Class<T> clazz, ParseProcess processor, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String json, Type type, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String input, Type clazz, ParseProcess processor, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String input, Type clazz, int featureValues, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String input, Type clazz, ParserConfig config, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String input, Type clazz, ParserConfig config, int featureValues,
+                                          Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(String input, Type clazz, ParserConfig config, ParseProcess processor,
+                                          int featureValues, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(byte[] bytes, Type clazz, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(byte[] bytes, int offset, int len, Charset charset, Type clazz, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(byte[] bytes,
+                                    Charset charset,
+                                    Type clazz,
+                                    ParserConfig config,
+                                    ParseProcess processor,
+                                    int featureValues,
+                                    Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(byte[] bytes, int offset, int len,
+                                    Charset charset,
+                                    Type clazz,
+                                    ParserConfig config,
+                                    ParseProcess processor,
+                                    int featureValues,
+                                    Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(byte[] input,
+                                    int off,
+                                    int len,
+                                    CharsetDecoder charsetDecoder,
+                                    Type clazz,
+                                    Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(char[] input, int length, Type clazz, Feature... features) {
+        return null;
+    }
+
+    public static <T> T parseObject(InputStream is,
+                                    Type type,
+                                    Feature... features) throws IOException {
+        return null;
+    }
+
+    public static <T> T parseObject(InputStream is,
+                                    Charset charset,
+                                    Type type,
+                                    Feature... features) throws IOException {
+        return null;
+    }
+
+    public static <T> T parseObject(InputStream is,
+                                    Charset charset,
+                                    Type type,
+                                    ParserConfig config,
+                                    Feature... features) throws IOException {
+        return null;
+    }
+
+    public static <T> T parseObject(InputStream is,
+                                    Charset charset,
+                                    Type type,
+                                    ParserConfig config,
+                                    ParseProcess processor,
+                                    int featureValues,
+                                    Feature... features) throws IOException {
+        return null;
+    }
+
+    public static <T> T parseObject(String text, Class<T> clazz) {
+        return null;
+    }
+
+    public static JSONArray parseArray(String text) {
+        return null;
+    }
+
+    public static JSONArray parseArray(String text, ParserConfig parserConfig) {
+        return null;
+    }
+
+    public static <T> List<T> parseArray(String text, Class<T> clazz) {
+        return null;
+    }
+
+    public static <T> List<T> parseArray(String text, Class<T> clazz, ParserConfig config) {
+        return null;
+    }
+
+    public static List<Object> parseArray(String text, Type[] types) {
+        return null;
+    }
+
+    public static List<Object> parseArray(String text, Type[] types, ParserConfig config) {
+        return null;
+    }
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSONArray.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSONArray.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastjson;
+
+public class JSONArray extends JSON {
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSONObject.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/JSONObject.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastjson;
+
+public class JSONObject extends JSON {
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/TypeReference.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/TypeReference.java
@@ -1,0 +1,4 @@
+package com.alibaba.fastjson;
+
+public class TypeReference<T> {
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/Feature.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/Feature.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastjson.parser;
+
+public enum Feature {
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/ParserConfig.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 1999-2017 Alibaba Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastjson.parser;
+
+public class ParserConfig {
+    public void setSafeMode(boolean safeMode) { }
+}

--- a/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/deserializer/ParseProcess.java
+++ b/java/ql/test/stubs/fastjson-1.2.74/com/alibaba/fastjson/parser/deserializer/ParseProcess.java
@@ -1,0 +1,4 @@
+package com.alibaba.fastjson.parser.deserializer;
+
+public interface ParseProcess {
+}


### PR DESCRIPTION
This cherry-picks the addition of FastJson deserialization sinks from https://github.com/github/codeql/pull/3674 and adds a check for safe mode sanitization and a change note.