### PR TITLE
C#: Add missing data-flow for switch expressions

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -171,6 +171,10 @@ module LocalFlow {
         e1 = e2.(ArrayCreation).getInitializer() and
         scope = e2 and
         isSuccessor = false
+        or
+        e1 = e2.(SwitchExpr).getACase().getBody() and
+        scope = e2 and
+        isSuccessor = false
       )
     }
 

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -139,7 +139,7 @@
 | Conditions.cs:77:17:77:20 | ...; | Conditions.cs:77:17:77:19 | ...++ | 3 |
 | Conditions.cs:78:13:79:26 | if (...) ... | Conditions.cs:78:17:78:21 | ... > ... | 4 |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | 3 |
-| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | 2 |
+| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b | 2 |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:15 | ...++ | 3 |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:70:9:70:10 | exit M6 | 3 |
 | Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:90:27:90:28 | access to parameter ss | 12 |
@@ -157,10 +157,10 @@
 | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:109:17:109:23 | ... = ... | 8 |
 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | 3 |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | exit M8 | 3 |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:17:116:21 | Int32 i = ... | 8 |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:18:116:22 | Int32 i = ... | 8 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 | 1 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:38 | ... < ... | 4 |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ | 2 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:39 | ... < ... | 4 |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ | 2 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:119:18:119:21 | access to local variable last | 12 |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | 5 |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:122:17:122:24 | ... = ... | 5 |
@@ -169,6 +169,10 @@
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | 9 |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | 4 |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | 14 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:17:145:17 | access to parameter b | 5 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 | 1 |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:147:13:147:48 | call to method WriteLine | 9 |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:149:13:149:48 | call to method WriteLine | 9 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | exit M1 | 7 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | exit M2 | 7 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | exit M3 | 6 |
@@ -670,35 +674,35 @@
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | exit M5 | 12 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:72:18:72:19 | "" | 9 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 | 1 |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:73:15:73:20 | break; | 1 |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; | 1 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:81:18:81:18 | 1 | 6 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 | 1 |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:15:82:26 | return ...; | 2 |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:18:83:18 | 2 | 2 |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:19:84:23 | ... > ... | 4 |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:85:17:85:22 | break; | 1 |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:15:86:26 | return ...; | 2 |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; | 2 |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | 2 |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:25 | ... > ... | 4 |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:85:21:85:26 | break; | 1 |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; | 2 |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; | 2 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:95:18:95:20 | access to type Int32 | 6 |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 | 1 |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:15:96:26 | return ...; | 2 |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; | 2 |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; | 2 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:103:17:103:17 | access to parameter s | 4 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 | 1 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length | 1 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:18:105:18 | 0 | 2 |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:22:105:30 | return ...; | 2 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:18:106:18 | 1 | 2 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:22:106:30 | return ...; | 2 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | 2 |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; | 2 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | 2 |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; | 2 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:9:108:18 | return ...; | 3 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | exit Throw | 4 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:18:117:18 | 3 | 7 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 | 1 |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:32 | ... == ... | 3 |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:36:117:44 | return ...; | 2 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:18:118:18 | 2 | 2 |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:31 | ... == ... | 3 |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:35:118:43 | return ...; | 2 |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:34 | ... == ... | 3 |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; | 2 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | 2 |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:33 | ... == ... | 3 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:9:120:18 | return ...; | 3 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:24:125:29 | Boolean b | 7 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | exit M11 | 1 |
@@ -722,6 +726,14 @@
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:22:149:31 | return ...; | 4 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | 2 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:28:156:31 | true | 7 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 | 1 |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:13:157:13 | access to parameter b | 3 |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | 1 |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | 2 |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" | 1 |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:48 | call to method WriteLine | 5 |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | 5 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:13:7:22 | ... is ... | 14 |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; | 1 |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | exit M | 4 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Condition.expected
@@ -126,11 +126,11 @@ conditionBlock
 | Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
 | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
 | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | true |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 | false |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i | true |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:117:9:123:9 | {...} | true |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 | false |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
@@ -139,6 +139,8 @@ conditionBlock
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | true |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | false |
 | ExitMethods.cs:43:9:46:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:47:9:50:9 | [exception: Exception] catch (...) {...} | false |
 | ExitMethods.cs:65:17:65:26 | enter ErrorMaybe | ExitMethods.cs:68:19:68:33 | object creation of type Exception | true |
 | ExitMethods.cs:71:17:71:27 | enter ErrorAlways | ExitMethods.cs:74:19:74:33 | object creation of type Exception | true |
@@ -567,33 +569,33 @@ conditionBlock
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:30:50:30 | access to parameter o | true |
 | Switch.cs:50:13:50:39 | case ...: | Switch.cs:51:17:51:22 | break; | true |
 | Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:51:17:51:22 | break; | true |
-| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:73:15:73:20 | break; | true |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:82:22:82:25 | true | true |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:83:13:83:20 | case ...: | false |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:84:15:85:22 | if (...) ... | false |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:85:17:85:22 | break; | false |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:86:22:86:25 | true | false |
+| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:73:17:73:22 | break; | true |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:82:24:82:27 | true | true |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:83:13:83:19 | case ...: | false |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:84:17:85:26 | if (...) ... | false |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:85:21:85:26 | break; | false |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:86:24:86:27 | true | false |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:88:16:88:20 | false | false |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:84:15:85:22 | if (...) ... | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:85:17:85:22 | break; | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:86:22:86:25 | true | true |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:85:17:85:22 | break; | true |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:86:22:86:25 | true | false |
-| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:96:22:96:25 | true | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:84:17:85:26 | if (...) ... | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:85:21:85:26 | break; | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:86:24:86:27 | true | true |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:85:21:85:26 | break; | true |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:86:24:86:27 | true | false |
+| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:96:24:96:27 | true | true |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:98:16:98:20 | false | false |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:103:19:103:25 | access to property Length | false |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:29:105:29 | 0 | true |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:106:13:106:20 | case ...: | false |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:106:29:106:29 | 1 | false |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:108:17:108:17 | 1 | false |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:29:106:29 | 1 | true |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:108:17:108:17 | 1 | false |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:28:105:28 | 0 | true |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:106:13:106:19 | case ...: | false |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:106:28:106:28 | 1 | false |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:108:17:108:17 | 1 | false |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:28:106:28 | 1 | true |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:108:17:108:17 | 1 | false |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:25:117:25 | access to parameter s | true |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:43:117:43 | 1 | true |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:43:117:43 | 1 | true |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:25:118:25 | access to parameter s | true |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:42:118:42 | 2 | true |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:42:118:42 | 2 | true |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:44:117:44 | 1 | true |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:44:117:44 | 1 | true |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:25 | access to parameter s | true |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:43:118:43 | 2 | true |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:43:118:43 | 2 | true |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:34:125:34 | access to local variable b | true |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:125:37:125:46 | ... => ... | false |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:126:13:126:19 | return ...; | true |
@@ -614,6 +616,12 @@ conditionBlock
 | Switch.cs:144:9:144:11 | enter M14 | Switch.cs:150:28:150:28 | 2 | false |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:149:13:149:20 | default: | false |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:28:150:28 | 2 | true |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" | true |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... | false |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:50:156:52 | "b" | false |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:158:13:158:49 | ...; | true |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:160:13:160:49 | ...; | false |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" | true |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:24:25:24 | access to local variable x | true |
 | VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:25:28:25:28 | access to local variable y | false |
@@ -869,8 +877,8 @@ conditionFlow
 | Conditions.cs:76:17:76:17 | access to local variable b | Conditions.cs:78:13:79:26 | if (...) ... | false |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | false |
 | Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; | true |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | true |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | false |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | true |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | false |
 | Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:93:17:93:20 | ...; | true |
 | Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:94:13:95:26 | if (...) ... | false |
 | Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; | true |
@@ -885,11 +893,11 @@ conditionFlow
 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
 | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:109:17:109:24 | ...; | false |
 | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:110:16:110:16 | access to local variable x | true |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | false |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:117:9:123:9 | {...} | true |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | true |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | false |
 | Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | true |
-| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:41:116:41 | access to local variable i | false |
+| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:42:116:42 | access to local variable i | false |
 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | true |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | true |
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | true |
@@ -904,6 +912,10 @@ conditionFlow
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
 | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | true |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | false |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | false |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | true |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:65:17:65:26 | exit ErrorMaybe | false |
 | ExitMethods.cs:67:13:67:13 | access to parameter b | ExitMethods.cs:68:19:68:33 | object creation of type Exception | true |
 | ExitMethods.cs:73:13:73:13 | access to parameter b | ExitMethods.cs:74:19:74:33 | object creation of type Exception | true |
@@ -1043,15 +1055,17 @@ conditionFlow
 | Switch.cs:24:48:24:55 | ... != ... | Switch.cs:27:13:27:39 | case ...: | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 | false |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | true |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:85:17:85:22 | break; | true |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:86:22:86:25 | true | false |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:43:117:43 | 1 | true |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:118:13:118:33 | case ...: | false |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:42:118:42 | 2 | true |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:120:17:120:17 | 1 | false |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | true |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | false |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 | true |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | false |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | true |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:123:10:123:12 | exit M11 | false |
 | Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:126:13:126:19 | return ...; | true |
 | Switch.cs:125:42:125:46 | false | Switch.cs:123:10:123:12 | exit M11 | false |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | true |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | false |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
 | TypeAccesses.cs:7:13:7:22 | ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | false |
 | VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | true |

--- a/csharp/ql/test/library-tests/controlflow/graph/Conditions.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Conditions.cs
@@ -78,7 +78,7 @@ class Conditions
             if (x > 0)
                 b = false;
         }
-        if(b)
+        if (b)
             x++;
         return x;
     }
@@ -113,7 +113,7 @@ class Conditions
     void M9(string[] args)
     {
         string s = null;
-        for(var i = 0; i < args.Length; i++)
+        for (var i = 0; i < args.Length; i++)
         {
             var last = i == args.Length - 1;
             if (!last)
@@ -138,5 +138,14 @@ class Conditions
                 }
             }
         }
+    }
+
+    void M11(bool b)
+    {
+        var s = b ? "a" : "b";
+        if (b)
+            System.Console.WriteLine($"a = {s}");
+        else
+            System.Console.WriteLine($"b = {s}");
     }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -733,9 +733,9 @@ dominance
 | Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... |
-| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x |
+| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:82:13:82:16 | ...; |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x |
 | Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 |
