### PR TITLE
C++: Additional taint flows through std::set

### DIFF
--- a/change-notes/1.26/analysis-cpp.md
+++ b/change-notes/1.26/analysis-cpp.md
@@ -25,6 +25,6 @@ The following changes in version 1.26 affect C/C++ analysis in all applications.
 * The models library now models many more taint flows through `std::string`.
 * The models library now models many taint flows through `std::istream` and `std::ostream`.
 * The models library now models some taint flows through `std::shared_ptr`, `std::unique_ptr`, `std::make_shared` and `std::make_unique`.
-* The models library now models some taint flows through `std::pair`, `std::map` and `std::unordered_map`.
+* The models library now models many taint flows through `std::pair`, `std::map`, `std::unordered_map`, `std::set` and `std::unordered_set`.
 * The `SimpleRangeAnalysis` library now supports multiplications of the form
   `e1 * e2` and `x *= e2` when `e1` and `e2` are unsigned or constant.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -50,6 +50,29 @@ class StdSetInsert extends TaintFunction {
 }
 
 /**
+ * The standard set `emplace` and `emplace_hint` functions.
+ */
+class StdSetEmplace extends TaintFunction {
+  StdSetEmplace() {
+    this.hasQualifiedName("std", ["set", "unordered_set"], ["emplace", "emplace_hint"])
+  }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // flow from any parameter to qualifier and return value
+    // (here we assume taint flow from any constructor parameter to the constructed object)
+    // (where the return value is a pair, this should really flow just to the first part of it)
+    input.isParameter([0 .. getNumberOfParameters() - 1]) and
+    (
+      output.isQualifierObject() or
+      output.isReturnValue()
+    )
+    or
+    input.isQualifierObject() and
+    output.isReturnValue()
+  }
+}
+
+/**
  * The standard set `swap` functions.
  */
 class StdSetSwap extends TaintFunction {

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -103,3 +103,20 @@ class StdSetErase extends TaintFunction {
     output.isReturnValue()
   }
 }
