### PR TITLE
JavaScript: Improve integration of TypeScript types into API graphs

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -286,6 +286,17 @@ module API {
   /** Gets a node corresponding to an export of module `m`. */
   Node moduleExport(string m) { result = Impl::MkModuleDef(m).(Node).getMember("exports") }
 
+  /** Provides helper predicates for accessing API-graph nodes. */
+  module Node {
+    /** Gets a node whose type has the given qualified name. */
+    Node ofType(string moduleName, string exportedName) {
+      exists(TypeName tn |
+        tn.hasQualifiedName(moduleName, exportedName) and
+        result = Impl::MkCanonicalNameUse(tn).(Node).getInstance()
+      )
+    }
+  }
+
   /**
    * An API entry point.
    *

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -312,9 +312,6 @@ module API {
 
     /** Gets a data-flow node that defines this entry point. */
     abstract DataFlow::Node getARhs();
-
-    /** Gets an API-graph node for this entry point. */
-    API::Node getNode() { result = root().getASuccessor(this) }
   }
 
   /**

--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -368,13 +368,25 @@ module API {
       } or
       MkDef(DataFlow::Node nd) { rhs(_, _, nd) } or
       MkUse(DataFlow::Node nd) { use(_, _, nd) } or
+      /**
+       * A TypeScript canonical name that is defined somewhere, and that isn't a module root.
+       * (Module roots are represented by `MkModuleExport` nodes instead.)
+       *
+       * For most purposes, you probably want to use the `mkCanonicalNameDef` predicate instead of
+       * this constructor.
+       */
       MkCanonicalNameDef(CanonicalName n) {
-        // module roots are represented by `MkModuleExport` nodes
         not n.isRoot() and
         isDefined(n)
       } or
+      /**
+       * A TypeScript canonical name that is used somewhere, and that isn't a module root.
+       * (Module roots are represented by `MkModuleImport` nodes instead.)
+       *
+       * For most purposes, you probably want to use the `mkCanonicalNameUse` predicate instead of
+       * this constructor.
+       */
       MkCanonicalNameUse(CanonicalName n) {
-        // module roots are represented by `MkModuleImport` nodes
         not n.isRoot() and
         isUsed(n)
       }
@@ -421,12 +433,14 @@ module API {
       )
     }
 
+    /** An API-graph node representing definitions of the canonical name `cn`. */
     private TApiNode mkCanonicalNameDef(CanonicalName cn) {
       if cn.isModuleRoot()
       then result = MkModuleExport(cn.getExternalModuleName())
       else result = MkCanonicalNameDef(cn)
     }
 
+    /** An API-graph node representing uses of the canonical name `cn`. */
     private TApiNode mkCanonicalNameUse(CanonicalName cn) {
       if cn.isModuleRoot()
       then result = MkModuleImport(cn.getExternalModuleName())

--- a/javascript/ql/src/semmle/javascript/CanonicalNames.qll
+++ b/javascript/ql/src/semmle/javascript/CanonicalNames.qll
@@ -25,9 +25,17 @@ class CanonicalName extends @symbol {
   CanonicalName getParent() { symbol_parent(this, result) }
 
   /**
-   * Gets a child of this canonical name, i.e. an extension of its qualified name.
+   * Gets a child of this canonical name, that is, an extension of its qualified name.
    */
   CanonicalName getAChild() { result.getParent() = this }
+
+  /**
+   * Gets the child of this canonical name that has the given `name`, if any.
+   */
+  CanonicalName getChild(string name) {
+    result = getAChild() and
+    result.getName() = name
+  }
 
   /**
    * Gets the name without prefix.

--- a/javascript/ql/test/ApiGraphs/typed/NodeOfType.expected
+++ b/javascript/ql/test/ApiGraphs/typed/NodeOfType.expected
@@ -1,0 +1,3 @@
+| mongodb | Collection | index.ts:14:3:14:17 | getCollection() |
+| mongoose | Model | index.ts:22:3:22:20 | getMongooseModel() |
+| mongoose | Query | index.ts:23:3:23:20 | getMongooseQuery() |

--- a/javascript/ql/test/ApiGraphs/typed/NodeOfType.ql
+++ b/javascript/ql/test/ApiGraphs/typed/NodeOfType.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from string mod, string tp
+select mod, tp, API::Node::ofType(mod, tp).getAnImmediateUse()

--- a/javascript/ql/test/ApiGraphs/typed/index.ts
+++ b/javascript/ql/test/ApiGraphs/typed/index.ts
@@ -11,7 +11,7 @@ app.use(bodyParser.json());
 
 app.post("/find", (req, res) => {
   let v = JSON.parse(req.body.x);
-  getCollection().find({ id: v }); /* use (member find (instance (member Collection (module mongodb)))) */
+  getCollection().find({ id: v }); /* use (member find (instance (member Collection (member exports (module mongodb))))) */
 });
 
 import * as mongoose from "mongoose";
@@ -19,6 +19,6 @@ declare function getMongooseModel(): mongoose.Model;
 declare function getMongooseQuery(): mongoose.Query;
 app.post("/find", (req, res) => {
   let v = JSON.parse(req.body.x);
-  getMongooseModel().find({ id: v }); /* def (parameter 0 (member find (instance (member Model (module mongoose))))) */
-  getMongooseQuery().find({ id: v }); /* def (parameter 0 (member find (instance (member Query (module mongoose))))) */
+  getMongooseModel().find({ id: v }); /* def (parameter 0 (member find (instance (member Model (member exports (module mongoose)))))) */
+  getMongooseQuery().find({ id: v }); /* def (parameter 0 (member find (instance (member Query (member exports (module mongoose)))))) */
 });


### PR DESCRIPTION
This fixes a bug in the API-graphs library that meant TypeScript types were considered successors of the module node rather than its exports node, adds the `Node::ofType` predicate suggested by @asgerf in https://github.com/github/codeql/pull/4363#discussion_r499675281, and uses it in the NoSQL model.

[Evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/5a8f764060fc2bc3e52694600b7400a0d6860e5c/js/api-graphs-type-handling-improvements/report.md) (internal link) took a little longer than I would have expected due to initial wobbliness. Rerunning produced a nice bell curve, though, so I think this PR is performance neutral. It also doesn't change results, which is expected. The API graph metrics show a slight reduction in API-graph size for some benchmarks because we no longer build nodes for canonical names that aren't rooted in a module.