### PR TITLE
Java: Track taint through java.io.File constructor and #toURI; URI#toURL

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -234,6 +234,11 @@ private predicate constructorStep(Expr tracked, ConstructorCall sink) {
       or
       //a URI constructed from a tainted string is tainted.
       s = "java.net.URI" and argi = 0 and sink.getNumArgument() = 1
+      or
+      //a File constructed from a tainted string is tainted.
+      s = "java.io.File" and argi = 0
+      or
+      s = "java.io.File" and argi = 1
     )
     or
     exists(RefType t | t.getQualifiedName() = "java.lang.Number" |
@@ -371,6 +376,12 @@ private predicate taintPreservingQualifierToMethod(Method m) {
   or
   m.getDeclaringType().hasQualifiedName("java.nio", "ByteBuffer") and
   m.hasName("get")
+  or
+  m.getDeclaringType().hasQualifiedName("java.io", "File") and
+  m.hasName("toURI")
+  or
+  m.getDeclaringType().hasQualifiedName("java.net", "URI") and
+  m.hasName("toURL")
   or
   m = any(GuiceProvider gp).getAnOverridingGetMethod()
   or

--- a/java/ql/test/library-tests/dataflow/taint/B.java
+++ b/java/ql/test/library-tests/dataflow/taint/B.java
@@ -129,6 +129,9 @@ public class B {
     String[][][] taintedArray3 = new String[][][] { { { s } } };
     sink(taintedArray3);
 
+    // Tainted file path and URI
+    sink(new java.io.File(s).toURI().toURL());
+
     return;
   }
 

--- a/java/ql/test/library-tests/dataflow/taint/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint/test.expected
@@ -33,6 +33,7 @@
 | B.java:15:21:15:27 | taint(...) | B.java:126:10:126:21 | taintedArray |
 | B.java:15:21:15:27 | taint(...) | B.java:128:10:128:22 | taintedArray2 |
 | B.java:15:21:15:27 | taint(...) | B.java:130:10:130:22 | taintedArray3 |
+| B.java:15:21:15:27 | taint(...) | B.java:133:10:133:44 | toURL(...) |
 | MethodFlow.java:7:22:7:28 | taint(...) | MethodFlow.java:8:10:8:16 | tainted |
 | MethodFlow.java:9:31:9:37 | taint(...) | MethodFlow.java:10:10:10:17 | tainted2 |
 | MethodFlow.java:11:35:11:41 | taint(...) | MethodFlow.java:12:10:12:17 | tainted3 |


### PR DESCRIPTION
I was trying to write a query to detect the taint in https://github.com/jenkinsci/persona-plugin/blob/58ea0d9ca16ece310e2002100649aab919a33333/src/main/java/hudson/plugins/persona/ResourceServer.java#L55-L58 from `#getRestOfPath` to `#serveFile` and it didn't work. I looked a bit under the hood and found these missing.

I did not find a straightforward way to test the impact of a change like this on existing queries on various projects, so other than a trivial query I have locally that now finds the above tainted data, and the addition to the taint test, this is untested.