@@ -814,15 +814,15 @@ dominance
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:21:116:21 | 0 |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:21 | Int32 i = ... |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:28:116:31 | access to parameter args |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:116:28:116:38 | access to property Length |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:24:116:38 | ... < ... |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:22:116:22 | 0 |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... |
@@ -883,6 +883,28 @@ dominance
 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:17 | access to parameter b |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:40:147:43 | "a = " |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:13:147:48 | call to method WriteLine |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:45:147:45 | access to local variable s |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:38:147:47 | $"..." |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:40:149:43 | "b = " |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:13:149:48 | call to method WriteLine |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; |
@@ -2387,9 +2409,9 @@ dominance
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | call to method Throw |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:29:17:29:23 | return ...; |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | return ...; |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; |
-| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:17:28:21 | Label: |
+| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw |
@@ -2410,63 +2432,63 @@ dominance
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 |
-| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:20 | case ...: |
+| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:19 | case ...: |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:59:18:59:18 | 2 |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:20 | case ...: |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:61:18:61:18 | 3 |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:15:62:20 | break; |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:55:10:55:11 | exit M5 |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s |
-| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:24 | case ...: |
+| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:21 | case ...: |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:72:18:72:19 | "" |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i |
-| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:20 | case ...: |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:81:18:81:18 | 1 |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:22:82:25 | true |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:15:82:26 | return ...; |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:18:83:18 | 2 |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:15:85:22 | if (...) ... |
+| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:24:82:27 | true |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:88:16:88:20 | false |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:19:84:19 | access to parameter j |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:84:23:84:23 | 2 |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:86:22:86:25 | true |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:84:19:84:23 | ... > ... |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:15:86:26 | return ...; |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:21 | access to parameter j |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:25 | ... > ... |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o |
-| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:24 | case ...: |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:22:96:25 | true |
+| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:24:96:27 | true |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:98:16:98:20 | false |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:15:96:26 | return ...; |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:18:105:18 | 0 |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:22:105:30 | return ...; |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:18:106:18 | 1 |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:108:17:108:17 | 1 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:22:106:30 | return ...; |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:34:111:48 | object creation of type Exception |
@@ -2476,21 +2498,21 @@ dominance
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length |
-| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:34 | case ...: |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:18:117:18 | 3 |
+| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:35 | case ...: |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:33 | case ...: |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:28:117:32 | "foo" |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:117:25:117:32 | ... == ... |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:36:117:44 | return ...; |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:18:118:18 | 2 |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:25 | access to parameter s |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:120:17:120:17 | 1 |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:28:118:31 | "fu" |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:42:118:42 | 2 |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:118:25:118:31 | ... == ... |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:35:118:43 | return ...; |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:33 | ... == ... |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} |
@@ -2545,6 +2567,28 @@ dominance
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:40:158:43 | "a = " |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:13:158:48 | call to method WriteLine |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:45:158:45 | access to local variable s |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:38:158:47 | $"..." |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:40:160:43 | "b = " |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:13:160:48 | call to method WriteLine |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o |
@@ -3935,11 +3979,11 @@ postDominance
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:21:79:25 | false |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:26 | ...; |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:81:9:82:16 | if (...) ... |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:81:9:82:16 | if (...) ... |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:16 | ...; |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:82:13:82:13 | access to local variable x |
 | Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:83:16:83:16 | access to local variable x |
-| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:81:12:81:12 | access to local variable b |
+| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:81:13:81:13 | access to local variable b |
 | Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ |
 | Conditions.cs:86:9:86:10 | exit M7 | Conditions.cs:99:9:99:17 | return ...; |
 | Conditions.cs:87:5:100:5 | {...} | Conditions.cs:86:9:86:10 | enter M7 |
@@ -4010,22 +4054,22 @@ postDominance
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:109:17:109:23 | ... = ... |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:24:116:38 | ... < ... |
+| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:25:116:39 | ... < ... |
 | Conditions.cs:114:5:124:5 | {...} | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:114:5:124:5 | {...} |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:9:115:24 | ... ...; |
 | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:115:16:115:23 | String s = ... |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:21:116:21 | 0 |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:17:116:21 | Int32 i = ... |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:28:116:38 | access to property Length |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:28:116:31 | access to parameter args |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:122:17:122:24 | ... = ... |
-| Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:41:116:41 | access to local variable i |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:22:116:22 | 0 |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:18:116:22 | Int32 i = ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:116:29:116:39 | access to property Length |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:29:116:32 | access to parameter args |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:122:17:122:24 | ... = ... |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:24:118:43 | ... == ... |
 | Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:13:118:44 | ... ...; |
@@ -4080,6 +4124,28 @@ postDominance
 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:147:13:147:48 | call to method WriteLine |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:149:13:149:48 | call to method WriteLine |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:143:10:143:12 | enter M11 |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:144:5:150:5 | {...} |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:9:145:30 | ... ...; |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:147:38:147:47 | $"..." |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:45:147:45 | access to local variable s |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:13:147:49 | ...; |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:40:147:43 | "a = " |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:149:38:149:47 | $"..." |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:45:149:45 | access to local variable s |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:13:149:49 | ...; |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:40:149:43 | "b = " |
 | ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:10:9:10:15 | return ...; |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | enter M1 |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
@@ -5533,8 +5599,8 @@ postDominance
 | Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:37 | ...; |
 | Switch.cs:26:17:26:23 | return ...; | Switch.cs:25:17:25:36 | call to method WriteLine |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:13:27:39 | case ...: |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:31:17:31:27 | goto ...; |
-| Switch.cs:29:17:29:23 | return ...; | Switch.cs:28:17:28:21 | Label: |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:31:17:31:27 | goto ...; |
+| Switch.cs:29:17:29:23 | return ...; | Switch.cs:28:13:28:17 | Label: |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:19:17:19:29 | goto default; |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:35:10:35:11 | exit M3 | Switch.cs:37:17:37:23 | call to method Throw |
@@ -5553,85 +5619,85 @@ postDominance
 | Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:13:50:39 | case ...: |
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:35:50:38 | null |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:30 | access to parameter o |
-| Switch.cs:55:10:55:11 | exit M5 | Switch.cs:62:15:62:20 | break; |
+| Switch.cs:55:10:55:11 | exit M5 | Switch.cs:62:17:62:22 | break; |
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:55:10:55:11 | enter M5 |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:56:5:64:5 | {...} |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:9:63:9 | switch (...) {...} |
 | Switch.cs:57:17:57:21 | ... + ... | Switch.cs:57:21:57:21 | 2 |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:17 | 1 |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:57:17:57:21 | ... + ... |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:13:59:20 | case ...: |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:59:18:59:18 | 2 |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:13:61:20 | case ...: |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:61:18:61:18 | 3 |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:57:17:57:21 | ... + ... |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:59:13:59:19 | case ...: |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:59:18:59:18 | 2 |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:61:13:61:19 | case ...: |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:61:18:61:18 | 3 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:72:18:72:19 | "" |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:66:10:66:11 | enter M6 |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:67:5:75:5 | {...} |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:68:25:68:25 | access to parameter s |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:9:74:9 | switch (...) {...} |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:68:17:68:25 | (...) ... |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:13:70:24 | case ...: |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:72:13:72:21 | case ...: |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:15:82:26 | return ...; |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:15:86:26 | return ...; |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:68:17:68:25 | (...) ... |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:13:70:23 | case ...: |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:72:13:72:20 | case ...: |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:17:82:28 | return ...; |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:17:86:28 | return ...; |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:88:9:88:21 | return ...; |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:77:10:77:11 | enter M7 |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:78:5:89:5 | {...} |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:9:87:9 | switch (...) {...} |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:79:17:79:17 | access to parameter i |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:13:81:20 | case ...: |
-| Switch.cs:82:15:82:26 | return ...; | Switch.cs:82:22:82:25 | true |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:84:23:84:23 | 2 |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:84:19:84:19 | access to parameter j |
-| Switch.cs:86:15:86:26 | return ...; | Switch.cs:86:22:86:25 | true |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:79:17:79:17 | access to parameter i |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:81:13:81:19 | case ...: |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:82:24:82:27 | true |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:84:25:84:25 | 2 |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:21 | access to parameter j |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:86:24:86:27 | true |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:88:16:88:20 | false |
-| Switch.cs:88:16:88:20 | false | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:15:96:26 | return ...; |
+| Switch.cs:88:16:88:20 | false | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:17:96:28 | return ...; |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:98:9:98:21 | return ...; |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:91:10:91:11 | enter M8 |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:92:5:99:5 | {...} |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:93:9:97:9 | switch (...) {...} |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:93:17:93:17 | access to parameter o |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:13:95:24 | case ...: |
-| Switch.cs:96:15:96:26 | return ...; | Switch.cs:96:22:96:25 | true |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:93:17:93:17 | access to parameter o |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:13:95:23 | case ...: |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:98:16:98:20 | false |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:22:105:30 | return ...; |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:22:106:30 | return ...; |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:21:105:29 | return ...; |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:21:106:29 | return ...; |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:108:9:108:18 | return ...; |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:102:5:109:5 | {...} |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:9:107:9 | switch (...) {...} |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:103:17:103:17 | access to parameter s |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:105:22:105:30 | return ...; | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:106:22:106:30 | return ...; | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:103:17:103:17 | access to parameter s |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:103:19:103:25 | access to property Length |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:108:16:108:17 | -... |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:111:17:111:21 | exit Throw | Switch.cs:111:28:111:48 | throw ... |
 | Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:34:111:48 | object creation of type Exception |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:17:111:21 | enter Throw |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:36:117:44 | return ...; |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:35:118:43 | return ...; |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:37:117:45 | return ...; |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:36:118:44 | return ...; |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:120:9:120:18 | return ...; |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:113:9:113:11 | enter M10 |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:114:5:121:5 | {...} |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:9:119:9 | switch (...) {...} |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:17 | access to parameter s |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:115:17:115:24 | access to property Length |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:13:117:34 | case ...: |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:28:117:32 | "foo" |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:36:117:44 | return ...; | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:13:118:33 | case ...: |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:28:118:31 | "fu" |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:35:118:43 | return ...; | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:115:17:115:24 | access to property Length |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:13:117:35 | case ...: |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:30:117:34 | "foo" |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:25 | access to parameter s |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:30:118:33 | "fu" |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:25 | access to parameter s |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:16:120:17 | -... |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:125:34:125:34 | access to local variable b |
