### PR TITLE
JavaScript: Add a negative test for API graphs.

### DIFF
--- a/javascript/ql/test/ApiGraphs/property-read-from-argument/VerifyAssertions.ql
+++ b/javascript/ql/test/ApiGraphs/property-read-from-argument/VerifyAssertions.ql
@@ -1,0 +1,1 @@
+import ApiGraphs.VerifyAssertions

--- a/javascript/ql/test/ApiGraphs/property-read-from-argument/index.js
+++ b/javascript/ql/test/ApiGraphs/property-read-from-argument/index.js
@@ -1,0 +1,9 @@
+exports.assertNotNull = function (x) {
+    if (x === null)
+        throw new TypeError();
+}
+
+exports.foo = function(x) {
+    exports.assertNotNull(x);
+    sink(x.f); /* !use (member f (parameter 0 (member assertNotNull (member exports (module property-read-from-argument))))) */ /* use (member f (parameter 0 (member foo (member exports (module property-read-from-argument))))) */
+}

--- a/javascript/ql/test/ApiGraphs/property-read-from-argument/package.json
+++ b/javascript/ql/test/ApiGraphs/property-read-from-argument/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "property-read-from-argument"
+}


### PR DESCRIPTION
The test ensures that flow summarization won't label property `f` of the first parameter of `assertNotNull` as a sink, which would be very imprecise.