### PR TITLE
JavaScript: Eliminate source of false positives in `UnsafeShellCommandConstruction`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstruction.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/UnsafeShellCommandConstruction.qll
@@ -31,5 +31,15 @@ module UnsafeShellCommandConstruction {
       guard instanceof PathExistsSanitizerGuard or
       guard instanceof TaintTracking::AdHocWhitelistCheckSanitizer
     }
+
+    // override to require that there is a path without unmatched return steps
+    override predicate hasFlowPath(DataFlow::SourcePathNode source, DataFlow::SinkPathNode sink) {
+      super.hasFlowPath(source, sink) and
+      exists(DataFlow::MidPathNode mid |
+        source.getASuccessor*() = mid and
+        sink = mid.getASuccessor() and
+        mid.getPathSummary().hasReturn() = false
+      )
+    }
   }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -185,6 +185,12 @@ nodes
 | lib/lib.js:330:9:330:9 | x |
 | lib/lib.js:336:22:336:31 | id("test") |
 | lib/lib.js:336:22:336:31 | id("test") |
+| lib/lib.js:339:39:339:39 | n |
+| lib/lib.js:339:39:339:39 | n |
+| lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:340:25:340:25 | n |
 edges
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
@@ -405,6 +411,12 @@ edges
 | lib/lib.js:329:13:329:13 | x | lib/lib.js:330:9:330:9 | x |
 | lib/lib.js:330:9:330:9 | x | lib/lib.js:336:22:336:31 | id("test") |
 | lib/lib.js:330:9:330:9 | x | lib/lib.js:336:22:336:31 | id("test") |
+| lib/lib.js:330:9:330:9 | x | lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:330:9:330:9 | x | lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:339:39:339:39 | n | lib/lib.js:340:25:340:25 | n |
+| lib/lib.js:339:39:339:39 | n | lib/lib.js:340:25:340:25 | n |
+| lib/lib.js:340:25:340:25 | n | lib/lib.js:340:22:340:26 | id(n) |
+| lib/lib.js:340:25:340:25 | n | lib/lib.js:340:22:340:26 | id(n) |
 #select
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:8:10:8:25 | "rm -rf " + name | lib/lib2.js:7:32:7:35 | name | lib/lib2.js:8:22:8:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/lib2.js:8:2:8:26 | cp.exec ... + name) | shell command |
@@ -459,3 +471,4 @@ edges
 | lib/lib.js:315:10:315:25 | "rm -rf " + name | lib/lib.js:314:40:314:43 | name | lib/lib.js:315:22:315:25 | name | $@ based on library input is later used in $@. | lib/lib.js:315:10:315:25 | "rm -rf " + name | String concatenation | lib/lib.js:315:2:315:26 | cp.exec ... + name) | shell command |
 | lib/lib.js:320:11:320:26 | "rm -rf " + name | lib/lib.js:314:40:314:43 | name | lib/lib.js:320:23:320:26 | name | $@ based on library input is later used in $@. | lib/lib.js:320:11:320:26 | "rm -rf " + name | String concatenation | lib/lib.js:320:3:320:27 | cp.exec ... + name) | shell command |
 | lib/lib.js:325:12:325:51 | "MyWind ... " + arg | lib/lib.js:324:40:324:42 | arg | lib/lib.js:325:49:325:51 | arg | $@ based on library input is later used in $@. | lib/lib.js:325:12:325:51 | "MyWind ... " + arg | String concatenation | lib/lib.js:326:2:326:13 | cp.exec(cmd) | shell command |
+| lib/lib.js:340:10:340:26 | "rm -rf " + id(n) | lib/lib.js:339:39:339:39 | n | lib/lib.js:340:22:340:26 | id(n) | $@ based on library input is later used in $@. | lib/lib.js:340:10:340:26 | "rm -rf " + id(n) | String concatenation | lib/lib.js:340:2:340:27 | cp.exec ...  id(n)) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction.expected
@@ -180,6 +180,11 @@ nodes
 | lib/lib.js:324:40:324:42 | arg |
 | lib/lib.js:325:49:325:51 | arg |
 | lib/lib.js:325:49:325:51 | arg |
+| lib/lib.js:329:13:329:13 | x |
+| lib/lib.js:329:13:329:13 | x |
+| lib/lib.js:330:9:330:9 | x |
+| lib/lib.js:336:22:336:31 | id("test") |
+| lib/lib.js:336:22:336:31 | id("test") |
 edges
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
 | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name |
@@ -396,6 +401,10 @@ edges
 | lib/lib.js:324:40:324:42 | arg | lib/lib.js:325:49:325:51 | arg |
 | lib/lib.js:324:40:324:42 | arg | lib/lib.js:325:49:325:51 | arg |
 | lib/lib.js:324:40:324:42 | arg | lib/lib.js:325:49:325:51 | arg |
+| lib/lib.js:329:13:329:13 | x | lib/lib.js:330:9:330:9 | x |
+| lib/lib.js:329:13:329:13 | x | lib/lib.js:330:9:330:9 | x |
+| lib/lib.js:330:9:330:9 | x | lib/lib.js:336:22:336:31 | id("test") |
+| lib/lib.js:330:9:330:9 | x | lib/lib.js:336:22:336:31 | id("test") |
 #select
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:4:10:4:25 | "rm -rf " + name | String concatenation | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:8:10:8:25 | "rm -rf " + name | lib/lib2.js:7:32:7:35 | name | lib/lib2.js:8:22:8:25 | name | $@ based on library input is later used in $@. | lib/lib2.js:8:10:8:25 | "rm -rf " + name | String concatenation | lib/lib2.js:8:2:8:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -325,3 +325,13 @@ module.exports.typeofcheck = function (arg) {
 	var cmd = "MyWindowCommand | findstr /i /c:" + arg; // NOT OK
 	cp.exec(cmd); 
 }
+
+function id(x) {
+	return x;
+}
+
+module.exports.id = id;
+
+module.exports.unproblematic = function() {
+	cp.exec("rm -rf " + id("test")); // OK [INCONSISTENCY]
+};

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -333,5 +333,5 @@ function id(x) {
 module.exports.id = id;
 
 module.exports.unproblematic = function() {
-	cp.exec("rm -rf " + id("test")); // OK [INCONSISTENCY]
+	cp.exec("rm -rf " + id("test")); // OK
 };

--- a/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/lib/lib.js
@@ -335,3 +335,7 @@ module.exports.id = id;
 module.exports.unproblematic = function() {
 	cp.exec("rm -rf " + id("test")); // OK
 };
+
+module.exports.problematic = function(n) {
+	cp.exec("rm -rf " + id(n)); // NOT OK
+};


### PR DESCRIPTION
Our unsafe shell-command construction query looks for paths from an API parameter to a command execution, where that parameter isn't obviously meant to represent a command. The idea is that on the client side, untrusted data may flow into that parameter, and from there into the command.

It will report any such path, even if it involves a return step. In practice, however, results relating to such paths tend to be false positives, since prepending a client-side path to it will result in an infeasible overall path. (The client cannot match the return step with a corresponding call step.)

The idea of this PR is to simply eliminate all results from paths involving a return step. This is annoyingly fiddly to implement due to our use of `SinkPathNode`s, which merge multiple paths ending in the same node. (What can I say, it seemed like a good idea at the time. :hangs-head-in-shame:)

An [evaluation](https://github.com/max-schaefer/dist-compare-reports/blob/master/js/unsafe-shell-command-construction-infeasible-paths/report.md) (internal link) came back clean.