@@ -5684,6 +5750,28 @@ postDominance
 | Switch.cs:149:30:149:30 | 1 | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:28:150:28 | 2 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:41:156:45 | false |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:158:13:158:48 | call to method WriteLine |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:160:13:160:48 | call to method WriteLine |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:155:5:161:5 | {...} |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:9:156:55 | ... ...; |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:38 | ... => ... |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:17 | access to parameter b |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:9:160:49 | if (...) ... |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:158:38:158:47 | $"..." |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:45:158:45 | access to local variable s |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:40:158:43 | "a = " |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:160:38:160:47 | $"..." |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:45:160:45 | access to local variable s |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:40:160:43 | "b = " |
 | TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:8:13:8:27 | Type t = ... |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:4:5:9:5 | {...} |
@@ -6712,20 +6800,20 @@ blockDominance
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:41:116:41 | access to local variable i |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i |
-| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:116:41:116:41 | access to local variable i |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | exit M9 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
@@ -6742,6 +6830,13 @@ blockDominance
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | enter M11 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | exit M11 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |
@@ -8122,79 +8217,79 @@ blockDominance
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | enter M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | enter M6 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | exit M6 |
-| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | enter M7 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | exit M7 |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:82:22:82:25 | true |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:86:22:86:25 | true |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:82:24:82:27 | true |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:86:24:86:27 | true |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:88:16:88:20 | false |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:22:82:25 | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:86:22:86:25 | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:88:16:88:20 | false |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:86:22:86:25 | true |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:22:86:25 | true |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:86:24:86:27 | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:88:16:88:20 | false |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:86:24:86:27 | true |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:24:86:27 | true |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | enter M8 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | exit M8 |
-| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:96:22:96:25 | true |
+| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:96:24:96:27 | true |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:98:16:98:20 | false |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:22:96:25 | true |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | exit M9 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:101:9:101:10 | exit M9 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:106:29:106:29 | 1 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:108:17:108:17 | 1 |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:29:106:29 | 1 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:108:17:108:17 | 1 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | exit M9 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:106:28:106:28 | 1 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:108:17:108:17 | 1 |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:28:106:28 | 1 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:108:17:108:17 | 1 |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | enter Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | enter M10 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | exit M10 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:13:118:33 | case ...: |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:13:118:33 | case ...: |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:42:118:42 | 2 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:120:17:120:17 | 1 |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:25 | access to parameter s |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:43:118:43 | 2 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:42:118:42 | 2 |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:43:118:43 | 2 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | exit M11 |
@@ -8242,6 +8337,24 @@ blockDominance
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | exit M15 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:8:9:8:28 | ... ...; |
@@ -9127,21 +9240,21 @@ postBlockDominance
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | enter M9 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | exit M9 |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:41:116:41 | access to local variable i |
+| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:113:10:113:11 | enter M9 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | enter M9 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:117:9:123:9 | {...} |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... |
@@ -9150,6 +9263,13 @@ postBlockDominance
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | enter M11 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | enter M11 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | exit M11 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | enter M1 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | enter M2 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | enter M3 |
@@ -10120,63 +10240,63 @@ postBlockDominance
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | enter M6 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | enter M6 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | exit M6 |
-| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:15:73:20 | break; |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:66:10:66:11 | exit M6 | Switch.cs:73:17:73:22 | break; |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | enter M7 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | enter M7 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | exit M7 |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:22:82:25 | true |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:22:86:25 | true |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:82:24:82:27 | true |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:77:10:77:11 | exit M7 | Switch.cs:86:24:86:27 | true |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:88:16:88:20 | false |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:22:82:25 | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:13:83:20 | case ...: |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:22:86:25 | true |
-| Switch.cs:88:16:88:20 | false | Switch.cs:85:17:85:22 | break; |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | case ...: |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:24:86:27 | true |
+| Switch.cs:88:16:88:20 | false | Switch.cs:85:21:85:26 | break; |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | enter M8 |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | enter M8 |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | exit M8 |
-| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:22:96:25 | true |
+| Switch.cs:91:10:91:11 | exit M8 | Switch.cs:96:24:96:27 | true |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:98:16:98:20 | false |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:22:96:25 | true |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | enter M9 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | exit M9 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:101:9:101:10 | exit M9 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:101:9:101:10 | enter M9 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:103:19:103:25 | access to property Length |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:13:105:20 | case ...: |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:13:106:20 | case ...: |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | enter M9 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:103:19:103:25 | access to property Length |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | case ...: |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | case ...: |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | enter Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | enter M10 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | enter M10 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | exit M10 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:13:118:33 | case ...: |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:113:9:113:11 | exit M10 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:13:118:33 | case ...: |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | enter M11 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | enter M11 |
@@ -10218,6 +10338,23 @@ postBlockDominance
 | Switch.cs:149:13:149:20 | default: | Switch.cs:149:13:149:20 | default: |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:13:150:19 | case ...: |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | enter M15 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | exit M15 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | enter M |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:7:25:7:25 | ; |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | enter M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -794,7 +794,7 @@ nodeEnclosing
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:70:9:70:10 | M6 |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:70:9:70:10 | M6 |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:70:9:70:10 | M6 |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:70:9:70:10 | M6 |
@@ -879,14 +879,14 @@ nodeEnclosing
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:113:10:113:11 | M9 |
@@ -949,6 +949,30 @@ nodeEnclosing
 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:129:10:129:12 | M10 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:143:10:143:12 | M11 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:7:10:7:11 | exit M1 | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:7:10:7:11 | M1 |
@@ -2725,7 +2749,7 @@ nodeEnclosing
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | M2 |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:10:10:10:11 | M2 |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:10:10:10:11 | M2 |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:10:10:10:11 | M2 |
@@ -2755,40 +2779,40 @@ nodeEnclosing
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:57:17:57:21 | ... + ... | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:55:10:55:11 | M5 |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:55:10:55:11 | M5 |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:82:15:82:26 | return ...; | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:82:22:82:25 | true | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:82:24:82:27 | true | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:86:15:86:26 | return ...; | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:86:22:86:25 | true | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:86:24:86:27 | true | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:88:16:88:20 | false | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | M8 |
@@ -2796,10 +2820,10 @@ nodeEnclosing
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:96:15:96:26 | return ...; | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:96:22:96:25 | true | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:96:24:96:27 | true | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:98:16:98:20 | false | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | M9 |
@@ -2808,14 +2832,14 @@ nodeEnclosing
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:22:105:30 | return ...; | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:22:106:30 | return ...; | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:101:9:101:10 | M9 |
@@ -2829,20 +2853,20 @@ nodeEnclosing
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:36:117:44 | return ...; | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:35:118:43 | return ...; | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:113:9:113:11 | M10 |
@@ -2906,6 +2930,31 @@ nodeEnclosing
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:31 | true | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:154:10:154:12 | M15 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:3:10:3:10 | exit M | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:3:10:3:10 | M |
@@ -3779,8 +3828,8 @@ blockEnclosing
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:102:12:102:13 | M8 |
 | Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:113:10:113:11 | exit M9 | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:113:10:113:11 | M9 |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:113:10:113:11 | M9 |
@@ -3789,6 +3838,10 @@ blockEnclosing
 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:129:10:129:12 | M10 |
 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:129:10:129:12 | M10 |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:143:10:143:12 | exit M11 | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:143:10:143:12 | M11 |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:143:10:143:12 | M11 |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:7:10:7:11 | M1 |
 | ExitMethods.cs:13:10:13:11 | enter M2 | ExitMethods.cs:13:10:13:11 | M2 |
 | ExitMethods.cs:19:10:19:11 | enter M3 | ExitMethods.cs:19:10:19:11 | M3 |
@@ -4321,35 +4374,35 @@ blockEnclosing
 | Switch.cs:55:10:55:11 | enter M5 | Switch.cs:55:10:55:11 | M5 |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:66:10:66:11 | exit M6 | Switch.cs:66:10:66:11 | M6 |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:66:10:66:11 | M6 |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | M6 |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:77:10:77:11 | exit M7 | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:82:22:82:25 | true | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:77:10:77:11 | M7 |
-| Switch.cs:86:22:86:25 | true | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:82:24:82:27 | true | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:77:10:77:11 | M7 |
+| Switch.cs:86:24:86:27 | true | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:88:16:88:20 | false | Switch.cs:77:10:77:11 | M7 |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:91:10:91:11 | exit M8 | Switch.cs:91:10:91:11 | M8 |
-| Switch.cs:96:22:96:25 | true | Switch.cs:91:10:91:11 | M8 |
+| Switch.cs:96:24:96:27 | true | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:98:16:98:20 | false | Switch.cs:91:10:91:11 | M8 |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:101:9:101:10 | exit M9 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:101:9:101:10 | M9 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:101:9:101:10 | M9 |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:101:9:101:10 | M9 |
 | Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:17:111:21 | Throw |
 | Switch.cs:113:9:113:11 | enter M10 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:113:9:113:11 | exit M10 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:113:9:113:11 | M10 |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:113:9:113:11 | M10 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:113:9:113:11 | M10 |
 | Switch.cs:123:10:123:12 | enter M11 | Switch.cs:123:10:123:12 | M11 |
 | Switch.cs:123:10:123:12 | exit M11 | Switch.cs:123:10:123:12 | M11 |
@@ -4373,6 +4426,14 @@ blockEnclosing
 | Switch.cs:149:13:149:20 | default: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:13:150:19 | case ...: | Switch.cs:144:9:144:11 | M14 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:144:9:144:11 | M14 |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:154:10:154:12 | exit M15 | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:154:10:154:12 | M15 |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:154:10:154:12 | M15 |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:3:10:3:10 | M |
 | TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:3:10:3:10 | M |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -649,7 +649,7 @@
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:26 | ...; |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:21:79:25 | false |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:9:82:16 | if (...) ... |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:81:12:81:12 | access to local variable b |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:81:13:81:13 | access to local variable b |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:13 | access to local variable x |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:82:13:82:13 | access to local variable x |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:16 | ...; |
@@ -722,14 +722,14 @@
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:20:115:23 | null |
 | Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:21:116:21 | 0 |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:21:116:21 | 0 |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:24:116:24 | access to local variable i |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:116:28:116:31 | access to parameter args |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:28:116:31 | access to parameter args |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i |
-| Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:41:116:41 | access to local variable i |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:22:116:22 | 0 |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:22:116:22 | 0 |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:116:25:116:25 | access to local variable i |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:32 | access to parameter args |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:29:116:32 | access to parameter args |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:42:116:42 | access to local variable i |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:117:9:123:9 | {...} |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:13:118:44 | ... ...; |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:118:24:118:24 | access to local variable i |
@@ -766,6 +766,25 @@
 | Conditions.cs:137:21:137:26 | this access | Conditions.cs:137:21:137:26 | this access |
 | Conditions.cs:137:21:137:37 | call to method ToString | Conditions.cs:137:21:137:26 | this access |
 | Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:38 | ...; |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:144:5:150:5 | {...} |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:9:145:30 | ... ...; |
+| Conditions.cs:145:13:145:29 | String s = ... | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:29 | ... ? ... : ... |
+| Conditions.cs:145:21:145:23 | "a" | Conditions.cs:145:21:145:23 | "a" |
+| Conditions.cs:145:27:145:29 | "b" | Conditions.cs:145:27:145:29 | "b" |
+| Conditions.cs:146:9:149:49 | if (...) ... | Conditions.cs:146:9:149:49 | if (...) ... |
+| Conditions.cs:146:13:146:13 | access to parameter b | Conditions.cs:146:13:146:13 | access to parameter b |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:147:40:147:43 | "a = " |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:13:147:49 | ...; |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:40:147:43 | "a = " |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:40:147:43 | "a = " |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:45:147:45 | access to local variable s |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:149:40:149:43 | "b = " |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:13:149:49 | ...; |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:40:149:43 | "b = " |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:40:149:43 | "b = " |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:45:149:45 | access to local variable s |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:20:9:23 | true |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:9:9:25 | ...; |
@@ -1884,7 +1903,7 @@
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:13:27:39 | case ...: |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | Double d |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:28:17:28:21 | Label: |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:28:13:28:17 | Label: |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:29:17:29:23 | return ...; |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:30:13:30:20 | default: |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:31:17:31:27 | goto ...; |
@@ -1910,61 +1929,61 @@
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:17:57:17 | 1 |
 | Switch.cs:57:17:57:21 | ... + ... | Switch.cs:57:17:57:17 | 1 |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:21:57:21 | 2 |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:59:13:59:20 | case ...: |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:13:59:19 | case ...: |
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | 2 |
-| Switch.cs:60:15:60:20 | break; | Switch.cs:60:15:60:20 | break; |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:61:13:61:20 | case ...: |
+| Switch.cs:60:17:60:22 | break; | Switch.cs:60:17:60:22 | break; |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:13:61:19 | case ...: |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | 3 |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:62:15:62:20 | break; |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:62:17:62:22 | break; |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:67:5:75:5 | {...} |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:9:74:9 | switch (...) {...} |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:68:25:68:25 | access to parameter s |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:25:68:25 | access to parameter s |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:70:13:70:24 | case ...: |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:13:70:23 | case ...: |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | access to type Int32 |
-| Switch.cs:71:15:71:20 | break; | Switch.cs:71:15:71:20 | break; |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:72:13:72:21 | case ...: |
+| Switch.cs:71:17:71:22 | break; | Switch.cs:71:17:71:22 | break; |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:13:72:20 | case ...: |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | "" |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:73:15:73:20 | break; |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:78:5:89:5 | {...} |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:9:87:9 | switch (...) {...} |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:17:79:17 | access to parameter i |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:81:13:81:20 | case ...: |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:13:81:19 | case ...: |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | 1 |
-| Switch.cs:82:15:82:26 | return ...; | Switch.cs:82:22:82:25 | true |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:22:82:25 | true |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:13:83:20 | case ...: |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:82:24:82:27 | true |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:13:83:19 | case ...: |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | 2 |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:15:85:22 | if (...) ... |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:84:19:84:19 | access to parameter j |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:84:19:84:19 | access to parameter j |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:84:23:84:23 | 2 |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:85:17:85:22 | break; |
-| Switch.cs:86:15:86:26 | return ...; | Switch.cs:86:22:86:25 | true |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:22:86:25 | true |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:17:85:26 | if (...) ... |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:21:84:21 | access to parameter j |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:84:21:84:21 | access to parameter j |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:25:84:25 | 2 |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:85:21:85:26 | break; |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:86:24:86:27 | true |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:24:86:27 | true |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:88:16:88:20 | false |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:92:5:99:5 | {...} |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:9:97:9 | switch (...) {...} |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:93:17:93:17 | access to parameter o |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:95:13:95:24 | case ...: |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:13:95:23 | case ...: |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | access to type Int32 |
-| Switch.cs:96:15:96:26 | return ...; | Switch.cs:96:22:96:25 | true |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:22:96:25 | true |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:96:24:96:27 | true |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:98:16:98:20 | false |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:102:5:109:5 | {...} |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:9:107:9 | switch (...) {...} |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:17:103:17 | access to parameter s |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:17:103:17 | access to parameter s |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:13:105:20 | case ...: |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:13:105:19 | case ...: |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | 0 |
-| Switch.cs:105:22:105:30 | return ...; | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:29:105:29 | 0 |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:13:106:20 | case ...: |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:28:105:28 | 0 |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:13:106:19 | case ...: |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | 1 |
-| Switch.cs:106:22:106:30 | return ...; | Switch.cs:106:29:106:29 | 1 |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:29:106:29 | 1 |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:106:28:106:28 | 1 |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:28:106:28 | 1 |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:17:108:17 | 1 |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 |
@@ -1974,20 +1993,20 @@
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:9:119:9 | switch (...) {...} |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:17 | access to parameter s |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:17 | access to parameter s |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:13:117:34 | case ...: |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:13:117:35 | case ...: |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | 3 |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:25:117:25 | access to parameter s |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:117:28:117:32 | "foo" |
-| Switch.cs:117:36:117:44 | return ...; | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:43:117:43 | 1 |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:13:118:33 | case ...: |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:25 | access to parameter s |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:30:117:34 | "foo" |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:13:118:34 | case ...: |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | 2 |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:25:118:25 | access to parameter s |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:118:28:118:31 | "fu" |
-| Switch.cs:118:35:118:43 | return ...; | Switch.cs:118:42:118:42 | 2 |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:42:118:42 | 2 |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:25 | access to parameter s |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:30:118:33 | "fu" |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:118:43:118:43 | 2 |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:17:120:17 | 1 |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 |
@@ -2043,6 +2062,29 @@
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | 2 |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:28:150:28 | 2 |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:155:5:161:5 | {...} |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:9:156:55 | ... ...; |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:17 | access to parameter b |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:54 | ... switch { ... } |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:38 | ... => ... |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:52 | ... => ... |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:9:160:49 | if (...) ... |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:13:157:13 | access to parameter b |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:158:40:158:43 | "a = " |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:49 | ...; |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:40:158:43 | "a = " |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:40:158:43 | "a = " |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:45:158:45 | access to local variable s |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:160:40:160:43 | "b = " |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:49 | ...; |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:40:160:43 | "b = " |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:40:160:43 | "b = " |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:45:160:45 | access to local variable s |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:4:5:9:5 | {...} |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:9:5:26 | ... ...; |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:25:5:25 | access to parameter o |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -783,10 +783,10 @@
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:79:17:79:25 | ... = ... | normal |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:17:79:25 | ... = ... | normal |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:21:79:25 | false | normal |
-| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | false |
+| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b | false |
 | Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:82:13:82:15 | ...++ | normal |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:81:12:81:12 | access to local variable b | false |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:81:12:81:12 | access to local variable b | true |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:81:13:81:13 | access to local variable b | false |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:81:13:81:13 | access to local variable b | true |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:13 | access to local variable x | normal |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:82:13:82:15 | ...++ | normal |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:15 | ...++ | normal |
@@ -869,20 +869,20 @@
 | Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:22:109:23 | "" | normal |
 | Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:110:9:110:17 | return ...; | return |
 | Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:16:110:16 | access to local variable x | normal |
-| Conditions.cs:114:5:124:5 | {...} | Conditions.cs:116:24:116:38 | ... < ... | false |
+| Conditions.cs:114:5:124:5 | {...} | Conditions.cs:116:25:116:39 | ... < ... | false |
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:16:115:23 | String s = ... | normal |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:115:16:115:23 | String s = ... | normal |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:20:115:23 | null | normal |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:24:116:38 | ... < ... | false |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:17:116:21 | Int32 i = ... | normal |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:21:116:21 | 0 | normal |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:24:116:24 | access to local variable i | normal |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:24:116:38 | ... < ... | false |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:116:24:116:38 | ... < ... | true |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:116:28:116:31 | access to parameter args | normal |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:28:116:38 | access to property Length | normal |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:41 | access to local variable i | normal |
-| Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:41:116:43 | ...++ | normal |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:25:116:39 | ... < ... | false |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:18:116:22 | Int32 i = ... | normal |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:22:116:22 | 0 | normal |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:25:116:25 | access to local variable i | normal |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:116:25:116:39 | ... < ... | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:116:25:116:39 | ... < ... | true |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:32 | access to parameter args | normal |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:29:116:39 | access to property Length | normal |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:42 | access to local variable i | normal |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:42:116:44 | ...++ | normal |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:121:17:121:20 | access to local variable last | false |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:122:17:122:24 | ... = ... | normal |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:17:118:43 | Boolean last = ... | normal |
@@ -931,6 +931,30 @@
 | Conditions.cs:137:21:137:26 | this access | Conditions.cs:137:21:137:26 | this access | normal |
 | Conditions.cs:137:21:137:37 | call to method ToString | Conditions.cs:137:21:137:37 | call to method ToString | normal |
 | Conditions.cs:137:21:137:38 | ...; | Conditions.cs:137:21:137:37 | call to method ToString | normal |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:147:13:147:48 | call to method WriteLine | normal |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:149:13:149:48 | call to method WriteLine | normal |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:13:145:29 | String s = ... | normal |
