### PR TITLE
Fix typo in CodeQL docs template

### DIFF
--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -81,7 +81,7 @@
                 </div>
                 <li><a class="dropdown-item" href="https://help.semmle.com/QL/ql-handbook/">QL language reference</a>
                 <li><a class="dropdown-item" href="https://help.semmle.com/QL/ql-libraries.html">CodeQL libraries</a>
-                <li><a class="dropdown-item" href="https://help.semmle.com/QL/ql-built-in-queries.htmll">CodeQL
+                <li><a class="dropdown-item" href="https://help.semmle.com/QL/ql-built-in-queries.html">CodeQL
                         queries</a>
                 <li class="dropdown-divider" role="separator"></li>
                 <div class="dropdown-header">


### PR DESCRIPTION
Fixes a typo in a link.