+
+/**
+ * The standard set `lower_bound`, `upper_bound` and `equal_range` functions.
+ */
+class StdSetEqualRange extends TaintFunction {
+  StdSetEqualRange() {
+    this
+        .hasQualifiedName("std", ["set", "unordered_set"],
+          ["lower_bound", "upper_bound", "equal_range"])
+  }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // flow from qualifier to return value
+    input.isQualifierObject() and
+    output.isReturnValue()
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdSet.qll
@@ -66,6 +66,19 @@ class StdSetSwap extends TaintFunction {
 }
 
 /**
+ * The standard set `merge` function.
+ */
+class StdSetMerge extends TaintFunction {
+  StdSetMerge() { this.hasQualifiedName("std", ["set", "unordered_set"], "merge") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // container1.merge(container2)
+    input.isParameterDeref(0) and
+    output.isQualifierObject()
+  }
+}
+
+/**
  * The standard set `find` function.
  */
 class StdSetFind extends TaintFunction {

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2298,10 +2298,16 @@
 | set.cpp:118:7:118:9 | ref arg s21 | set.cpp:120:7:120:9 | s21 |  |
 | set.cpp:118:7:118:9 | ref arg s21 | set.cpp:121:7:121:9 | s21 |  |
 | set.cpp:118:7:118:9 | ref arg s21 | set.cpp:126:1:126:1 | s21 |  |
+| set.cpp:118:7:118:9 | s21 | set.cpp:118:11:118:17 | call to emplace | TAINT |
+| set.cpp:118:19:118:23 | abc | set.cpp:118:7:118:9 | ref arg s21 | TAINT |
+| set.cpp:118:19:118:23 | abc | set.cpp:118:11:118:17 | call to emplace | TAINT |
 | set.cpp:118:26:118:30 | first | set.cpp:118:7:118:30 | call to iterator |  |
 | set.cpp:119:7:119:9 | s21 | set.cpp:119:7:119:9 | call to set |  |
 | set.cpp:120:7:120:9 | ref arg s21 | set.cpp:121:7:121:9 | s21 |  |
 | set.cpp:120:7:120:9 | ref arg s21 | set.cpp:126:1:126:1 | s21 |  |
+| set.cpp:120:7:120:9 | s21 | set.cpp:120:11:120:17 | call to emplace | TAINT |
+| set.cpp:120:19:120:24 | call to source | set.cpp:120:7:120:9 | ref arg s21 | TAINT |
+| set.cpp:120:19:120:24 | call to source | set.cpp:120:11:120:17 | call to emplace | TAINT |
 | set.cpp:120:29:120:33 | first | set.cpp:120:7:120:33 | call to iterator |  |
 | set.cpp:121:7:121:9 | s21 | set.cpp:121:7:121:9 | call to set |  |
 | set.cpp:122:7:122:9 | ref arg s22 | set.cpp:123:7:123:9 | s22 |  |
@@ -2309,6 +2315,7 @@
 | set.cpp:122:7:122:9 | ref arg s22 | set.cpp:124:24:124:26 | s22 |  |
 | set.cpp:122:7:122:9 | ref arg s22 | set.cpp:125:7:125:9 | s22 |  |
 | set.cpp:122:7:122:9 | ref arg s22 | set.cpp:126:1:126:1 | s22 |  |
+| set.cpp:122:7:122:9 | s22 | set.cpp:122:11:122:22 | call to emplace_hint | TAINT |
 | set.cpp:122:24:122:26 | ref arg s22 | set.cpp:122:7:122:9 | s22 |  |
 | set.cpp:122:24:122:26 | ref arg s22 | set.cpp:123:7:123:9 | s22 |  |
 | set.cpp:122:24:122:26 | ref arg s22 | set.cpp:124:7:124:9 | s22 |  |
@@ -2316,15 +2323,24 @@
 | set.cpp:122:24:122:26 | ref arg s22 | set.cpp:125:7:125:9 | s22 |  |
 | set.cpp:122:24:122:26 | ref arg s22 | set.cpp:126:1:126:1 | s22 |  |
 | set.cpp:122:24:122:26 | s22 | set.cpp:122:28:122:32 | call to begin | TAINT |
+| set.cpp:122:24:122:34 | call to iterator | set.cpp:122:7:122:9 | ref arg s22 | TAINT |
+| set.cpp:122:24:122:34 | call to iterator | set.cpp:122:11:122:22 | call to emplace_hint | TAINT |
 | set.cpp:122:28:122:32 | call to begin | set.cpp:122:24:122:34 | call to iterator | TAINT |
+| set.cpp:122:37:122:41 | abc | set.cpp:122:7:122:9 | ref arg s22 | TAINT |
+| set.cpp:122:37:122:41 | abc | set.cpp:122:11:122:22 | call to emplace_hint | TAINT |
 | set.cpp:123:7:123:9 | s22 | set.cpp:123:7:123:9 | call to set |  |
 | set.cpp:124:7:124:9 | ref arg s22 | set.cpp:125:7:125:9 | s22 |  |
 | set.cpp:124:7:124:9 | ref arg s22 | set.cpp:126:1:126:1 | s22 |  |
+| set.cpp:124:7:124:9 | s22 | set.cpp:124:11:124:22 | call to emplace_hint | TAINT |
 | set.cpp:124:24:124:26 | ref arg s22 | set.cpp:124:7:124:9 | s22 |  |
 | set.cpp:124:24:124:26 | ref arg s22 | set.cpp:125:7:125:9 | s22 |  |
 | set.cpp:124:24:124:26 | ref arg s22 | set.cpp:126:1:126:1 | s22 |  |
 | set.cpp:124:24:124:26 | s22 | set.cpp:124:28:124:32 | call to begin | TAINT |
+| set.cpp:124:24:124:34 | call to iterator | set.cpp:124:7:124:9 | ref arg s22 | TAINT |
+| set.cpp:124:24:124:34 | call to iterator | set.cpp:124:11:124:22 | call to emplace_hint | TAINT |
 | set.cpp:124:28:124:32 | call to begin | set.cpp:124:24:124:34 | call to iterator | TAINT |
+| set.cpp:124:37:124:42 | call to source | set.cpp:124:7:124:9 | ref arg s22 | TAINT |
+| set.cpp:124:37:124:42 | call to source | set.cpp:124:11:124:22 | call to emplace_hint | TAINT |
 | set.cpp:125:7:125:9 | s22 | set.cpp:125:7:125:9 | call to set |  |
 | set.cpp:131:29:131:30 | call to unordered_set | set.cpp:133:7:133:8 | s1 |  |
 | set.cpp:131:29:131:30 | call to unordered_set | set.cpp:137:12:137:13 | s1 |  |
@@ -2763,10 +2779,16 @@
 | set.cpp:230:7:230:9 | ref arg s21 | set.cpp:232:7:232:9 | s21 |  |
 | set.cpp:230:7:230:9 | ref arg s21 | set.cpp:233:7:233:9 | s21 |  |
 | set.cpp:230:7:230:9 | ref arg s21 | set.cpp:238:1:238:1 | s21 |  |
+| set.cpp:230:7:230:9 | s21 | set.cpp:230:11:230:17 | call to emplace | TAINT |
+| set.cpp:230:19:230:23 | abc | set.cpp:230:7:230:9 | ref arg s21 | TAINT |
+| set.cpp:230:19:230:23 | abc | set.cpp:230:11:230:17 | call to emplace | TAINT |
 | set.cpp:230:26:230:30 | first | set.cpp:230:7:230:30 | call to iterator |  |
 | set.cpp:231:7:231:9 | s21 | set.cpp:231:7:231:9 | call to unordered_set |  |
 | set.cpp:232:7:232:9 | ref arg s21 | set.cpp:233:7:233:9 | s21 |  |
 | set.cpp:232:7:232:9 | ref arg s21 | set.cpp:238:1:238:1 | s21 |  |
+| set.cpp:232:7:232:9 | s21 | set.cpp:232:11:232:17 | call to emplace | TAINT |
+| set.cpp:232:19:232:24 | call to source | set.cpp:232:7:232:9 | ref arg s21 | TAINT |
+| set.cpp:232:19:232:24 | call to source | set.cpp:232:11:232:17 | call to emplace | TAINT |
 | set.cpp:232:29:232:33 | first | set.cpp:232:7:232:33 | call to iterator |  |
 | set.cpp:233:7:233:9 | s21 | set.cpp:233:7:233:9 | call to unordered_set |  |
 | set.cpp:234:7:234:9 | ref arg s22 | set.cpp:235:7:235:9 | s22 |  |
@@ -2774,6 +2796,7 @@
 | set.cpp:234:7:234:9 | ref arg s22 | set.cpp:236:24:236:26 | s22 |  |
 | set.cpp:234:7:234:9 | ref arg s22 | set.cpp:237:7:237:9 | s22 |  |
 | set.cpp:234:7:234:9 | ref arg s22 | set.cpp:238:1:238:1 | s22 |  |
+| set.cpp:234:7:234:9 | s22 | set.cpp:234:11:234:22 | call to emplace_hint | TAINT |
 | set.cpp:234:24:234:26 | ref arg s22 | set.cpp:234:7:234:9 | s22 |  |
 | set.cpp:234:24:234:26 | ref arg s22 | set.cpp:235:7:235:9 | s22 |  |
 | set.cpp:234:24:234:26 | ref arg s22 | set.cpp:236:7:236:9 | s22 |  |
@@ -2781,15 +2804,24 @@
 | set.cpp:234:24:234:26 | ref arg s22 | set.cpp:237:7:237:9 | s22 |  |
 | set.cpp:234:24:234:26 | ref arg s22 | set.cpp:238:1:238:1 | s22 |  |
 | set.cpp:234:24:234:26 | s22 | set.cpp:234:28:234:32 | call to begin | TAINT |
+| set.cpp:234:24:234:34 | call to iterator | set.cpp:234:7:234:9 | ref arg s22 | TAINT |
+| set.cpp:234:24:234:34 | call to iterator | set.cpp:234:11:234:22 | call to emplace_hint | TAINT |
 | set.cpp:234:28:234:32 | call to begin | set.cpp:234:24:234:34 | call to iterator | TAINT |
+| set.cpp:234:37:234:41 | abc | set.cpp:234:7:234:9 | ref arg s22 | TAINT |
+| set.cpp:234:37:234:41 | abc | set.cpp:234:11:234:22 | call to emplace_hint | TAINT |
 | set.cpp:235:7:235:9 | s22 | set.cpp:235:7:235:9 | call to unordered_set |  |
 | set.cpp:236:7:236:9 | ref arg s22 | set.cpp:237:7:237:9 | s22 |  |
 | set.cpp:236:7:236:9 | ref arg s22 | set.cpp:238:1:238:1 | s22 |  |
+| set.cpp:236:7:236:9 | s22 | set.cpp:236:11:236:22 | call to emplace_hint | TAINT |
 | set.cpp:236:24:236:26 | ref arg s22 | set.cpp:236:7:236:9 | s22 |  |
 | set.cpp:236:24:236:26 | ref arg s22 | set.cpp:237:7:237:9 | s22 |  |
 | set.cpp:236:24:236:26 | ref arg s22 | set.cpp:238:1:238:1 | s22 |  |
 | set.cpp:236:24:236:26 | s22 | set.cpp:236:28:236:32 | call to begin | TAINT |
+| set.cpp:236:24:236:34 | call to iterator | set.cpp:236:7:236:9 | ref arg s22 | TAINT |
+| set.cpp:236:24:236:34 | call to iterator | set.cpp:236:11:236:22 | call to emplace_hint | TAINT |
 | set.cpp:236:28:236:32 | call to begin | set.cpp:236:24:236:34 | call to iterator | TAINT |
+| set.cpp:236:37:236:42 | call to source | set.cpp:236:7:236:9 | ref arg s22 | TAINT |
+| set.cpp:236:37:236:42 | call to source | set.cpp:236:11:236:22 | call to emplace_hint | TAINT |
 | set.cpp:237:7:237:9 | s22 | set.cpp:237:7:237:9 | call to unordered_set |  |
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:12:11:12:11 | p |  |
 | smart_pointer.cpp:11:30:11:50 | call to make_shared | smart_pointer.cpp:13:10:13:10 | p |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2114,13 +2114,17 @@
 | set.cpp:69:7:69:9 | ref arg s11 | set.cpp:71:7:71:9 | s11 |  |
 | set.cpp:69:7:69:9 | ref arg s11 | set.cpp:72:7:72:9 | s11 |  |
 | set.cpp:69:7:69:9 | ref arg s11 | set.cpp:126:1:126:1 | s11 |  |
+| set.cpp:69:7:69:9 | s11 | set.cpp:69:11:69:21 | call to lower_bound | TAINT |
 | set.cpp:70:7:70:9 | ref arg s11 | set.cpp:71:7:71:9 | s11 |  |
 | set.cpp:70:7:70:9 | ref arg s11 | set.cpp:72:7:72:9 | s11 |  |
 | set.cpp:70:7:70:9 | ref arg s11 | set.cpp:126:1:126:1 | s11 |  |
+| set.cpp:70:7:70:9 | s11 | set.cpp:70:11:70:21 | call to upper_bound | TAINT |
 | set.cpp:71:7:71:9 | ref arg s11 | set.cpp:72:7:72:9 | s11 |  |
 | set.cpp:71:7:71:9 | ref arg s11 | set.cpp:126:1:126:1 | s11 |  |
+| set.cpp:71:7:71:9 | s11 | set.cpp:71:11:71:21 | call to equal_range | TAINT |
 | set.cpp:71:28:71:32 | first | set.cpp:71:7:71:32 | call to iterator |  |
 | set.cpp:72:7:72:9 | ref arg s11 | set.cpp:126:1:126:1 | s11 |  |
+| set.cpp:72:7:72:9 | s11 | set.cpp:72:11:72:21 | call to equal_range | TAINT |
 | set.cpp:72:28:72:33 | second | set.cpp:72:7:72:33 | call to iterator |  |
 | set.cpp:75:19:75:21 | call to set | set.cpp:76:2:76:4 | s12 |  |
 | set.cpp:75:19:75:21 | call to set | set.cpp:78:7:78:9 | s12 |  |
@@ -2582,8 +2586,10 @@
 | set.cpp:182:13:182:15 | c | set.cpp:182:6:182:11 | call to insert | TAINT |
 | set.cpp:183:7:183:9 | ref arg s11 | set.cpp:184:7:184:9 | s11 |  |
 | set.cpp:183:7:183:9 | ref arg s11 | set.cpp:238:1:238:1 | s11 |  |
+| set.cpp:183:7:183:9 | s11 | set.cpp:183:11:183:21 | call to equal_range | TAINT |
 | set.cpp:183:28:183:32 | first | set.cpp:183:7:183:32 | call to iterator |  |
 | set.cpp:184:7:184:9 | ref arg s11 | set.cpp:238:1:238:1 | s11 |  |
+| set.cpp:184:7:184:9 | s11 | set.cpp:184:11:184:21 | call to equal_range | TAINT |
 | set.cpp:184:28:184:33 | second | set.cpp:184:7:184:33 | call to iterator |  |
 | set.cpp:187:29:187:31 | call to unordered_set | set.cpp:188:2:188:4 | s12 |  |
 | set.cpp:187:29:187:31 | call to unordered_set | set.cpp:190:7:190:9 | s12 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -2224,10 +2224,12 @@
 | set.cpp:99:2:99:4 | ref arg s16 | set.cpp:126:1:126:1 | s16 |  |
 | set.cpp:99:12:99:14 | ref arg s17 | set.cpp:102:7:102:9 | s17 |  |
 | set.cpp:99:12:99:14 | ref arg s17 | set.cpp:126:1:126:1 | s17 |  |
+| set.cpp:99:12:99:14 | s17 | set.cpp:99:2:99:4 | ref arg s16 | TAINT |
 | set.cpp:100:2:100:4 | ref arg s18 | set.cpp:103:7:103:9 | s18 |  |
 | set.cpp:100:2:100:4 | ref arg s18 | set.cpp:126:1:126:1 | s18 |  |
 | set.cpp:100:12:100:14 | ref arg s19 | set.cpp:104:7:104:9 | s19 |  |
 | set.cpp:100:12:100:14 | ref arg s19 | set.cpp:126:1:126:1 | s19 |  |
+| set.cpp:100:12:100:14 | s19 | set.cpp:100:2:100:4 | ref arg s18 | TAINT |
 | set.cpp:101:7:101:9 | s16 | set.cpp:101:7:101:9 | call to set |  |
 | set.cpp:102:7:102:9 | s17 | set.cpp:102:7:102:9 | call to set |  |
 | set.cpp:103:7:103:9 | s18 | set.cpp:103:7:103:9 | call to set |  |
@@ -2685,10 +2687,12 @@
 | set.cpp:211:2:211:4 | ref arg s16 | set.cpp:238:1:238:1 | s16 |  |
 | set.cpp:211:12:211:14 | ref arg s17 | set.cpp:214:7:214:9 | s17 |  |
 | set.cpp:211:12:211:14 | ref arg s17 | set.cpp:238:1:238:1 | s17 |  |
+| set.cpp:211:12:211:14 | s17 | set.cpp:211:2:211:4 | ref arg s16 | TAINT |
 | set.cpp:212:2:212:4 | ref arg s18 | set.cpp:215:7:215:9 | s18 |  |
 | set.cpp:212:2:212:4 | ref arg s18 | set.cpp:238:1:238:1 | s18 |  |
 | set.cpp:212:12:212:14 | ref arg s19 | set.cpp:216:7:216:9 | s19 |  |
 | set.cpp:212:12:212:14 | ref arg s19 | set.cpp:238:1:238:1 | s19 |  |
+| set.cpp:212:12:212:14 | s19 | set.cpp:212:2:212:4 | ref arg s18 | TAINT |
 | set.cpp:213:7:213:9 | s16 | set.cpp:213:7:213:9 | call to unordered_set |  |
 | set.cpp:214:7:214:9 | s17 | set.cpp:214:7:214:9 | call to unordered_set |  |
 | set.cpp:215:7:215:9 | s18 | set.cpp:215:7:215:9 | call to unordered_set |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
@@ -117,12 +117,12 @@ void test_set()
 	std::set<char *> s21, s22;
 	sink(s21.emplace("abc").first);
 	sink(s21);
-	sink(s21.emplace(source()).first); // tainted [NOT DETECTED]
-	sink(s21); // tainted [NOT DETECTED]
+	sink(s21.emplace(source()).first); // tainted
+	sink(s21); // tainted
 	sink(s22.emplace_hint(s22.begin(), "abc"));
 	sink(s22);
-	sink(s22.emplace_hint(s22.begin(), source())); // tainted [NOT DETECTED]
-	sink(s22); // tainted [NOT DETECTED]
+	sink(s22.emplace_hint(s22.begin(), source())); // tainted
+	sink(s22); // tainted
 }
 
 void test_unordered_set()
@@ -229,10 +229,10 @@ void test_unordered_set()
 	std::unordered_set<char *> s21, s22;
 	sink(s21.emplace("abc").first);
 	sink(s21);
-	sink(s21.emplace(source()).first); // tainted [NOT DETECTED]
-	sink(s21); // tainted [NOT DETECTED]
+	sink(s21.emplace(source()).first); // tainted
+	sink(s21); // tainted
 	sink(s22.emplace_hint(s22.begin(), "abc"));
 	sink(s22);
-	sink(s22.emplace_hint(s22.begin(), source())); // tainted [NOT DETECTED]
-	sink(s22); // tainted [NOT DETECTED]
+	sink(s22.emplace_hint(s22.begin(), source())); // tainted
+	sink(s22); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
@@ -66,10 +66,10 @@ void test_set()
 	s11.insert("a");
 	s11.insert(source());
 	s11.insert("c");
-	sink(s11.lower_bound("b")); // tainted [NOT DETECTED]
-	sink(s11.upper_bound("b")); // tainted [NOT DETECTED]
-	sink(s11.equal_range("b").first); // tainted [NOT DETECTED]
-	sink(s11.equal_range("b").second); // tainted [NOT DETECTED]
+	sink(s11.lower_bound("b")); // tainted
+	sink(s11.upper_bound("b")); // tainted
+	sink(s11.equal_range("b").first); // tainted
+	sink(s11.equal_range("b").second); // tainted
 
 	// swap
 	std::set<char *> s12, s13, s14, s15;
@@ -180,8 +180,8 @@ void test_unordered_set()
 	s11.insert("a");
 	s11.insert(source());
 	s11.insert("c");
-	sink(s11.equal_range("b").first); // tainted [NOT DETECTED]
-	sink(s11.equal_range("b").second); // tainted [NOT DETECTED]
+	sink(s11.equal_range("b").first); // tainted
+	sink(s11.equal_range("b").second); // tainted
 
 	// swap
 	std::unordered_set<char *> s12, s13, s14, s15;

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/set.cpp
@@ -99,8 +99,8 @@ void test_set()
 	s16.merge(s17);
 	s18.merge(s19);
 	sink(s16); // tainted
-	sink(s17); // tainted [NOT DETECTED]
-	sink(s18); // tainted [NOT DETECTED]
+	sink(s17);
+	sink(s18); // tainted
 	sink(s19); // tainted
 
 	// erase, clear
@@ -211,8 +211,8 @@ void test_unordered_set()
 	s16.merge(s17);
 	s18.merge(s19);
 	sink(s16); // tainted
-	sink(s17); // tainted [NOT DETECTED]
-	sink(s18); // tainted [NOT DETECTED]
+	sink(s17);
+	sink(s18); // tainted
 	sink(s19); // tainted
 
 	// erase, clear

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -167,6 +167,7 @@
 | set.cpp:95:7:95:9 | call to set | set.cpp:91:13:91:18 | call to source |
 | set.cpp:98:7:98:9 | call to set | set.cpp:94:13:94:18 | call to source |
 | set.cpp:101:7:101:9 | call to set | set.cpp:91:13:91:18 | call to source |
+| set.cpp:103:7:103:9 | call to set | set.cpp:94:13:94:18 | call to source |
 | set.cpp:104:7:104:9 | call to set | set.cpp:94:13:94:18 | call to source |
 | set.cpp:110:7:110:9 | call to set | set.cpp:108:13:108:18 | call to source |
 | set.cpp:110:7:110:9 | call to set | set.cpp:109:13:109:18 | call to source |
@@ -201,6 +202,7 @@
 | set.cpp:207:7:207:9 | call to unordered_set | set.cpp:203:13:203:18 | call to source |
 | set.cpp:210:7:210:9 | call to unordered_set | set.cpp:206:13:206:18 | call to source |
 | set.cpp:213:7:213:9 | call to unordered_set | set.cpp:203:13:203:18 | call to source |
+| set.cpp:215:7:215:9 | call to unordered_set | set.cpp:206:13:206:18 | call to source |
 | set.cpp:216:7:216:9 | call to unordered_set | set.cpp:206:13:206:18 | call to source |
 | set.cpp:222:7:222:9 | call to unordered_set | set.cpp:220:13:220:18 | call to source |
 | set.cpp:222:7:222:9 | call to unordered_set | set.cpp:221:13:221:18 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -158,6 +158,8 @@
 | set.cpp:50:10:50:13 | call to find | set.cpp:20:17:20:22 | call to source |
 | set.cpp:51:11:51:14 | call to find | set.cpp:20:17:20:22 | call to source |
 | set.cpp:61:8:61:8 | call to operator* | set.cpp:20:17:20:22 | call to source |
+| set.cpp:69:11:69:21 | call to lower_bound | set.cpp:67:13:67:18 | call to source |
+| set.cpp:70:11:70:21 | call to upper_bound | set.cpp:67:13:67:18 | call to source |
 | set.cpp:78:7:78:9 | call to set | set.cpp:76:13:76:18 | call to source |
 | set.cpp:81:7:81:9 | call to set | set.cpp:77:13:77:18 | call to source |
 | set.cpp:84:7:84:9 | call to set | set.cpp:76:13:76:18 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -179,6 +179,9 @@
 | set.cpp:112:7:112:9 | call to set | set.cpp:109:13:109:18 | call to source |
 | set.cpp:114:7:114:9 | call to set | set.cpp:108:13:108:18 | call to source |
 | set.cpp:114:7:114:9 | call to set | set.cpp:109:13:109:18 | call to source |
+| set.cpp:121:7:121:9 | call to set | set.cpp:120:19:120:24 | call to source |
+| set.cpp:124:11:124:22 | call to emplace_hint | set.cpp:124:37:124:42 | call to source |
+| set.cpp:125:7:125:9 | call to set | set.cpp:124:37:124:42 | call to source |
 | set.cpp:136:10:136:15 | call to insert | set.cpp:136:29:136:34 | call to source |
 | set.cpp:140:7:140:8 | call to unordered_set | set.cpp:134:17:134:22 | call to source |
 | set.cpp:142:7:142:8 | call to unordered_set | set.cpp:136:29:136:34 | call to source |
@@ -214,6 +217,9 @@
 | set.cpp:224:7:224:9 | call to unordered_set | set.cpp:221:13:221:18 | call to source |
 | set.cpp:226:7:226:9 | call to unordered_set | set.cpp:220:13:220:18 | call to source |
 | set.cpp:226:7:226:9 | call to unordered_set | set.cpp:221:13:221:18 | call to source |
+| set.cpp:233:7:233:9 | call to unordered_set | set.cpp:232:19:232:24 | call to source |
+| set.cpp:236:11:236:22 | call to emplace_hint | set.cpp:236:37:236:42 | call to source |
+| set.cpp:237:7:237:9 | call to unordered_set | set.cpp:236:37:236:42 | call to source |
 | smart_pointer.cpp:12:10:12:10 | call to operator* | smart_pointer.cpp:11:52:11:57 | call to source |
 | smart_pointer.cpp:13:10:13:10 | p | smart_pointer.cpp:11:52:11:57 | call to source |
 | smart_pointer.cpp:24:10:24:10 | call to operator* | smart_pointer.cpp:23:52:23:57 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -115,6 +115,8 @@
 | set.cpp:48:10:48:13 | set.cpp:20:17:20:22 | AST only |
 | set.cpp:49:10:49:13 | set.cpp:20:17:20:22 | AST only |
 | set.cpp:61:8:61:11 | set.cpp:20:17:20:22 | IR only |
+| set.cpp:71:7:71:32 | set.cpp:67:13:67:18 | IR only |
+| set.cpp:72:7:72:33 | set.cpp:67:13:67:18 | IR only |
 | set.cpp:78:7:78:9 | set.cpp:76:13:76:18 | AST only |
 | set.cpp:81:7:81:9 | set.cpp:77:13:77:18 | AST only |
 | set.cpp:84:7:84:9 | set.cpp:76:13:76:18 | AST only |
@@ -143,6 +145,8 @@
 | set.cpp:162:10:162:13 | set.cpp:134:17:134:22 | AST only |
 | set.cpp:163:10:163:13 | set.cpp:134:17:134:22 | AST only |
 | set.cpp:175:8:175:11 | set.cpp:134:17:134:22 | IR only |
+| set.cpp:183:7:183:32 | set.cpp:181:13:181:18 | IR only |
+| set.cpp:184:7:184:33 | set.cpp:181:13:181:18 | IR only |
 | set.cpp:190:7:190:9 | set.cpp:188:13:188:18 | AST only |
 | set.cpp:193:7:193:9 | set.cpp:189:13:189:18 | AST only |
 | set.cpp:196:7:196:9 | set.cpp:188:13:188:18 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -124,6 +124,7 @@
 | set.cpp:95:7:95:9 | set.cpp:91:13:91:18 | AST only |
 | set.cpp:98:7:98:9 | set.cpp:94:13:94:18 | AST only |
 | set.cpp:101:7:101:9 | set.cpp:91:13:91:18 | AST only |
+| set.cpp:103:7:103:9 | set.cpp:94:13:94:18 | AST only |
 | set.cpp:104:7:104:9 | set.cpp:94:13:94:18 | AST only |
 | set.cpp:110:7:110:9 | set.cpp:108:13:108:18 | AST only |
 | set.cpp:110:7:110:9 | set.cpp:109:13:109:18 | AST only |
@@ -151,6 +152,7 @@
 | set.cpp:207:7:207:9 | set.cpp:203:13:203:18 | AST only |
 | set.cpp:210:7:210:9 | set.cpp:206:13:206:18 | AST only |
 | set.cpp:213:7:213:9 | set.cpp:203:13:203:18 | AST only |
+| set.cpp:215:7:215:9 | set.cpp:206:13:206:18 | AST only |
 | set.cpp:216:7:216:9 | set.cpp:206:13:206:18 | AST only |
 | set.cpp:222:7:222:9 | set.cpp:220:13:220:18 | AST only |
 | set.cpp:222:7:222:9 | set.cpp:221:13:221:18 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -134,6 +134,9 @@
 | set.cpp:112:7:112:9 | set.cpp:109:13:109:18 | AST only |
 | set.cpp:114:7:114:9 | set.cpp:108:13:108:18 | AST only |
 | set.cpp:114:7:114:9 | set.cpp:109:13:109:18 | AST only |
+| set.cpp:120:7:120:33 | set.cpp:120:19:120:24 | IR only |
+| set.cpp:121:7:121:9 | set.cpp:120:19:120:24 | AST only |
+| set.cpp:125:7:125:9 | set.cpp:124:37:124:42 | AST only |
 | set.cpp:134:7:134:31 | set.cpp:134:17:134:22 | IR only |
 | set.cpp:140:7:140:8 | set.cpp:134:17:134:22 | AST only |
 | set.cpp:142:7:142:8 | set.cpp:136:29:136:34 | AST only |
@@ -164,6 +167,9 @@
 | set.cpp:224:7:224:9 | set.cpp:221:13:221:18 | AST only |
 | set.cpp:226:7:226:9 | set.cpp:220:13:220:18 | AST only |
 | set.cpp:226:7:226:9 | set.cpp:221:13:221:18 | AST only |
+| set.cpp:232:7:232:33 | set.cpp:232:19:232:24 | IR only |
+| set.cpp:233:7:233:9 | set.cpp:232:19:232:24 | AST only |
+| set.cpp:237:7:237:9 | set.cpp:236:37:236:42 | AST only |
 | smart_pointer.cpp:12:10:12:10 | smart_pointer.cpp:11:52:11:57 | AST only |
 | smart_pointer.cpp:24:10:24:10 | smart_pointer.cpp:23:52:23:57 | AST only |
 | standalone_iterators.cpp:41:10:41:10 | standalone_iterators.cpp:39:45:39:51 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -121,6 +121,10 @@
 | set.cpp:51:11:51:14 | call to find | set.cpp:20:17:20:22 | call to source |
 | set.cpp:61:8:61:8 | call to operator* | set.cpp:20:17:20:22 | call to source |
 | set.cpp:61:8:61:11 | (reference dereference) | set.cpp:20:17:20:22 | call to source |
+| set.cpp:69:11:69:21 | call to lower_bound | set.cpp:67:13:67:18 | call to source |
+| set.cpp:70:11:70:21 | call to upper_bound | set.cpp:67:13:67:18 | call to source |
+| set.cpp:71:7:71:32 | call to iterator | set.cpp:67:13:67:18 | call to source |
+| set.cpp:72:7:72:33 | call to iterator | set.cpp:67:13:67:18 | call to source |
 | set.cpp:111:11:111:15 | call to erase | set.cpp:108:13:108:18 | call to source |
 | set.cpp:111:11:111:15 | call to erase | set.cpp:109:13:109:18 | call to source |
 | set.cpp:134:7:134:31 | call to iterator | set.cpp:134:17:134:22 | call to source |
@@ -132,6 +136,8 @@
 | set.cpp:165:11:165:14 | call to find | set.cpp:134:17:134:22 | call to source |
 | set.cpp:175:8:175:8 | call to operator* | set.cpp:134:17:134:22 | call to source |
 | set.cpp:175:8:175:11 | (reference dereference) | set.cpp:134:17:134:22 | call to source |
+| set.cpp:183:7:183:32 | call to iterator | set.cpp:181:13:181:18 | call to source |
+| set.cpp:184:7:184:33 | call to iterator | set.cpp:181:13:181:18 | call to source |
 | set.cpp:223:11:223:15 | call to erase | set.cpp:220:13:220:18 | call to source |
 | set.cpp:223:11:223:15 | call to erase | set.cpp:221:13:221:18 | call to source |
 | smart_pointer.cpp:13:10:13:10 | Argument 0 indirection | smart_pointer.cpp:11:52:11:57 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -127,6 +127,8 @@
 | set.cpp:72:7:72:33 | call to iterator | set.cpp:67:13:67:18 | call to source |
 | set.cpp:111:11:111:15 | call to erase | set.cpp:108:13:108:18 | call to source |
 | set.cpp:111:11:111:15 | call to erase | set.cpp:109:13:109:18 | call to source |
+| set.cpp:120:7:120:33 | call to iterator | set.cpp:120:19:120:24 | call to source |
+| set.cpp:124:11:124:22 | call to emplace_hint | set.cpp:124:37:124:42 | call to source |
 | set.cpp:134:7:134:31 | call to iterator | set.cpp:134:17:134:22 | call to source |
 | set.cpp:136:10:136:15 | call to insert | set.cpp:136:29:136:34 | call to source |
 | set.cpp:146:10:146:13 | call to find | set.cpp:134:17:134:22 | call to source |
@@ -140,6 +142,8 @@
 | set.cpp:184:7:184:33 | call to iterator | set.cpp:181:13:181:18 | call to source |
 | set.cpp:223:11:223:15 | call to erase | set.cpp:220:13:220:18 | call to source |
 | set.cpp:223:11:223:15 | call to erase | set.cpp:221:13:221:18 | call to source |
+| set.cpp:232:7:232:33 | call to iterator | set.cpp:232:19:232:24 | call to source |
+| set.cpp:236:11:236:22 | call to emplace_hint | set.cpp:236:37:236:42 | call to source |
 | smart_pointer.cpp:13:10:13:10 | Argument 0 indirection | smart_pointer.cpp:11:52:11:57 | call to source |
 | smart_pointer.cpp:25:10:25:10 | Argument 0 indirection | smart_pointer.cpp:23:52:23:57 | call to source |
 | smart_pointer.cpp:52:12:52:14 | call to get | smart_pointer.cpp:51:52:51:57 | call to source |


### PR DESCRIPTION
Model additional taint flows through `std::set` and `std::unordered_set`.  Similar to https://github.com/github/codeql/pull/4439 but a bit simpler.