+| Conditions.cs:145:13:145:29 | String s = ... | Conditions.cs:145:13:145:29 | String s = ... | normal |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b | false |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:17:145:17 | access to parameter b | true |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:21:145:23 | "a" | normal |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:27:145:29 | "b" | normal |
+| Conditions.cs:145:21:145:23 | "a" | Conditions.cs:145:21:145:23 | "a" | normal |
+| Conditions.cs:145:27:145:29 | "b" | Conditions.cs:145:27:145:29 | "b" | normal |
+| Conditions.cs:146:9:149:49 | if (...) ... | Conditions.cs:147:13:147:48 | call to method WriteLine | normal |
+| Conditions.cs:146:9:149:49 | if (...) ... | Conditions.cs:149:13:149:48 | call to method WriteLine | normal |
+| Conditions.cs:146:13:146:13 | access to parameter b | Conditions.cs:146:13:146:13 | access to parameter b | false |
+| Conditions.cs:146:13:146:13 | access to parameter b | Conditions.cs:146:13:146:13 | access to parameter b | true |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:147:13:147:48 | call to method WriteLine | normal |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:13:147:48 | call to method WriteLine | normal |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:38:147:47 | $"..." | normal |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:40:147:43 | "a = " | normal |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:45:147:45 | access to local variable s | normal |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:149:13:149:48 | call to method WriteLine | normal |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:13:149:48 | call to method WriteLine | normal |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:38:149:47 | $"..." | normal |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:40:149:43 | "b = " | normal |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:45:149:45 | access to local variable s | normal |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:10:9:10:15 | return ...; | return |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | normal |
 | ExitMethods.cs:9:9:9:25 | ...; | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | normal |
@@ -2487,11 +2511,11 @@
 | Switch.cs:26:17:26:23 | return ...; | Switch.cs:26:17:26:23 | return ...; | return |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d | no-match |
 | Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:32:27:38 | call to method Throw | throw(Exception) |
-| Switch.cs:27:13:27:39 | case ...: | Switch.cs:28:17:28:21 | Label: | normal |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:28:13:28:17 | Label: | normal |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | Double d | match |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:18:27:25 | Double d | no-match |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:27:32:27:38 | call to method Throw | throw(Exception) |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:28:17:28:21 | Label: | normal |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:28:13:28:17 | Label: | normal |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:29:17:29:23 | return ...; | return |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; | goto(Label) |
 | Switch.cs:31:17:31:27 | goto ...; | Switch.cs:31:17:31:27 | goto ...; | goto(Label) |
@@ -2526,138 +2550,138 @@
 | Switch.cs:50:30:50:38 | ... != ... | Switch.cs:50:30:50:38 | ... != ... | true |
 | Switch.cs:50:35:50:38 | null | Switch.cs:50:35:50:38 | null | normal |
 | Switch.cs:51:17:51:22 | break; | Switch.cs:51:17:51:22 | break; | break |
-| Switch.cs:56:5:64:5 | {...} | Switch.cs:60:15:60:20 | break; | normal (break) |
-| Switch.cs:56:5:64:5 | {...} | Switch.cs:62:15:62:20 | break; | normal (break) |
-| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:60:15:60:20 | break; | normal (break) |
-| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:62:15:62:20 | break; | normal (break) |
+| Switch.cs:56:5:64:5 | {...} | Switch.cs:60:17:60:22 | break; | normal (break) |
+| Switch.cs:56:5:64:5 | {...} | Switch.cs:62:17:62:22 | break; | normal (break) |
+| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:60:17:60:22 | break; | normal (break) |
+| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:62:17:62:22 | break; | normal (break) |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:17:57:17 | 1 | normal |
 | Switch.cs:57:17:57:21 | ... + ... | Switch.cs:57:17:57:21 | ... + ... | normal |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:21:57:21 | 2 | normal |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:59:18:59:18 | 2 | no-match |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:60:15:60:20 | break; | break |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 | no-match |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:60:17:60:22 | break; | break |
 | Switch.cs:59:18:59:18 | 2 | Switch.cs:59:18:59:18 | 2 | no-match |
-| Switch.cs:60:15:60:20 | break; | Switch.cs:60:15:60:20 | break; | break |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:62:15:62:20 | break; | break |
+| Switch.cs:60:17:60:22 | break; | Switch.cs:60:17:60:22 | break; | break |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:62:17:62:22 | break; | break |
 | Switch.cs:61:18:61:18 | 3 | Switch.cs:61:18:61:18 | 3 | match |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:62:15:62:20 | break; | break |
-| Switch.cs:67:5:75:5 | {...} | Switch.cs:71:15:71:20 | break; | normal (break) |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:62:17:62:22 | break; | break |
+| Switch.cs:67:5:75:5 | {...} | Switch.cs:71:17:71:22 | break; | normal (break) |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:67:5:75:5 | {...} | Switch.cs:73:15:73:20 | break; | normal (break) |
-| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:71:15:71:20 | break; | normal (break) |
+| Switch.cs:67:5:75:5 | {...} | Switch.cs:73:17:73:22 | break; | normal (break) |
+| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:71:17:71:22 | break; | normal (break) |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:73:15:73:20 | break; | normal (break) |
+| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:73:17:73:22 | break; | normal (break) |
 | Switch.cs:68:17:68:25 | (...) ... | Switch.cs:68:17:68:25 | (...) ... | normal |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:25:68:25 | access to parameter s | normal |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | no-match |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:71:15:71:20 | break; | break |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | no-match |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:71:17:71:22 | break; | break |
 | Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:70:18:70:20 | access to type Int32 | no-match |
-| Switch.cs:71:15:71:20 | break; | Switch.cs:71:15:71:20 | break; | break |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:73:15:73:20 | break; | break |
+| Switch.cs:71:17:71:22 | break; | Switch.cs:71:17:71:22 | break; | break |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" | no-match |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:73:17:73:22 | break; | break |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | "" | match |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:72:18:72:19 | "" | no-match |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:73:15:73:20 | break; | break |
-| Switch.cs:78:5:89:5 | {...} | Switch.cs:82:15:82:26 | return ...; | return |
-| Switch.cs:78:5:89:5 | {...} | Switch.cs:86:15:86:26 | return ...; | return |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:73:17:73:22 | break; | break |
+| Switch.cs:78:5:89:5 | {...} | Switch.cs:82:17:82:28 | return ...; | return |
+| Switch.cs:78:5:89:5 | {...} | Switch.cs:86:17:86:28 | return ...; | return |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:88:9:88:21 | return ...; | return |
-| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:82:15:82:26 | return ...; | return |
+| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:82:17:82:28 | return ...; | return |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:83:18:83:18 | 2 | no-match |
-| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:85:17:85:22 | break; | normal (break) |
-| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:86:15:86:26 | return ...; | return |
+| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:85:21:85:26 | break; | normal (break) |
+| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:86:17:86:28 | return ...; | return |
 | Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:79:17:79:17 | access to parameter i | normal |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:81:18:81:18 | 1 | no-match |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:82:15:82:26 | return ...; | return |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 | no-match |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:82:17:82:28 | return ...; | return |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | 1 | match |
 | Switch.cs:81:18:81:18 | 1 | Switch.cs:81:18:81:18 | 1 | no-match |
-| Switch.cs:82:15:82:26 | return ...; | Switch.cs:82:15:82:26 | return ...; | return |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:22:82:25 | true | normal |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:18:83:18 | 2 | no-match |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:84:19:84:23 | ... > ... | false |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:85:17:85:22 | break; | break |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:82:17:82:28 | return ...; | return |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:24:82:27 | true | normal |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | no-match |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:84:21:84:25 | ... > ... | false |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:85:21:85:26 | break; | break |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | 2 | match |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:83:18:83:18 | 2 | no-match |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:19:84:23 | ... > ... | false |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:85:17:85:22 | break; | break |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:84:19:84:19 | access to parameter j | normal |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:84:19:84:23 | ... > ... | false |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:84:19:84:23 | ... > ... | true |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:84:23:84:23 | 2 | normal |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:85:17:85:22 | break; | break |
-| Switch.cs:86:15:86:26 | return ...; | Switch.cs:86:15:86:26 | return ...; | return |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:22:86:25 | true | normal |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:25 | ... > ... | false |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:85:21:85:26 | break; | break |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:21:84:21 | access to parameter j | normal |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:84:21:84:25 | ... > ... | false |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:84:21:84:25 | ... > ... | true |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:25:84:25 | 2 | normal |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:85:21:85:26 | break; | break |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:86:17:86:28 | return ...; | return |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:24:86:27 | true | normal |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:88:9:88:21 | return ...; | return |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:16:88:20 | false | normal |
-| Switch.cs:92:5:99:5 | {...} | Switch.cs:96:15:96:26 | return ...; | return |
+| Switch.cs:92:5:99:5 | {...} | Switch.cs:96:17:96:28 | return ...; | return |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:98:9:98:21 | return ...; | return |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:95:18:95:20 | access to type Int32 | no-match |
-| Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:96:15:96:26 | return ...; | return |
+| Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:96:17:96:28 | return ...; | return |
 | Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:93:17:93:17 | access to parameter o | normal |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | no-match |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:96:15:96:26 | return ...; | return |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | no-match |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:96:17:96:28 | return ...; | return |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | access to type Int32 | match |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:95:18:95:20 | access to type Int32 | no-match |
-| Switch.cs:96:15:96:26 | return ...; | Switch.cs:96:15:96:26 | return ...; | return |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:22:96:25 | true | normal |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:96:17:96:28 | return ...; | return |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:24:96:27 | true | normal |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:98:9:98:21 | return ...; | return |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:16:98:20 | false | normal |
-| Switch.cs:102:5:109:5 | {...} | Switch.cs:105:22:105:30 | return ...; | return |
-| Switch.cs:102:5:109:5 | {...} | Switch.cs:106:22:106:30 | return ...; | return |
+| Switch.cs:102:5:109:5 | {...} | Switch.cs:105:21:105:29 | return ...; | return |
+| Switch.cs:102:5:109:5 | {...} | Switch.cs:106:21:106:29 | return ...; | return |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:108:9:108:18 | return ...; | return |
-| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:105:22:105:30 | return ...; | return |
+| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:105:21:105:29 | return ...; | return |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:106:18:106:18 | 1 | no-match |
-| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:106:22:106:30 | return ...; | return |
+| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:106:21:106:29 | return ...; | return |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:17:103:17 | access to parameter s | non-null |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:17:103:17 | access to parameter s | null |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:17:103:17 | access to parameter s | null |
 | Switch.cs:103:19:103:25 | access to property Length | Switch.cs:103:19:103:25 | access to property Length | normal |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:18:105:18 | 0 | no-match |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:22:105:30 | return ...; | return |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | no-match |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:21:105:29 | return ...; | return |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | 0 | match |
 | Switch.cs:105:18:105:18 | 0 | Switch.cs:105:18:105:18 | 0 | no-match |
