### PR TITLE
RFC - framework data-flow packs

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
@@ -140,23 +140,23 @@ class FlowSource = Impl::FlowSource;
 module FlowSource {
   class Range = Impl::FlowSource::Range;
 
-  private class RemoteFlowSource extends Range {
-    RemoteFlowSource() { this = "remote" }
+  private class RemoteFlowSourceRange extends Range {
+    RemoteFlowSourceRange() { this = "remote" }
   }
 
-  FlowSource remote() { result = any(RemoteFlowSource s).toFlowSource() }
+  FlowSource remote() { result = any(RemoteFlowSourceRange s).toFlowSource() }
 
-  private class LocalFlowSource extends Range {
-    LocalFlowSource() { this = "local" }
+  private class LocalFlowSourceRange extends Range {
+    LocalFlowSourceRange() { this = "local" }
   }
 
-  FlowSource local() { result = any(LocalFlowSource s).toFlowSource() }
+  FlowSource local() { result = any(LocalFlowSourceRange s).toFlowSource() }
 
-  private class StoredFlowSource extends Range {
-    StoredFlowSource() { this = "stored" }
+  private class StoredFlowSourceRange extends Range {
+    StoredFlowSourceRange() { this = "stored" }
   }
 
-  FlowSource stored() { result = any(StoredFlowSource s).toFlowSource() }
+  FlowSource stored() { result = any(StoredFlowSourceRange s).toFlowSource() }
 }
 
 class FlowSink = Impl::FlowSink;
@@ -165,39 +165,36 @@ class FlowSink = Impl::FlowSink;
 module FlowSink {
   class Range = Impl::FlowSink::Range;
 
-  private class RemoteFlowSink extends Range {
-    RemoteFlowSink() { this = "remote" }
+  abstract private class RemoteFlowSinkRange extends Range {
+    bindingset[this]
+    RemoteFlowSinkRange() { any() }
   }
 
-  FlowSink remote() { result = any(RemoteFlowSink s).toFlowSink() }
+  FlowSink remote() { result = any(RemoteFlowSinkRange s).toFlowSink() }
 
-  private class HtmlFlowSink extends Range {
-    HtmlFlowSink() { this = "html" }
-
-    override predicate isSubsetOf(FlowSink fs) { fs = remote() }
+  private class HtmlFlowSinkRange extends RemoteFlowSinkRange {
+    HtmlFlowSinkRange() { this = "html" }
   }
 
-  FlowSink html() { result = any(HtmlFlowSink s).toFlowSink() }
+  FlowSink html() { result = any(HtmlFlowSinkRange s).toFlowSink() }
 
-  private class EmailFlowSink extends Range {
-    EmailFlowSink() { this = "email" }
-
-    override predicate isSubsetOf(FlowSink fs) { fs = remote() }
+  private class EmailFlowSinkRange extends RemoteFlowSinkRange {
+    EmailFlowSinkRange() { this = "email" }
   }
 
-  FlowSink email() { result = any(EmailFlowSink s).toFlowSink() }
+  FlowSink email() { result = any(EmailFlowSinkRange s).toFlowSink() }
 
-  private class SqlFlowSink extends Range {
-    SqlFlowSink() { this = "sql" }
+  private class SqlFlowSinkRange extends Range {
+    SqlFlowSinkRange() { this = "sql" }
   }
 
-  FlowSink sql() { result = any(SqlFlowSink s).toFlowSink() }
+  FlowSink sql() { result = any(SqlFlowSinkRange s).toFlowSink() }
 
-  private class CommandFlowSink extends Range {
-    CommandFlowSink() { this = "command" }
+  private class CommandFlowSinkRange extends Range {
+    CommandFlowSinkRange() { this = "command" }
   }
 
-  FlowSink command() { result = any(CommandFlowSink s).toFlowSink() }
+  FlowSink command() { result = any(CommandFlowSinkRange s).toFlowSink() }
 }
 
 class FrameworkDataFlow = Impl::FrameworkDataFlow;

--- a/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
@@ -5,7 +5,9 @@
 import csharp
 private import internal.FrameworkDataFlowImpl as Impl
 private import internal.FrameworkDataFlowSpecific::Private
-private import internal.DataFlowPublic
+private import internal.DataFlowPublic as DataFlowPublic
+// import all instances below
+private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
 
 class FrameworkCallable = Impl::FrameworkCallable;
 
@@ -19,16 +21,18 @@ module ContentList {
   import Impl::ContentList
 
   /** Gets the singleton "element content" content list. */
-  ContentList element() { result = singleton(any(ElementContent c)) }
+  ContentList element() { result = singleton(any(DataFlowPublic::ElementContent c)) }
 
   /** Gets a singleton property content list. */
   ContentList property(Property p) {
-    result = singleton(any(PropertyContent c | c.getProperty() = p.getSourceDeclaration()))
+    result =
+      singleton(any(DataFlowPublic::PropertyContent c | c.getProperty() = p.getSourceDeclaration()))
   }
 
   /** Gets a singleton field content list. */
   ContentList field(Field f) {
-    result = singleton(any(FieldContent c | c.getField() = f.getSourceDeclaration()))
+    result =
+      singleton(any(DataFlowPublic::FieldContent c | c.getField() = f.getSourceDeclaration()))
   }
 }
 
@@ -113,6 +117,12 @@ module SummaryOutput {
    * as the output.
    */
   SummaryOutput thisParameter() { result = TParameterSummaryOutput(-1) }
+
+  /**
+   * Gets an output specification that specifies parameter `j` of the delegate at
+   * parameter `i` as the output.
+   */
+  SummaryOutput delegate(int i, int j) { result = TDelegateSummaryOutput(i, j) }
 
   /**
    * Gets an output specification that specifies parameter `j` of the delegate at
@@ -221,7 +231,7 @@ module Examples {
         name = "ToString" and
         input = SummaryInput::thisParameter() and
         inputContents = ContentList::element() and
-        output = SummaryOutput::thisParameter() and
+        output = SummaryOutput::return() and
         outputContents = ContentList::empty() and
         preservesValue = false
         or
@@ -255,7 +265,7 @@ module Examples {
     override predicate clearsContent(FrameworkCallable c, SummaryInput input, Content content) {
       c = this.getClass().getAMethod("Clear") and
       input = SummaryInput::thisParameter() and
-      content instanceof ElementContent
+      content instanceof DataFlowPublic::ElementContent
     }
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/FrameworkDataFlow.qll
@@ -1,0 +1,502 @@
+/**
+ * Provides classes and predicates for definining data-flow through frameworks.
+ */
+
+import csharp
+private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
+private import semmle.code.csharp.dataflow.internal.DataFlowPublic
+private import semmle.code.csharp.frameworks.system.Collections
+private import semmle.code.csharp.frameworks.system.collections.Generic
+private import semmle.code.csharp.frameworks.system.linq.Expressions
+
+/** An unbound callable. */
+class SourceDeclarationCallable extends Callable {
+  SourceDeclarationCallable() { this = this.getSourceDeclaration() }
+}
+
+/** An unbound method. */
+class SourceDeclarationMethod extends SourceDeclarationCallable, Method { }
+
+private predicate hasDelegateArgumentPosition(SourceDeclarationCallable c, int i) {
+  exists(DelegateType dt |
+    dt = c.getParameter(i).getType().(SystemLinqExpressions::DelegateExtType).getDelegateType()
+  |
+    not dt.getReturnType() instanceof VoidType
+  )
+}
+
+private predicate hasDelegateArgumentPosition2(SourceDeclarationCallable c, int i, int j) {
+  exists(DelegateType dt |
+    dt = c.getParameter(i).getType().(SystemLinqExpressions::DelegateExtType).getDelegateType()
+  |
+    exists(dt.getParameter(j))
+  )
+}
+
+/** INTERNAL: Do not use. */
+module Internal {
+  newtype TContentStack =
+    TNilContentStack() or
+    TPushContentStack(Content head, ContentStack tail) {
+      tail = TNilContentStack()
+      or
+      exists(FrameworkDataFlow fdf |
+        fdf.requiresContentStack(head, tail) and
+        tail.length() < accessPathLimit()
+      )
+      or
+      tail = ContentStack::singleton(_) and
+      head instanceof ElementContent
+      or
+      tail = ContentStack::element()
+    }
+
+  newtype TSummaryInput =
+    TQualifierSummaryInput() or
+    TArgumentSummaryInput(int i) { i = any(Parameter p).getPosition() } or
+    TDelegateSummaryInput(int i) { hasDelegateArgumentPosition(_, i) }
+
+  newtype TSummaryOutput =
+    TQualifierSummaryOutput() or
+    TReturnSummaryOutput() or
+    TArgumentSummaryOutput(int i) {
+      exists(SourceDeclarationCallable c | exists(c.getParameter(i)))
+    } or
+    TDelegateSummaryOutput(int i, int j) { hasDelegateArgumentPosition2(_, i, j) }
+
+  newtype TFlowSource =
+    TRemoteFlowSource() or
+    TLocalFlowSource() or
+    TStoredFlowSource()
+
+  newtype TFlowSink =
+    TRemoteFlowSink() or
+    THtmlFlowSink() or
+    TEmailFlowSink() or
+    TSqlFlowSink() or
+    TCommandFlowSink()
+
+  /** Holds if a flow-source of kind `a` is also a flow-source of kind `b`. */
+  predicate flowSourceSubset(FlowSource a, FlowSource b) { none() }
+
+  /** Holds if a flow-sink of kind `a` is also a flow-sink of kind `b`. */
+  predicate flowSinkSubset(FlowSink a, FlowSink b) {
+    a in [THtmlFlowSink().(FlowSink), TEmailFlowSink().(FlowSink)] and
+    b = TRemoteFlowSink()
+  }
+}
+
+private import Internal
+
+/** A content stack. */
+class ContentStack extends TContentStack {
+  /** Gets the content stack obtained by popping `c` from this stack, if any. */
+  ContentStack pop(Content c) { this = TPushContentStack(c, result) }
+
+  /** Gets the length of this content stack. */
+  int length() {
+    this = TNilContentStack() and result = 0
+    or
+    result = 1 + this.pop(_).length()
+  }
+
+  /** Gets the content stack obtained by dropping the first `i` elements, if any. */
+  ContentStack drop(int i) {
+    i = 0 and result = this
+    or
+    result = this.pop(_).drop(i - 1)
+  }
+
+  /** Holds if this content stack contains content `c`. */
+  predicate contains(Content c) { exists(this.drop(_).pop(c)) }
+
+  /** Gets a textual representation of this content stack. */
+  string toString() {
+    exists(Content head, ContentStack tail |
+      tail = this.pop(head) and
+      if tail.length() = 0 then result = head.toString() else result = head + ", " + tail
+    )
+    or
+    this = TNilContentStack() and
+    result = "<empty>"
+  }
+}
+
+/** Provides predicates for constructing content stacks. */
+module ContentStack {
+  /** Gets the empty content stack. */
+  ContentStack empty() { result = TNilContentStack() }
+
+  /** Gets a singleton content stack containing `c`. */
+  ContentStack singleton(Content c) { result = TPushContentStack(c, TNilContentStack()) }
+
+  /** Gets the content stack obtained by pushing `head` onto `tail`. */
+  ContentStack push(Content head, ContentStack tail) { result = TPushContentStack(head, tail) }
+
+  /** Gets the singleton "element content" content stack. */
+  ContentStack element() { result = singleton(any(ElementContent c)) }
+
+  /** Gets a singleton property content stack. */
+  ContentStack property(Property p) {
+    result = singleton(any(PropertyContent c | c.getProperty() = p.getSourceDeclaration()))
+  }
+
+  /** Gets a singleton field content stack. */
+  ContentStack field(Field f) {
+    result = singleton(any(FieldContent c | c.getField() = f.getSourceDeclaration()))
+  }
+}
+
+/** A flow-summary input specification. */
+class SummaryInput extends TSummaryInput {
+  /** Gets a textual representation of this input specification. */
+  final string toString() {
+    this = TQualifierSummaryInput() and
+    result = "qualifier"
+    or
+    exists(int i |
+      this = TArgumentSummaryInput(i) and
+      result = "argument " + i
+      or
+      this = TDelegateSummaryInput(i) and
+      result = "output from argument " + i
+    )
+  }
+}
+
+/** Provides predicate for constructing flow-summary input specifications */
+module SummaryInput {
+  /**
+   * Gets an input specification that specifies the qualifier in a call as
+   * the input.
+   */
+  SummaryInput qualifier() { result = TQualifierSummaryInput() }
+
+  /**
+   * Gets an input specification that specifies the `i`th argument in a call as
+   * the input.
+   */
+  SummaryInput argument(int i) { result = TArgumentSummaryInput(i) }
+
+  private predicate isCollectionType(ValueOrRefType t) {
+    t.getABaseType*() instanceof SystemCollectionsIEnumerableInterface and
+    not t instanceof StringType
+  }
+
+  /**
+   * Gets an input specification that specifies the `i`th argument as the input.
+   *
+   * `inputStack` is either empty or a singleton element content stack, depending
+   * on whether the type of the `i`th parameter of `c` is a collection type.
+   */
+  SummaryInput argument(SourceDeclarationCallable c, int i, ContentStack inputStack) {
+    result = argument(i) and
+    exists(Parameter p |
+      p = c.getParameter(i) and
+      if isCollectionType(p.getType())
+      then inputStack = ContentStack::element()
+      else inputStack = ContentStack::empty()
+    )
+  }
+
+  /**
+   * Gets an input specification that specifies output from the delegate at
+   * argument `i` as the input.
+   */
+  SummaryInput delegate(int i) { result = TDelegateSummaryInput(i) }
+
+  /**
+   * Gets an input specification that specifies output from the delegate at
+   * argument `i` as the input.
+   *
+   * `c` must be a compatible callable, that is, a callable where the `i`th
+   * parameter is a delegate.
+   */
+  SummaryInput delegate(SourceDeclarationCallable c, int i) {
+    result = delegate(i) and
+    hasDelegateArgumentPosition(c, i)
+  }
+}
+
+/** A flow-summary output specification. */
+class SummaryOutput extends TSummaryOutput {
+  /** Gets a textual representation of this flow sink specification. */
+  final string toString() {
+    this = TQualifierSummaryOutput() and
+    result = "qualifier"
+    or
+    this = TReturnSummaryOutput() and
+    result = "return"
+    or
+    exists(int i |
+      this = TArgumentSummaryOutput(i) and
+      result = "argument " + i
+    )
+    or
+    exists(int delegateIndex, int parameterIndex |
+      this = TDelegateSummaryOutput(delegateIndex, parameterIndex) and
+      result = "parameter " + parameterIndex + " of argument " + delegateIndex
+    )
+  }
+}
+
+/** Provides predicate for constructing flow-summary output specifications. */
+module SummaryOutput {
+  /**
+   * Gets an output specification that specifies the qualifier in a call as
+   * the output.
+   */
+  SummaryOutput qualifier() { result = TQualifierSummaryOutput() }
+
+  /**
+   * Gets an output specification that specifies the return value from a call as
+   * the output.
+   */
+  SummaryOutput return() { result = TReturnSummaryOutput() }
+
+  /**
+   * Gets an output specification that specifies the `i`th argument in a call as
+   * the output.
+   */
+  SummaryOutput argument(int i) { result = TArgumentSummaryOutput(i) }
+
+  /**
+   * Gets an output specification that specifies parameter `j` of the delegate at
+   * argument `i` as the output.
+   */
+  SummaryOutput delegate(SourceDeclarationCallable callable, int i, int j) {
+    result = TDelegateSummaryOutput(i, j) and
+    hasDelegateArgumentPosition2(callable, i, j)
+  }
+}
+
+/** A flow-source specification. */
+class FlowSource extends TFlowSource {
+  final string toString() {
+    this = TRemoteFlowSource() and
+    result = "remote"
+    or
+    this = TLocalFlowSource() and
+    result = "local"
+    or
+    this = TStoredFlowSource() and
+    result = "stored"
+  }
+}
+
+/** Provides predicates for constructing flow-source specifications. */
+module FlowSource {
+  FlowSource remote() { result = TRemoteFlowSource() }
+
+  FlowSource local() { result = TLocalFlowSource() }
+
+  FlowSource stored() { result = TStoredFlowSource() }
+}
+
+/** A flow-sink specification. */
+class FlowSink extends TFlowSink {
+  final string toString() {
+    this = TRemoteFlowSink() and
+    result = "remote"
+    or
+    this = THtmlFlowSink() and
+    result = "html"
+    or
+    this = TEmailFlowSink() and
+    result = "email"
+    or
+    this = TSqlFlowSink() and
+    result = "sql"
+    or
+    this = TCommandFlowSink() and
+    result = "command"
+  }
+}
+
+/** Provides predicates for constructing flow-sink specifications. */
+module FlowSink {
+  FlowSink remote() { result = TRemoteFlowSink() }
+
+  FlowSink html() { result = THtmlFlowSink() }
+
+  FlowSink email() { result = TEmailFlowSink() }
+
+  FlowSink sql() { result = TSqlFlowSink() }
+
+  FlowSink command() { result = TCommandFlowSink() }
+}
+
+/** A data-flow model for a given framework. */
+abstract class FrameworkDataFlow extends string {
+  bindingset[this]
+  FrameworkDataFlow() { any() }
+
+  /**
+   * Holds if data may flow from `input` to `output` when calling `c`.
+   *
+   * `inputStack` describes the contents that is popped from the access
+   * path from the input and `outputStack` describes the contents that
+   * is pushed onto the resulting access path.
+   *
+   * `preservesValue` indicates whether this is a value-preserving step
+   * or a taint-step.
+   */
+  pragma[nomagic]
+  predicate hasSummary(
+    SourceDeclarationCallable c, SummaryInput input, ContentStack inputStack, SummaryOutput output,
+    ContentStack outputStack, boolean preservesValue
+  ) {
+    none()
+  }
+
+  /**
+   * Holds if the content stack obtained by pushing `head` onto `tail` is
+   * needed for a summary specified by `hasSummary()`.
+   *
+   * This predicate is needed for QL technical reasons only (the IPA type used
+   * to represent content stacks needs to be bounded).
+   */
+  pragma[nomagic]
+  predicate requiresContentStack(Content head, ContentStack tail) { none() }
+
+  /**
+   * Holds if values stored inside `content` are cleared on objects passed as
+   * arguments of type `input` to calls that target `c`.
+   */
+  pragma[nomagic]
+  predicate clearsContent(SourceDeclarationCallable c, SummaryInput input, Content content) {
+    none()
+  }
+
+  /** Holds if `n` is a flow source of type `source. */
+  pragma[nomagic]
+  predicate hasSource(DataFlow::Node n, FlowSource source) { none() }
+
+  /** Holds if `n` is a flow sink of type `sink. */
+  pragma[nomagic]
+  predicate hasSink(DataFlow::Node n, FlowSink sink) { none() }
+}
+
+module Examples {
+  private import semmle.code.csharp.frameworks.system.Text
+
+  /** Data flow for `System.Text.StringBuilder`. */
+  class StringBuilderDataFlow extends FrameworkDataFlow {
+    StringBuilderDataFlow() { this = "System.Text.StringBuilder" }
+
+    private SystemTextStringBuilderClass getClass() { any() }
+
+    private predicate constructorFlow(
+      Constructor c, SummaryInput input, ContentStack inputAp, SummaryOutput output,
+      ContentStack outputAp
+    ) {
+      c = this.getClass().getAMember() and
+      c.getParameter(0).getType() instanceof StringType and
+      input = TArgumentSummaryInput(0) and
+      inputAp = ContentStack::empty() and
+      output = TReturnSummaryOutput() and
+      outputAp = ContentStack::element()
+    }
+
+    private predicate methodFlow(
+      SourceDeclarationMethod m, SummaryInput input, ContentStack inputAp, SummaryOutput output,
+      ContentStack outputAp, boolean preservesValue
+    ) {
+      exists(string name | m = this.getClass().getAMethod(name) |
+        name = "ToString" and
+        input = TQualifierSummaryInput() and
+        inputAp = ContentStack::element() and
+        output = TReturnSummaryOutput() and
+        outputAp = ContentStack::empty() and
+        preservesValue = false
+        or
+        exists(int i, Type t |
+          name.regexpMatch("Append(Format|Line)?") and
+          t = m.getParameter(i).getType() and
+          input = TArgumentSummaryInput(i) and
+          inputAp = ContentStack::empty() and
+          output = [TQualifierSummaryOutput().(TSummaryOutput), TReturnSummaryOutput()] and
+          outputAp = ContentStack::element() and
+          preservesValue = true
+        |
+          t instanceof StringType or
+          t instanceof ObjectType
+        )
+      )
+    }
+
+    override predicate hasSummary(
+      SourceDeclarationCallable c, SummaryInput input, ContentStack inputStack,
+      SummaryOutput output, ContentStack outputStack, boolean preservesValue
+    ) {
+      (
+        this.constructorFlow(c, input, inputStack, output, outputStack) and
+        preservesValue = true
+        or
+        this.methodFlow(c, input, inputStack, output, outputStack, preservesValue)
+      )
+    }
+
+    override predicate clearsContent(
+      SourceDeclarationCallable c, SummaryInput input, Content content
+    ) {
+      c = this.getClass().getAMethod("Clear") and
+      input = TQualifierSummaryInput() and
+      content instanceof ElementContent
+    }
+  }
+
+  private import semmle.code.csharp.frameworks.System
+
+  /** Data flow for `System.Lazy`. */
+  class LazyDataFlow extends FrameworkDataFlow {
+    LazyDataFlow() { this = "System.Lazy" }
+
+    private SystemLazyClass getClass() { any() }
+
+    override predicate hasSummary(
+      SourceDeclarationCallable c, SummaryInput input, ContentStack inputStack,
+      SummaryOutput output, ContentStack outputStack, boolean preservesValue
+    ) {
+      preservesValue = true and
+      exists(SystemFuncDelegateType t, int i | t.getNumberOfTypeParameters() = 1 |
+        c.(Constructor).getDeclaringType() = this.getClass() and
+        c.getParameter(i).getType().getSourceDeclaration() = t and
+        input = SummaryInput::delegate(c, i) and
+        inputStack = ContentStack::empty() and
+        output = TReturnSummaryOutput() and
+        outputStack = ContentStack::property(this.getClass().getValueProperty())
+      )
+      or
+      preservesValue = false and
+      c = this.getClass().getValueProperty().getGetter() and
+      input = TQualifierSummaryInput() and
+      inputStack = ContentStack::empty() and
+      output = TReturnSummaryOutput() and
+      outputStack = ContentStack::empty()
+    }
+  }
+
+  private import semmle.code.csharp.frameworks.system.Data
+  private import semmle.code.csharp.frameworks.system.data.SqlClient
+
+  class SqlClientDataFlow extends FrameworkDataFlow {
+    SqlClientDataFlow() { this = "SqlClientDataFlow" }
+
+    override predicate hasSink(Node n, FlowSink sink) {
+      sink = FlowSink::sql() and
+      (
+        exists(Property p, SystemDataIDbCommandInterface i, Property text |
+          text = i.getCommandTextProperty() and
+          p.overridesOrImplementsOrEquals(text) and
+          n.(ParameterNode).getParameter() = p.getSetter().getAParameter()
+        )
+        or
+        exists(InstanceConstructor ic | ic = n.asExpr().(ObjectCreation).getTarget() |
+          ic.getDeclaringType().getABaseType*() instanceof SystemDataIDbCommandInterface and
+          ic.getParameter(0).getType() instanceof StringType
+        )
+      )
+    }
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
@@ -174,11 +174,11 @@ abstract class FrameworkDataFlow extends string {
   pragma[nomagic]
   predicate clearsContent(FrameworkCallable c, SummaryInput input, Content content) { none() }
 
-  /** Holds if `n` is a flow source of type `source. */
+  /** Holds if output of type `output` from `c` is a flow source of type `source`. */
   pragma[nomagic]
-  predicate hasSource(Node n, FlowSource source) { none() }
+  predicate hasSource(FrameworkCallable c, SummaryOutput output, FlowSource source) { none() }
 
-  /** Holds if `n` is a flow sink of type `sink. */
+  /** Holds if input of type `input` to `c` is a flow sink of type `sink`. */
   pragma[nomagic]
-  predicate hasSink(Node n, FlowSink sink) { none() }
+  predicate hasSink(FrameworkCallable c, SummaryInput input, FlowSink sink) { none() }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
@@ -126,6 +126,19 @@ abstract class FrameworkDataFlow extends string {
   /**
    * Holds if data may flow from `input` to `output` when calling `c`.
    *
+   * `preservesValue` indicates whether this is a value-preserving step
+   * or a taint-step.
+   */
+  pragma[nomagic]
+  predicate hasSummary(
+    FrameworkCallable c, SummaryInput input, SummaryOutput output, boolean preservesValue
+  ) {
+    none()
+  }
+
+  /**
+   * Holds if data may flow from `input` to `output` when calling `c`.
+   *
    * `inputContents` describes the contents that is popped from the access
    * path from the input and `outputContents` describes the contents that
    * is pushed onto the resulting access path.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
@@ -2,7 +2,7 @@
  * Provides classes and predicates for definining data-flow through frameworks.
  *
  * The definitions in this file are language-independant, and language-specific
- * definitions are passed in via the `FrameworkDataFlowSpecific::Public` module.
+ * definitions are passed in via the `FrameworkDataFlowSpecific` module.
  */
 
 import FrameworkDataFlowSpecific::Public
@@ -77,8 +77,6 @@ class FlowSource extends MkFlowSource {
 
   FlowSource() { this = MkFlowSource(r) }
 
-  predicate isSubsetOf(FlowSource fs) { r.isSubsetOf(fs) }
-
   string toString() { result = r }
 }
 
@@ -86,8 +84,6 @@ module FlowSource {
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
-
-    predicate isSubsetOf(FlowSource fs) { none() }
 
     FlowSource toFlowSource() { result = MkFlowSource(this) }
   }
@@ -101,8 +97,6 @@ class FlowSink extends MkFlowSink {
 
   FlowSink() { this = MkFlowSink(r) }
 
-  predicate isSubsetOf(FlowSink fs) { r.isSubsetOf(fs) }
-
   string toString() { result = r }
 }
 
@@ -110,8 +104,6 @@ module FlowSink {
   abstract class Range extends string {
     bindingset[this]
     Range() { any() }
-
-    predicate isSubsetOf(FlowSink fs) { none() }
 
     FlowSink toFlowSink() { result = MkFlowSink(this) }
   }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
@@ -5,9 +5,8 @@
  * definitions are passed in via the `FrameworkDataFlowSpecific::Public` module.
  */
 
-private import DataFlowPrivate
-private import DataFlowPublic
 import FrameworkDataFlowSpecific::Public
+private import FrameworkDataFlowSpecific::Private
 
 private newtype TContentList =
   TNilContentList() or
@@ -181,4 +180,275 @@ abstract class FrameworkDataFlow extends string {
   /** Holds if input of type `input` to `c` is a flow sink of type `sink`. */
   pragma[nomagic]
   predicate hasSink(FrameworkCallable c, SummaryInput input, FlowSink sink) { none() }
+}
+
+/**
+ * Provides predicates for compiling flow summaries down to atomic local steps,
+ * read steps, and store steps.
+ */
+module Compilation {
+  private import DataFlowDispatch
+
+  /**
+   * Holds if data may flow from `input` to `output` when calling `c`.
+   *
+   * `inputContents` describes the contents that is popped from the access
+   * path from the input and `outputContents` describes the contents that
+   * is pushed onto the resulting access path.
+   *
+   * `preservesValue` indicates whether this is a value-preserving step
+   * or a taint-step.
+   */
+  pragma[nomagic]
+  predicate summary(
+    FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput output,
+    ContentList outputContents, boolean preservesValue
+  ) {
+    any(FrameworkDataFlow fdf).hasSummary(c, input, output, preservesValue) and
+    inputContents = ContentList::empty() and
+    outputContents = ContentList::empty()
+    or
+    any(FrameworkDataFlow fdf)
+        .hasSummary(c, input, inputContents, output, outputContents, preservesValue)
+  }
+
+  private newtype TSummaryInternalNodeState =
+    TSummaryInternalNodeAfterReadState(ContentList cl) { cl.length() > 0 } or
+    TSummaryInternalNodeBeforeStoreState(ContentList cl) { cl.length() > 0 }
+
+  /**
+   * A state used to break up (complex) flow summaries into atomic flow steps.
+   * For a flow summary with input contents `inputContents` and output contents
+   * `outputContents`, the following states are used:
+   *
+   * - `TSummaryInternalNodeAfterReadState(ContentList cl)`: this state represents
+   *   that the head of `cl` has been read from, where `cl` is a suffix of
+   *   `inputContents`.
+   * - `TSummaryInternalNodeBeforeStoreState(ContentList cl)`: this state represents
+   *   that the head of `cl` is to be stored into next, where `cl` is a suffix of
+   *   `outputContents`.
+   *
+   * The state machine for flow summaries has no branching, hence from the entry
+   * state there is a unique path to the exit state.
+   */
+  class SummaryInternalNodeState extends TSummaryInternalNodeState {
+    string toString() {
+      exists(ContentList cl |
+        this = TSummaryInternalNodeAfterReadState(cl) and
+        result = "after read: " + cl
+      )
+      or
+      exists(ContentList cl |
+        this = TSummaryInternalNodeBeforeStoreState(cl) and
+        result = "before store: " + cl
+      )
+    }
+
+    /** Holds if this state represents the state after the last read. */
+    predicate isLastReadState() {
+      this = TSummaryInternalNodeAfterReadState(ContentList::singleton(_))
+    }
+
+    /** Holds if this state represents the state before the first store. */
+    predicate isFirstStoreState() {
+      this = TSummaryInternalNodeBeforeStoreState(ContentList::singleton(_))
+    }
+  }
+
+  /** Holds if an internal summary node is needed for the given values. */
+  predicate internalNodeRange(
+    FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput output,
+    ContentList outputContents, boolean preservesValue, SummaryInternalNodeState state
+  ) {
+    summary(c, input, inputContents, output, outputContents, preservesValue) and
+    (
+      state = TSummaryInternalNodeAfterReadState(inputContents.drop(_))
+      or
+      state = TSummaryInternalNodeBeforeStoreState(outputContents.drop(_))
+    )
+  }
+
+  /** Gets a type for an internal node with the given values. */
+  bindingset[preservesValue]
+  DataFlowType internalNodeType(
+    FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput output,
+    ContentList outputContents, boolean preservesValue, SummaryInternalNodeState state
+  ) {
+    exists(ContentList cl |
+      state = TSummaryInternalNodeAfterReadState(cl) and
+      if outputContents.length() = 0 and state.isLastReadState() and preservesValue = true
+      then result = getOutputNodeType(c, output)
+      else result = getContentType(cl.head())
+      or
+      state = TSummaryInternalNodeBeforeStoreState(cl) and
+      if inputContents.length() = 0 and state.isFirstStoreState() and preservesValue = true
+      then result = getInputNodeType(c, input)
+      else result = getContentType(cl.head())
+    )
+  }
+
+  /**
+   * Holds if there is a local step from `pred` to `succ`, which is synthesized
+   * from a flow summary.
+   */
+  predicate localStep(Node pred, Node succ, boolean preservesValue) {
+    exists(
+      FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput sink,
+      ContentList outputContents
+    |
+      pred = inputNode(c, input)
+    |
+      // Simple flow summary without reads or stores
+      inputContents = ContentList::empty() and
+      outputContents = ContentList::empty() and
+      summary(c, input, inputContents, sink, outputContents, preservesValue) and
+      succ = outputNode(c, sink)
+      or
+      // Flow summary with stores but no reads
+      exists(SummaryInternalNodeState succState |
+        inputContents = ContentList::empty() and
+        succState.isFirstStoreState() and
+        succ =
+          internalNode(c, input, inputContents, sink, outputContents, preservesValue, succState)
+      )
+    )
+    or
+    // Exit step after last read (no stores)
+    exists(
+      FrameworkCallable c, SummaryInternalNodeState predState, SummaryOutput output,
+      ContentList outputContents
+    |
+      outputContents = ContentList::empty() and
+      predState.isLastReadState() and
+      pred = internalNode(c, _, _, output, outputContents, preservesValue, predState) and
+      succ = outputNode(c, output)
+    )
+    or
+    // Internal step for complex flow summaries with both reads and writes
+    exists(
+      FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput output,
+      ContentList outputContents, SummaryInternalNodeState predState,
+      SummaryInternalNodeState succState
+    |
+      predState.isLastReadState() and
+      pred =
+        internalNode(c, input, inputContents, output, outputContents, preservesValue, predState) and
+      succState.isFirstStoreState() and
+      succ =
+        internalNode(c, input, inputContents, output, outputContents, preservesValue, succState)
+    )
+  }
+
+  /**
+   * Holds if there is a read step from `pred` to `succ`, which is synthesized
+   * from a flow summary.
+   */
+  predicate readStep(Node pred, Content c, Node succ) {
+    exists(
+      FrameworkCallable sdc, SummaryInput source, ContentList inputContents, SummaryOutput sink,
+      ContentList outputContents, boolean preservesValue, SummaryInternalNodeState succState,
+      ContentList succContents
+    |
+      succState = TSummaryInternalNodeAfterReadState(succContents) and
+      succ =
+        internalNode(sdc, source, inputContents, sink, outputContents, preservesValue, succState) and
+      c = succContents.head()
+    |
+      // First read
+      succContents = inputContents and
+      pred = inputNode(sdc, source)
+      or
+      // Subsequent reads
+      exists(SummaryInternalNodeState predState, ContentList predContents |
+        predState = TSummaryInternalNodeAfterReadState(predContents) and
+        predContents.tail() = succContents and
+        pred =
+          internalNode(sdc, source, inputContents, sink, outputContents, preservesValue, predState)
+      )
+    )
+  }
+
+  /**
+   * Holds if there is a store step from `pred` to `succ`, which is synthesized
+   * from a flow summary.
+   */
+  predicate storeStep(Node pred, Content c, Node succ) {
+    exists(
+      FrameworkCallable sdc, SummaryInput source, ContentList inputContents, SummaryOutput sink,
+      ContentList outputContents, boolean preservesValue, SummaryInternalNodeState predState,
+      ContentList predContents
+    |
+      predState = TSummaryInternalNodeBeforeStoreState(predContents) and
+      pred =
+        internalNode(sdc, source, inputContents, sink, outputContents, preservesValue, predState) and
+      c = predContents.head()
+    |
+      // More stores needed
+      exists(SummaryInternalNodeState succState |
+        succState =
+          TSummaryInternalNodeBeforeStoreState(any(ContentList succContents |
+              succContents.tail() = predContents
+            )) and
+        succ =
+          internalNode(sdc, source, inputContents, sink, outputContents, preservesValue, succState)
+      )
+      or
+      // Last store
+      predContents = outputContents and
+      succ = outputNode(sdc, sink)
+    )
+  }
+
+  pragma[nomagic]
+  private ParameterNode summaryArgParam(ArgumentNode arg, ReturnKind rk, OutNode out) {
+    exists(DataFlowCall call, int pos, FrameworkCallable callable |
+      arg.argumentOf(call, pos) and
+      viableCallable(call) = callable and
+      result.isParameterOf(callable, pos) and
+      call = out.getCall(rk)
+    )
+  }
+
+  /**
+   * Holds if `arg` flows to `out` using a simple flow summary, that is, a flow
+   * summary without reads and stores.
+   */
+  predicate throughStep(ArgumentNode arg, OutNode out, boolean preservesValue) {
+    exists(ReturnKind rk, ReturnNode ret |
+      localStep(summaryArgParam(arg, rk, out), ret, preservesValue) and
+      ret.getKind() = rk
+    )
+  }
+
+  /**
+   * Holds if there is a read(+taint) of `c` from `arg` to `out` using a
+   * flow summary.
+   */
+  predicate getterStep(ArgumentNode arg, Content c, OutNode out) {
+    exists(ReturnKind rk, Node mid, ReturnNode ret |
+      readStep(summaryArgParam(arg, rk, out), c, mid) and
+      localStep(mid, ret, _) and
+      ret.getKind() = rk
+    )
+  }
+
+  /**
+   * Holds if there is a (taint+)store of `arg` into content `c` of `out` using a
+   * flow summary.
+   */
+  predicate setterStep(ArgumentNode arg, Content c, OutNode out) {
+    exists(ReturnKind rk, Node mid, ReturnNode ret |
+      localStep(summaryArgParam(arg, rk, out), mid, _) and
+      storeStep(mid, c, ret) and
+      ret.getKind() = rk
+    )
+  }
+
+  /**
+   * Holds if values stored inside content `c` are cleared when passed as
+   * input of type `input` in `call`.
+   */
+  predicate clearsContent(SummaryInput input, DataFlowCall call, Content c) {
+    any(FrameworkDataFlow fdf).clearsContent(viableCallable(call), input, c)
+  }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowImpl.qll
@@ -1,0 +1,171 @@
+/**
+ * Provides classes and predicates for definining data-flow through frameworks.
+ *
+ * The definitions in this file are language-independant, and language-specific
+ * definitions are passed in via the `FrameworkDataFlowSpecific::Public` module.
+ */
+
+private import DataFlowPrivate
+private import DataFlowPublic
+import FrameworkDataFlowSpecific::Public
+
+private newtype TContentList =
+  TNilContentList() or
+  TConsContentList(Content head, ContentList tail) {
+    tail = TNilContentList()
+    or
+    exists(FrameworkDataFlow fdf |
+      fdf.requiresContentList(head, tail) and
+      tail.length() < accessPathLimit()
+    )
+  }
+
+/** A content list. */
+class ContentList extends TContentList {
+  /** Gets the head of this content list, if any. */
+  Content head() { this = TConsContentList(result, _) }
+
+  /** Gets the tail of this content list, if any. */
+  ContentList tail() { this = TConsContentList(_, result) }
+
+  /** Gets the length of this content list. */
+  int length() {
+    this = TNilContentList() and result = 0
+    or
+    result = 1 + this.tail().length()
+  }
+
+  /** Gets the content list obtained by dropping the first `i` elements, if any. */
+  ContentList drop(int i) {
+    i = 0 and result = this
+    or
+    result = this.tail().drop(i - 1)
+  }
+
+  /** Holds if this content list contains content `c`. */
+  predicate contains(Content c) { c = this.drop(_).head() }
+
+  /** Gets a textual representation of this content list. */
+  string toString() {
+    exists(Content head, ContentList tail |
+      head = this.head() and
+      tail = this.tail() and
+      if tail.length() = 0 then result = head.toString() else result = head + ", " + tail
+    )
+    or
+    this = TNilContentList() and
+    result = "<empty>"
+  }
+}
+
+/** Provides predicates for constructing content lists. */
+module ContentList {
+  /** Gets the empty content list. */
+  ContentList empty() { result = TNilContentList() }
+
+  /** Gets a singleton content list containing `c`. */
+  ContentList singleton(Content c) { result = TConsContentList(c, TNilContentList()) }
+
+  /** Gets the content list obtained by consing `head` onto `tail`. */
+  ContentList cons(Content head, ContentList tail) { result = TConsContentList(head, tail) }
+}
+
+private newtype TFlowSource = MkFlowSource(FlowSource::Range r)
+
+/** A flow-source specification. */
+class FlowSource extends MkFlowSource {
+  private FlowSource::Range r;
+
+  FlowSource() { this = MkFlowSource(r) }
+
+  predicate isSubsetOf(FlowSource fs) { r.isSubsetOf(fs) }
+
+  string toString() { result = r }
+}
+
+module FlowSource {
+  abstract class Range extends string {
+    bindingset[this]
+    Range() { any() }
+
+    predicate isSubsetOf(FlowSource fs) { none() }
+
+    FlowSource toFlowSource() { result = MkFlowSource(this) }
+  }
+}
+
+private newtype TFlowSink = MkFlowSink(FlowSink::Range r)
+
+/** A flow-sink specification. */
+class FlowSink extends MkFlowSink {
+  private FlowSink::Range r;
+
+  FlowSink() { this = MkFlowSink(r) }
+
+  predicate isSubsetOf(FlowSink fs) { r.isSubsetOf(fs) }
+
+  string toString() { result = r }
+}
+
+module FlowSink {
+  abstract class Range extends string {
+    bindingset[this]
+    Range() { any() }
+
+    predicate isSubsetOf(FlowSink fs) { none() }
+
+    FlowSink toFlowSink() { result = MkFlowSink(this) }
+  }
+}
+
+/** A data-flow model for a given framework. */
+abstract class FrameworkDataFlow extends string {
+  bindingset[this]
+  FrameworkDataFlow() { any() }
+
+  /**
+   * Holds if data may flow from `input` to `output` when calling `c`.
+   *
+   * `inputContents` describes the contents that is popped from the access
+   * path from the input and `outputContents` describes the contents that
+   * is pushed onto the resulting access path.
+   *
+   * `preservesValue` indicates whether this is a value-preserving step
+   * or a taint-step.
+   */
+  pragma[nomagic]
+  predicate hasSummary(
+    FrameworkCallable c, SummaryInput input, ContentList inputContents, SummaryOutput output,
+    ContentList outputContents, boolean preservesValue
+  ) {
+    none()
+  }
+
+  /**
+   * Holds if the content list obtained by consing `head` onto `tail` is needed
+   * for a summary specified by `hasSummary()`.
+   *
+   * This predicate is needed for QL technical reasons only (the IPA type used
+   * to represent content lists needs to be bounded).
+   *
+   * Only summaries using content lists of length >= 2 need to override this
+   * predicate.
+   */
+  pragma[nomagic]
+  predicate requiresContentList(Content head, ContentList tail) { none() }
+
+  /**
+   * Holds if values stored inside `content` are cleared on objects passed as
+   * arguments of type `input` to calls that target `c`.
+   */
+  pragma[nomagic]
+  predicate clearsContent(FrameworkCallable c, SummaryInput input, Content content) { none() }
+
+  /** Holds if `n` is a flow source of type `source. */
+  pragma[nomagic]
+  predicate hasSource(Node n, FlowSource source) { none() }
+
+  /** Holds if `n` is a flow sink of type `sink. */
+  pragma[nomagic]
+  predicate hasSink(Node n, FlowSink sink) { none() }
+}

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
@@ -23,14 +23,14 @@ module Private {
   }
 
   newtype TSummaryInput =
-    TQualifierSummaryInput() or
-    TArgumentSummaryInput(int i) { i = any(Parameter p).getPosition() } or
+    TParameterSummaryInput(int i) { i in [-1, any(Parameter p).getPosition()] } or
     TDelegateSummaryInput(int i) { hasDelegateArgumentPosition(_, i) }
 
   newtype TSummaryOutput =
-    TQualifierSummaryOutput() or
     TReturnSummaryOutput() or
-    TArgumentSummaryOutput(int i) { exists(FrameworkCallable c | exists(c.getParameter(i))) } or
+    TParameterSummaryOutput(int i) {
+      i in [-1, any(FrameworkCallable c).getAParameter().getPosition()]
+    } or
     TDelegateSummaryOutput(int i, int j) { hasDelegateArgumentPosition2(_, i, j) }
 }
 
@@ -46,15 +46,12 @@ module Public {
   class SummaryInput extends TSummaryInput {
     /** Gets a textual representation of this input specification. */
     final string toString() {
-      this = TQualifierSummaryInput() and
-      result = "qualifier"
-      or
       exists(int i |
-        this = TArgumentSummaryInput(i) and
-        result = "argument " + i
+        this = TParameterSummaryInput(i) and
+        result = "parameter " + i
         or
         this = TDelegateSummaryInput(i) and
-        result = "output from argument " + i
+        result = "deleget output from parameter " + i
       )
     }
   }
@@ -63,20 +60,17 @@ module Public {
   class SummaryOutput extends TSummaryOutput {
     /** Gets a textual representation of this flow sink specification. */
     final string toString() {
-      this = TQualifierSummaryOutput() and
-      result = "qualifier"
-      or
       this = TReturnSummaryOutput() and
       result = "return"
       or
       exists(int i |
-        this = TArgumentSummaryOutput(i) and
-        result = "argument " + i
+        this = TParameterSummaryOutput(i) and
+        result = "parameter " + i
       )
       or
       exists(int delegateIndex, int parameterIndex |
         this = TDelegateSummaryOutput(delegateIndex, parameterIndex) and
-        result = "parameter " + parameterIndex + " of argument " + delegateIndex
+        result = "parameter " + parameterIndex + " of delegate parameter " + delegateIndex
       )
     }
   }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
@@ -1,0 +1,85 @@
+/**
+ * Provides C# specific classes and predicates for definining data-flow through frameworks.
+ */
+
+private import csharp
+private import semmle.code.csharp.frameworks.system.linq.Expressions
+
+module Private {
+  predicate hasDelegateArgumentPosition(FrameworkCallable c, int i) {
+    exists(DelegateType dt |
+      dt = c.getParameter(i).getType().(SystemLinqExpressions::DelegateExtType).getDelegateType()
+    |
+      not dt.getReturnType() instanceof VoidType
+    )
+  }
+
+  predicate hasDelegateArgumentPosition2(FrameworkCallable c, int i, int j) {
+    exists(DelegateType dt |
+      dt = c.getParameter(i).getType().(SystemLinqExpressions::DelegateExtType).getDelegateType()
+    |
+      exists(dt.getParameter(j))
+    )
+  }
+
+  newtype TSummaryInput =
+    TQualifierSummaryInput() or
+    TArgumentSummaryInput(int i) { i = any(Parameter p).getPosition() } or
+    TDelegateSummaryInput(int i) { hasDelegateArgumentPosition(_, i) }
+
+  newtype TSummaryOutput =
+    TQualifierSummaryOutput() or
+    TReturnSummaryOutput() or
+    TArgumentSummaryOutput(int i) { exists(FrameworkCallable c | exists(c.getParameter(i))) } or
+    TDelegateSummaryOutput(int i, int j) { hasDelegateArgumentPosition2(_, i, j) }
+}
+
+private import Private
+
+module Public {
+  /** An unbound callable. */
+  class FrameworkCallable extends Callable {
+    FrameworkCallable() { this = this.getSourceDeclaration() }
+  }
+
+  /** A flow-summary input specification. */
+  class SummaryInput extends TSummaryInput {
+    /** Gets a textual representation of this input specification. */
+    final string toString() {
+      this = TQualifierSummaryInput() and
+      result = "qualifier"
+      or
+      exists(int i |
+        this = TArgumentSummaryInput(i) and
+        result = "argument " + i
+        or
+        this = TDelegateSummaryInput(i) and
+        result = "output from argument " + i
+      )
+    }
+  }
+
+  /** A flow-summary output specification. */
+  class SummaryOutput extends TSummaryOutput {
+    /** Gets a textual representation of this flow sink specification. */
+    final string toString() {
+      this = TQualifierSummaryOutput() and
+      result = "qualifier"
+      or
+      this = TReturnSummaryOutput() and
+      result = "return"
+      or
+      exists(int i |
+        this = TArgumentSummaryOutput(i) and
+        result = "argument " + i
+      )
+      or
+      exists(int delegateIndex, int parameterIndex |
+        this = TDelegateSummaryOutput(delegateIndex, parameterIndex) and
+        result = "parameter " + parameterIndex + " of argument " + delegateIndex
+      )
+    }
+  }
+}
+
+private import Public

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/FrameworkDataFlowSpecific.qll
@@ -6,6 +6,30 @@ private import csharp
 private import semmle.code.csharp.frameworks.system.linq.Expressions
 
 module Private {
+  private import DataFlowPrivate as DataFlowPrivate
+  private import DataFlowPublic as DataFlowPublic
+  private import FrameworkDataFlowImpl as FrameworkDataFlowImpl
+  private import DataFlowDispatch
+  private import semmle.code.csharp.Unification
+
+  class Content = DataFlowPublic::Content;
+
+  class DataFlowType = DataFlowPrivate::DataFlowType;
+
+  class Node = DataFlowPublic::Node;
+
+  class ParameterNode = DataFlowPublic::ParameterNode;
+
+  class ArgumentNode = DataFlowPrivate::ArgumentNode;
+
+  class ReturnNode = DataFlowPrivate::ReturnNode;
+
+  class OutNode = DataFlowPrivate::OutNode;
+
+  private class NodeImpl = DataFlowPrivate::NodeImpl;
+
+  predicate accessPathLimit = DataFlowPrivate::accessPathLimit/0;
+
   predicate hasDelegateArgumentPosition(FrameworkCallable c, int i) {
     exists(DelegateType dt |
       dt = c.getParameter(i).getType().(SystemLinqExpressions::DelegateExtType).getDelegateType()
@@ -32,6 +56,76 @@ module Private {
       i in [-1, any(FrameworkCallable c).getAParameter().getPosition()]
     } or
     TDelegateSummaryOutput(int i, int j) { hasDelegateArgumentPosition2(_, i, j) }
+
+  /** Gets the return kind that matches `sink`, if any. */
+  ReturnKind toReturnKind(SummaryOutput output) {
+    output = TReturnSummaryOutput() and
+    result instanceof NormalReturnKind
+    or
+    exists(int i | output = TParameterSummaryOutput(i) |
+      i = -1 and
+      result instanceof QualifierReturnKind
+      or
+      i = result.(OutRefReturnKind).getPosition()
+    )
+  }
+
+  /** Gets the input node for `c` of type `input`. */
+  NodeImpl inputNode(FrameworkCallable c, SummaryInput input) {
+    exists(int i |
+      input = TParameterSummaryInput(i) and
+      result = DataFlowPrivate::TSummaryParameterNode(c, i)
+    )
+    or
+    exists(int i |
+      input = TDelegateSummaryInput(i) and
+      result = DataFlowPrivate::TSummaryDelegateOutNode(c, i)
+    )
+  }
+
+  /** Gets the type of the input node for `c` of type `input`. */
+  DataFlowType getInputNodeType(FrameworkCallable c, SummaryInput input) {
+    result = inputNode(c, input).getDataFlowType()
+  }
+
+  /** Gets the output node for `c` of type `output`. */
+  NodeImpl outputNode(FrameworkCallable c, SummaryOutput output) {
+    result = DataFlowPrivate::TSummaryReturnNode(c, toReturnKind(output))
+    or
+    exists(int i, int j |
+      output = TDelegateSummaryOutput(i, j) and
+      result = DataFlowPrivate::TSummaryDelegateArgumentNode(c, i, j)
+    )
+  }
+
+  /** Gets the type of the output node for `c` of type `output`. */
+  DataFlowType getOutputNodeType(FrameworkCallable c, SummaryOutput output) {
+    result = outputNode(c, output).getDataFlowType()
+  }
+
+  /** Gets the internal summary node for the given values. */
+  Node internalNode(
+    FrameworkCallable c, SummaryInput input, FrameworkDataFlowImpl::ContentList inputContents,
+    SummaryOutput output, FrameworkDataFlowImpl::ContentList outputContents, boolean preservesValue,
+    FrameworkDataFlowImpl::Compilation::SummaryInternalNodeState state
+  ) {
+    result =
+      DataFlowPrivate::TSummaryInternalNode(c, input, inputContents, output, outputContents,
+        preservesValue, state)
+  }
+
+  /** Gets the type of content `c`. */
+  pragma[noinline]
+  DataFlowType getContentType(Content c) {
+    exists(Type t | result = Gvn::getGlobalValueNumber(t) |
+      t = c.(DataFlowPublic::FieldContent).getField().getType()
+      or
+      t = c.(DataFlowPublic::PropertyContent).getProperty().getType()
+      or
+      c instanceof DataFlowPublic::ElementContent and
+      t instanceof ObjectType // we don't know what the actual element type is
+    )
+  }
 }
 
 private import Private

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/TaintTrackingPrivate.qll
@@ -1,10 +1,10 @@
 private import csharp
 private import TaintTrackingPublic
 private import DataFlowImplCommon
+private import FrameworkDataFlowImpl as FrameworkDataFlowImpl
 private import semmle.code.csharp.Caching
 private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
 private import semmle.code.csharp.dataflow.internal.ControlFlowReachability
-private import semmle.code.csharp.dataflow.LibraryTypeDataFlow
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.commons.ComparisonTest
 private import cil
@@ -112,8 +112,6 @@ private predicate localTaintStepCommon(DataFlow::Node nodeFrom, DataFlow::Node n
 
 cached
 private module Cached {
-  private import Summaries
-
   /**
    * Holds if taint propagates from `nodeFrom` to `nodeTo` in exactly one local
    * (intra-procedural) step.
@@ -130,19 +128,19 @@ private module Cached {
     (
       // Simple flow through library code is included in the exposed local
       // step relation, even though flow is technically inter-procedural
-      summaryThroughStep(nodeFrom, nodeTo, false)
+      FrameworkDataFlowImpl::Compilation::throughStep(nodeFrom, nodeTo, false)
       or
       // Taint collection by adding a tainted element
       exists(DataFlow::ElementContent c |
         storeStep(nodeFrom, c, nodeTo)
         or
-        summarySetterStep(nodeFrom, c, nodeTo)
+        FrameworkDataFlowImpl::Compilation::setterStep(nodeFrom, c, nodeTo)
       )
       or
       exists(DataFlow::Content c |
         readStep(nodeFrom, c, nodeTo)
         or
-        summaryGetterStep(nodeFrom, c, nodeTo)
+        FrameworkDataFlowImpl::Compilation::getterStep(nodeFrom, c, nodeTo)
       |
         // Taint members
         c = any(TaintedMember m).(FieldOrProperty).getContent()
@@ -169,7 +167,7 @@ private module Cached {
     // tracking configurations where the source is a collection
     readStep(nodeFrom, TElementContent(), nodeTo)
     or
-    summaryLocalStep(nodeFrom, nodeTo, false)
+    FrameworkDataFlowImpl::Compilation::localStep(nodeFrom, nodeTo, false)
     or
     nodeTo = nodeFrom.(DataFlow::NonLocalJumpNode).getAJumpSuccessor(false)
   }

--- a/csharp/ql/test/library-tests/frameworks/test/Test.ql
+++ b/csharp/ql/test/library-tests/frameworks/test/Test.ql
@@ -13,5 +13,6 @@ where
   not framework = "SourceDeclarationCallable" and
   not framework = "SourceDeclarationMethod" and
   not framework = "NonConstructedMethod" and
-  not framework = "RuntimeInstanceMethod"
+  not framework = "RuntimeInstanceMethod" and
+  not framework = "FrameworkMethod"
 select e, type, framework


### PR DESCRIPTION
DO NOT MERGE: This a RFC PR.

This PR attempts to introduce a means of specifying framework data-flow packs, which for now means flow-summaries, sources, sinks (and content-clearing callables). The hope is that we can agree on similar interfaces for languages that use the shared data-flow library (and perhaps at some point shared implementation of the machinery that interprets the framework models).

The following entities will be language-specific (but there will likely be much overlap):
- `SummaryInput`: The type of inputs that can be specified in flow summaries.
- `SummaryOutput`: The type of outputs that can be specified in flow summaries.
- `FlowSource`: The various kinds of flow sources.
- `FlowSink`: The various kinds of flow sinks.

The reason for defining `FrameworkDataFlow` as an abstract class that extends `string`, as opposed to a unit type, is that we can use it to provide some numbers on how much coverage we have for a given framework, e.g.
```ql
int countCallables(FrameworkDataFlow framework) {
  result =
    count(Callable c | framework.hasSummary(c, _, _, _, _, _) or framework.clearsContent(c, _, _))
}
```