### PR TITLE
Pyhon: fix os.path.join model

### DIFF
--- a/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/src/experimental/semmle/python/frameworks/Stdlib.qll
@@ -77,8 +77,20 @@ private module Stdlib {
 
   /** Provides models for the `os` module. */
   module os {
+    /** Gets a reference to a direct import of the `os.path` module. */
+    private DataFlow::Node pathDirectImport(DataFlow::TypeTracker t) {
+      t.start() and
+      result = DataFlow::importModule("os.path")
+      or
+      exists(DataFlow::TypeTracker t2 | result = pathDirectImport(t2).track(t2, t))
+    }
+
     /** Gets a reference to the `os.path` module. */
-    DataFlow::Node path() { result = os_attr("path") }
+    DataFlow::Node path() {
+      result = os_attr("path")
+      or
+      result = pathDirectImport(DataFlow::TypeTracker::end())
+    }
 
     /** Provides models for the `os.path` module */
     module path {

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/TestTaint.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/TestTaint.expected
@@ -137,9 +137,10 @@
 | test_string.py:143 | fail | binary_decode_encode | base64.decodestring(..) |
 | test_string.py:148 | fail | binary_decode_encode | quopri.encodestring(..) |
 | test_string.py:149 | fail | binary_decode_encode | quopri.decodestring(..) |
-| test_string.py:158 | ok   | test_os_path_join | os.path.join(..) |
 | test_string.py:159 | ok   | test_os_path_join | os.path.join(..) |
 | test_string.py:160 | ok   | test_os_path_join | os.path.join(..) |
+| test_string.py:161 | ok   | test_os_path_join | os.path.join(..) |
+| test_string.py:162 | fail | test_os_path_join | ospath_alias.join(..) |
 | test_unpacking.py:16 | ok   | unpacking | a |
 | test_unpacking.py:16 | ok   | unpacking | b |
 | test_unpacking.py:16 | ok   | unpacking | c |

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/TestTaint.expected
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/TestTaint.expected
@@ -140,7 +140,7 @@
 | test_string.py:159 | ok   | test_os_path_join | os.path.join(..) |
 | test_string.py:160 | ok   | test_os_path_join | os.path.join(..) |
 | test_string.py:161 | ok   | test_os_path_join | os.path.join(..) |
-| test_string.py:162 | fail | test_os_path_join | ospath_alias.join(..) |
+| test_string.py:162 | ok   | test_os_path_join | ospath_alias.join(..) |
 | test_unpacking.py:16 | ok   | unpacking | a |
 | test_unpacking.py:16 | ok   | unpacking | b |
 | test_unpacking.py:16 | ok   | unpacking | c |

--- a/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/test_string.py
+++ b/python/ql/test/experimental/dataflow/tainttracking/defaultAdditionalTaintStep/test_string.py
@@ -152,12 +152,14 @@ def binary_decode_encode():
 
 def test_os_path_join():
     import os
+    import os.path as ospath_alias
     print("\n# test_os_path_join")
     ts = TAINTED_STRING
     ensure_tainted(
         os.path.join(ts, "foo", "bar"),
         os.path.join(ts),
         os.path.join("foo", "bar", ts),
+        ospath_alias.join("foo", "bar", ts),
     )
 
 


### PR DESCRIPTION
We didn't handle `import os.path as alias` before. Woopsie.

When fixing this I was rather torn between adding a predicate for this direct import specifically (which is what I did), and changing the implementation of the helper predicate `os_attr` so it was just handled there.

The argument for changing `os_attr` is that it would make things simple, and as long as we update this template for easy access of module attributes, we don't have to worry about forgetting this in the future. The main argument against is that semantically there is a difference between importing module `import pkg.mod` and importing attribute `from pkg import mod`.

I think that semantic difference is what made me create both `importMember` and `importModule` in the first place... but I also explicitly made `importModule` handle `from pkg import mod` saying that we would be highly unlikely to encounter problems from this.

In conclusion I only have myself to blame for running into this problem.

I think instead of this PR I'll make one that removes `importMember` and `importModule` to only expose a single interface for handling imports. That will allow us to recognize invalid code, for example for `import os.system as runtime_error` we would then happily model that `runtime_error` as a reference to the `os.system` function (although the actual import would result in a runtime error). But it _does_ makes things simpler from a QL modeling point of view, and THAT sounds nice :+1:

---

The change I considered for `os_attr` would be like:

```diff
 t.start() and
 result = DataFlow::importMember("os", attr_name)
 or
 t.startInAttr(attr_name) and
 result = DataFlow::importModule("os")
+or
+t.start() and
+result = DataFlow::importModule("os."+attr_name)
```