-| Switch.cs:105:22:105:30 | return ...; | Switch.cs:105:22:105:30 | return ...; | return |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:29:105:29 | 0 | normal |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:18:106:18 | 1 | no-match |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:22:106:30 | return ...; | return |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:105:21:105:29 | return ...; | return |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:28:105:28 | 0 | normal |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | no-match |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:21:106:29 | return ...; | return |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | 1 | match |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:106:18:106:18 | 1 | no-match |
-| Switch.cs:106:22:106:30 | return ...; | Switch.cs:106:22:106:30 | return ...; | return |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:29:106:29 | 1 | normal |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:106:21:106:29 | return ...; | return |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:28:106:28 | 1 | normal |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:108:9:108:18 | return ...; | return |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:16:108:17 | -... | normal |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:17:108:17 | 1 | normal |
 | Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:28:111:48 | throw ... | throw(Exception) |
 | Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:34:111:48 | object creation of type Exception | normal |
-| Switch.cs:114:5:121:5 | {...} | Switch.cs:117:36:117:44 | return ...; | return |
-| Switch.cs:114:5:121:5 | {...} | Switch.cs:118:35:118:43 | return ...; | return |
+| Switch.cs:114:5:121:5 | {...} | Switch.cs:117:37:117:45 | return ...; | return |
+| Switch.cs:114:5:121:5 | {...} | Switch.cs:118:36:118:44 | return ...; | return |
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:120:9:120:18 | return ...; | return |
-| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:117:36:117:44 | return ...; | return |
+| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:117:37:117:45 | return ...; | return |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:118:18:118:18 | 2 | no-match |
-| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:118:25:118:31 | ... == ... | false |
-| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:118:35:118:43 | return ...; | return |
+| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:118:25:118:33 | ... == ... | false |
+| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:118:36:118:44 | return ...; | return |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:17 | access to parameter s | normal |
 | Switch.cs:115:17:115:24 | access to property Length | Switch.cs:115:17:115:24 | access to property Length | normal |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:18:117:18 | 3 | no-match |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:25:117:32 | ... == ... | false |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:36:117:44 | return ...; | return |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 | no-match |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:25:117:34 | ... == ... | false |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:37:117:45 | return ...; | return |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | 3 | match |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:117:18:117:18 | 3 | no-match |
 | Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:25:117:25 | access to parameter s | normal |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:25:117:32 | ... == ... | false |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:25:117:32 | ... == ... | true |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:117:28:117:32 | "foo" | normal |
-| Switch.cs:117:36:117:44 | return ...; | Switch.cs:117:36:117:44 | return ...; | return |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:43:117:43 | 1 | normal |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:18:118:18 | 2 | no-match |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:25:118:31 | ... == ... | false |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:35:118:43 | return ...; | return |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | ... == ... | false |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:25:117:34 | ... == ... | true |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:30:117:34 | "foo" | normal |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:117:37:117:45 | return ...; | return |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:44:117:44 | 1 | normal |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | no-match |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:25:118:33 | ... == ... | false |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:36:118:44 | return ...; | return |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | 2 | match |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:18:118:18 | 2 | no-match |
 | Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:25:118:25 | access to parameter s | normal |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:25:118:31 | ... == ... | false |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:25:118:31 | ... == ... | true |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:118:28:118:31 | "fu" | normal |
-| Switch.cs:118:35:118:43 | return ...; | Switch.cs:118:35:118:43 | return ...; | return |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:42:118:42 | 2 | normal |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | ... == ... | false |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:25:118:33 | ... == ... | true |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:30:118:33 | "fu" | normal |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:118:36:118:44 | return ...; | return |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:43:118:43 | 2 | normal |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:120:9:120:18 | return ...; | return |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:16:120:17 | -... | normal |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:17:120:17 | 1 | normal |
@@ -2747,6 +2771,41 @@
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:18:150:18 | 2 | no-match |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:150:21:150:29 | return ...; | return |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:28:150:28 | 2 | normal |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:13:156:54 | String s = ... | normal |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:13:156:54 | String s = ... | normal |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:17:156:17 | access to parameter b | normal |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:36:156:38 | "a" | normal |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:41:156:45 | false | throw(InvalidOperationException) [no-match] |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:50:156:52 | "b" | normal |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | match |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:28:156:31 | true | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:36:156:38 | "a" | normal |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:36:156:38 | "a" | normal |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | match |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:41:156:45 | false | no-match |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | no-match |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:50:156:52 | "b" | normal |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:50:156:52 | "b" | normal |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:13:157:13 | access to parameter b | false |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:157:13:157:13 | access to parameter b | true |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:13:158:48 | call to method WriteLine | normal |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:38:158:47 | $"..." | normal |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:40:158:43 | "a = " | normal |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:45:158:45 | access to local variable s | normal |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:13:160:48 | call to method WriteLine | normal |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:38:160:47 | $"..." | normal |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:40:160:43 | "b = " | normal |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:45:160:45 | access to local variable s | normal |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:8:13:8:27 | Type t = ... | normal |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:13:5:25 | String s = ... | normal |
 | TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:5:13:5:25 | String s = ... | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -793,9 +793,9 @@
 | Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | semmle.label | successor |
 | Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false | semmle.label | successor |
 | Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... | semmle.label | successor |
-| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:12:81:12 | access to local variable b | semmle.label | successor |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | semmle.label | true |
-| Conditions.cs:81:12:81:12 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | false |
+| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b | semmle.label | successor |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | semmle.label | true |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | false |
 | Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ | semmle.label | successor |
 | Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:83:16:83:16 | access to local variable x | semmle.label | successor |
 | Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x | semmle.label | successor |
@@ -883,16 +883,16 @@
 | Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null | semmle.label | successor |
 | Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... | semmle.label | successor |
 | Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... | semmle.label | successor |
-| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:21:116:21 | 0 | semmle.label | successor |
-| Conditions.cs:116:17:116:21 | Int32 i = ... | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
-| Conditions.cs:116:21:116:21 | 0 | Conditions.cs:116:17:116:21 | Int32 i = ... | semmle.label | successor |
-| Conditions.cs:116:24:116:24 | access to local variable i | Conditions.cs:116:28:116:31 | access to parameter args | semmle.label | successor |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | semmle.label | false |
-| Conditions.cs:116:24:116:38 | ... < ... | Conditions.cs:117:9:123:9 | {...} | semmle.label | true |
-| Conditions.cs:116:28:116:31 | access to parameter args | Conditions.cs:116:28:116:38 | access to property Length | semmle.label | successor |
-| Conditions.cs:116:28:116:38 | access to property Length | Conditions.cs:116:24:116:38 | ... < ... | semmle.label | successor |
-| Conditions.cs:116:41:116:41 | access to local variable i | Conditions.cs:116:41:116:43 | ...++ | semmle.label | successor |
-| Conditions.cs:116:41:116:43 | ...++ | Conditions.cs:116:24:116:24 | access to local variable i | semmle.label | successor |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:22:116:22 | 0 | semmle.label | successor |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i | semmle.label | successor |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... | semmle.label | successor |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args | semmle.label | successor |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 | semmle.label | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | semmle.label | true |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length | semmle.label | successor |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... | semmle.label | successor |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ | semmle.label | successor |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:25:116:25 | access to local variable i | semmle.label | successor |
 | Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; | semmle.label | successor |
 | Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i | semmle.label | successor |
 | Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... | semmle.label | successor |
@@ -911,9 +911,9 @@
 | Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | semmle.label | successor |
 | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | semmle.label | successor |
 | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | semmle.label | successor |
-| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | false |
+| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:42:116:42 | access to local variable i | semmle.label | false |
 | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | semmle.label | true |
-| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:41:116:41 | access to local variable i | semmle.label | successor |
+| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:42:116:42 | access to local variable i | semmle.label | successor |
 | Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null | semmle.label | successor |
 | Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... | semmle.label | successor |
 | Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} | semmle.label | successor |
@@ -958,6 +958,30 @@
 | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | semmle.label | successor |
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | semmle.label | successor |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | semmle.label | successor |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} | semmle.label | successor |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; | semmle.label | successor |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:29 | ... ? ... : ... | semmle.label | successor |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | semmle.label | successor |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | semmle.label | successor |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | semmle.label | true |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | semmle.label | false |
+| Conditions.cs:145:17:145:29 | ... ? ... : ... | Conditions.cs:145:17:145:17 | access to parameter b | semmle.label | successor |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | semmle.label | successor |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | semmle.label | successor |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | semmle.label | successor |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | semmle.label | successor |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | semmle.label | false |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | semmle.label | true |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:40:147:43 | "a = " | semmle.label | successor |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:13:147:48 | call to method WriteLine | semmle.label | successor |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:45:147:45 | access to local variable s | semmle.label | successor |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:38:147:47 | $"..." | semmle.label | successor |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 | semmle.label | successor |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:40:149:43 | "b = " | semmle.label | successor |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:13:149:48 | call to method WriteLine | semmle.label | successor |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s | semmle.label | successor |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." | semmle.label | successor |
 | ExitMethods.cs:7:10:7:11 | enter M1 | ExitMethods.cs:8:5:11:5 | {...} | semmle.label | successor |
 | ExitMethods.cs:8:5:11:5 | {...} | ExitMethods.cs:9:9:9:25 | ...; | semmle.label | successor |
 | ExitMethods.cs:9:9:9:24 | call to method ErrorMaybe | ExitMethods.cs:10:9:10:15 | return ...; | semmle.label | successor |
@@ -2722,10 +2746,10 @@
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | call to method Throw | semmle.label | match |
 | Switch.cs:27:18:27:25 | Double d | Switch.cs:30:13:30:20 | default: | semmle.label | no-match |
 | Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | exit M2 | semmle.label | exception(Exception) |
-| Switch.cs:28:17:28:21 | Label: | Switch.cs:29:17:29:23 | return ...; | semmle.label | successor |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | return ...; | semmle.label | successor |
 | Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 | semmle.label | return |
 | Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; | semmle.label | successor |
-| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:17:28:21 | Label: | semmle.label | goto(Label) |
+| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: | semmle.label | goto(Label) |
 | Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} | semmle.label | successor |
 | Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw | semmle.label | successor |
@@ -2750,73 +2774,73 @@
 | Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 | semmle.label | successor |
 | Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 | semmle.label | successor |
-| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:20 | case ...: | semmle.label | successor |
+| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:19 | case ...: | semmle.label | successor |
 | Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... | semmle.label | successor |
-| Switch.cs:59:13:59:20 | case ...: | Switch.cs:59:18:59:18 | 2 | semmle.label | successor |
-| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:20 | case ...: | semmle.label | no-match |
-| Switch.cs:61:13:61:20 | case ...: | Switch.cs:61:18:61:18 | 3 | semmle.label | successor |
-| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:15:62:20 | break; | semmle.label | match |
-| Switch.cs:62:15:62:20 | break; | Switch.cs:55:10:55:11 | exit M5 | semmle.label | break |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 | semmle.label | successor |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: | semmle.label | no-match |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 | semmle.label | successor |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; | semmle.label | match |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 | semmle.label | break |
 | Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} | semmle.label | successor |
 | Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s | semmle.label | successor |
-| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:24 | case ...: | semmle.label | successor |
+| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: | semmle.label | successor |
 | Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... | semmle.label | successor |
-| Switch.cs:70:13:70:24 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | semmle.label | successor |
-| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:21 | case ...: | semmle.label | no-match |
-| Switch.cs:72:13:72:21 | case ...: | Switch.cs:72:18:72:19 | "" | semmle.label | successor |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 | semmle.label | successor |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: | semmle.label | no-match |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" | semmle.label | successor |
 | Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 | semmle.label | no-match |
-| Switch.cs:72:18:72:19 | "" | Switch.cs:73:15:73:20 | break; | semmle.label | match |
-| Switch.cs:73:15:73:20 | break; | Switch.cs:66:10:66:11 | exit M6 | semmle.label | break |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; | semmle.label | match |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | exit M6 | semmle.label | break |
 | Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} | semmle.label | successor |
 | Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i | semmle.label | successor |
-| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:20 | case ...: | semmle.label | successor |
-| Switch.cs:81:13:81:20 | case ...: | Switch.cs:81:18:81:18 | 1 | semmle.label | successor |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:22:82:25 | true | semmle.label | match |
-| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:20 | case ...: | semmle.label | no-match |
-| Switch.cs:82:15:82:26 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
-| Switch.cs:82:22:82:25 | true | Switch.cs:82:15:82:26 | return ...; | semmle.label | successor |
-| Switch.cs:83:13:83:20 | case ...: | Switch.cs:83:18:83:18 | 2 | semmle.label | successor |
-| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:15:85:22 | if (...) ... | semmle.label | match |
+| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: | semmle.label | successor |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 | semmle.label | successor |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:24:82:27 | true | semmle.label | match |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:19 | case ...: | semmle.label | no-match |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; | semmle.label | successor |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 | semmle.label | successor |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... | semmle.label | match |
 | Switch.cs:83:18:83:18 | 2 | Switch.cs:88:16:88:20 | false | semmle.label | no-match |
-| Switch.cs:84:15:85:22 | if (...) ... | Switch.cs:84:19:84:19 | access to parameter j | semmle.label | successor |
-| Switch.cs:84:19:84:19 | access to parameter j | Switch.cs:84:23:84:23 | 2 | semmle.label | successor |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:85:17:85:22 | break; | semmle.label | true |
-| Switch.cs:84:19:84:23 | ... > ... | Switch.cs:86:22:86:25 | true | semmle.label | false |
-| Switch.cs:84:23:84:23 | 2 | Switch.cs:84:19:84:23 | ... > ... | semmle.label | successor |
-| Switch.cs:85:17:85:22 | break; | Switch.cs:88:16:88:20 | false | semmle.label | break |
-| Switch.cs:86:15:86:26 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
-| Switch.cs:86:22:86:25 | true | Switch.cs:86:15:86:26 | return ...; | semmle.label | successor |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:21 | access to parameter j | semmle.label | successor |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 | semmle.label | successor |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | semmle.label | true |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | semmle.label | false |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:25 | ... > ... | semmle.label | successor |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:88:16:88:20 | false | semmle.label | break |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; | semmle.label | successor |
 | Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | exit M7 | semmle.label | return |
 | Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; | semmle.label | successor |
 | Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} | semmle.label | successor |
 | Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o | semmle.label | successor |
-| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:24 | case ...: | semmle.label | successor |
-| Switch.cs:95:13:95:24 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | semmle.label | successor |
-| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:22:96:25 | true | semmle.label | match |
+| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: | semmle.label | successor |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 | semmle.label | successor |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:24:96:27 | true | semmle.label | match |
 | Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:98:16:98:20 | false | semmle.label | no-match |
-| Switch.cs:96:15:96:26 | return ...; | Switch.cs:91:10:91:11 | exit M8 | semmle.label | return |
-| Switch.cs:96:22:96:25 | true | Switch.cs:96:15:96:26 | return ...; | semmle.label | successor |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | exit M8 | semmle.label | return |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; | semmle.label | successor |
 | Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | exit M8 | semmle.label | return |
 | Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; | semmle.label | successor |
 | Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} | semmle.label | successor |
 | Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s | semmle.label | successor |
 | Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:19:103:25 | access to property Length | semmle.label | non-null |
-| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:20 | case ...: | semmle.label | null |
-| Switch.cs:103:19:103:25 | access to property Length | Switch.cs:105:13:105:20 | case ...: | semmle.label | successor |
-| Switch.cs:105:13:105:20 | case ...: | Switch.cs:105:18:105:18 | 0 | semmle.label | successor |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:29:105:29 | 0 | semmle.label | match |
-| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:20 | case ...: | semmle.label | no-match |
-| Switch.cs:105:22:105:30 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
-| Switch.cs:105:29:105:29 | 0 | Switch.cs:105:22:105:30 | return ...; | semmle.label | successor |
-| Switch.cs:106:13:106:20 | case ...: | Switch.cs:106:18:106:18 | 1 | semmle.label | successor |
-| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:29:106:29 | 1 | semmle.label | match |
+| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:19 | case ...: | semmle.label | null |
+| Switch.cs:103:19:103:25 | access to property Length | Switch.cs:105:13:105:19 | case ...: | semmle.label | successor |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 | semmle.label | successor |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:28:105:28 | 0 | semmle.label | match |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:19 | case ...: | semmle.label | no-match |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; | semmle.label | successor |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 | semmle.label | successor |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:28:106:28 | 1 | semmle.label | match |
 | Switch.cs:106:18:106:18 | 1 | Switch.cs:108:17:108:17 | 1 | semmle.label | no-match |
-| Switch.cs:106:22:106:30 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
-| Switch.cs:106:29:106:29 | 1 | Switch.cs:106:22:106:30 | return ...; | semmle.label | successor |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; | semmle.label | successor |
 | Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | exit M9 | semmle.label | return |
 | Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; | semmle.label | successor |
 | Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... | semmle.label | successor |
@@ -2827,25 +2851,25 @@
 | Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} | semmle.label | successor |
 | Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s | semmle.label | successor |
 | Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length | semmle.label | successor |
-| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:34 | case ...: | semmle.label | successor |
-| Switch.cs:117:13:117:34 | case ...: | Switch.cs:117:18:117:18 | 3 | semmle.label | successor |
+| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:35 | case ...: | semmle.label | successor |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 | semmle.label | successor |
 | Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:25 | access to parameter s | semmle.label | match |
-| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:33 | case ...: | semmle.label | no-match |
-| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:28:117:32 | "foo" | semmle.label | successor |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:117:43:117:43 | 1 | semmle.label | true |
-| Switch.cs:117:25:117:32 | ... == ... | Switch.cs:118:13:118:33 | case ...: | semmle.label | false |
-| Switch.cs:117:28:117:32 | "foo" | Switch.cs:117:25:117:32 | ... == ... | semmle.label | successor |
-| Switch.cs:117:36:117:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
-| Switch.cs:117:43:117:43 | 1 | Switch.cs:117:36:117:44 | return ...; | semmle.label | successor |
-| Switch.cs:118:13:118:33 | case ...: | Switch.cs:118:18:118:18 | 2 | semmle.label | successor |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:34 | case ...: | semmle.label | no-match |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" | semmle.label | successor |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 | semmle.label | true |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | semmle.label | false |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... | semmle.label | successor |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; | semmle.label | successor |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 | semmle.label | successor |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:25 | access to parameter s | semmle.label | match |
 | Switch.cs:118:18:118:18 | 2 | Switch.cs:120:17:120:17 | 1 | semmle.label | no-match |
-| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:28:118:31 | "fu" | semmle.label | successor |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:118:42:118:42 | 2 | semmle.label | true |
-| Switch.cs:118:25:118:31 | ... == ... | Switch.cs:120:17:120:17 | 1 | semmle.label | false |
-| Switch.cs:118:28:118:31 | "fu" | Switch.cs:118:25:118:31 | ... == ... | semmle.label | successor |
-| Switch.cs:118:35:118:43 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
-| Switch.cs:118:42:118:42 | 2 | Switch.cs:118:35:118:43 | return ...; | semmle.label | successor |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" | semmle.label | successor |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | semmle.label | true |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | semmle.label | false |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:33 | ... == ... | semmle.label | successor |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; | semmle.label | successor |
 | Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | exit M10 | semmle.label | return |
 | Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; | semmle.label | successor |
 | Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... | semmle.label | successor |
@@ -2913,6 +2937,33 @@
 | Switch.cs:150:18:150:18 | 2 | Switch.cs:150:28:150:28 | 2 | semmle.label | match |
 | Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 | semmle.label | return |
 | Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; | semmle.label | successor |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} | semmle.label | successor |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; | semmle.label | successor |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:54 | ... switch { ... } | semmle.label | successor |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... | semmle.label | successor |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:38 | ... => ... | semmle.label | successor |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:17:156:17 | access to parameter b | semmle.label | successor |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" | semmle.label | match |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:52 | ... => ... | semmle.label | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:28:156:31 | true | semmle.label | successor |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 | semmle.label | exception(InvalidOperationException) |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | semmle.label | match |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:41:156:45 | false | semmle.label | successor |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:13:156:54 | String s = ... | semmle.label | successor |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b | semmle.label | successor |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | semmle.label | true |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | semmle.label | false |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:40:158:43 | "a = " | semmle.label | successor |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:13:158:48 | call to method WriteLine | semmle.label | successor |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:45:158:45 | access to local variable s | semmle.label | successor |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:38:158:47 | $"..." | semmle.label | successor |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 | semmle.label | successor |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:40:160:43 | "b = " | semmle.label | successor |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:13:160:48 | call to method WriteLine | semmle.label | successor |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s | semmle.label | successor |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." | semmle.label | successor |
 | TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} | semmle.label | successor |
 | TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; | semmle.label | successor |
 | TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -160,6 +160,14 @@ booleanNode
 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Field2 (line 129): true |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Field1 (line 129): true |
 | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Field2 (line 129): true |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | b (line 143): false |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | b (line 143): true |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | b (line 143): true |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | b (line 143): false |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | b (line 143): false |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | b (line 143): true |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | b (line 143): false |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | b (line 143): true |
 | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | b1 (line 176): true |
 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | b1 (line 176): true |
 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | b1 (line 176): false |
@@ -678,6 +686,7 @@ entryPoint
 | Conditions.cs:102:12:102:13 | M8 | Conditions.cs:103:5:111:5 | {...} |
 | Conditions.cs:113:10:113:11 | M9 | Conditions.cs:114:5:124:5 | {...} |
 | Conditions.cs:129:10:129:12 | M10 | Conditions.cs:130:5:141:5 | {...} |
+| Conditions.cs:143:10:143:12 | M11 | Conditions.cs:144:5:150:5 | {...} |
 | ExitMethods.cs:7:10:7:11 | M1 | ExitMethods.cs:8:5:11:5 | {...} |
 | ExitMethods.cs:13:10:13:11 | M2 | ExitMethods.cs:14:5:17:5 | {...} |
 | ExitMethods.cs:19:10:19:11 | M3 | ExitMethods.cs:20:5:23:5 | {...} |
@@ -821,6 +830,7 @@ entryPoint
 | Switch.cs:129:12:129:14 | M12 | Switch.cs:130:5:132:5 | {...} |
 | Switch.cs:134:9:134:11 | M13 | Switch.cs:135:5:142:5 | {...} |
 | Switch.cs:144:9:144:11 | M14 | Switch.cs:145:5:152:5 | {...} |
+| Switch.cs:154:10:154:12 | M15 | Switch.cs:155:5:161:5 | {...} |
 | TypeAccesses.cs:3:10:3:10 | M | TypeAccesses.cs:4:5:9:5 | {...} |
 | VarDecls.cs:5:18:5:19 | M1 | VarDecls.cs:6:5:11:5 | {...} |
 | VarDecls.cs:13:12:13:13 | M2 | VarDecls.cs:14:5:17:5 | {...} |

--- a/csharp/ql/test/library-tests/controlflow/graph/Switch.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Switch.cs
@@ -25,7 +25,7 @@ class Switch
                 Console.WriteLine(s);
                 return;
             case double d when Throw():
-                Label:
+            Label:
                 return;
             default:
                 goto Label;
@@ -56,10 +56,10 @@ class Switch
     {
         switch (1 + 2)
         {
-            case 2 :
-              break;
-            case 3 :
-              break;
+            case 2:
+                break;
+            case 3:
+                break;
         }
     }
 
@@ -67,10 +67,10 @@ class Switch
     {
         switch ((object)s)
         {
-            case int _ :
-              break;
-            case "" :
-              break;
+            case int _:
+                break;
+            case "":
+                break;
         }
     }
 
@@ -78,12 +78,12 @@ class Switch
     {
         switch (i)
         {
-            case 1 :
-              return true;
-            case 2 :
-              if (j > 2)
-                break;
-              return true;
+            case 1:
+                return true;
+            case 2:
+                if (j > 2)
+                    break;
+                return true;
         }
         return false;
     }
@@ -92,8 +92,8 @@ class Switch
     {
         switch (o)
         {
-            case int _ :
-              return true;
+            case int _:
+                return true;
         }
         return false;
     }
@@ -102,8 +102,8 @@ class Switch
     {
         switch (s?.Length)
         {
-            case 0 : return 0;
-            case 1 : return 1;
+            case 0: return 0;
+            case 1: return 1;
         }
         return -1;
     }
@@ -114,8 +114,8 @@ class Switch
     {
         switch (s.Length)
         {
-            case 3 when s=="foo" : return 1;
-            case 2 when s=="fu" : return 2;
+            case 3 when s == "foo": return 1;
+            case 2 when s == "fu": return 2;
         }
         return -1;
     }
@@ -149,5 +149,14 @@ class Switch
             default: return -1;
             case 2: return 2;
         }
+    }
+
+    void M15(bool b)
+    {
+        var s = b switch { true => "a", false => "b" };
+        if (b)
+            System.Console.WriteLine($"a = {s}");
+        else
+            System.Console.WriteLine($"b = {s}");
     }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -60,3 +60,5 @@
 | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s |
+| Splitting.cs:50:19:50:19 | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlow.expected
@@ -58,3 +58,5 @@
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x |
+| Splitting.cs:41:19:41:19 | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -240,6 +240,8 @@ edges
 | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element : String |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
 nodes
 | Capture.cs:7:20:7:26 | tainted : String | semmle.label | tainted : String |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
@@ -443,12 +445,17 @@ nodes
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | semmle.label | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | semmle.label | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
+| Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
 #select
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | [b (line 24): true] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): false] access to local variable x | [b (line 3): false] access to local variable x |
 | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | Splitting.cs:3:28:3:34 | tainted : String | Splitting.cs:9:15:9:15 | [b (line 3): true] access to local variable x | [b (line 3): true] access to local variable x |
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
+| Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |
 | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | access to local variable sink1 |
 | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -242,6 +242,8 @@ edges
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s |
 nodes
 | Capture.cs:7:20:7:26 | tainted : String | semmle.label | tainted : String |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
@@ -448,6 +450,9 @@ nodes
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
 | Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | semmle.label | "taint source" : String |
+| Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
 #select
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | [b (line 24): true] access to local variable x |
@@ -456,6 +461,8 @@ nodes
 | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:19:15:19:29 | access to field SinkField0 | access to field SinkField0 |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |
+| Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |
 | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:72:15:72:19 | access to local variable sink0 | access to local variable sink0 |
 | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | GlobalDataFlow.cs:18:27:18:40 | "taint source" : String | GlobalDataFlow.cs:74:15:74:19 | access to local variable sink1 | access to local variable sink1 |
 | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | GlobalDataFlow.cs:338:16:338:29 | "taint source" : String | GlobalDataFlow.cs:191:15:191:20 | access to local variable sink10 | access to local variable sink10 |

--- a/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
@@ -47,8 +47,8 @@ class Splitting
     {
         var s = b switch { true => "taint source", false => "not tainted" };
         if (b)
-            Check(s); // flow [MISSING]
+            Check(s); // flow
         else
-            Check(s); // no flow
+            Check(s); // no flow [FALSE POSITIVE]
     }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
+++ b/csharp/ql/test/library-tests/dataflow/global/Splitting.cs
@@ -33,4 +33,22 @@ class Splitting
         if (b)
             Check(x);
     }
+
+    void M3(bool b)
+    {
+        var s = b ? "taint source" : "not tainted";
+        if (b)
+            Check(s); // flow
+        else
+            Check(s); // no flow [FALSE POSITIVE]
+    }
+
+    void M4(bool b)
+    {
+        var s = b switch { true => "taint source", false => "not tainted" };
+        if (b)
+            Check(s); // flow [MISSING]
+        else
+            Check(s); // no flow
+    }
 }

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -62,3 +62,5 @@
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x |
+| Splitting.cs:41:19:41:19 | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTracking.expected
@@ -64,3 +64,5 @@
 | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s |
+| Splitting.cs:50:19:50:19 | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -247,6 +247,8 @@ edges
 | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String | Splitting.cs:34:19:34:19 | access to local variable x |
 | Splitting.cs:31:19:31:25 | [b (line 24): false] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): false] dynamic access to element : String |
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
 nodes
 | Capture.cs:7:20:7:26 | tainted : String | semmle.label | tainted : String |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
@@ -457,6 +459,9 @@ nodes
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | semmle.label | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | semmle.label | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | semmle.label | access to local variable x |
+| Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
+| Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
 #select
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
@@ -522,3 +527,5 @@ nodes
 | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): false] access to local variable x | [b (line 24): false] access to local variable x |
 | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:32:15:32:15 | [b (line 24): true] access to local variable x | [b (line 24): true] access to local variable x |
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
+| Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
+| Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -249,6 +249,8 @@ edges
 | Splitting.cs:31:19:31:25 | [b (line 24): true] access to parameter tainted : String | Splitting.cs:31:17:31:26 | [b (line 24): true] dynamic access to element : String |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s |
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s |
 nodes
 | Capture.cs:7:20:7:26 | tainted : String | semmle.label | tainted : String |
 | Capture.cs:12:19:12:24 | access to local variable sink27 | semmle.label | access to local variable sink27 |
@@ -462,6 +464,9 @@ nodes
 | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | semmle.label | [b (line 37): true] "taint source" : String |
 | Splitting.cs:41:19:41:19 | access to local variable s | semmle.label | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:48:36:48:49 | "taint source" : String | semmle.label | "taint source" : String |
+| Splitting.cs:50:19:50:19 | access to local variable s | semmle.label | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s | semmle.label | access to local variable s |
 #select
 | Capture.cs:12:19:12:24 | access to local variable sink27 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:12:19:12:24 | access to local variable sink27 | access to local variable sink27 |
 | Capture.cs:21:23:21:28 | access to local variable sink28 | Capture.cs:7:20:7:26 | tainted : String | Capture.cs:21:23:21:28 | access to local variable sink28 | access to local variable sink28 |
@@ -529,3 +534,5 @@ nodes
 | Splitting.cs:34:19:34:19 | access to local variable x | Splitting.cs:24:28:24:34 | tainted : String | Splitting.cs:34:19:34:19 | access to local variable x | access to local variable x |
 | Splitting.cs:41:19:41:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:41:19:41:19 | access to local variable s | access to local variable s |
 | Splitting.cs:43:19:43:19 | access to local variable s | Splitting.cs:39:21:39:34 | [b (line 37): true] "taint source" : String | Splitting.cs:43:19:43:19 | access to local variable s | access to local variable s |
+| Splitting.cs:50:19:50:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:50:19:50:19 | access to local variable s | access to local variable s |
+| Splitting.cs:52:19:52:19 | access to local variable s | Splitting.cs:48:36:48:49 | "taint source" : String | Splitting.cs:52:19:52:19 | access to local variable s | access to local variable s |


### PR DESCRIPTION
Turns out we had forgotten to add flow from switch-arm expressions to the surrounding switch expression.

This PR also adds a couple of tests that illustrate problems with data-flow and control-flow splitting; I intend to address those in a separate PR.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/514/