### PR TITLE
Python: implement printAst for Python

### DIFF
--- a/python/ql/src/printAst.ql
+++ b/python/ql/src/printAst.ql
@@ -1,0 +1,28 @@
+/**
+ * @name Print AST
+ * @description Outputs a representation of a file's Abstract Syntax Tree. This
+ *              query is used by the VS Code extension.
+ * @id py/print-ast
+ * @kind graph
+ * @tags ide-contextual-queries/print-ast
+ */
+
+import python
+import semmle.python.PrintAst
+import analysis.DefinitionTracking
+
+/**
+ * The source file to generate an AST from.
+ */
+external string selectedSourceFile();
+
+class PrintAstConfigurationOverride extends PrintAstConfiguration {
+  /**
+   * Holds if the location matches the selected file in the VS Code extension and
+   * the element is not a synthetic constructor.
+   */
+  override predicate shouldPrint(AstNode e, Location l) {
+    super.shouldPrint(e, l) and
+    l.getFile() = getEncodedFile(selectedSourceFile())
+  }
+}

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -550,7 +550,7 @@ private module PrettyPrinting {
       or
       a instanceof Ellipsis and result = "..."
       or
-      result = a.(Num).toString()
+      result = a.(Num).getText()
       or
       result = a.(NegativeIntegerLiteral).getValue().toString()
       or

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -539,8 +539,6 @@ private module PrettyPrinting {
       or
       result = "`" + a.(Repr).getValue() + "`"
       or
-      result = "b' " + a.(Bytes).getS() + "'"
-      or
       a instanceof Ellipsis and result = "..."
       or
       result = a.(Num).toString()

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -409,7 +409,7 @@ private module PrettyPrinting {
   string getQlClass(AstNode a) {
     not exists(getQlCustomClass(a)) and result = a.toString()
     or
-    result = getQlCustomClass(a)
+    result = strictconcat(getQlCustomClass(a), " | ")
   }
 
   /**
@@ -418,7 +418,8 @@ private module PrettyPrinting {
   string getQlCustomClass(AstNode a) {
     a instanceof Name and
     result = "Name" and
-    not a instanceof Parameter
+    not a instanceof Parameter and 
+    not a instanceof NameConstant
     or
     a instanceof Parameter and result = "Parameter"
     or

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -423,6 +423,7 @@ class ParameterNode extends AstElementNode {
  * Gets the `i`th child from `node` ordered by location.
  */
 private AstNode getChild(AstNode node, int i) {
+  shouldPrint(node, _) and
   result =
     rank[i](AstNode child |
       child = node.getAChildNode()
@@ -444,31 +445,37 @@ private module PrettyPrinting {
    * These exceptions are handled in the `getQlCustomClass` predicate.
    */
   string getQlClass(AstNode a) {
-    not exists(getQlCustomClass(a)) and result = a.toString()
-    or
-    result = strictconcat(getQlCustomClass(a), " | ")
+    shouldPrint(a, _) and
+    (
+      not exists(getQlCustomClass(a)) and result = a.toString()
+      or
+      result = strictconcat(getQlCustomClass(a), " | ")
+    )
   }
 
   /**
    * Gets the QL class for `a` for the `AstNode`s where the toString method does not print the QL class.
    */
   string getQlCustomClass(AstNode a) {
-    a instanceof Name and
-    result = "Name" and
-    not a instanceof Parameter and
-    not a instanceof NameConstant
-    or
-    a instanceof Parameter and result = "Parameter"
-    or
-    a instanceof PlaceHolder and result = "PlaceHolder"
-    or
-    a instanceof Function and result = "Function"
-    or
-    a instanceof Class and result = "Class"
-    or
-    a instanceof Call and result = "Call"
-    or
-    a instanceof NameConstant and result = "NameConstant"
+    shouldPrint(a, _) and
+    (
+      a instanceof Name and
+      result = "Name" and
+      not a instanceof Parameter and
+      not a instanceof NameConstant
+      or
+      a instanceof Parameter and result = "Parameter"
+      or
+      a instanceof PlaceHolder and result = "PlaceHolder"
+      or
+      a instanceof Function and result = "Function"
+      or
+      a instanceof Class and result = "Class"
+      or
+      a instanceof Call and result = "Call"
+      or
+      a instanceof NameConstant and result = "NameConstant"
+    )
   }
 
   /**
@@ -477,12 +484,15 @@ private module PrettyPrinting {
    * Has one and only result for every AstNode.
    */
   string prettyPrint(AstNode a) {
-    // this strictconcat should not be needed.
-    // However, the printAst feature breaks if this predicate has more than one result for an `AstNode`, so the strictconcat stays.
-    result = strictconcat(reprRec(a), " | ")
-    or
-    not exists(reprRec(a)) and
-    result = ""
+    shouldPrint(a, _) and
+    (
+      // this strictconcat should not be needed.
+      // However, the printAst feature breaks if this predicate has more than one result for an `AstNode`, so the strictconcat stays.
+      result = strictconcat(reprRec(a), " | ")
+      or
+      not exists(reprRec(a)) and
+      result = ""
+    )
   }
 
   /**

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -20,8 +20,8 @@ class PrintAstConfiguration extends TPrintAstConfiguration {
   string toString() { result = "PrintAstConfiguration" }
 
   /**
-   * Controls whether the `Element` should be considered for AST printing.
-   * By default it checks whether the `Element` `e` belongs to `Location` `l`.
+   * Controls whether the `AstNode` should be considered for AST printing.
+   * By default it checks whether the `AstNode` `e` belongs to `Location` `l`.
    */
   predicate shouldPrint(AstNode e, Location l) { l = e.getLocation() }
 }
@@ -132,9 +132,9 @@ class TopLevelPrintAstNode extends PrintAstNode {
 /**
  * An `AstNode` printed in the print-viewer.
  *
- * This class can be overwriten to define more specific behavior for some `AstNode`s.
- * The `getChildNode` and `getStmtList` methods can be overwritten to easily set up a child-parent relation between different `AstElementNode`s.
- * Be very carefull about overriding `getChild`, as `getChildNode` and `getStmtList` depends on the default beavior of `getChild`.
+ * This class can be overridden to define more specific behavior for some `AstNode`s.
+ * The `getChildNode` and `getStmtList` methods can be overridden to easily set up a child-parent relation between different `AstElementNode`s.
+ * Be very careful about overriding `getChild`, as `getChildNode` and `getStmtList` depend on the default behavior of `getChild`.
  */
 class AstElementNode extends PrintAstNode, TElementNode {
   AstNode element;
@@ -276,8 +276,8 @@ class WhilePrintNode extends AstElementNode {
 
 /**
  * A print node for `StmtList`.
- * A `StmtListNode` is always a child of a `AstElementNode`,
- * and the child-parent relation is decided by the `getStmtList` predicate in `AstElementNode.
+ * A `StmtListNode` is always a child of an `AstElementNode`,
+ * and the child-parent relation is defined by the `getStmtList` predicate in `AstElementNode`.
  *
  * The label for a `StmtList` is decided based on the result from the `getStmtList` predicate in `AstElementNode`.
  */
@@ -440,7 +440,7 @@ private AstNode getChild(AstNode node, int i) {
  */
 private module PrettyPrinting {
   /**
-   * Gets the QL class for `a`.
+   * Gets the QL class for the `AstNode` `a`.
    * Most `AstNode`s print their QL class in the `toString()` method, however there are exceptions.
    * These exceptions are handled in the `getQlCustomClass` predicate.
    */
@@ -454,7 +454,7 @@ private module PrettyPrinting {
   }
 
   /**
-   * Gets the QL class for `a` for the `AstNode`s where the toString method does not print the QL class.
+   * Gets the QL class for `AstNode`s where the `toString` method does not print the QL class.
    */
   string getQlCustomClass(AstNode a) {
     shouldPrint(a, _) and
@@ -481,7 +481,7 @@ private module PrettyPrinting {
   /**
    * Gets a human-readable representation of the `AstNode` `a`, or the empty string.
    *
-   * Has one and only result for every AstNode.
+   * Has exactly one result for every `AstNode`.
    */
   string prettyPrint(AstNode a) {
     shouldPrint(a, _) and
@@ -572,7 +572,7 @@ private module PrettyPrinting {
 
   /**
    * Gets a human-readable representation of the given `AstNode`.
-   * Is only defined for the an `AstNode` where a human-readable representation can be created without using recursion.
+   * Is only defined for `AstNode`s for which a human-readable representation can be created without using recursion.
    */
   private string reprBase(AstNode a) {
     shouldPrint(a, _) and

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -134,7 +134,7 @@ class TopLevelPrintAstNode extends PrintAstNode {
  *
  * This class can be overwriten to define more specific behavior for some `AstNode`s.
  * The `getChildNode` and `getStmtList` methods can be overwritten to easily set up a child-parent relation between different `AstElementNode`s.
- * Be very carefull about overridding `getChild`, as `getChildNode` and `getStmtList` depends on the default beavior of `getChild`.
+ * Be very carefull about overriding `getChild`, as `getChildNode` and `getStmtList` depends on the default beavior of `getChild`.
  */
 class AstElementNode extends PrintAstNode, TElementNode {
   AstNode element;

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -297,8 +297,6 @@ class StmtListNode extends PrintAstNode, TStmtListNode {
 
   override string toString() { result = "(StmtList) " + getLabel() }
 
-  override Location getLocation() { result = list.getItem(0).getLocation() }
-
   override PrintAstNode getChild(int childIndex) {
     exists(AstNode el | result.(AstElementNode).getAstNode() = el | el = list.getItem(childIndex))
   }
@@ -357,8 +355,6 @@ class FunctionParamsNode extends PrintAstNode, TFunctionParamsNode {
   Function getFunction() { result = func }
 
   override string toString() { result = "(parameters)" }
-
-  override Location getLocation() { result = func.getLocation() }
 
   override PrintAstNode getChild(int childIndex) {
     // everything that is not a stmt is a parameter.

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -1,0 +1,592 @@
+/**
+ * Provides queries to pretty-print a Python AST as a graph.
+ *
+ * By default, this will print the AST for all elements in the database. To change this behavior,
+ * extend `PrintAstConfiguration` and override `shouldPrint` to hold for only the elements
+ * you wish to view the AST for.
+ */
+
+import python
+
+private newtype TPrintAstConfiguration = MkPrintAstConfiguration()
+
+/**
+ * The query can extend this class to control which elements are printed.
+ */
+class PrintAstConfiguration extends TPrintAstConfiguration {
+  /**
+   * Gets a textual representation of this `PrintAstConfiguration`.
+   */
+  string toString() { result = "PrintAstConfiguration" }
+
+  /**
+   * Controls whether the `Element` should be considered for AST printing.
+   * By default it checks whether the `Element` `e` belongs to `Location` `l`.
+   */
+  predicate shouldPrint(AstNode e, Location l) { l = e.getLocation() }
+}
+
+private predicate shouldPrint(AstNode e, Location l) {
+  exists(PrintAstConfiguration config | config.shouldPrint(e, l))
+}
+
+/** Holds if the given element does not need to be rendered in the AST. */
+private predicate isNotNeeded(AstNode el) {
+  el.isArtificial()
+  or
+  el instanceof Module
+  or
+  exists(AstNode parent | isNotNeeded(parent) and not parent instanceof Module |
+    el = parent.getAChildNode()
+  )
+}
+
+/**
+ * Printed nodes.
+ */
+private newtype TPrintAstNode =
+  TElementNode(AstNode el) { shouldPrint(el, _) and not isNotNeeded(el) } or
+  TFunctionParamsNode(AstNode f) { shouldPrint(f, _) and not isNotNeeded(f) } or
+  TStmtListNode(StmtList list) {
+    shouldPrint(list.getAnItem(), _) and
+    not list = any(Module mod).getBody() and
+    not forall(AstNode child | child = list.getAnItem() | isNotNeeded(child)) and
+    exists(list.getAnItem())
+  }
+
+/**
+ * A node in the output tree.
+ */
+class PrintAstNode extends TPrintAstNode {
+  /**
+   * Gets a textual representation of this node in the PrintAst output tree.
+   */
+  string toString() { none() }
+
+  /**
+   * Gets the child node at index `childIndex`. Child indices must be unique,
+   * but need not be contiguous.
+   */
+  PrintAstNode getChild(int childIndex) { none() }
+
+  /**
+   * Gets a child of this node.
+   */
+  final PrintAstNode getAChild() { result = getChild(_) }
+
+  /**
+   * Gets the parent of this node, if any.
+   */
+  final PrintAstNode getParent() { result.getAChild() = this }
+
+  /**
+   * Gets the location of this node in the source code.
+   */
+  Location getLocation() { none() }
+
+  /**
+   * Gets the value of the property of this node, where the name of the property
+   * is `key`.
+   */
+  string getProperty(string key) {
+    key = "semmle.label" and
+    result = toString()
+  }
+
+  /**
+   * Gets the label for the edge from this node to the specified child. By
+   * default, this is just the index of the child, but subclasses can override
+   * this.
+   */
+  string getChildEdgeLabel(int childIndex) {
+    exists(getChild(childIndex)) and
+    result = childIndex.toString()
+  }
+}
+
+/** A top-level AST node. */
+class TopLevelPrintAstNode extends PrintAstNode {
+  TopLevelPrintAstNode() { not exists(this.getParent()) }
+
+  private int getOrder() {
+    this =
+      rank[result](TopLevelPrintAstNode n, Location l |
+        l = n.getLocation()
+      |
+        n
+        order by
+          l.getFile().getRelativePath(), l.getStartLine(), l.getStartColumn(), l.getEndLine(),
+          l.getEndColumn()
+      )
+  }
+
+  override string getProperty(string key) {
+    result = super.getProperty(key)
+    or
+    key = "semmle.order" and
+    result = this.getOrder().toString()
+  }
+}
+
+/**
+ * An `AstNode` printed in the print-viewer.
+ *
+ * This class can be overwriten to define more specific behavior for some `AstNode`s.
+ * The `getChildNode` and `getStmtList` methods can be overwritten to easily set up a child-parent relation between different `AstElementNode`s.
+ * Be very carefull about overridding `getChild`, as `getChildNode` and `getStmtList` depends on the default beavior of `getChild`.
+ */
+class AstElementNode extends PrintAstNode, TElementNode {
+  AstNode element;
+
+  AstElementNode() { this = TElementNode(element) }
+
+  override string toString() {
+    result = "[" + PrettyPrinting::getQlClass(element) + "] " + PrettyPrinting::prettyPrint(element)
+  }
+
+  override Location getLocation() { result = element.getLocation() }
+
+  /**
+   * Gets the `AstNode` that is printed by this print node.
+   */
+  final AstNode getAstNode() { result = element }
+
+  override PrintAstNode getChild(int childIndex) {
+    exists(AstNode el | result.(AstElementNode).getAstNode() = el |
+      el = this.getChildNode(childIndex) and not el = getStmtList(_, _).getAnItem()
+    )
+    or
+    // displaying all `StmtList` after the other children.
+    exists(int offset | offset = 1 + max([0, any(int index | exists(this.getChildNode(index)))]) |
+      exists(int index | childIndex = index + offset |
+        result.(StmtListNode).getList() = getStmtList(index, _)
+      )
+    )
+  }
+
+  /**
+   * Gets a child node for the AstNode that this print node represents.
+   *
+   * The default behavior in `getChild` uses `getChildNode` to easily define a parent-child relation between different `AstElementNode`s.
+   */
+  AstNode getChildNode(int childIndex) { result = getChild(element, childIndex) }
+
+  /**
+   * Gets the `index`th `StmtList` that is a child of the `AstNode` that this print node represents.
+   * `label` is used for pretty-printing a label in the parent-child relation in the ast-viewer.
+   *
+   * The `StmtListNode` class and the `getChild` predicate uses `getStmtList` to define a parent-child relation with labels.
+   *
+   * `index` must be 0 or positive.
+   */
+  StmtList getStmtList(int index, string label) { none() }
+}
+
+/**
+ * A print node for `Try` statements.
+ */
+class TryNode extends AstElementNode {
+  override Try element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 0 and result = element.getBody() and label = "body"
+    or
+    index = 1 and result = element.getOrelse() and label = "orelse"
+    or
+    index = 2 and result = element.getHandlers() and label = "handlers"
+    or
+    index = 3 and result = element.getFinalbody() and label = "final body"
+  }
+}
+
+/**
+ * A print node for `If` statements.
+ */
+class IfNode extends AstElementNode {
+  override If element;
+
+  override AstNode getChildNode(int childIndex) { childIndex = 0 and result = element.getTest() }
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+    or
+    index = 2 and result = element.getOrelse() and label = "orelse"
+  }
+}
+
+/**
+ * A print node for classes.
+ */
+class ClassNode extends AstElementNode {
+  override Class element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+  }
+}
+
+/**
+ * A print node for `ExceptStmt`.
+ */
+class ExceptNode extends AstElementNode {
+  override ExceptStmt element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+  }
+}
+
+/**
+ * A print node for `With` statements.
+ */
+class WithNode extends AstElementNode {
+  override With element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+  }
+}
+
+/**
+ * A print node for `For` statements.
+ */
+class ForPrintNode extends AstElementNode {
+  override For element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+    or
+    index = 2 and result = element.getOrelse() and label = "orelse"
+  }
+}
+
+/**
+ * A print node for `While` statements.
+ */
+class WhilePrintNode extends AstElementNode {
+  override While element;
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+    or
+    index = 2 and result = element.getOrelse() and label = "orelse"
+  }
+}
+
+/**
+ * A print node for `StmtList`.
+ * A `StmtListNode` is always a child of a `AstElementNode`,
+ * and the child-parent relation is decided by the `getStmtList` predicate in `AstElementNode.
+ *
+ * The label for a `StmtList` is decided based on the result from the `getStmtList` predicate in `AstElementNode`.
+ */
+class StmtListNode extends PrintAstNode, TStmtListNode {
+  StmtList list;
+
+  StmtListNode() {
+    this = TStmtListNode(list) and
+    list = any(AstElementNode node).getStmtList(_, _)
+  }
+
+  /**
+   * Gets the `StmtList` that this print node represents.
+   */
+  StmtList getList() { result = list }
+
+  private string getLabel() { this.getList() = any(AstElementNode node).getStmtList(_, result) }
+
+  override string toString() { result = "(StmtList) " + getLabel() }
+
+  override Location getLocation() { result = list.getItem(0).getLocation() }
+
+  override PrintAstNode getChild(int childIndex) {
+    exists(AstNode el | result.(AstElementNode).getAstNode() = el | el = list.getItem(childIndex))
+  }
+}
+
+/**
+ * A print node for a `Function`.
+ */
+class FunctionNode extends AstElementNode {
+  override Function element;
+
+  override PrintAstNode getChild(int childIndex) {
+    exists(FunctionParamsNode paramsNode | paramsNode.getFunction() = element |
+      childIndex = 0 and result = paramsNode
+      or
+      result = AstElementNode.super.getChild(childIndex) and
+      // parameters is handled above
+      not result.(AstElementNode).getAstNode() =
+        paramsNode.getChild(_).(AstElementNode).getAstNode() and
+      // The default of a Parameter is handled by `ParameterNode`
+      not result.(AstElementNode).getAstNode() = any(Parameter param).getDefault() and
+      // The annotation is a parameter is handled by `ParameterNode`.
+      not result.(AstElementNode).getAstNode() = any(Parameter param).getAnnotation()
+    )
+  }
+
+  override StmtList getStmtList(int index, string label) {
+    index = 1 and result = element.getBody() and label = "body"
+  }
+}
+
+/**
+ * A print node for the parameters in `func`.
+ */
+class FunctionParamsNode extends PrintAstNode, TFunctionParamsNode {
+  Function func;
+
+  FunctionParamsNode() { this = TFunctionParamsNode(func) }
+
+  /**
+   * Gets the `Function` that this print node represents.
+   */
+  Function getFunction() { result = func }
+
+  override string toString() { result = "(parameters)" }
+
+  override Location getLocation() { result = func.getLocation() }
+
+  override PrintAstNode getChild(int childIndex) {
+    // everything that is not a stmt is a parameter.
+    exists(AstNode el | result.(AstElementNode).getAstNode() = el |
+      el = getChild(func, childIndex) and not el = func.getAStmt()
+    )
+  }
+}
+
+/**
+ * A print node for a `Parameter`.
+ *
+ * This print node has the annotation and default value of the `Parameter` as children.
+ * The type annotation and default value would by default exist as children of the parent `Function`.
+ */
+class ParameterNode extends AstElementNode {
+  Parameter param;
+
+  ParameterNode() { this.getAstNode() = param.asName() or this.getAstNode() = param.asTuple() }
+
+  override AstNode getChildNode(int childIndex) {
+    childIndex = 0 and result = param.getAnnotation()
+    or
+    childIndex = 1 and result = param.getDefault()
+  }
+}
+
+/**
+ * Gets the `i`th child from `node` ordered by location.
+ */
+private AstNode getChild(AstNode node, int i) {
+  result =
+    rank[i](AstNode child |
+      child = node.getAChildNode()
+    |
+      child
+      order by
+        child.getLocation().getStartLine(), child.getLocation().getStartColumn(),
+        child.getLocation().getEndLine(), child.getLocation().getEndColumn()
+    )
+}
+
+/**
+ * A module for pretty-printing some `AstNode`s.
+ */
+private module PrettyPrinting {
+  /**
+   * Gets the QL class for `a`.
+   * Most `AstNode`s print their QL class in the `toString()` method, however there are exceptions.
+   * These exceptions are handled in the `getQlCustomClass` predicate.
+   */
+  string getQlClass(AstNode a) {
+    not exists(getQlCustomClass(a)) and result = a.toString()
+    or
+    result = getQlCustomClass(a)
+  }
+
+  /**
+   * Gets the QL class for `a` for the `AstNode`s where the toString method does not print the QL class.
+   */
+  string getQlCustomClass(AstNode a) {
+    a instanceof Name and
+    result = "Name" and
+    not a instanceof Parameter
+    or
+    a instanceof Parameter and result = "Parameter"
+    or
+    a instanceof PlaceHolder and result = "PlaceHolder"
+    or
+    a instanceof Function and result = "Function"
+    or
+    a instanceof Class and result = "Class"
+    or
+    a instanceof Call and result = "Call"
+    or
+    a instanceof NameConstant and result = "NameConstant"
+  }
+
+  /**
+   * Gets a human-readable representation of the `AstNode` `a`, or the empty string.
+   *
+   * Has one and only result for every AstNode.
+   */
+  string prettyPrint(AstNode a) {
+    // this strictconcat should not be needed.
+    // However, the printAst feature breaks if this predicate has more than one result for an `AstNode`, so the strictconcat stays.
+    result = strictconcat(reprRec(a), " | ")
+    or
+    not exists(reprRec(a)) and
+    result = ""
+  }
+
+  /**
+   * Gets a human-readable representation of the given `AstNode`.
+   *
+   * Only has a result for some `AstNode`s.
+   *
+   * The monotonicity of this recursive predicate is kept by defining the non-recursive cases inside the `reprBase` predicate,
+   * and then using `reprBase` when there is a negative edge.
+   */
+  private string reprRec(AstNode a) {
+    shouldPrint(a, _) and
+    not isNotNeeded(a) and
+    (
+      // For NameNodes, we just use the underlying variable name
+      result = reprBase(a)
+      or
+      exists(Expr obj |
+        obj = a.(Attribute).getObject() // Attribute .getname .getObject
+      |
+        // Attributes of the form `name.name2`
+        result = reprBase(obj) + "." + a.(Attribute).getName()
+        or
+        // Attributes where the object is a more complicated expression
+        not exists(reprBase(obj)) and
+        result = "(...)." + a.(Attribute).getName()
+      )
+      or
+      result = "import " + reprRec(a.(Import).getName(_).getAsname())
+      or
+      exists(Keyword keyword | keyword = a |
+        result = keyword.getArg() + "=" + reprRec(keyword.getValue())
+      )
+      or
+      result = reprRec(a.(Call).getFunc()) + "(" + printArgs(a) + ")"
+      or
+      not exists(printArgs(a)) and result = reprRec(a.(Call).getFunc()) + "(...)"
+      or
+      result = "try " + reprRec(a.(Try).getBody().getItem(0))
+      or
+      result = "if " + reprRec(a.(If).getTest()) + ":"
+      or
+      result = reprRec(a.(Compare).getLeft()) + " " + a.(Compare).getOp(0).getSymbol() + " ..."
+      or
+      result = a.(Subscript).getObject() + "[" + reprRec(a.(Subscript).getIndex()) + "]"
+      or
+      exists(Assign asn | asn = a |
+        strictcount(asn.getTargets()) = 1 and
+        result = reprRec(a.(Assign).getTarget(0)) + " = " + reprRec(asn.getValue())
+      )
+      or
+      result = "return " + reprRec(a.(Return).getValue())
+      or
+      result = reprRec(a.(ExprStmt).getValue())
+      or
+      exists(BoolExpr b, string op |
+        a = b and
+        (
+          b.getOp() instanceof And and op = "and"
+          or
+          b.getOp() instanceof Or and op = "or"
+        )
+      |
+        result = reprRec(b.getValue(0)) + " " + op + " " + reprRec(b.getValue(1))
+      )
+    )
+  }
+
+  /**
+   * Gets a comma separated pretty printed list of the arguments in `call`.
+   */
+  string printArgs(Call call) {
+    not exists(call.getAnArg()) and result = ""
+    or
+    result = strictconcat(int i | | reprBase(call.getArg(i)), ", ")
+  }
+
+  /**
+   * Gets a human-readable representation of the given `AstNode`.
+   * Is only defined for the an `AstNode` where a human-readable representation can be created without using recursion.
+   */
+  private string reprBase(AstNode a) {
+    shouldPrint(a, _) and
+    not isNotNeeded(a) and
+    (
+      result = a.(Name).getId()
+      or
+      result = a.(PlaceHolder).toString()
+      or
+      result = "class " + a.(ClassExpr).getName()
+      or
+      result = "class " + a.(Class).getName()
+      or
+      result = a.(StrConst).getText()
+      or
+      result = "yield " + a.(Yield).getValue()
+      or
+      result = "yield from " + a.(YieldFrom).getValue()
+      or
+      result = "*" + a.(Starred).getValue()
+      or
+      result = "`" + a.(Repr).getValue() + "`"
+      or
+      result = "b' " + a.(Bytes).getS() + "'"
+      or
+      a instanceof Ellipsis and result = "..."
+      or
+      result = a.(Num).toString()
+      or
+      result = a.(NegativeIntegerLiteral).getValue().toString()
+      or
+      result = a.(NameConstant).toString()
+      or
+      result = "await " + a.(Await).getValue()
+      or
+      result = "function " + a.(FunctionExpr).getName() + "(...)"
+      or
+      result = "function " + a.(Function).getName() + "(...)"
+      or
+      a instanceof List and result = "[...]"
+      or
+      a instanceof Set and result = "{...}"
+      or
+      a instanceof Continue and result = "continue"
+      or
+      a instanceof Break and result = "break"
+      or
+      a instanceof Pass and result = "pass"
+    )
+  }
+}
+
+/** Holds if `node` belongs to the output tree, and its property `key` has the given `value`. */
+query predicate nodes(PrintAstNode node, string key, string value) { value = node.getProperty(key) }
+
+/**
+ * Holds if `target` is a child of `source` in the AST, and property `key` of the edge has the
+ * given `value`.
+ */
+query predicate edges(PrintAstNode source, PrintAstNode target, string key, string value) {
+  exists(int childIndex |
+    target = source.getChild(childIndex) and
+    (
+      key = "semmle.label" and value = source.getChildEdgeLabel(childIndex)
+      or
+      key = "semmle.order" and value = childIndex.toString()
+    )
+  )
+}
+
+/** Holds if property `key` of the graph has the given `value`. */
+query predicate graphProperties(string key, string value) {
+  key = "semmle.graphKind" and value = "tree"
+}

--- a/python/ql/src/semmle/python/PrintAst.qll
+++ b/python/ql/src/semmle/python/PrintAst.qll
@@ -331,6 +331,19 @@ class FunctionNode extends AstElementNode {
 }
 
 /**
+ * A print node for a `FunctionDef`.
+ */
+class FunctionDefNode extends AstElementNode {
+  override FunctionDef element;
+
+  override AstNode getChildNode(int childIndex) {
+    childIndex = 0 and result = element.getTarget(0)
+    or
+    childIndex = 1 and result = element.getValue()
+  }
+}
+
+/**
  * A print node for the parameters in `func`.
  */
 class FunctionParamsNode extends PrintAstNode, TFunctionParamsNode {

--- a/python/ql/test/library-tests/taint/general/printAst.expected
+++ b/python/ql/test/library-tests/taint/general/printAst.expected
@@ -1,0 +1,3824 @@
+nodes
+| assignment.py:1:1:1:16 | (parameters) | semmle.label | (parameters) |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | semmle.label | [FunctionDef] test = function test(...) |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | semmle.order | 1 |
+| assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.label | [FunctionExpr] function test(...) |
+| assignment.py:1:1:1:16 | [Function] function test(...) | semmle.label | [Function] function test(...) |
+| assignment.py:1:5:1:8 | [Name] test | semmle.label | [Name] test |
+| assignment.py:1:11:1:14 | [Parameter] args | semmle.label | [Parameter] args |
+| assignment.py:2:5:2:8 | (StmtList) body | semmle.label | (StmtList) body |
+| assignment.py:2:5:2:8 | [Pass] pass | semmle.label | [Pass] pass |
+| assignment.py:4:1:4:17 | (parameters) | semmle.label | (parameters) |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | semmle.label | [FunctionDef] swap_taint = function swap_taint(...) |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | semmle.order | 2 |
+| assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.label | [FunctionExpr] function swap_taint(...) |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | semmle.label | [Function] function swap_taint(...) |
+| assignment.py:4:5:4:14 | [Name] swap_taint | semmle.label | [Name] swap_taint |
+| assignment.py:5:5:5:5 | [Name] a | semmle.label | [Name] a |
+| assignment.py:5:5:5:8 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:5:5:5:25 | (StmtList) body | semmle.label | (StmtList) body |
+| assignment.py:5:5:5:25 | [AssignStmt]  | semmle.label | [AssignStmt]  |
+| assignment.py:5:8:5:8 | [Name] b | semmle.label | [Name] b |
+| assignment.py:5:12:5:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| assignment.py:5:12:5:25 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:5:20:5:25 | [Str] safe | semmle.label | [Str] safe |
+| assignment.py:6:5:6:8 | [Name] test | semmle.label | [Name] test |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | semmle.label | [Call] test(a, b) |
+| assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.label | [ExprStmt] test(a, b) |
+| assignment.py:6:10:6:10 | [Name] a | semmle.label | [Name] a |
+| assignment.py:6:13:6:13 | [Name] b | semmle.label | [Name] b |
+| assignment.py:7:5:7:5 | [Name] a | semmle.label | [Name] a |
+| assignment.py:7:5:7:8 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:7:5:7:15 | [AssignStmt]  | semmle.label | [AssignStmt]  |
+| assignment.py:7:8:7:8 | [Name] b | semmle.label | [Name] b |
+| assignment.py:7:12:7:12 | [Name] b | semmle.label | [Name] b |
+| assignment.py:7:12:7:15 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:7:15:7:15 | [Name] a | semmle.label | [Name] a |
+| assignment.py:8:5:8:8 | [Name] test | semmle.label | [Name] test |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | semmle.label | [Call] test(a, b) |
+| assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.label | [ExprStmt] test(a, b) |
+| assignment.py:8:10:8:10 | [Name] a | semmle.label | [Name] a |
+| assignment.py:8:13:8:13 | [Name] b | semmle.label | [Name] b |
+| assignment.py:10:1:10:24 | (parameters) | semmle.label | (parameters) |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | semmle.label | [FunctionDef] nested_assignment = function nested_assignment(...) |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | semmle.order | 3 |
+| assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.label | [FunctionExpr] function nested_assignment(...) |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.label | [Function] function nested_assignment(...) |
+| assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.label | [Name] nested_assignment |
+| assignment.py:13:5:13:59 | (StmtList) body | semmle.label | (StmtList) body |
+| assignment.py:13:5:13:59 | [AssignStmt]  | semmle.label | [AssignStmt]  |
+| assignment.py:13:6:13:21 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:13:7:13:8 | [Name] t1 | semmle.label | [Name] t1 |
+| assignment.py:13:7:13:12 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:13:11:13:12 | [Name] s1 | semmle.label | [Name] s1 |
+| assignment.py:13:16:13:17 | [Name] t2 | semmle.label | [Name] t2 |
+| assignment.py:13:20:13:21 | [Name] s2 | semmle.label | [Name] s2 |
+| assignment.py:13:27:13:58 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:13:28:13:33 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| assignment.py:13:28:13:41 | [Tuple]  | semmle.label | [Tuple]  |
+| assignment.py:13:36:13:41 | [Str] safe | semmle.label | [Str] safe |
+| assignment.py:13:45:13:50 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| assignment.py:13:53:13:58 | [Str] safe | semmle.label | [Str] safe |
+| assignment.py:14:5:14:8 | [Name] test | semmle.label | [Name] test |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | semmle.label | [Call] test(s1, s2, t1, t2) |
+| assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.label | [ExprStmt] test(s1, s2, t1, t2) |
+| assignment.py:14:10:14:11 | [Name] t1 | semmle.label | [Name] t1 |
+| assignment.py:14:14:14:15 | [Name] s1 | semmle.label | [Name] s1 |
+| assignment.py:14:18:14:19 | [Name] t2 | semmle.label | [Name] t2 |
+| assignment.py:14:22:14:23 | [Name] s2 | semmle.label | [Name] s2 |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | semmle.label | [ClassDef] ImplicitCarrier = class ImplicitCarrier |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | semmle.order | 4 |
+| carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | semmle.label | [ClassExpr] class ImplicitCarrier |
+| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | semmle.label | [Class] class ImplicitCarrier |
+| carrier.py:2:7:2:21 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
+| carrier.py:2:23:2:28 | [Name] object | semmle.label | [Name] object |
+| carrier.py:4:5:4:28 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:4:5:4:28 | (parameters) | semmle.label | (parameters) |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.label | [FunctionDef] __init__ = function __init__(...) |
+| carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.label | [FunctionExpr] function __init__(...) |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.label | [Function] function __init__(...) |
+| carrier.py:4:9:4:16 | [Name] __init__ | semmle.label | [Name] __init__ |
+| carrier.py:4:18:4:21 | [Parameter] self | semmle.label | [Parameter] self |
+| carrier.py:4:24:4:26 | [Parameter] arg | semmle.label | [Parameter] arg |
+| carrier.py:5:9:5:12 | [Name] self | semmle.label | [Name] self |
+| carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
+| carrier.py:5:9:5:23 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.label | [AssignStmt] self.attr = arg |
+| carrier.py:5:21:5:23 | [Name] arg | semmle.label | [Name] arg |
+| carrier.py:7:5:7:28 | (parameters) | semmle.label | (parameters) |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.label | [FunctionDef] set_attr = function set_attr(...) |
+| carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.label | [FunctionExpr] function set_attr(...) |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.label | [Function] function set_attr(...) |
+| carrier.py:7:9:7:16 | [Name] set_attr | semmle.label | [Name] set_attr |
+| carrier.py:7:18:7:21 | [Parameter] self | semmle.label | [Parameter] self |
+| carrier.py:7:24:7:26 | [Parameter] arg | semmle.label | [Parameter] arg |
+| carrier.py:8:9:8:12 | [Name] self | semmle.label | [Name] self |
+| carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
+| carrier.py:8:9:8:23 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.label | [AssignStmt] self.attr = arg |
+| carrier.py:8:21:8:23 | [Name] arg | semmle.label | [Name] arg |
+| carrier.py:10:5:10:23 | (parameters) | semmle.label | (parameters) |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.label | [FunctionDef] get_attr = function get_attr(...) |
+| carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.label | [FunctionExpr] function get_attr(...) |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.label | [Function] function get_attr(...) |
+| carrier.py:10:9:10:16 | [Name] get_attr | semmle.label | [Name] get_attr |
+| carrier.py:10:18:10:21 | [Parameter] self | semmle.label | [Parameter] self |
+| carrier.py:11:9:11:24 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:11:9:11:24 | [Return] return self.attr | semmle.label | [Return] return self.attr |
+| carrier.py:11:16:11:19 | [Name] self | semmle.label | [Name] self |
+| carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
+| carrier.py:13:1:13:13 | (parameters) | semmle.label | (parameters) |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | semmle.label | [FunctionDef] hub = function hub(...) |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | semmle.order | 5 |
+| carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.label | [FunctionExpr] function hub(...) |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.label | [Function] function hub(...) |
+| carrier.py:13:5:13:7 | [Name] hub | semmle.label | [Name] hub |
+| carrier.py:13:9:13:11 | [Parameter] arg | semmle.label | [Parameter] arg |
+| carrier.py:14:5:14:14 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:14:5:14:14 | [Return] return arg | semmle.label | [Return] return arg |
+| carrier.py:14:12:14:14 | [Name] arg | semmle.label | [Name] arg |
+| carrier.py:16:1:16:12 | (parameters) | semmle.label | (parameters) |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 6 |
+| carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
+| carrier.py:16:5:16:9 | [Name] test1 | semmle.label | [Name] test1 |
+| carrier.py:17:5:17:5 | [Name] c | semmle.label | [Name] c |
+| carrier.py:17:5:17:31 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.label | [AssignStmt] c = ImplicitCarrier(SOURCE) |
+| carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.label | [Call] ImplicitCarrier(SOURCE) |
+| carrier.py:17:25:17:30 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| carrier.py:18:5:18:8 | [Name] SINK | semmle.label | [Name] SINK |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| carrier.py:18:10:18:10 | [Name] c | semmle.label | [Name] c |
+| carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.label | [Attribute] c.attr |
+| carrier.py:20:1:20:12 | (parameters) | semmle.label | (parameters) |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 7 |
+| carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
+| carrier.py:20:5:20:9 | [Name] test2 | semmle.label | [Name] test2 |
+| carrier.py:21:5:21:5 | [Name] c | semmle.label | [Name] c |
+| carrier.py:21:5:21:28 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.label | [AssignStmt] c = TAINT_CARRIER_SOURCE |
+| carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.label | [Name] TAINT_CARRIER_SOURCE |
+| carrier.py:22:5:22:8 | [Name] SINK | semmle.label | [Name] SINK |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| carrier.py:22:10:22:10 | [Name] c | semmle.label | [Name] c |
+| carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.label | [Attribute] c.get_taint |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.label | [Call] c.get_taint() |
+| carrier.py:24:1:24:12 | (parameters) | semmle.label | (parameters) |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 8 |
+| carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
+| carrier.py:24:5:24:9 | [Name] test3 | semmle.label | [Name] test3 |
+| carrier.py:25:5:25:5 | [Name] c | semmle.label | [Name] c |
+| carrier.py:25:5:25:36 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.label | [AssignStmt] c = hub(...) |
+| carrier.py:25:9:25:11 | [Name] hub | semmle.label | [Name] hub |
+| carrier.py:25:9:25:36 | [Call] hub(...) | semmle.label | [Call] hub(...) |
+| carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.label | [Call] ImplicitCarrier(SOURCE) |
+| carrier.py:25:29:25:34 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| carrier.py:26:5:26:8 | [Name] SINK | semmle.label | [Name] SINK |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| carrier.py:26:10:26:10 | [Name] c | semmle.label | [Name] c |
+| carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.label | [Attribute] c.get_attr |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.label | [Call] c.get_attr() |
+| carrier.py:28:1:28:12 | (parameters) | semmle.label | (parameters) |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 9 |
+| carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
+| carrier.py:28:5:28:9 | [Name] test4 | semmle.label | [Name] test4 |
+| carrier.py:29:5:29:5 | [Name] c | semmle.label | [Name] c |
+| carrier.py:29:5:29:33 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.label | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) |
+| carrier.py:29:9:29:11 | [Name] hub | semmle.label | [Name] hub |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.label | [Call] hub(TAINT_CARRIER_SOURCE) |
+| carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.label | [Name] TAINT_CARRIER_SOURCE |
+| carrier.py:30:5:30:8 | [Name] SINK | semmle.label | [Name] SINK |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| carrier.py:30:10:30:10 | [Name] c | semmle.label | [Name] c |
+| carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.label | [Attribute] c.get_taint |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.label | [Call] c.get_taint() |
+| carrier.py:32:1:32:12 | (parameters) | semmle.label | (parameters) |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 10 |
+| carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
+| carrier.py:32:5:32:9 | [Name] test5 | semmle.label | [Name] test5 |
+| carrier.py:33:5:33:5 | [Name] c | semmle.label | [Name] c |
+| carrier.py:33:5:33:45 | (StmtList) body | semmle.label | (StmtList) body |
+| carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) |
+| carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) |
+| carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.label | [Name] TAINT_CARRIER_SOURCE |
+| carrier.py:34:5:34:5 | [Name] x | semmle.label | [Name] x |
+| carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.label | [AssignStmt] x = c.attr |
+| carrier.py:34:9:34:9 | [Name] c | semmle.label | [Name] c |
+| carrier.py:34:9:34:14 | [Attribute] c.attr | semmle.label | [Attribute] c.attr |
+| carrier.py:35:5:35:8 | [Name] SINK | semmle.label | [Name] SINK |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| carrier.py:35:10:35:10 | [Name] x | semmle.label | [Name] x |
+| carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.label | [Attribute] x.get_taint |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.label | [Call] x.get_taint() |
+| deep.py:2:1:2:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | semmle.label | [FunctionDef] f1 = function f1(...) |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | semmle.order | 11 |
+| deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.label | [FunctionExpr] function f1(...) |
+| deep.py:2:1:2:12 | [Function] function f1(...) | semmle.label | [Function] function f1(...) |
+| deep.py:2:5:2:6 | [Name] f1 | semmle.label | [Name] f1 |
+| deep.py:2:8:2:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:3:5:3:14 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:3:5:3:14 | [Return] return arg | semmle.label | [Return] return arg |
+| deep.py:3:12:3:14 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:5:1:5:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | semmle.label | [FunctionDef] f2 = function f2(...) |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | semmle.order | 12 |
+| deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.label | [FunctionExpr] function f2(...) |
+| deep.py:5:1:5:12 | [Function] function f2(...) | semmle.label | [Function] function f2(...) |
+| deep.py:5:5:5:6 | [Name] f2 | semmle.label | [Name] f2 |
+| deep.py:5:8:5:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:6:5:6:18 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.label | [Return] return f1(arg) |
+| deep.py:6:12:6:13 | [Name] f1 | semmle.label | [Name] f1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | semmle.label | [Call] f1(arg) |
+| deep.py:6:15:6:17 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:8:1:8:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | semmle.label | [FunctionDef] f3 = function f3(...) |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | semmle.order | 13 |
+| deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.label | [FunctionExpr] function f3(...) |
+| deep.py:8:1:8:12 | [Function] function f3(...) | semmle.label | [Function] function f3(...) |
+| deep.py:8:5:8:6 | [Name] f3 | semmle.label | [Name] f3 |
+| deep.py:8:8:8:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:9:5:9:18 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.label | [Return] return f2(arg) |
+| deep.py:9:12:9:13 | [Name] f2 | semmle.label | [Name] f2 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | semmle.label | [Call] f2(arg) |
+| deep.py:9:15:9:17 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:11:1:11:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | semmle.label | [FunctionDef] f4 = function f4(...) |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | semmle.order | 14 |
+| deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.label | [FunctionExpr] function f4(...) |
+| deep.py:11:1:11:12 | [Function] function f4(...) | semmle.label | [Function] function f4(...) |
+| deep.py:11:5:11:6 | [Name] f4 | semmle.label | [Name] f4 |
+| deep.py:11:8:11:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:12:5:12:18 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.label | [Return] return f3(arg) |
+| deep.py:12:12:12:13 | [Name] f3 | semmle.label | [Name] f3 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | semmle.label | [Call] f3(arg) |
+| deep.py:12:15:12:17 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:14:1:14:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | semmle.label | [FunctionDef] f5 = function f5(...) |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | semmle.order | 15 |
+| deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.label | [FunctionExpr] function f5(...) |
+| deep.py:14:1:14:12 | [Function] function f5(...) | semmle.label | [Function] function f5(...) |
+| deep.py:14:5:14:6 | [Name] f5 | semmle.label | [Name] f5 |
+| deep.py:14:8:14:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:15:5:15:18 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.label | [Return] return f4(arg) |
+| deep.py:15:12:15:13 | [Name] f4 | semmle.label | [Name] f4 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | semmle.label | [Call] f4(arg) |
+| deep.py:15:15:15:17 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:17:1:17:12 | (parameters) | semmle.label | (parameters) |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | semmle.label | [FunctionDef] f6 = function f6(...) |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | semmle.order | 16 |
+| deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.label | [FunctionExpr] function f6(...) |
+| deep.py:17:1:17:12 | [Function] function f6(...) | semmle.label | [Function] function f6(...) |
+| deep.py:17:5:17:6 | [Name] f6 | semmle.label | [Name] f6 |
+| deep.py:17:8:17:10 | [Parameter] arg | semmle.label | [Parameter] arg |
+| deep.py:18:5:18:18 | (StmtList) body | semmle.label | (StmtList) body |
+| deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.label | [Return] return f5(arg) |
+| deep.py:18:12:18:13 | [Name] f5 | semmle.label | [Name] f5 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | semmle.label | [Call] f5(arg) |
+| deep.py:18:15:18:17 | [Name] arg | semmle.label | [Name] arg |
+| deep.py:20:1:20:1 | [Name] x | semmle.label | [Name] x |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | semmle.label | [AssignStmt] x = f6(SOURCE) |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | semmle.order | 17 |
+| deep.py:20:5:20:6 | [Name] f6 | semmle.label | [Name] f6 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | semmle.label | [Call] f6(SOURCE) |
+| deep.py:20:8:20:13 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| deep.py:22:1:22:1 | [ExprStmt] x | semmle.label | [ExprStmt] x |
+| deep.py:22:1:22:1 | [ExprStmt] x | semmle.order | 18 |
+| deep.py:22:1:22:1 | [Name] x | semmle.label | [Name] x |
+| module.py:3:1:3:9 | [Name] dangerous | semmle.label | [Name] dangerous |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | semmle.label | [AssignStmt] dangerous = SOURCE |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | semmle.order | 19 |
+| module.py:3:13:3:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| module.py:4:1:4:4 | [Name] safe | semmle.label | [Name] safe |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | semmle.label | [AssignStmt] safe = safe |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | semmle.order | 20 |
+| module.py:4:8:4:13 | [Str] safe | semmle.label | [Str] safe |
+| module.py:6:1:6:21 | (parameters) | semmle.label | (parameters) |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | semmle.label | [FunctionDef] dangerous_func = function dangerous_func(...) |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | semmle.order | 21 |
+| module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.label | [FunctionExpr] function dangerous_func(...) |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.label | [Function] function dangerous_func(...) |
+| module.py:6:5:6:18 | [Name] dangerous_func | semmle.label | [Name] dangerous_func |
+| module.py:7:5:7:17 | (StmtList) body | semmle.label | (StmtList) body |
+| module.py:7:5:7:17 | [Return] return SOURCE | semmle.label | [Return] return SOURCE |
+| module.py:7:12:7:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| module.py:10:1:10:5 | [Name] safe2 | semmle.label | [Name] safe2 |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | semmle.label | [AssignStmt] safe2 = SOURCE |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | semmle.order | 22 |
+| module.py:10:9:10:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| module.py:11:1:11:5 | [Name] safe2 | semmle.label | [Name] safe2 |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | semmle.label | [AssignStmt] safe2 = safe |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | semmle.order | 23 |
+| module.py:11:9:11:14 | [Str] safe | semmle.label | [Str] safe |
+| rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | semmle.label | [FunctionDef] rock = function rock(...) |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | semmle.order | 24 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.label | [FunctionExpr] function rock(...) |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.label | [Function] function rock(...) |
+| rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.label | [Name] rock |
+| rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.label | [Parameter] arg |
+| rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.label | [ExprStmt] SCISSORS are vulnerable |
+| rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.label | [Str] SCISSORS are vulnerable |
+| rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | semmle.label | [FunctionDef] paper = function paper(...) |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | semmle.order | 25 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.label | [FunctionExpr] function paper(...) |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.label | [Function] function paper(...) |
+| rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.label | [Name] paper |
+| rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.label | [Parameter] arg |
+| rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.label | [ExprStmt] ROCK is vulnerable |
+| rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.label | [Str] ROCK is vulnerable |
+| rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | semmle.label | [FunctionDef] scissors = function scissors(...) |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | semmle.order | 26 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.label | [FunctionExpr] function scissors(...) |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.label | [Function] function scissors(...) |
+| rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.label | [Name] scissors |
+| rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.label | [Parameter] arg |
+| rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.label | [ExprStmt] PAPER is vulnerable |
+| rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.label | [Str] PAPER is vulnerable |
+| rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 27 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
+| rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.label | [Name] test1 |
+| rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.label | [Name] rock |
+| rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.label | [Call] rock(SCISSORS) |
+| rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.label | [ExprStmt] rock(SCISSORS) |
+| rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.label | [Name] SCISSORS |
+| rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 28 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
+| rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.label | [Name] test2 |
+| rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.label | [Name] paper |
+| rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.label | [Call] paper(ROCK) |
+| rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.label | [ExprStmt] paper(ROCK) |
+| rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.label | [Name] ROCK |
+| rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 29 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
+| rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.label | [Name] test3 |
+| rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.label | [AssignStmt] x = ROCK |
+| rockpaperscissors.py:19:9:19:12 | [Name] ROCK | semmle.label | [Name] ROCK |
+| rockpaperscissors.py:20:5:20:5 | [Name] y | semmle.label | [Name] y |
+| rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.label | [AssignStmt] y = x.prev() |
+| rockpaperscissors.py:20:9:20:9 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.label | [Attribute] x.prev |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | semmle.label | [Call] x.prev() |
+| rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.label | [Name] scissors |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.label | [Call] scissors(y) |
+| rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.label | [ExprStmt] scissors(y) |
+| rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.label | [Name] y |
+| rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 30 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
+| rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.label | [Name] test4 |
+| rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.label | [AssignStmt] x = ROCK |
+| rockpaperscissors.py:24:9:24:12 | [Name] ROCK | semmle.label | [Name] ROCK |
+| rockpaperscissors.py:25:5:25:5 | [Name] y | semmle.label | [Name] y |
+| rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.label | [AssignStmt] y = (...).prev() |
+| rockpaperscissors.py:25:9:25:9 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.label | [Attribute] x.prev |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | semmle.label | [Call] x.prev() |
+| rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.label | [Attribute] (...).prev |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | semmle.label | [Call] (...).prev() |
+| rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.label | [Name] scissors |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.label | [Call] scissors(y) |
+| rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.label | [ExprStmt] scissors(y) |
+| rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.label | [Name] y |
+| rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.label | (parameters) |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 31 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
+| rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.label | [Name] test5 |
+| rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.label | (StmtList) body |
+| rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.label | [AssignStmt] x = SCISSORS |
+| rockpaperscissors.py:29:9:29:16 | [Name] SCISSORS | semmle.label | [Name] SCISSORS |
+| rockpaperscissors.py:30:5:30:5 | [Name] y | semmle.label | [Name] y |
+| rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.label | [AssignStmt] y = x.prev() |
+| rockpaperscissors.py:30:9:30:9 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.label | [Attribute] x.prev |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | semmle.label | [Call] x.prev() |
+| rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.label | [Name] paper |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | semmle.label | [Call] paper(x) |
+| rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.label | [ExprStmt] paper(x) |
+| rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.label | [Name] x |
+| rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.label | [Name] paper |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.label | [Call] paper(y) |
+| rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.label | [ExprStmt] paper(y) |
+| rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.label | [Name] y |
+| sanitizer.py:3:1:3:22 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | semmle.label | [FunctionDef] isEscapedSql = function isEscapedSql(...) |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | semmle.order | 32 |
+| sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.label | [FunctionExpr] function isEscapedSql(...) |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.label | [Function] function isEscapedSql(...) |
+| sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.label | [Name] isEscapedSql |
+| sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.label | [Parameter] arg |
+| sanitizer.py:3:24:3:27 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:3:24:3:27 | [Pass] pass | semmle.label | [Pass] pass |
+| sanitizer.py:5:1:5:24 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | semmle.label | [FunctionDef] isValidCommand = function isValidCommand(...) |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | semmle.order | 33 |
+| sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.label | [FunctionExpr] function isValidCommand(...) |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.label | [Function] function isValidCommand(...) |
+| sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.label | [Name] isValidCommand |
+| sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.label | [Parameter] arg |
+| sanitizer.py:5:26:5:29 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:5:26:5:29 | [Pass] pass | semmle.label | [Pass] pass |
+| sanitizer.py:8:1:8:18 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | semmle.label | [FunctionDef] sql_inject1 = function sql_inject1(...) |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | semmle.order | 34 |
+| sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.label | [FunctionExpr] function sql_inject1(...) |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.label | [Function] function sql_inject1(...) |
+| sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.label | [Name] sql_inject1 |
+| sanitizer.py:9:5:9:5 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:9:5:9:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
+| sanitizer.py:9:9:9:18 | [Name] user_input | semmle.label | [Name] user_input |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.label | [Call] user_input() |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.label | [If] if isEscapedSql(x): |
+| sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.label | [Name] isEscapedSql |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.label | [Call] isEscapedSql(x) |
+| sanitizer.py:10:21:10:21 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.label | [Name] sql_query |
+| sanitizer.py:11:9:11:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
+| sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
+| sanitizer.py:11:19:11:19 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.label | [Name] sql_query |
+| sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
+| sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
+| sanitizer.py:13:19:13:19 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:15:1:15:22 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | semmle.label | [FunctionDef] command_inject1 = function command_inject1(...) |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | semmle.order | 35 |
+| sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.label | [FunctionExpr] function command_inject1(...) |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.label | [Function] function command_inject1(...) |
+| sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.label | [Name] command_inject1 |
+| sanitizer.py:16:5:16:5 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:16:5:16:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
+| sanitizer.py:16:9:16:18 | [Name] user_input | semmle.label | [Name] user_input |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.label | [Call] user_input() |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.label | [If] if isValidCommand(x): |
+| sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.label | [Name] isValidCommand |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.label | [Call] isValidCommand(x) |
+| sanitizer.py:17:23:17:23 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:18:9:18:18 | [Name] os_command | semmle.label | [Name] os_command |
+| sanitizer.py:18:9:18:21 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
+| sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
+| sanitizer.py:18:20:18:20 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:20:9:20:18 | [Name] os_command | semmle.label | [Name] os_command |
+| sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
+| sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
+| sanitizer.py:20:20:20:20 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:23:1:23:18 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | semmle.label | [FunctionDef] sql_inject2 = function sql_inject2(...) |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | semmle.order | 36 |
+| sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.label | [FunctionExpr] function sql_inject2(...) |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.label | [Function] function sql_inject2(...) |
+| sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.label | [Name] sql_inject2 |
+| sanitizer.py:24:5:24:5 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:24:5:24:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
+| sanitizer.py:24:9:24:18 | [Name] user_input | semmle.label | [Name] user_input |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.label | [Call] user_input() |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.label | [If] if notASanitizer(x): |
+| sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.label | [Name] notASanitizer |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.label | [Call] notASanitizer(x) |
+| sanitizer.py:25:22:25:22 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.label | [Name] sql_query |
+| sanitizer.py:26:9:26:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
+| sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
+| sanitizer.py:26:19:26:19 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.label | [Name] sql_query |
+| sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
+| sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
+| sanitizer.py:28:19:28:19 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:30:1:30:22 | (parameters) | semmle.label | (parameters) |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | semmle.label | [FunctionDef] command_inject2 = function command_inject2(...) |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | semmle.order | 37 |
+| sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.label | [FunctionExpr] function command_inject2(...) |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.label | [Function] function command_inject2(...) |
+| sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.label | [Name] command_inject2 |
+| sanitizer.py:31:5:31:5 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:31:5:31:20 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
+| sanitizer.py:31:9:31:18 | [Name] user_input | semmle.label | [Name] user_input |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.label | [Call] user_input() |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.label | [If] if notASanitizer(x): |
+| sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.label | [Name] notASanitizer |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.label | [Call] notASanitizer(x) |
+| sanitizer.py:32:22:32:22 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:33:9:33:18 | [Name] os_command | semmle.label | [Name] os_command |
+| sanitizer.py:33:9:33:21 | (StmtList) body | semmle.label | (StmtList) body |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
+| sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
+| sanitizer.py:33:20:33:20 | [Name] x | semmle.label | [Name] x |
+| sanitizer.py:35:9:35:18 | [Name] os_command | semmle.label | [Name] os_command |
+| sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
+| sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
+| sanitizer.py:35:20:35:20 | [Name] x | semmle.label | [Name] x |
+| test.py:2:1:2:12 | (parameters) | semmle.label | (parameters) |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 38 |
+| test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
+| test.py:2:1:2:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
+| test.py:2:5:2:9 | [Name] test1 | semmle.label | [Name] test1 |
+| test.py:3:5:3:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:3:5:3:16 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.label | [Call] SINK(SOURCE) |
+| test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.label | [ExprStmt] SINK(SOURCE) |
+| test.py:3:10:3:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:5:1:5:12 | (parameters) | semmle.label | (parameters) |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 39 |
+| test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
+| test.py:5:1:5:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
+| test.py:5:5:5:9 | [Name] test2 | semmle.label | [Name] test2 |
+| test.py:6:5:6:5 | [Name] s | semmle.label | [Name] s |
+| test.py:6:5:6:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.label | [AssignStmt] s = SOURCE |
+| test.py:6:9:6:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:7:5:7:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:7:5:7:11 | [Call] SINK(s) | semmle.label | [Call] SINK(s) |
+| test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.label | [ExprStmt] SINK(s) |
+| test.py:7:10:7:10 | [Name] s | semmle.label | [Name] s |
+| test.py:9:1:9:13 | (parameters) | semmle.label | (parameters) |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | semmle.label | [FunctionDef] source = function source(...) |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | semmle.order | 40 |
+| test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.label | [FunctionExpr] function source(...) |
+| test.py:9:1:9:13 | [Function] function source(...) | semmle.label | [Function] function source(...) |
+| test.py:9:5:9:10 | [Name] source | semmle.label | [Name] source |
+| test.py:10:5:10:17 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:10:5:10:17 | [Return] return SOURCE | semmle.label | [Return] return SOURCE |
+| test.py:10:12:10:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:12:1:12:14 | (parameters) | semmle.label | (parameters) |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | semmle.label | [FunctionDef] sink = function sink(...) |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | semmle.order | 41 |
+| test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.label | [FunctionExpr] function sink(...) |
+| test.py:12:1:12:14 | [Function] function sink(...) | semmle.label | [Function] function sink(...) |
+| test.py:12:5:12:8 | [Name] sink | semmle.label | [Name] sink |
+| test.py:12:10:12:12 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:13:5:13:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:13:5:13:13 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:13:5:13:13 | [Call] SINK(arg) | semmle.label | [Call] SINK(arg) |
+| test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.label | [ExprStmt] SINK(arg) |
+| test.py:13:10:13:12 | [Name] arg | semmle.label | [Name] arg |
+| test.py:15:1:15:12 | (parameters) | semmle.label | (parameters) |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 42 |
+| test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
+| test.py:15:1:15:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
+| test.py:15:5:15:9 | [Name] test3 | semmle.label | [Name] test3 |
+| test.py:16:5:16:5 | [Name] t | semmle.label | [Name] t |
+| test.py:16:5:16:16 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.label | [AssignStmt] t = source() |
+| test.py:16:9:16:14 | [Name] source | semmle.label | [Name] source |
+| test.py:16:9:16:16 | [Call] source() | semmle.label | [Call] source() |
+| test.py:17:5:17:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:17:5:17:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:17:10:17:10 | [Name] t | semmle.label | [Name] t |
+| test.py:19:1:19:12 | (parameters) | semmle.label | (parameters) |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 43 |
+| test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
+| test.py:19:1:19:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
+| test.py:19:5:19:9 | [Name] test4 | semmle.label | [Name] test4 |
+| test.py:20:5:20:5 | [Name] t | semmle.label | [Name] t |
+| test.py:20:5:20:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:20:9:20:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:21:5:21:8 | [Name] sink | semmle.label | [Name] sink |
+| test.py:21:5:21:11 | [Call] sink(t) | semmle.label | [Call] sink(t) |
+| test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.label | [ExprStmt] sink(t) |
+| test.py:21:10:21:10 | [Name] t | semmle.label | [Name] t |
+| test.py:23:1:23:12 | (parameters) | semmle.label | (parameters) |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 44 |
+| test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
+| test.py:23:1:23:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
+| test.py:23:5:23:9 | [Name] test5 | semmle.label | [Name] test5 |
+| test.py:24:5:24:5 | [Name] t | semmle.label | [Name] t |
+| test.py:24:5:24:16 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.label | [AssignStmt] t = source() |
+| test.py:24:9:24:14 | [Name] source | semmle.label | [Name] source |
+| test.py:24:9:24:16 | [Call] source() | semmle.label | [Call] source() |
+| test.py:25:5:25:8 | [Name] sink | semmle.label | [Name] sink |
+| test.py:25:5:25:11 | [Call] sink(t) | semmle.label | [Call] sink(t) |
+| test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.label | [ExprStmt] sink(t) |
+| test.py:25:10:25:10 | [Name] t | semmle.label | [Name] t |
+| test.py:27:1:27:16 | (parameters) | semmle.label | (parameters) |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | semmle.label | [FunctionDef] test6 = function test6(...) |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | semmle.order | 45 |
+| test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.label | [FunctionExpr] function test6(...) |
+| test.py:27:1:27:16 | [Function] function test6(...) | semmle.label | [Function] function test6(...) |
+| test.py:27:5:27:9 | [Name] test6 | semmle.label | [Name] test6 |
+| test.py:27:11:27:14 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:28:5:28:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:28:5:28:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:28:8:28:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:29:9:29:9 | [Name] t | semmle.label | [Name] t |
+| test.py:29:9:29:18 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
+| test.py:29:13:29:18 | [Str] Safe | semmle.label | [Str] Safe |
+| test.py:31:9:31:9 | [Name] t | semmle.label | [Name] t |
+| test.py:31:9:31:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:31:13:31:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:32:5:32:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:32:8:32:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:33:9:33:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:33:9:33:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:33:9:33:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:33:14:33:14 | [Name] t | semmle.label | [Name] t |
+| test.py:35:1:35:16 | (parameters) | semmle.label | (parameters) |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | semmle.label | [FunctionDef] test7 = function test7(...) |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | semmle.order | 46 |
+| test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.label | [FunctionExpr] function test7(...) |
+| test.py:35:1:35:16 | [Function] function test7(...) | semmle.label | [Function] function test7(...) |
+| test.py:35:5:35:9 | [Name] test7 | semmle.label | [Name] test7 |
+| test.py:35:11:35:14 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:36:5:36:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:36:5:36:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:36:8:36:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:37:9:37:9 | [Name] t | semmle.label | [Name] t |
+| test.py:37:9:37:18 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:37:13:37:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:39:9:39:9 | [Name] t | semmle.label | [Name] t |
+| test.py:39:9:39:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
+| test.py:39:13:39:18 | [Str] Safe | semmle.label | [Str] Safe |
+| test.py:40:5:40:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:40:8:40:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:41:9:41:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:41:9:41:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:41:9:41:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:41:14:41:14 | [Name] t | semmle.label | [Name] t |
+| test.py:43:1:43:17 | (parameters) | semmle.label | (parameters) |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | semmle.label | [FunctionDef] source2 = function source2(...) |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | semmle.order | 47 |
+| test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.label | [FunctionExpr] function source2(...) |
+| test.py:43:1:43:17 | [Function] function source2(...) | semmle.label | [Function] function source2(...) |
+| test.py:43:5:43:11 | [Name] source2 | semmle.label | [Name] source2 |
+| test.py:43:13:43:15 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:44:5:44:22 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:44:5:44:22 | [Return] return source(arg) | semmle.label | [Return] return source(arg) |
+| test.py:44:12:44:17 | [Name] source | semmle.label | [Name] source |
+| test.py:44:12:44:22 | [Call] source(arg) | semmle.label | [Call] source(arg) |
+| test.py:44:19:44:21 | [Name] arg | semmle.label | [Name] arg |
+| test.py:46:1:46:15 | (parameters) | semmle.label | (parameters) |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | semmle.label | [FunctionDef] sink2 = function sink2(...) |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | semmle.order | 48 |
+| test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.label | [FunctionExpr] function sink2(...) |
+| test.py:46:1:46:15 | [Function] function sink2(...) | semmle.label | [Function] function sink2(...) |
+| test.py:46:5:46:9 | [Name] sink2 | semmle.label | [Name] sink2 |
+| test.py:46:11:46:13 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:47:5:47:8 | [Name] sink | semmle.label | [Name] sink |
+| test.py:47:5:47:13 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:47:5:47:13 | [Call] sink(arg) | semmle.label | [Call] sink(arg) |
+| test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.label | [ExprStmt] sink(arg) |
+| test.py:47:10:47:12 | [Name] arg | semmle.label | [Name] arg |
+| test.py:49:1:49:21 | (parameters) | semmle.label | (parameters) |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | semmle.label | [FunctionDef] sink3 = function sink3(...) |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | semmle.order | 49 |
+| test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.label | [FunctionExpr] function sink3(...) |
+| test.py:49:1:49:21 | [Function] function sink3(...) | semmle.label | [Function] function sink3(...) |
+| test.py:49:5:49:9 | [Name] sink3 | semmle.label | [Name] sink3 |
+| test.py:49:11:49:14 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:49:17:49:19 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:50:5:50:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:50:5:50:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:50:8:50:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:51:9:51:12 | [Name] sink | semmle.label | [Name] sink |
+| test.py:51:9:51:17 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:51:9:51:17 | [Call] sink(arg) | semmle.label | [Call] sink(arg) |
+| test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.label | [ExprStmt] sink(arg) |
+| test.py:51:14:51:16 | [Name] arg | semmle.label | [Name] arg |
+| test.py:53:1:53:16 | (parameters) | semmle.label | (parameters) |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | semmle.label | [FunctionDef] test8 = function test8(...) |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | semmle.order | 50 |
+| test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.label | [FunctionExpr] function test8(...) |
+| test.py:53:1:53:16 | [Function] function test8(...) | semmle.label | [Function] function test8(...) |
+| test.py:53:5:53:9 | [Name] test8 | semmle.label | [Name] test8 |
+| test.py:53:11:53:14 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:54:5:54:5 | [Name] t | semmle.label | [Name] t |
+| test.py:54:5:54:17 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.label | [AssignStmt] t = source2() |
+| test.py:54:9:54:15 | [Name] source2 | semmle.label | [Name] source2 |
+| test.py:54:9:54:17 | [Call] source2() | semmle.label | [Call] source2() |
+| test.py:55:5:55:9 | [Name] sink2 | semmle.label | [Name] sink2 |
+| test.py:55:5:55:12 | [Call] sink2(t) | semmle.label | [Call] sink2(t) |
+| test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.label | [ExprStmt] sink2(t) |
+| test.py:55:11:55:11 | [Name] t | semmle.label | [Name] t |
+| test.py:58:1:58:16 | (parameters) | semmle.label | (parameters) |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | semmle.label | [FunctionDef] test9 = function test9(...) |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | semmle.order | 51 |
+| test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.label | [FunctionExpr] function test9(...) |
+| test.py:58:1:58:16 | [Function] function test9(...) | semmle.label | [Function] function test9(...) |
+| test.py:58:5:58:9 | [Name] test9 | semmle.label | [Name] test9 |
+| test.py:58:11:58:14 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:59:5:59:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:59:5:59:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:59:8:59:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:60:9:60:9 | [Name] t | semmle.label | [Name] t |
+| test.py:60:9:60:19 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
+| test.py:60:14:60:19 | [Str] Safe | semmle.label | [Str] Safe |
+| test.py:62:9:62:9 | [Name] t | semmle.label | [Name] t |
+| test.py:62:9:62:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:62:13:62:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:63:5:63:9 | [Name] sink3 | semmle.label | [Name] sink3 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | semmle.label | [Call] sink3(cond, t) |
+| test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.label | [ExprStmt] sink3(cond, t) |
+| test.py:63:11:63:14 | [Name] cond | semmle.label | [Name] cond |
+| test.py:63:17:63:17 | [Name] t | semmle.label | [Name] t |
+| test.py:65:1:65:17 | (parameters) | semmle.label | (parameters) |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | semmle.label | [FunctionDef] test10 = function test10(...) |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | semmle.order | 52 |
+| test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.label | [FunctionExpr] function test10(...) |
+| test.py:65:1:65:17 | [Function] function test10(...) | semmle.label | [Function] function test10(...) |
+| test.py:65:5:65:10 | [Name] test10 | semmle.label | [Name] test10 |
+| test.py:65:12:65:15 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:66:5:66:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:66:5:66:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:66:8:66:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:67:9:67:9 | [Name] t | semmle.label | [Name] t |
+| test.py:67:9:67:18 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:67:13:67:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:69:9:69:9 | [Name] t | semmle.label | [Name] t |
+| test.py:69:9:69:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
+| test.py:69:13:69:18 | [Str] Safe | semmle.label | [Str] Safe |
+| test.py:70:5:70:9 | [Name] sink3 | semmle.label | [Name] sink3 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | semmle.label | [Call] sink3(cond, t) |
+| test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.label | [ExprStmt] sink3(cond, t) |
+| test.py:70:11:70:14 | [Name] cond | semmle.label | [Name] cond |
+| test.py:70:17:70:17 | [Name] t | semmle.label | [Name] t |
+| test.py:72:1:72:13 | (parameters) | semmle.label | (parameters) |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | semmle.label | [FunctionDef] hub = function hub(...) |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | semmle.order | 53 |
+| test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.label | [FunctionExpr] function hub(...) |
+| test.py:72:1:72:13 | [Function] function hub(...) | semmle.label | [Function] function hub(...) |
+| test.py:72:5:72:7 | [Name] hub | semmle.label | [Name] hub |
+| test.py:72:9:72:11 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:73:5:73:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:73:5:73:14 | [Return] return arg | semmle.label | [Return] return arg |
+| test.py:73:12:73:14 | [Name] arg | semmle.label | [Name] arg |
+| test.py:75:1:75:13 | (parameters) | semmle.label | (parameters) |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | semmle.label | [FunctionDef] test11 = function test11(...) |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | semmle.order | 54 |
+| test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.label | [FunctionExpr] function test11(...) |
+| test.py:75:1:75:13 | [Function] function test11(...) | semmle.label | [Function] function test11(...) |
+| test.py:75:5:75:10 | [Name] test11 | semmle.label | [Name] test11 |
+| test.py:76:5:76:5 | [Name] t | semmle.label | [Name] t |
+| test.py:76:5:76:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:76:9:76:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:77:5:77:5 | [Name] t | semmle.label | [Name] t |
+| test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.label | [AssignStmt] t = hub(t) |
+| test.py:77:9:77:11 | [Name] hub | semmle.label | [Name] hub |
+| test.py:77:9:77:14 | [Call] hub(t) | semmle.label | [Call] hub(t) |
+| test.py:77:13:77:13 | [Name] t | semmle.label | [Name] t |
+| test.py:78:5:78:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:78:5:78:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:78:10:78:10 | [Name] t | semmle.label | [Name] t |
+| test.py:80:1:80:13 | (parameters) | semmle.label | (parameters) |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | semmle.label | [FunctionDef] test12 = function test12(...) |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | semmle.order | 55 |
+| test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.label | [FunctionExpr] function test12(...) |
+| test.py:80:1:80:13 | [Function] function test12(...) | semmle.label | [Function] function test12(...) |
+| test.py:80:5:80:10 | [Name] test12 | semmle.label | [Name] test12 |
+| test.py:81:5:81:5 | [Name] t | semmle.label | [Name] t |
+| test.py:81:5:81:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.label | [AssignStmt] t = safe |
+| test.py:81:9:81:14 | [Str] safe | semmle.label | [Str] safe |
+| test.py:82:5:82:5 | [Name] t | semmle.label | [Name] t |
+| test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.label | [AssignStmt] t = hub(t) |
+| test.py:82:9:82:11 | [Name] hub | semmle.label | [Name] hub |
+| test.py:82:9:82:14 | [Call] hub(t) | semmle.label | [Call] hub(t) |
+| test.py:82:13:82:13 | [Name] t | semmle.label | [Name] t |
+| test.py:83:5:83:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:83:5:83:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:83:10:83:10 | [Name] t | semmle.label | [Name] t |
+| test.py:85:1:85:13 | [Import] import module | semmle.label | [Import] import module |
+| test.py:85:1:85:13 | [Import] import module | semmle.order | 56 |
+| test.py:85:8:85:13 | [ImportExpr]  | semmle.label | [ImportExpr]  |
+| test.py:85:8:85:13 | [Name] module | semmle.label | [Name] module |
+| test.py:87:1:87:13 | (parameters) | semmle.label | (parameters) |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | semmle.label | [FunctionDef] test13 = function test13(...) |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | semmle.order | 57 |
+| test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.label | [FunctionExpr] function test13(...) |
+| test.py:87:1:87:13 | [Function] function test13(...) | semmle.label | [Function] function test13(...) |
+| test.py:87:5:87:10 | [Name] test13 | semmle.label | [Name] test13 |
+| test.py:88:5:88:5 | [Name] t | semmle.label | [Name] t |
+| test.py:88:5:88:24 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.label | [AssignStmt] t = module.dangerous |
+| test.py:88:9:88:14 | [Name] module | semmle.label | [Name] module |
+| test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.label | [Attribute] module.dangerous |
+| test.py:89:5:89:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:89:5:89:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:89:10:89:10 | [Name] t | semmle.label | [Name] t |
+| test.py:91:1:91:13 | (parameters) | semmle.label | (parameters) |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | semmle.label | [FunctionDef] test14 = function test14(...) |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | semmle.order | 58 |
+| test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.label | [FunctionExpr] function test14(...) |
+| test.py:91:1:91:13 | [Function] function test14(...) | semmle.label | [Function] function test14(...) |
+| test.py:91:5:91:10 | [Name] test14 | semmle.label | [Name] test14 |
+| test.py:92:5:92:5 | [Name] t | semmle.label | [Name] t |
+| test.py:92:5:92:19 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.label | [AssignStmt] t = module.safe |
+| test.py:92:9:92:14 | [Name] module | semmle.label | [Name] module |
+| test.py:92:9:92:19 | [Attribute] module.safe | semmle.label | [Attribute] module.safe |
+| test.py:93:5:93:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:93:5:93:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:93:10:93:10 | [Name] t | semmle.label | [Name] t |
+| test.py:95:1:95:13 | (parameters) | semmle.label | (parameters) |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | semmle.label | [FunctionDef] test15 = function test15(...) |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | semmle.order | 59 |
+| test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.label | [FunctionExpr] function test15(...) |
+| test.py:95:1:95:13 | [Function] function test15(...) | semmle.label | [Function] function test15(...) |
+| test.py:95:5:95:10 | [Name] test15 | semmle.label | [Name] test15 |
+| test.py:96:5:96:5 | [Name] t | semmle.label | [Name] t |
+| test.py:96:5:96:20 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.label | [AssignStmt] t = module.safe2 |
+| test.py:96:9:96:14 | [Name] module | semmle.label | [Name] module |
+| test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.label | [Attribute] module.safe2 |
+| test.py:97:5:97:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:97:5:97:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:97:10:97:10 | [Name] t | semmle.label | [Name] t |
+| test.py:99:1:99:13 | (parameters) | semmle.label | (parameters) |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | semmle.label | [FunctionDef] test16 = function test16(...) |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | semmle.order | 60 |
+| test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.label | [FunctionExpr] function test16(...) |
+| test.py:99:1:99:13 | [Function] function test16(...) | semmle.label | [Function] function test16(...) |
+| test.py:99:5:99:10 | [Name] test16 | semmle.label | [Name] test16 |
+| test.py:100:5:100:5 | [Name] t | semmle.label | [Name] t |
+| test.py:100:5:100:31 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.label | [AssignStmt] t = module.dangerous_func() |
+| test.py:100:9:100:14 | [Name] module | semmle.label | [Name] module |
+| test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.label | [Attribute] module.dangerous_func |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | semmle.label | [Call] module.dangerous_func() |
+| test.py:101:5:101:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:101:5:101:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:101:10:101:10 | [Name] t | semmle.label | [Name] t |
+| test.py:103:1:103:16 | [ClassDef] C = class C | semmle.label | [ClassDef] C = class C |
+| test.py:103:1:103:16 | [ClassDef] C = class C | semmle.order | 61 |
+| test.py:103:1:103:16 | [ClassExpr] class C | semmle.label | [ClassExpr] class C |
+| test.py:103:1:103:16 | [Class] class C | semmle.label | [Class] class C |
+| test.py:103:7:103:7 | [Name] C | semmle.label | [Name] C |
+| test.py:103:9:103:14 | [Name] object | semmle.label | [Name] object |
+| test.py:103:18:103:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:103:18:103:21 | [Pass] pass | semmle.label | [Pass] pass |
+| test.py:105:1:105:16 | (parameters) | semmle.label | (parameters) |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | semmle.label | [FunctionDef] x_sink = function x_sink(...) |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | semmle.order | 62 |
+| test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.label | [FunctionExpr] function x_sink(...) |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | semmle.label | [Function] function x_sink(...) |
+| test.py:105:5:105:10 | [Name] x_sink | semmle.label | [Name] x_sink |
+| test.py:105:12:105:14 | [Parameter] arg | semmle.label | [Parameter] arg |
+| test.py:106:5:106:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:106:5:106:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:106:5:106:15 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| test.py:106:10:106:12 | [Name] arg | semmle.label | [Name] arg |
+| test.py:106:10:106:14 | [Attribute] arg.x | semmle.label | [Attribute] arg.x |
+| test.py:108:1:108:13 | (parameters) | semmle.label | (parameters) |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | semmle.label | [FunctionDef] test17 = function test17(...) |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | semmle.order | 63 |
+| test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.label | [FunctionExpr] function test17(...) |
+| test.py:108:1:108:13 | [Function] function test17(...) | semmle.label | [Function] function test17(...) |
+| test.py:108:5:108:10 | [Name] test17 | semmle.label | [Name] test17 |
+| test.py:109:5:109:5 | [Name] t | semmle.label | [Name] t |
+| test.py:109:5:109:11 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.label | [AssignStmt] t = C() |
+| test.py:109:9:109:9 | [Name] C | semmle.label | [Name] C |
+| test.py:109:9:109:11 | [Call] C() | semmle.label | [Call] C() |
+| test.py:110:5:110:5 | [Name] t | semmle.label | [Name] t |
+| test.py:110:5:110:7 | [Attribute] t.x | semmle.label | [Attribute] t.x |
+| test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.label | [AssignStmt] t.x = module.dangerous |
+| test.py:110:11:110:16 | [Name] module | semmle.label | [Name] module |
+| test.py:110:11:110:26 | [Attribute] module.dangerous | semmle.label | [Attribute] module.dangerous |
+| test.py:111:5:111:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:111:5:111:13 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| test.py:111:10:111:10 | [Name] t | semmle.label | [Name] t |
+| test.py:111:10:111:12 | [Attribute] t.x | semmle.label | [Attribute] t.x |
+| test.py:113:1:113:13 | (parameters) | semmle.label | (parameters) |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | semmle.label | [FunctionDef] test18 = function test18(...) |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | semmle.order | 64 |
+| test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.label | [FunctionExpr] function test18(...) |
+| test.py:113:1:113:13 | [Function] function test18(...) | semmle.label | [Function] function test18(...) |
+| test.py:113:5:113:10 | [Name] test18 | semmle.label | [Name] test18 |
+| test.py:114:5:114:5 | [Name] t | semmle.label | [Name] t |
+| test.py:114:5:114:11 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.label | [AssignStmt] t = C() |
+| test.py:114:9:114:9 | [Name] C | semmle.label | [Name] C |
+| test.py:114:9:114:11 | [Call] C() | semmle.label | [Call] C() |
+| test.py:115:5:115:5 | [Name] t | semmle.label | [Name] t |
+| test.py:115:5:115:7 | [Attribute] t.x | semmle.label | [Attribute] t.x |
+| test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.label | [AssignStmt] t.x = module.dangerous |
+| test.py:115:11:115:16 | [Name] module | semmle.label | [Name] module |
+| test.py:115:11:115:26 | [Attribute] module.dangerous | semmle.label | [Attribute] module.dangerous |
+| test.py:116:5:116:5 | [Name] t | semmle.label | [Name] t |
+| test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.label | [AssignStmt] t = hub(t) |
+| test.py:116:9:116:11 | [Name] hub | semmle.label | [Name] hub |
+| test.py:116:9:116:14 | [Call] hub(t) | semmle.label | [Call] hub(t) |
+| test.py:116:13:116:13 | [Name] t | semmle.label | [Name] t |
+| test.py:117:5:117:10 | [Name] x_sink | semmle.label | [Name] x_sink |
+| test.py:117:5:117:13 | [Call] x_sink(t) | semmle.label | [Call] x_sink(t) |
+| test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.label | [ExprStmt] x_sink(t) |
+| test.py:117:12:117:12 | [Name] t | semmle.label | [Name] t |
+| test.py:119:1:119:13 | (parameters) | semmle.label | (parameters) |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | semmle.label | [FunctionDef] test19 = function test19(...) |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | semmle.order | 65 |
+| test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.label | [FunctionExpr] function test19(...) |
+| test.py:119:1:119:13 | [Function] function test19(...) | semmle.label | [Function] function test19(...) |
+| test.py:119:5:119:10 | [Name] test19 | semmle.label | [Name] test19 |
+| test.py:120:5:120:5 | [Name] t | semmle.label | [Name] t |
+| test.py:120:5:120:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
+| test.py:120:9:120:21 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
+| test.py:121:5:121:5 | [Name] t | semmle.label | [Name] t |
+| test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.label | [AssignStmt] t = hub(...) |
+| test.py:121:9:121:11 | [Name] hub | semmle.label | [Name] hub |
+| test.py:121:9:121:30 | [Call] hub(...) | semmle.label | [Call] hub(...) |
+| test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.label | [Name] TAINT_FROM_ARG |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.label | [Call] TAINT_FROM_ARG(t) |
+| test.py:121:28:121:28 | [Name] t | semmle.label | [Name] t |
+| test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
+| test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
+| test.py:122:17:122:17 | [Name] t | semmle.label | [Name] t |
+| test.py:124:1:124:17 | (parameters) | semmle.label | (parameters) |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | semmle.label | [FunctionDef] test20 = function test20(...) |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | semmle.order | 66 |
+| test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.label | [FunctionExpr] function test20(...) |
+| test.py:124:1:124:17 | [Function] function test20(...) | semmle.label | [Function] function test20(...) |
+| test.py:124:5:124:10 | [Name] test20 | semmle.label | [Name] test20 |
+| test.py:124:12:124:15 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:125:5:125:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:125:5:125:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:125:8:125:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:126:9:126:9 | [Name] t | semmle.label | [Name] t |
+| test.py:126:9:126:25 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
+| test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
+| test.py:128:9:128:9 | [Name] t | semmle.label | [Name] t |
+| test.py:128:9:128:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:128:13:128:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:129:5:129:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:129:8:129:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
+| test.py:130:9:130:22 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
+| test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
+| test.py:130:21:130:21 | [Name] t | semmle.label | [Name] t |
+| test.py:132:9:132:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:132:9:132:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:132:9:132:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:132:14:132:14 | [Name] t | semmle.label | [Name] t |
+| test.py:134:1:134:17 | (parameters) | semmle.label | (parameters) |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | semmle.label | [FunctionDef] test21 = function test21(...) |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | semmle.order | 67 |
+| test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.label | [FunctionExpr] function test21(...) |
+| test.py:134:1:134:17 | [Function] function test21(...) | semmle.label | [Function] function test21(...) |
+| test.py:134:5:134:10 | [Name] test21 | semmle.label | [Name] test21 |
+| test.py:134:12:134:15 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:135:5:135:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:135:5:135:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:135:8:135:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:136:9:136:9 | [Name] t | semmle.label | [Name] t |
+| test.py:136:9:136:25 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
+| test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
+| test.py:138:9:138:9 | [Name] t | semmle.label | [Name] t |
+| test.py:138:9:138:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:138:13:138:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:139:5:139:16 | [If]  | semmle.label | [If]  |
+| test.py:139:8:139:15 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
+| test.py:139:12:139:15 | [Name] cond | semmle.label | [Name] cond |
+| test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
+| test.py:140:9:140:22 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
+| test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
+| test.py:140:21:140:21 | [Name] t | semmle.label | [Name] t |
+| test.py:142:9:142:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:142:9:142:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:142:9:142:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:142:14:142:14 | [Name] t | semmle.label | [Name] t |
+| test.py:144:1:144:17 | (parameters) | semmle.label | (parameters) |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | semmle.label | [FunctionDef] test22 = function test22(...) |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | semmle.order | 68 |
+| test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.label | [FunctionExpr] function test22(...) |
+| test.py:144:1:144:17 | [Function] function test22(...) | semmle.label | [Function] function test22(...) |
+| test.py:144:5:144:10 | [Name] test22 | semmle.label | [Name] test22 |
+| test.py:144:12:144:15 | [Parameter] cond | semmle.label | [Parameter] cond |
+| test.py:145:5:145:12 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:145:5:145:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:145:8:145:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:146:9:146:9 | [Name] t | semmle.label | [Name] t |
+| test.py:146:9:146:25 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
+| test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
+| test.py:148:9:148:9 | [Name] t | semmle.label | [Name] t |
+| test.py:148:9:148:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:148:13:148:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:149:5:149:5 | [Name] t | semmle.label | [Name] t |
+| test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.label | [AssignStmt] t = TAINT_FROM_ARG(t) |
+| test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.label | [Name] TAINT_FROM_ARG |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | semmle.label | [Call] TAINT_FROM_ARG(t) |
+| test.py:149:24:149:24 | [Name] t | semmle.label | [Name] t |
+| test.py:150:5:150:12 | [If] if cond: | semmle.label | [If] if cond: |
+| test.py:150:8:150:11 | [Name] cond | semmle.label | [Name] cond |
+| test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
+| test.py:151:9:151:22 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
+| test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
+| test.py:151:21:151:21 | [Name] t | semmle.label | [Name] t |
+| test.py:153:9:153:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:153:9:153:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:153:9:153:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:153:14:153:14 | [Name] t | semmle.label | [Name] t |
+| test.py:155:1:155:38 | [Import] import unsafe | semmle.label | [Import] import unsafe |
+| test.py:155:1:155:38 | [Import] import unsafe | semmle.order | 69 |
+| test.py:155:6:155:11 | [ImportExpr]  | semmle.label | [ImportExpr]  |
+| test.py:155:20:155:38 | [ImportMember]  | semmle.label | [ImportMember]  |
+| test.py:155:33:155:38 | [Name] unsafe | semmle.label | [Name] unsafe |
+| test.py:156:1:156:4 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | semmle.label | [Call] SINK(unsafe) |
+| test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | semmle.label | [ExprStmt] SINK(unsafe) |
+| test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | semmle.order | 70 |
+| test.py:156:6:156:11 | [Name] unsafe | semmle.label | [Name] unsafe |
+| test.py:158:1:158:13 | (parameters) | semmle.label | (parameters) |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | semmle.label | [FunctionDef] test23 = function test23(...) |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | semmle.order | 71 |
+| test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.label | [FunctionExpr] function test23(...) |
+| test.py:158:1:158:13 | [Function] function test23(...) | semmle.label | [Function] function test23(...) |
+| test.py:158:5:158:10 | [Name] test23 | semmle.label | [Name] test23 |
+| test.py:159:5:159:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:159:5:159:21 | [With]  | semmle.label | [With]  |
+| test.py:159:10:159:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:159:20:159:20 | [Name] t | semmle.label | [Name] t |
+| test.py:160:9:160:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:160:9:160:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:160:9:160:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:160:14:160:14 | [Name] t | semmle.label | [Name] t |
+| test.py:162:1:162:13 | (parameters) | semmle.label | (parameters) |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | semmle.label | [FunctionDef] test24 = function test24(...) |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | semmle.order | 72 |
+| test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.label | [FunctionExpr] function test24(...) |
+| test.py:162:1:162:13 | [Function] function test24(...) | semmle.label | [Function] function test24(...) |
+| test.py:162:5:162:10 | [Name] test24 | semmle.label | [Name] test24 |
+| test.py:163:5:163:5 | [Name] s | semmle.label | [Name] s |
+| test.py:163:5:163:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.label | [AssignStmt] s = SOURCE |
+| test.py:163:9:163:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:164:5:164:12 | [Name] SANITIZE | semmle.label | [Name] SANITIZE |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | semmle.label | [Call] SANITIZE(s) |
+| test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.label | [ExprStmt] SANITIZE(s) |
+| test.py:164:14:164:14 | [Name] s | semmle.label | [Name] s |
+| test.py:165:5:165:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:165:5:165:11 | [Call] SINK(s) | semmle.label | [Call] SINK(s) |
+| test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.label | [ExprStmt] SINK(s) |
+| test.py:165:10:165:10 | [Name] s | semmle.label | [Name] s |
+| test.py:167:1:167:29 | (parameters) | semmle.label | (parameters) |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | semmle.label | [FunctionDef] test_update_extend = function test_update_extend(...) |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | semmle.order | 73 |
+| test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.label | [FunctionExpr] function test_update_extend(...) |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | semmle.label | [Function] function test_update_extend(...) |
+| test.py:167:5:167:22 | [Name] test_update_extend | semmle.label | [Name] test_update_extend |
+| test.py:167:24:167:24 | [Parameter] x | semmle.label | [Parameter] x |
+| test.py:167:27:167:27 | [Parameter] y | semmle.label | [Parameter] y |
+| test.py:168:5:168:5 | [Name] l | semmle.label | [Name] l |
+| test.py:168:5:168:16 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.label | [AssignStmt] l = [...] |
+| test.py:168:9:168:16 | [List] [...] | semmle.label | [List] [...] |
+| test.py:168:10:168:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:169:5:169:5 | [Name] d | semmle.label | [Name] d |
+| test.py:169:5:169:24 | [AssignStmt]  | semmle.label | [AssignStmt]  |
+| test.py:169:9:169:24 | [Dict]  | semmle.label | [Dict]  |
+| test.py:169:10:169:14 | [Str] key | semmle.label | [Str] key |
+| test.py:169:10:169:23 | [KeyValuePair]  | semmle.label | [KeyValuePair]  |
+| test.py:169:18:169:23 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:170:5:170:5 | [Name] x | semmle.label | [Name] x |
+| test.py:170:5:170:12 | [Attribute] x.extend | semmle.label | [Attribute] x.extend |
+| test.py:170:5:170:15 | [Call] x.extend(l) | semmle.label | [Call] x.extend(l) |
+| test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.label | [ExprStmt] x.extend(l) |
+| test.py:170:14:170:14 | [Name] l | semmle.label | [Name] l |
+| test.py:171:5:171:5 | [Name] y | semmle.label | [Name] y |
+| test.py:171:5:171:12 | [Attribute] y.update | semmle.label | [Attribute] y.update |
+| test.py:171:5:171:15 | [Call] y.update(d) | semmle.label | [Call] y.update(d) |
+| test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.label | [ExprStmt] y.update(d) |
+| test.py:171:14:171:14 | [Name] d | semmle.label | [Name] d |
+| test.py:172:5:172:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:172:5:172:14 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| test.py:172:10:172:10 | [Name] x | semmle.label | [Name] x |
+| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.label | [Subscript] x[IntegerLiteral] |
+| test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.label | [IntegerLiteral] IntegerLiteral |
+| test.py:173:5:173:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:173:5:173:18 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
+| test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
+| test.py:173:10:173:10 | [Name] y | semmle.label | [Name] y |
+| test.py:173:10:173:17 | [Subscript] y[key] | semmle.label | [Subscript] y[key] |
+| test.py:173:12:173:16 | [Str] key | semmle.label | [Str] key |
+| test.py:174:5:174:6 | [Name] l2 | semmle.label | [Name] l2 |
+| test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.label | [AssignStmt] l2 = list(l) |
+| test.py:174:10:174:13 | [Name] list | semmle.label | [Name] list |
+| test.py:174:10:174:16 | [Call] list(l) | semmle.label | [Call] list(l) |
+| test.py:174:15:174:15 | [Name] l | semmle.label | [Name] l |
+| test.py:175:5:175:6 | [Name] d2 | semmle.label | [Name] d2 |
+| test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.label | [AssignStmt] d2 = dict(d) |
+| test.py:175:10:175:13 | [Name] dict | semmle.label | [Name] dict |
+| test.py:175:10:175:16 | [Call] dict(d) | semmle.label | [Call] dict(d) |
+| test.py:175:15:175:15 | [Name] d | semmle.label | [Name] d |
+| test.py:177:1:177:17 | (parameters) | semmle.label | (parameters) |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | semmle.label | [FunctionDef] test_truth = function test_truth(...) |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | semmle.order | 74 |
+| test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.label | [FunctionExpr] function test_truth(...) |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.label | [Function] function test_truth(...) |
+| test.py:177:5:177:14 | [Name] test_truth | semmle.label | [Name] test_truth |
+| test.py:178:5:178:5 | [Name] t | semmle.label | [Name] t |
+| test.py:178:5:178:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:178:9:178:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:179:5:179:9 | [If] if t: | semmle.label | [If] if t: |
+| test.py:179:8:179:8 | [Name] t | semmle.label | [Name] t |
+| test.py:180:9:180:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:180:9:180:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:180:9:180:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:180:14:180:14 | [Name] t | semmle.label | [Name] t |
+| test.py:182:9:182:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:182:9:182:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:182:9:182:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:182:14:182:14 | [Name] t | semmle.label | [Name] t |
+| test.py:183:5:183:13 | [If]  | semmle.label | [If]  |
+| test.py:183:8:183:12 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
+| test.py:183:12:183:12 | [Name] t | semmle.label | [Name] t |
+| test.py:184:9:184:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:184:9:184:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:184:9:184:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:184:14:184:14 | [Name] t | semmle.label | [Name] t |
+| test.py:186:9:186:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:186:9:186:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:186:9:186:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:186:14:186:14 | [Name] t | semmle.label | [Name] t |
+| test.py:188:1:188:22 | (parameters) | semmle.label | (parameters) |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | semmle.label | [FunctionDef] test_early_exit = function test_early_exit(...) |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | semmle.order | 75 |
+| test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.label | [FunctionExpr] function test_early_exit(...) |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.label | [Function] function test_early_exit(...) |
+| test.py:188:5:188:19 | [Name] test_early_exit | semmle.label | [Name] test_early_exit |
+| test.py:189:5:189:5 | [Name] t | semmle.label | [Name] t |
+| test.py:189:5:189:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.label | [AssignStmt] t = FALSEY |
+| test.py:189:9:189:14 | [Name] FALSEY | semmle.label | [Name] FALSEY |
+| test.py:190:5:190:13 | [If]  | semmle.label | [If]  |
+| test.py:190:8:190:12 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
+| test.py:190:12:190:12 | [Name] t | semmle.label | [Name] t |
+| test.py:191:9:191:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:191:9:191:14 | [Return]  | semmle.label | [Return]  |
+| test.py:192:5:192:5 | [ExprStmt] t | semmle.label | [ExprStmt] t |
+| test.py:192:5:192:5 | [Name] t | semmle.label | [Name] t |
+| test.py:194:1:194:41 | (parameters) | semmle.label | (parameters) |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | semmle.label | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | semmle.order | 76 |
+| test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.label | [FunctionExpr] function flow_through_type_test_if_no_class(...) |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.label | [Function] function flow_through_type_test_if_no_class(...) |
+| test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.label | [Name] flow_through_type_test_if_no_class |
+| test.py:195:5:195:5 | [Name] t | semmle.label | [Name] t |
+| test.py:195:5:195:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
+| test.py:195:9:195:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.label | [If] if isinstance(str, t): |
+| test.py:196:8:196:17 | [Name] isinstance | semmle.label | [Name] isinstance |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | semmle.label | [Call] isinstance(str, t) |
+| test.py:196:19:196:19 | [Name] t | semmle.label | [Name] t |
+| test.py:196:22:196:24 | [Name] str | semmle.label | [Name] str |
+| test.py:197:9:197:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:197:9:197:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:197:9:197:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:197:14:197:14 | [Name] t | semmle.label | [Name] t |
+| test.py:199:9:199:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:199:9:199:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| test.py:199:9:199:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
+| test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
+| test.py:199:14:199:14 | [Name] t | semmle.label | [Name] t |
+| test.py:201:1:201:24 | (parameters) | semmle.label | (parameters) |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | semmle.label | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | semmle.order | 77 |
+| test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.label | [FunctionExpr] function flow_in_iteration(...) |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.label | [Function] function flow_in_iteration(...) |
+| test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.label | [Name] flow_in_iteration |
+| test.py:202:5:202:5 | [Name] t | semmle.label | [Name] t |
+| test.py:202:5:202:23 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.label | [AssignStmt] t = ITERABLE_SOURCE |
+| test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.label | [Name] ITERABLE_SOURCE |
+| test.py:203:5:203:15 | [For]  | semmle.label | [For]  |
+| test.py:203:9:203:9 | [Name] i | semmle.label | [Name] i |
+| test.py:203:14:203:14 | [Name] t | semmle.label | [Name] t |
+| test.py:204:9:204:9 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:204:9:204:9 | [ExprStmt] i | semmle.label | [ExprStmt] i |
+| test.py:204:9:204:9 | [Name] i | semmle.label | [Name] i |
+| test.py:205:5:205:12 | [Return] return i | semmle.label | [Return] return i |
+| test.py:205:12:205:12 | [Name] i | semmle.label | [Name] i |
+| test.py:207:1:207:24 | (parameters) | semmle.label | (parameters) |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | semmle.label | [FunctionDef] flow_in_generator = function flow_in_generator(...) |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | semmle.order | 78 |
+| test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.label | [FunctionExpr] function flow_in_generator(...) |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.label | [Function] function flow_in_generator(...) |
+| test.py:207:5:207:21 | [Name] flow_in_generator | semmle.label | [Name] flow_in_generator |
+| test.py:208:5:208:7 | [Name] seq | semmle.label | [Name] seq |
+| test.py:208:5:208:18 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.label | [AssignStmt] seq = [...] |
+| test.py:208:11:208:18 | [List] [...] | semmle.label | [List] [...] |
+| test.py:208:12:208:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:209:5:209:17 | [For]  | semmle.label | [For]  |
+| test.py:209:9:209:9 | [Name] i | semmle.label | [Name] i |
+| test.py:209:14:209:16 | [Name] seq | semmle.label | [Name] seq |
+| test.py:210:9:210:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:210:9:210:15 | [ExprStmt] yield i | semmle.label | [ExprStmt] yield i |
+| test.py:210:9:210:15 | [Yield] yield i | semmle.label | [Yield] yield i |
+| test.py:210:15:210:15 | [Name] i | semmle.label | [Name] i |
+| test.py:212:1:212:26 | (parameters) | semmle.label | (parameters) |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | semmle.label | [FunctionDef] flow_from_generator = function flow_from_generator(...) |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | semmle.order | 79 |
+| test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.label | [FunctionExpr] function flow_from_generator(...) |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.label | [Function] function flow_from_generator(...) |
+| test.py:212:5:212:23 | [Name] flow_from_generator | semmle.label | [Name] flow_from_generator |
+| test.py:213:5:213:33 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:213:5:213:33 | [For]  | semmle.label | [For]  |
+| test.py:213:9:213:9 | [Name] x | semmle.label | [Name] x |
+| test.py:213:14:213:30 | [Name] flow_in_generator | semmle.label | [Name] flow_in_generator |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.label | [Call] flow_in_generator() |
+| test.py:214:9:214:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:214:9:214:15 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:214:9:214:15 | [Call] SINK(x) | semmle.label | [Call] SINK(x) |
+| test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.label | [ExprStmt] SINK(x) |
+| test.py:214:14:214:14 | [Name] x | semmle.label | [Name] x |
+| test.py:216:1:216:28 | (parameters) | semmle.label | (parameters) |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | semmle.label | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | semmle.order | 80 |
+| test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.label | [FunctionExpr] function const_eq_clears_taint(...) |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.label | [Function] function const_eq_clears_taint(...) |
+| test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.label | [Name] const_eq_clears_taint |
+| test.py:217:5:217:11 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:217:5:217:20 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
+| test.py:217:15:217:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:218:5:218:25 | [If] if tainted == ...: | semmle.label | [If] if tainted == ...: |
+| test.py:218:8:218:14 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:218:8:218:24 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
+| test.py:218:19:218:24 | [Str] safe | semmle.label | [Str] safe |
+| test.py:219:9:219:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:219:9:219:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
+| test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
+| test.py:219:14:219:20 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:220:5:220:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
+| test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
+| test.py:220:10:220:16 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:222:1:222:29 | (parameters) | semmle.label | (parameters) |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | semmle.label | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | semmle.order | 81 |
+| test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.label | [FunctionExpr] function const_eq_clears_taint2(...) |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.label | [Function] function const_eq_clears_taint2(...) |
+| test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.label | [Name] const_eq_clears_taint2 |
+| test.py:223:5:223:11 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:223:5:223:20 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
+| test.py:223:15:223:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:224:5:224:25 | [If] if tainted != ...: | semmle.label | [If] if tainted != ...: |
+| test.py:224:8:224:14 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:224:8:224:24 | [Compare] tainted != ... | semmle.label | [Compare] tainted != ... |
+| test.py:224:19:224:24 | [Str] safe | semmle.label | [Str] safe |
+| test.py:225:9:225:14 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:225:9:225:14 | [Return]  | semmle.label | [Return]  |
+| test.py:226:5:226:8 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
+| test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
+| test.py:226:10:226:16 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:228:1:228:36 | (parameters) | semmle.label | (parameters) |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | semmle.label | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | semmle.order | 82 |
+| test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.label | [FunctionExpr] function non_const_eq_preserves_taint(...) |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | semmle.label | [Function] function non_const_eq_preserves_taint(...) |
+| test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.label | [Name] non_const_eq_preserves_taint |
+| test.py:228:34:228:34 | [Parameter] x | semmle.label | [Parameter] x |
+| test.py:229:5:229:11 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:229:5:229:20 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
+| test.py:229:15:229:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
+| test.py:230:5:230:26 | [If] if tainted == ...: | semmle.label | [If] if tainted == ...: |
+| test.py:230:8:230:14 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:230:8:230:25 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
+| test.py:230:19:230:25 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:231:9:231:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:231:9:231:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
+| test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
+| test.py:231:14:231:20 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:232:5:232:20 | [If] if tainted == ...: | semmle.label | [If] if tainted == ...: |
+| test.py:232:8:232:14 | [Name] tainted | semmle.label | [Name] tainted |
+| test.py:232:8:232:19 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
+| test.py:232:19:232:19 | [Name] x | semmle.label | [Name] x |
+| test.py:233:9:233:12 | [Name] SINK | semmle.label | [Name] SINK |
+| test.py:233:9:233:21 | (StmtList) body | semmle.label | (StmtList) body |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
+| test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
+| test.py:233:14:233:20 | [Name] tainted | semmle.label | [Name] tainted |
+edges
+| assignment.py:1:1:1:16 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.label | 1 |
+| assignment.py:1:1:1:16 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.order | 1 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.label | 1 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.order | 1 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.label | 2 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.order | 2 |
+| assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | assignment.py:1:1:1:16 | [Function] function test(...) | semmle.label | 1 |
+| assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | assignment.py:1:1:1:16 | [Function] function test(...) | semmle.order | 1 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:1:1:1:16 | (parameters) | semmle.label | 0 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:1:1:1:16 | (parameters) | semmle.order | 0 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:2:5:2:8 | (StmtList) body | semmle.label | 4 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:2:5:2:8 | (StmtList) body | semmle.order | 4 |
+| assignment.py:2:5:2:8 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.label | 0 |
+| assignment.py:2:5:2:8 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.order | 0 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.label | 1 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.order | 1 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.label | 2 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.order | 2 |
+| assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | assignment.py:4:1:4:17 | [Function] function swap_taint(...) | semmle.label | 1 |
+| assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | assignment.py:4:1:4:17 | [Function] function swap_taint(...) | semmle.order | 1 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:4:1:4:17 | (parameters) | semmle.label | 0 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:4:1:4:17 | (parameters) | semmle.order | 0 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:5:5:5:25 | (StmtList) body | semmle.label | 6 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:5:5:5:25 | (StmtList) body | semmle.order | 6 |
+| assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:5:5:5 | [Name] a | semmle.label | 1 |
+| assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:5:5:5 | [Name] a | semmle.order | 1 |
+| assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:8:5:8 | [Name] b | semmle.label | 2 |
+| assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:8:5:8 | [Name] b | semmle.order | 2 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.label | 0 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.order | 0 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.label | 1 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.order | 1 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.label | 2 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.order | 2 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.label | 3 |
+| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.order | 3 |
+| assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:5:5:8 | [Tuple]  | semmle.label | 1 |
+| assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:5:5:8 | [Tuple]  | semmle.order | 1 |
+| assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:12:5:25 | [Tuple]  | semmle.label | 2 |
+| assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:12:5:25 | [Tuple]  | semmle.order | 2 |
+| assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:12:5:17 | [Name] SOURCE | semmle.label | 1 |
+| assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:12:5:17 | [Name] SOURCE | semmle.order | 1 |
+| assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:20:5:25 | [Str] safe | semmle.label | 2 |
+| assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:20:5:25 | [Str] safe | semmle.order | 2 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.label | 1 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.order | 1 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:10:6:10 | [Name] a | semmle.label | 2 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:10:6:10 | [Name] a | semmle.order | 2 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:13:6:13 | [Name] b | semmle.label | 3 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:13:6:13 | [Name] b | semmle.order | 3 |
+| assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | assignment.py:6:5:6:14 | [Call] test(a, b) | semmle.label | 1 |
+| assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | assignment.py:6:5:6:14 | [Call] test(a, b) | semmle.order | 1 |
+| assignment.py:7:5:7:8 | [Tuple]  | assignment.py:7:5:7:5 | [Name] a | semmle.label | 1 |
+| assignment.py:7:5:7:8 | [Tuple]  | assignment.py:7:5:7:5 | [Name] a | semmle.order | 1 |
+| assignment.py:7:5:7:8 | [Tuple]  | assignment.py:7:8:7:8 | [Name] b | semmle.label | 2 |
+| assignment.py:7:5:7:8 | [Tuple]  | assignment.py:7:8:7:8 | [Name] b | semmle.order | 2 |
+| assignment.py:7:5:7:15 | [AssignStmt]  | assignment.py:7:5:7:8 | [Tuple]  | semmle.label | 1 |
+| assignment.py:7:5:7:15 | [AssignStmt]  | assignment.py:7:5:7:8 | [Tuple]  | semmle.order | 1 |
+| assignment.py:7:5:7:15 | [AssignStmt]  | assignment.py:7:12:7:15 | [Tuple]  | semmle.label | 2 |
+| assignment.py:7:5:7:15 | [AssignStmt]  | assignment.py:7:12:7:15 | [Tuple]  | semmle.order | 2 |
+| assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:12:7:12 | [Name] b | semmle.label | 1 |
+| assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:12:7:12 | [Name] b | semmle.order | 1 |
+| assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:15:7:15 | [Name] a | semmle.label | 2 |
+| assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:15:7:15 | [Name] a | semmle.order | 2 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.label | 1 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.order | 1 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:10:8:10 | [Name] a | semmle.label | 2 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:10:8:10 | [Name] a | semmle.order | 2 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:13:8:13 | [Name] b | semmle.label | 3 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:13:8:13 | [Name] b | semmle.order | 3 |
+| assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | assignment.py:8:5:8:14 | [Call] test(a, b) | semmle.label | 1 |
+| assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | assignment.py:8:5:8:14 | [Call] test(a, b) | semmle.order | 1 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.label | 1 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.order | 1 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.label | 2 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.order | 2 |
+| assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.label | 1 |
+| assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.order | 1 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:10:1:10:24 | (parameters) | semmle.label | 0 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:10:1:10:24 | (parameters) | semmle.order | 0 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:13:5:13:59 | (StmtList) body | semmle.label | 4 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:13:5:13:59 | (StmtList) body | semmle.order | 4 |
+| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.label | 0 |
+| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.order | 0 |
+| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.label | 1 |
+| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.order | 1 |
+| assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:6:13:21 | [Tuple]  | semmle.label | 1 |
+| assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:6:13:21 | [Tuple]  | semmle.order | 1 |
+| assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:27:13:58 | [Tuple]  | semmle.label | 2 |
+| assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:27:13:58 | [Tuple]  | semmle.order | 2 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:7:13:12 | [Tuple]  | semmle.label | 1 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:7:13:12 | [Tuple]  | semmle.order | 1 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:16:13:17 | [Name] t2 | semmle.label | 2 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:16:13:17 | [Name] t2 | semmle.order | 2 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:20:13:21 | [Name] s2 | semmle.label | 3 |
+| assignment.py:13:6:13:21 | [Tuple]  | assignment.py:13:20:13:21 | [Name] s2 | semmle.order | 3 |
+| assignment.py:13:7:13:12 | [Tuple]  | assignment.py:13:7:13:8 | [Name] t1 | semmle.label | 1 |
+| assignment.py:13:7:13:12 | [Tuple]  | assignment.py:13:7:13:8 | [Name] t1 | semmle.order | 1 |
+| assignment.py:13:7:13:12 | [Tuple]  | assignment.py:13:11:13:12 | [Name] s1 | semmle.label | 2 |
+| assignment.py:13:7:13:12 | [Tuple]  | assignment.py:13:11:13:12 | [Name] s1 | semmle.order | 2 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:28:13:41 | [Tuple]  | semmle.label | 1 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:28:13:41 | [Tuple]  | semmle.order | 1 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:45:13:50 | [Name] SOURCE | semmle.label | 2 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:45:13:50 | [Name] SOURCE | semmle.order | 2 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:53:13:58 | [Str] safe | semmle.label | 3 |
+| assignment.py:13:27:13:58 | [Tuple]  | assignment.py:13:53:13:58 | [Str] safe | semmle.order | 3 |
+| assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:28:13:33 | [Name] SOURCE | semmle.label | 1 |
+| assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:28:13:33 | [Name] SOURCE | semmle.order | 1 |
+| assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:36:13:41 | [Str] safe | semmle.label | 2 |
+| assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:36:13:41 | [Str] safe | semmle.order | 2 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.label | 1 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.order | 1 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:10:14:11 | [Name] t1 | semmle.label | 2 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:10:14:11 | [Name] t1 | semmle.order | 2 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:14:14:15 | [Name] s1 | semmle.label | 3 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:14:14:15 | [Name] s1 | semmle.order | 3 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:18:14:19 | [Name] t2 | semmle.label | 4 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:18:14:19 | [Name] t2 | semmle.order | 4 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:22:14:23 | [Name] s2 | semmle.label | 5 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:22:14:23 | [Name] s2 | semmle.order | 5 |
+| assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | semmle.label | 1 |
+| assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | semmle.order | 1 |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | semmle.label | 1 |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | semmle.order | 1 |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | carrier.py:2:7:2:21 | [Name] ImplicitCarrier | semmle.label | 2 |
+| carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | carrier.py:2:7:2:21 | [Name] ImplicitCarrier | semmle.order | 2 |
+| carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | semmle.label | 1 |
+| carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | semmle.order | 1 |
+| carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:23:2:28 | [Name] object | semmle.label | 2 |
+| carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:23:2:28 | [Name] object | semmle.order | 2 |
+| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | carrier.py:4:5:4:28 | (StmtList) body | semmle.label | 5 |
+| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | carrier.py:4:5:4:28 | (StmtList) body | semmle.order | 5 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.label | 0 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.order | 0 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.label | 1 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.order | 1 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.label | 2 |
+| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.order | 2 |
+| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.label | 1 |
+| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.order | 1 |
+| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.label | 2 |
+| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.order | 2 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.label | 1 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.order | 1 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.label | 2 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.order | 2 |
+| carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.label | 1 |
+| carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.order | 1 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:4:5:4:28 | (parameters) | semmle.label | 0 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:4:5:4:28 | (parameters) | semmle.order | 0 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:5:9:5:23 | (StmtList) body | semmle.label | 5 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:5:9:5:23 | (StmtList) body | semmle.order | 5 |
+| carrier.py:5:9:5:17 | [Attribute] self.attr | carrier.py:5:9:5:12 | [Name] self | semmle.label | 1 |
+| carrier.py:5:9:5:17 | [Attribute] self.attr | carrier.py:5:9:5:12 | [Name] self | semmle.order | 1 |
+| carrier.py:5:9:5:23 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
+| carrier.py:5:9:5:23 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
+| carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.label | 1 |
+| carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.order | 1 |
+| carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:21:5:23 | [Name] arg | semmle.label | 2 |
+| carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:21:5:23 | [Name] arg | semmle.order | 2 |
+| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.label | 1 |
+| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.order | 1 |
+| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.label | 2 |
+| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.order | 2 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.label | 1 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.order | 1 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.label | 2 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.order | 2 |
+| carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.label | 1 |
+| carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.order | 1 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:7:5:7:28 | (parameters) | semmle.label | 0 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:7:5:7:28 | (parameters) | semmle.order | 0 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:8:9:8:23 | (StmtList) body | semmle.label | 5 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:8:9:8:23 | (StmtList) body | semmle.order | 5 |
+| carrier.py:8:9:8:17 | [Attribute] self.attr | carrier.py:8:9:8:12 | [Name] self | semmle.label | 1 |
+| carrier.py:8:9:8:17 | [Attribute] self.attr | carrier.py:8:9:8:12 | [Name] self | semmle.order | 1 |
+| carrier.py:8:9:8:23 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
+| carrier.py:8:9:8:23 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
+| carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.label | 1 |
+| carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.order | 1 |
+| carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:21:8:23 | [Name] arg | semmle.label | 2 |
+| carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:21:8:23 | [Name] arg | semmle.order | 2 |
+| carrier.py:10:5:10:23 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.label | 1 |
+| carrier.py:10:5:10:23 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.order | 1 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.label | 1 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.order | 1 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.label | 2 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.order | 2 |
+| carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.label | 1 |
+| carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.order | 1 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:10:5:10:23 | (parameters) | semmle.label | 0 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:10:5:10:23 | (parameters) | semmle.order | 0 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:11:9:11:24 | (StmtList) body | semmle.label | 4 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:11:9:11:24 | (StmtList) body | semmle.order | 4 |
+| carrier.py:11:9:11:24 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.label | 0 |
+| carrier.py:11:9:11:24 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.order | 0 |
+| carrier.py:11:9:11:24 | [Return] return self.attr | carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.label | 1 |
+| carrier.py:11:9:11:24 | [Return] return self.attr | carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.order | 1 |
+| carrier.py:11:16:11:24 | [Attribute] self.attr | carrier.py:11:16:11:19 | [Name] self | semmle.label | 1 |
+| carrier.py:11:16:11:24 | [Attribute] self.attr | carrier.py:11:16:11:19 | [Name] self | semmle.order | 1 |
+| carrier.py:13:1:13:13 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.label | 1 |
+| carrier.py:13:1:13:13 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.order | 1 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.label | 1 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.order | 1 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.label | 2 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.order | 2 |
+| carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.label | 1 |
+| carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.order | 1 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:13:1:13:13 | (parameters) | semmle.label | 0 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:13:1:13:13 | (parameters) | semmle.order | 0 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:14:5:14:14 | (StmtList) body | semmle.label | 4 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:14:5:14:14 | (StmtList) body | semmle.order | 4 |
+| carrier.py:14:5:14:14 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.label | 0 |
+| carrier.py:14:5:14:14 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.order | 0 |
+| carrier.py:14:5:14:14 | [Return] return arg | carrier.py:14:12:14:14 | [Name] arg | semmle.label | 1 |
+| carrier.py:14:5:14:14 | [Return] return arg | carrier.py:14:12:14:14 | [Name] arg | semmle.order | 1 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.label | 2 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.order | 2 |
+| carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.label | 1 |
+| carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.order | 1 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:16:1:16:12 | (parameters) | semmle.label | 0 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:16:1:16:12 | (parameters) | semmle.order | 0 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:17:5:17:31 | (StmtList) body | semmle.label | 4 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:17:5:17:31 | (StmtList) body | semmle.order | 4 |
+| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.label | 0 |
+| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.order | 0 |
+| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:5:17:5 | [Name] c | semmle.label | 1 |
+| carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:5:17:5 | [Name] c | semmle.order | 1 |
+| carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.label | 2 |
+| carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.order | 2 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.label | 1 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.order | 1 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.label | 2 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.order | 2 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.label | 1 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.order | 1 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.label | 2 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.order | 2 |
+| carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | carrier.py:18:5:18:16 | [Call] SINK(...) | semmle.label | 1 |
+| carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | carrier.py:18:5:18:16 | [Call] SINK(...) | semmle.order | 1 |
+| carrier.py:18:10:18:15 | [Attribute] c.attr | carrier.py:18:10:18:10 | [Name] c | semmle.label | 1 |
+| carrier.py:18:10:18:15 | [Attribute] c.attr | carrier.py:18:10:18:10 | [Name] c | semmle.order | 1 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.label | 2 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.order | 2 |
+| carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.label | 1 |
+| carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.order | 1 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:20:1:20:12 | (parameters) | semmle.label | 0 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:20:1:20:12 | (parameters) | semmle.order | 0 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:21:5:21:28 | (StmtList) body | semmle.label | 4 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:21:5:21:28 | (StmtList) body | semmle.order | 4 |
+| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.label | 0 |
+| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.order | 0 |
+| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:5:21:5 | [Name] c | semmle.label | 1 |
+| carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:5:21:5 | [Name] c | semmle.order | 1 |
+| carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
+| carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.label | 1 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.order | 1 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.label | 2 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.order | 2 |
+| carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | carrier.py:22:5:22:23 | [Call] SINK(...) | semmle.label | 1 |
+| carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | carrier.py:22:5:22:23 | [Call] SINK(...) | semmle.order | 1 |
+| carrier.py:22:10:22:20 | [Attribute] c.get_taint | carrier.py:22:10:22:10 | [Name] c | semmle.label | 1 |
+| carrier.py:22:10:22:20 | [Attribute] c.get_taint | carrier.py:22:10:22:10 | [Name] c | semmle.order | 1 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.label | 1 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.order | 1 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.label | 2 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.order | 2 |
+| carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.label | 1 |
+| carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.order | 1 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:24:1:24:12 | (parameters) | semmle.label | 0 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:24:1:24:12 | (parameters) | semmle.order | 0 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:25:5:25:36 | (StmtList) body | semmle.label | 4 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:25:5:25:36 | (StmtList) body | semmle.order | 4 |
+| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.label | 0 |
+| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.order | 0 |
+| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:5:25:5 | [Name] c | semmle.label | 1 |
+| carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:5:25:5 | [Name] c | semmle.order | 1 |
+| carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:9:25:36 | [Call] hub(...) | semmle.label | 2 |
+| carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:9:25:36 | [Call] hub(...) | semmle.order | 2 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.label | 1 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.order | 1 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.label | 2 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.order | 2 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.label | 1 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.order | 1 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.label | 2 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.order | 2 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.label | 1 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.order | 1 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.label | 2 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.order | 2 |
+| carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | carrier.py:26:5:26:22 | [Call] SINK(...) | semmle.label | 1 |
+| carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | carrier.py:26:5:26:22 | [Call] SINK(...) | semmle.order | 1 |
+| carrier.py:26:10:26:19 | [Attribute] c.get_attr | carrier.py:26:10:26:10 | [Name] c | semmle.label | 1 |
+| carrier.py:26:10:26:19 | [Attribute] c.get_attr | carrier.py:26:10:26:10 | [Name] c | semmle.order | 1 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.label | 1 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.order | 1 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.label | 2 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.order | 2 |
+| carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.label | 1 |
+| carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.order | 1 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:28:1:28:12 | (parameters) | semmle.label | 0 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:28:1:28:12 | (parameters) | semmle.order | 0 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:29:5:29:33 | (StmtList) body | semmle.label | 4 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:29:5:29:33 | (StmtList) body | semmle.order | 4 |
+| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
+| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
+| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:5:29:5 | [Name] c | semmle.label | 1 |
+| carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:5:29:5 | [Name] c | semmle.order | 1 |
+| carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.label | 2 |
+| carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.order | 2 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.label | 1 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.order | 1 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.label | 1 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.order | 1 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.label | 2 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.order | 2 |
+| carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | carrier.py:30:5:30:23 | [Call] SINK(...) | semmle.label | 1 |
+| carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | carrier.py:30:5:30:23 | [Call] SINK(...) | semmle.order | 1 |
+| carrier.py:30:10:30:20 | [Attribute] c.get_taint | carrier.py:30:10:30:10 | [Name] c | semmle.label | 1 |
+| carrier.py:30:10:30:20 | [Attribute] c.get_taint | carrier.py:30:10:30:10 | [Name] c | semmle.order | 1 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.label | 1 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.order | 1 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.label | 2 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.order | 2 |
+| carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.label | 1 |
+| carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.order | 1 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:32:1:32:12 | (parameters) | semmle.label | 0 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:32:1:32:12 | (parameters) | semmle.order | 0 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:33:5:33:45 | (StmtList) body | semmle.label | 5 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:33:5:33:45 | (StmtList) body | semmle.order | 5 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.label | 1 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.order | 1 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.label | 2 |
+| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:5:33:5 | [Name] c | semmle.label | 1 |
+| carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:5:33:5 | [Name] c | semmle.order | 1 |
+| carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | 2 |
+| carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.order | 2 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.label | 1 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.order | 1 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:5:34:5 | [Name] x | semmle.label | 1 |
+| carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:5:34:5 | [Name] x | semmle.order | 1 |
+| carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:9:34:14 | [Attribute] c.attr | semmle.label | 2 |
+| carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:9:34:14 | [Attribute] c.attr | semmle.order | 2 |
+| carrier.py:34:9:34:14 | [Attribute] c.attr | carrier.py:34:9:34:9 | [Name] c | semmle.label | 1 |
+| carrier.py:34:9:34:14 | [Attribute] c.attr | carrier.py:34:9:34:9 | [Name] c | semmle.order | 1 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.label | 1 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.order | 1 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.label | 2 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.order | 2 |
+| carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | carrier.py:35:5:35:23 | [Call] SINK(...) | semmle.label | 1 |
+| carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | carrier.py:35:5:35:23 | [Call] SINK(...) | semmle.order | 1 |
+| carrier.py:35:10:35:20 | [Attribute] x.get_taint | carrier.py:35:10:35:10 | [Name] x | semmle.label | 1 |
+| carrier.py:35:10:35:20 | [Attribute] x.get_taint | carrier.py:35:10:35:10 | [Name] x | semmle.order | 1 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.label | 1 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.order | 1 |
+| deep.py:2:1:2:12 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:2:1:2:12 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.label | 1 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.order | 1 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.label | 2 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.order | 2 |
+| deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | deep.py:2:1:2:12 | [Function] function f1(...) | semmle.label | 1 |
+| deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | deep.py:2:1:2:12 | [Function] function f1(...) | semmle.order | 1 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:2:1:2:12 | (parameters) | semmle.label | 0 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:2:1:2:12 | (parameters) | semmle.order | 0 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:3:5:3:14 | (StmtList) body | semmle.label | 4 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:3:5:3:14 | (StmtList) body | semmle.order | 4 |
+| deep.py:3:5:3:14 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.label | 0 |
+| deep.py:3:5:3:14 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.order | 0 |
+| deep.py:3:5:3:14 | [Return] return arg | deep.py:3:12:3:14 | [Name] arg | semmle.label | 1 |
+| deep.py:3:5:3:14 | [Return] return arg | deep.py:3:12:3:14 | [Name] arg | semmle.order | 1 |
+| deep.py:5:1:5:12 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:5:1:5:12 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.label | 1 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.order | 1 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.label | 2 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.order | 2 |
+| deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | deep.py:5:1:5:12 | [Function] function f2(...) | semmle.label | 1 |
+| deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | deep.py:5:1:5:12 | [Function] function f2(...) | semmle.order | 1 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:5:1:5:12 | (parameters) | semmle.label | 0 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:5:1:5:12 | (parameters) | semmle.order | 0 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:6:5:6:18 | (StmtList) body | semmle.label | 4 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:6:5:6:18 | (StmtList) body | semmle.order | 4 |
+| deep.py:6:5:6:18 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.label | 0 |
+| deep.py:6:5:6:18 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.order | 0 |
+| deep.py:6:5:6:18 | [Return] return f1(arg) | deep.py:6:12:6:18 | [Call] f1(arg) | semmle.label | 1 |
+| deep.py:6:5:6:18 | [Return] return f1(arg) | deep.py:6:12:6:18 | [Call] f1(arg) | semmle.order | 1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.label | 1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.order | 1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:15:6:17 | [Name] arg | semmle.label | 2 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:15:6:17 | [Name] arg | semmle.order | 2 |
+| deep.py:8:1:8:12 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:8:1:8:12 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.label | 1 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.order | 1 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.label | 2 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.order | 2 |
+| deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | deep.py:8:1:8:12 | [Function] function f3(...) | semmle.label | 1 |
+| deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | deep.py:8:1:8:12 | [Function] function f3(...) | semmle.order | 1 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:8:1:8:12 | (parameters) | semmle.label | 0 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:8:1:8:12 | (parameters) | semmle.order | 0 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:9:5:9:18 | (StmtList) body | semmle.label | 4 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:9:5:9:18 | (StmtList) body | semmle.order | 4 |
+| deep.py:9:5:9:18 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.label | 0 |
+| deep.py:9:5:9:18 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.order | 0 |
+| deep.py:9:5:9:18 | [Return] return f2(arg) | deep.py:9:12:9:18 | [Call] f2(arg) | semmle.label | 1 |
+| deep.py:9:5:9:18 | [Return] return f2(arg) | deep.py:9:12:9:18 | [Call] f2(arg) | semmle.order | 1 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.label | 1 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.order | 1 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:15:9:17 | [Name] arg | semmle.label | 2 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:15:9:17 | [Name] arg | semmle.order | 2 |
+| deep.py:11:1:11:12 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:11:1:11:12 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.label | 1 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.order | 1 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.label | 2 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.order | 2 |
+| deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | deep.py:11:1:11:12 | [Function] function f4(...) | semmle.label | 1 |
+| deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | deep.py:11:1:11:12 | [Function] function f4(...) | semmle.order | 1 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:11:1:11:12 | (parameters) | semmle.label | 0 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:11:1:11:12 | (parameters) | semmle.order | 0 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:12:5:12:18 | (StmtList) body | semmle.label | 4 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:12:5:12:18 | (StmtList) body | semmle.order | 4 |
+| deep.py:12:5:12:18 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.label | 0 |
+| deep.py:12:5:12:18 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.order | 0 |
+| deep.py:12:5:12:18 | [Return] return f3(arg) | deep.py:12:12:12:18 | [Call] f3(arg) | semmle.label | 1 |
+| deep.py:12:5:12:18 | [Return] return f3(arg) | deep.py:12:12:12:18 | [Call] f3(arg) | semmle.order | 1 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.label | 1 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.order | 1 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:15:12:17 | [Name] arg | semmle.label | 2 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:15:12:17 | [Name] arg | semmle.order | 2 |
+| deep.py:14:1:14:12 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:14:1:14:12 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.label | 1 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.order | 1 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.label | 2 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.order | 2 |
+| deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | deep.py:14:1:14:12 | [Function] function f5(...) | semmle.label | 1 |
+| deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | deep.py:14:1:14:12 | [Function] function f5(...) | semmle.order | 1 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:14:1:14:12 | (parameters) | semmle.label | 0 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:14:1:14:12 | (parameters) | semmle.order | 0 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:15:5:15:18 | (StmtList) body | semmle.label | 4 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:15:5:15:18 | (StmtList) body | semmle.order | 4 |
+| deep.py:15:5:15:18 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.label | 0 |
+| deep.py:15:5:15:18 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.order | 0 |
+| deep.py:15:5:15:18 | [Return] return f4(arg) | deep.py:15:12:15:18 | [Call] f4(arg) | semmle.label | 1 |
+| deep.py:15:5:15:18 | [Return] return f4(arg) | deep.py:15:12:15:18 | [Call] f4(arg) | semmle.order | 1 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.label | 1 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.order | 1 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:15:15:17 | [Name] arg | semmle.label | 2 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:15:15:17 | [Name] arg | semmle.order | 2 |
+| deep.py:17:1:17:12 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.label | 1 |
+| deep.py:17:1:17:12 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.label | 1 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.order | 1 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.label | 2 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.order | 2 |
+| deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | deep.py:17:1:17:12 | [Function] function f6(...) | semmle.label | 1 |
+| deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | deep.py:17:1:17:12 | [Function] function f6(...) | semmle.order | 1 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:17:1:17:12 | (parameters) | semmle.label | 0 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:17:1:17:12 | (parameters) | semmle.order | 0 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:18:5:18:18 | (StmtList) body | semmle.label | 4 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:18:5:18:18 | (StmtList) body | semmle.order | 4 |
+| deep.py:18:5:18:18 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.label | 0 |
+| deep.py:18:5:18:18 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.order | 0 |
+| deep.py:18:5:18:18 | [Return] return f5(arg) | deep.py:18:12:18:18 | [Call] f5(arg) | semmle.label | 1 |
+| deep.py:18:5:18:18 | [Return] return f5(arg) | deep.py:18:12:18:18 | [Call] f5(arg) | semmle.order | 1 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.label | 1 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.order | 1 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:15:18:17 | [Name] arg | semmle.label | 2 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:15:18:17 | [Name] arg | semmle.order | 2 |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:1:20:1 | [Name] x | semmle.label | 1 |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:1:20:1 | [Name] x | semmle.order | 1 |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:5:20:14 | [Call] f6(SOURCE) | semmle.label | 2 |
+| deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:5:20:14 | [Call] f6(SOURCE) | semmle.order | 2 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.label | 1 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.order | 1 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.label | 2 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.order | 2 |
+| deep.py:22:1:22:1 | [ExprStmt] x | deep.py:22:1:22:1 | [Name] x | semmle.label | 1 |
+| deep.py:22:1:22:1 | [ExprStmt] x | deep.py:22:1:22:1 | [Name] x | semmle.order | 1 |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:1:3:9 | [Name] dangerous | semmle.label | 1 |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:1:3:9 | [Name] dangerous | semmle.order | 1 |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:13:3:18 | [Name] SOURCE | semmle.label | 2 |
+| module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:13:3:18 | [Name] SOURCE | semmle.order | 2 |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | module.py:4:1:4:4 | [Name] safe | semmle.label | 1 |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | module.py:4:1:4:4 | [Name] safe | semmle.order | 1 |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | module.py:4:8:4:13 | [Str] safe | semmle.label | 2 |
+| module.py:4:1:4:13 | [AssignStmt] safe = safe | module.py:4:8:4:13 | [Str] safe | semmle.order | 2 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.label | 1 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.order | 1 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.label | 2 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.order | 2 |
+| module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.label | 1 |
+| module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.order | 1 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:6:1:6:21 | (parameters) | semmle.label | 0 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:6:1:6:21 | (parameters) | semmle.order | 0 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:7:5:7:17 | (StmtList) body | semmle.label | 3 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:7:5:7:17 | (StmtList) body | semmle.order | 3 |
+| module.py:7:5:7:17 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.label | 0 |
+| module.py:7:5:7:17 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.order | 0 |
+| module.py:7:5:7:17 | [Return] return SOURCE | module.py:7:12:7:17 | [Name] SOURCE | semmle.label | 1 |
+| module.py:7:5:7:17 | [Return] return SOURCE | module.py:7:12:7:17 | [Name] SOURCE | semmle.order | 1 |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | module.py:10:1:10:5 | [Name] safe2 | semmle.label | 1 |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | module.py:10:1:10:5 | [Name] safe2 | semmle.order | 1 |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | module.py:10:9:10:14 | [Name] SOURCE | semmle.label | 2 |
+| module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | module.py:10:9:10:14 | [Name] SOURCE | semmle.order | 2 |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:1:11:5 | [Name] safe2 | semmle.label | 1 |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:1:11:5 | [Name] safe2 | semmle.order | 1 |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:9:11:14 | [Str] safe | semmle.label | 2 |
+| module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:9:11:14 | [Str] safe | semmle.order | 2 |
+| rockpaperscissors.py:3:1:3:14 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.label | 1 |
+| rockpaperscissors.py:3:1:3:14 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.order | 1 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.label | 1 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.order | 1 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.label | 2 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.order | 2 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.label | 1 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.order | 1 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:4:5:4:29 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.label | 0 |
+| rockpaperscissors.py:4:5:4:29 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.label | 1 |
+| rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.order | 1 |
+| rockpaperscissors.py:6:1:6:15 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.label | 1 |
+| rockpaperscissors.py:6:1:6:15 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.order | 1 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.label | 1 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.order | 1 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.label | 2 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.order | 2 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.label | 1 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.order | 1 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:7:5:7:24 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.label | 0 |
+| rockpaperscissors.py:7:5:7:24 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.label | 1 |
+| rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.order | 1 |
+| rockpaperscissors.py:9:1:9:18 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.label | 1 |
+| rockpaperscissors.py:9:1:9:18 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.order | 1 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.label | 1 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.order | 1 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.label | 2 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.order | 2 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.label | 1 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.order | 1 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:10:5:10:25 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.label | 0 |
+| rockpaperscissors.py:10:5:10:25 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.label | 1 |
+| rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.order | 1 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.label | 2 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.order | 2 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.label | 1 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.order | 1 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.label | 3 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.order | 3 |
+| rockpaperscissors.py:13:5:13:18 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.label | 0 |
+| rockpaperscissors.py:13:5:13:18 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.order | 0 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.label | 1 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.order | 1 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.label | 2 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.order | 2 |
+| rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.label | 1 |
+| rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.order | 1 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.label | 2 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.order | 2 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.label | 1 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.order | 1 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.label | 3 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.order | 3 |
+| rockpaperscissors.py:16:5:16:15 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.label | 0 |
+| rockpaperscissors.py:16:5:16:15 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.order | 0 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.label | 1 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.order | 1 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.label | 2 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.order | 2 |
+| rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.label | 1 |
+| rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.order | 1 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.label | 2 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.order | 2 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.label | 1 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.order | 1 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.label | 5 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.order | 5 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
+| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:9:19:12 | [Name] ROCK | semmle.label | 2 |
+| rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:9:19:12 | [Name] ROCK | semmle.order | 2 |
+| rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:20:5:20:5 | [Name] y | semmle.label | 1 |
+| rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:20:5:20:5 | [Name] y | semmle.order | 1 |
+| rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | semmle.label | 2 |
+| rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | semmle.order | 2 |
+| rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | rockpaperscissors.py:20:9:20:9 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | rockpaperscissors.py:20:9:20:9 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.label | 1 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.order | 1 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.label | 1 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.order | 1 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.label | 2 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.label | 1 |
+| rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.order | 1 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.label | 2 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.order | 2 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.label | 1 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.order | 1 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.label | 5 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.order | 5 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.label | 1 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.order | 1 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
+| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:9:24:12 | [Name] ROCK | semmle.label | 2 |
+| rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:9:24:12 | [Name] ROCK | semmle.order | 2 |
+| rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | rockpaperscissors.py:25:5:25:5 | [Name] y | semmle.label | 1 |
+| rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | rockpaperscissors.py:25:5:25:5 | [Name] y | semmle.order | 1 |
+| rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | semmle.label | 2 |
+| rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | semmle.order | 2 |
+| rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | rockpaperscissors.py:25:9:25:9 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | rockpaperscissors.py:25:9:25:9 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.order | 1 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.label | 1 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.order | 1 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.label | 2 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.label | 1 |
+| rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.order | 1 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.label | 2 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.order | 2 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.label | 1 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.order | 1 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.label | 6 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.order | 6 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.label | 0 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.order | 0 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.label | 2 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.order | 2 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.label | 3 |
+| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.order | 3 |
+| rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:9:29:16 | [Name] SCISSORS | semmle.label | 2 |
+| rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:9:29:16 | [Name] SCISSORS | semmle.order | 2 |
+| rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:30:5:30:5 | [Name] y | semmle.label | 1 |
+| rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:30:5:30:5 | [Name] y | semmle.order | 1 |
+| rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | semmle.label | 2 |
+| rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | semmle.order | 2 |
+| rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | rockpaperscissors.py:30:9:30:9 | [Name] x | semmle.label | 1 |
+| rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | rockpaperscissors.py:30:9:30:9 | [Name] x | semmle.order | 1 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.label | 1 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.order | 1 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.label | 1 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.order | 1 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.label | 2 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.order | 2 |
+| rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | semmle.label | 1 |
+| rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | semmle.order | 1 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.label | 1 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.order | 1 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.label | 2 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.label | 1 |
+| rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.order | 1 |
+| sanitizer.py:3:1:3:22 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.label | 1 |
+| sanitizer.py:3:1:3:22 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.order | 1 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.label | 1 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.order | 1 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.label | 2 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.order | 2 |
+| sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.label | 1 |
+| sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.order | 1 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | (parameters) | semmle.label | 0 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | (parameters) | semmle.order | 0 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:24:3:27 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:24:3:27 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:3:24:3:27 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.label | 0 |
+| sanitizer.py:3:24:3:27 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.order | 0 |
+| sanitizer.py:5:1:5:24 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.label | 1 |
+| sanitizer.py:5:1:5:24 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.order | 1 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.label | 1 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.order | 1 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.label | 2 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.order | 2 |
+| sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.label | 1 |
+| sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.order | 1 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:1:5:24 | (parameters) | semmle.label | 0 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:1:5:24 | (parameters) | semmle.order | 0 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:26:5:29 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:26:5:29 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:5:26:5:29 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.label | 0 |
+| sanitizer.py:5:26:5:29 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.order | 0 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.label | 1 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.order | 1 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.label | 2 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.order | 2 |
+| sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.label | 1 |
+| sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.order | 1 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:8:1:8:18 | (parameters) | semmle.label | 0 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:8:1:8:18 | (parameters) | semmle.order | 0 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:9:5:9:20 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:9:5:9:20 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.label | 1 |
+| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.order | 1 |
+| sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:5:9:5 | [Name] x | semmle.label | 1 |
+| sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:5:9:5 | [Name] x | semmle.order | 1 |
+| sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.label | 2 |
+| sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.order | 2 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.label | 1 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.label | 0 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.order | 0 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:11:9:11:20 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:11:9:11:20 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.order | 3 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.label | 1 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.order | 1 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:21:10:21 | [Name] x | semmle.label | 2 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:21:10:21 | [Name] x | semmle.order | 2 |
+| sanitizer.py:11:9:11:20 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| sanitizer.py:11:9:11:20 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.label | 1 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.order | 1 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:19:11:19 | [Name] x | semmle.label | 2 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:19:11:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.label | 1 |
+| sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.order | 1 |
+| sanitizer.py:13:9:13:20 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| sanitizer.py:13:9:13:20 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.label | 1 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.order | 1 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:19:13:19 | [Name] x | semmle.label | 2 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:19:13:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.label | 1 |
+| sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.order | 1 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.label | 1 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.order | 1 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.label | 2 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.order | 2 |
+| sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.label | 1 |
+| sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.order | 1 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:15:1:15:22 | (parameters) | semmle.label | 0 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:15:1:15:22 | (parameters) | semmle.order | 0 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:16:5:16:20 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:16:5:16:20 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.label | 1 |
+| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.order | 1 |
+| sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:5:16:5 | [Name] x | semmle.label | 1 |
+| sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:5:16:5 | [Name] x | semmle.order | 1 |
+| sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.label | 2 |
+| sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.order | 2 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.label | 1 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.label | 0 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.order | 0 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:18:9:18:21 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:18:9:18:21 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.order | 3 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.label | 1 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.order | 1 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:23:17:23 | [Name] x | semmle.label | 2 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:23:17:23 | [Name] x | semmle.order | 2 |
+| sanitizer.py:18:9:18:21 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| sanitizer.py:18:9:18:21 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.label | 1 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.order | 1 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:20:18:20 | [Name] x | semmle.label | 2 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:20:18:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.label | 1 |
+| sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.order | 1 |
+| sanitizer.py:20:9:20:21 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| sanitizer.py:20:9:20:21 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.label | 1 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.order | 1 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:20:20:20 | [Name] x | semmle.label | 2 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:20:20:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.label | 1 |
+| sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.order | 1 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.label | 1 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.order | 1 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.label | 2 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.order | 2 |
+| sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.label | 1 |
+| sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.order | 1 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:23:1:23:18 | (parameters) | semmle.label | 0 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:23:1:23:18 | (parameters) | semmle.order | 0 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:24:5:24:20 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:24:5:24:20 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.label | 1 |
+| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:5:24:5 | [Name] x | semmle.label | 1 |
+| sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:5:24:5 | [Name] x | semmle.order | 1 |
+| sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.label | 2 |
+| sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.order | 2 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.label | 1 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.label | 0 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.order | 0 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:26:9:26:20 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:26:9:26:20 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.order | 3 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.label | 1 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.order | 1 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:22:25:22 | [Name] x | semmle.label | 2 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:22:25:22 | [Name] x | semmle.order | 2 |
+| sanitizer.py:26:9:26:20 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| sanitizer.py:26:9:26:20 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.label | 1 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.order | 1 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:19:26:19 | [Name] x | semmle.label | 2 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:19:26:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.label | 1 |
+| sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.order | 1 |
+| sanitizer.py:28:9:28:20 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| sanitizer.py:28:9:28:20 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.label | 1 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.order | 1 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:19:28:19 | [Name] x | semmle.label | 2 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:19:28:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.label | 1 |
+| sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.order | 1 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.label | 1 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.order | 1 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.label | 2 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.order | 2 |
+| sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.label | 1 |
+| sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.order | 1 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:30:1:30:22 | (parameters) | semmle.label | 0 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:30:1:30:22 | (parameters) | semmle.order | 0 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:31:5:31:20 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:31:5:31:20 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.label | 1 |
+| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:5:31:5 | [Name] x | semmle.label | 1 |
+| sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:5:31:5 | [Name] x | semmle.order | 1 |
+| sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.label | 2 |
+| sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.order | 2 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.label | 1 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.label | 0 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.order | 0 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:33:9:33:21 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:33:9:33:21 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.order | 3 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.label | 1 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.order | 1 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:22:32:22 | [Name] x | semmle.label | 2 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:22:32:22 | [Name] x | semmle.order | 2 |
+| sanitizer.py:33:9:33:21 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| sanitizer.py:33:9:33:21 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.label | 1 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.order | 1 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:20:33:20 | [Name] x | semmle.label | 2 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:20:33:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.label | 1 |
+| sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.order | 1 |
+| sanitizer.py:35:9:35:21 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| sanitizer.py:35:9:35:21 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.label | 1 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.order | 1 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:20:35:20 | [Name] x | semmle.label | 2 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:20:35:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.label | 1 |
+| sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.order | 1 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.label | 2 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.order | 2 |
+| test.py:2:1:2:12 | [FunctionExpr] function test1(...) | test.py:2:1:2:12 | [Function] function test1(...) | semmle.label | 1 |
+| test.py:2:1:2:12 | [FunctionExpr] function test1(...) | test.py:2:1:2:12 | [Function] function test1(...) | semmle.order | 1 |
+| test.py:2:1:2:12 | [Function] function test1(...) | test.py:2:1:2:12 | (parameters) | semmle.label | 0 |
+| test.py:2:1:2:12 | [Function] function test1(...) | test.py:2:1:2:12 | (parameters) | semmle.order | 0 |
+| test.py:2:1:2:12 | [Function] function test1(...) | test.py:3:5:3:16 | (StmtList) body | semmle.label | 3 |
+| test.py:2:1:2:12 | [Function] function test1(...) | test.py:3:5:3:16 | (StmtList) body | semmle.order | 3 |
+| test.py:3:5:3:16 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.label | 0 |
+| test.py:3:5:3:16 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.order | 0 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.label | 1 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.order | 1 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:10:3:15 | [Name] SOURCE | semmle.label | 2 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:10:3:15 | [Name] SOURCE | semmle.order | 2 |
+| test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.label | 1 |
+| test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.order | 1 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.label | 2 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.order | 2 |
+| test.py:5:1:5:12 | [FunctionExpr] function test2(...) | test.py:5:1:5:12 | [Function] function test2(...) | semmle.label | 1 |
+| test.py:5:1:5:12 | [FunctionExpr] function test2(...) | test.py:5:1:5:12 | [Function] function test2(...) | semmle.order | 1 |
+| test.py:5:1:5:12 | [Function] function test2(...) | test.py:5:1:5:12 | (parameters) | semmle.label | 0 |
+| test.py:5:1:5:12 | [Function] function test2(...) | test.py:5:1:5:12 | (parameters) | semmle.order | 0 |
+| test.py:5:1:5:12 | [Function] function test2(...) | test.py:6:5:6:14 | (StmtList) body | semmle.label | 4 |
+| test.py:5:1:5:12 | [Function] function test2(...) | test.py:6:5:6:14 | (StmtList) body | semmle.order | 4 |
+| test.py:6:5:6:14 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
+| test.py:6:5:6:14 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
+| test.py:6:5:6:14 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.label | 1 |
+| test.py:6:5:6:14 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.order | 1 |
+| test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:5:6:5 | [Name] s | semmle.label | 1 |
+| test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:5:6:5 | [Name] s | semmle.order | 1 |
+| test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:9:6:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:9:6:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.label | 1 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.order | 1 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:10:7:10 | [Name] s | semmle.label | 2 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:10:7:10 | [Name] s | semmle.order | 2 |
+| test.py:7:5:7:11 | [ExprStmt] SINK(s) | test.py:7:5:7:11 | [Call] SINK(s) | semmle.label | 1 |
+| test.py:7:5:7:11 | [ExprStmt] SINK(s) | test.py:7:5:7:11 | [Call] SINK(s) | semmle.order | 1 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.label | 1 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.order | 1 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.label | 2 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.order | 2 |
+| test.py:9:1:9:13 | [FunctionExpr] function source(...) | test.py:9:1:9:13 | [Function] function source(...) | semmle.label | 1 |
+| test.py:9:1:9:13 | [FunctionExpr] function source(...) | test.py:9:1:9:13 | [Function] function source(...) | semmle.order | 1 |
+| test.py:9:1:9:13 | [Function] function source(...) | test.py:9:1:9:13 | (parameters) | semmle.label | 0 |
+| test.py:9:1:9:13 | [Function] function source(...) | test.py:9:1:9:13 | (parameters) | semmle.order | 0 |
+| test.py:9:1:9:13 | [Function] function source(...) | test.py:10:5:10:17 | (StmtList) body | semmle.label | 3 |
+| test.py:9:1:9:13 | [Function] function source(...) | test.py:10:5:10:17 | (StmtList) body | semmle.order | 3 |
+| test.py:10:5:10:17 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.label | 0 |
+| test.py:10:5:10:17 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.order | 0 |
+| test.py:10:5:10:17 | [Return] return SOURCE | test.py:10:12:10:17 | [Name] SOURCE | semmle.label | 1 |
+| test.py:10:5:10:17 | [Return] return SOURCE | test.py:10:12:10:17 | [Name] SOURCE | semmle.order | 1 |
+| test.py:12:1:12:14 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.label | 1 |
+| test.py:12:1:12:14 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.order | 1 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.label | 1 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.order | 1 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.label | 2 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.order | 2 |
+| test.py:12:1:12:14 | [FunctionExpr] function sink(...) | test.py:12:1:12:14 | [Function] function sink(...) | semmle.label | 1 |
+| test.py:12:1:12:14 | [FunctionExpr] function sink(...) | test.py:12:1:12:14 | [Function] function sink(...) | semmle.order | 1 |
+| test.py:12:1:12:14 | [Function] function sink(...) | test.py:12:1:12:14 | (parameters) | semmle.label | 0 |
+| test.py:12:1:12:14 | [Function] function sink(...) | test.py:12:1:12:14 | (parameters) | semmle.order | 0 |
+| test.py:12:1:12:14 | [Function] function sink(...) | test.py:13:5:13:13 | (StmtList) body | semmle.label | 4 |
+| test.py:12:1:12:14 | [Function] function sink(...) | test.py:13:5:13:13 | (StmtList) body | semmle.order | 4 |
+| test.py:13:5:13:13 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.label | 0 |
+| test.py:13:5:13:13 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.order | 0 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.label | 1 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.order | 1 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:10:13:12 | [Name] arg | semmle.label | 2 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:10:13:12 | [Name] arg | semmle.order | 2 |
+| test.py:13:5:13:13 | [ExprStmt] SINK(arg) | test.py:13:5:13:13 | [Call] SINK(arg) | semmle.label | 1 |
+| test.py:13:5:13:13 | [ExprStmt] SINK(arg) | test.py:13:5:13:13 | [Call] SINK(arg) | semmle.order | 1 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.label | 2 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.order | 2 |
+| test.py:15:1:15:12 | [FunctionExpr] function test3(...) | test.py:15:1:15:12 | [Function] function test3(...) | semmle.label | 1 |
+| test.py:15:1:15:12 | [FunctionExpr] function test3(...) | test.py:15:1:15:12 | [Function] function test3(...) | semmle.order | 1 |
+| test.py:15:1:15:12 | [Function] function test3(...) | test.py:15:1:15:12 | (parameters) | semmle.label | 0 |
+| test.py:15:1:15:12 | [Function] function test3(...) | test.py:15:1:15:12 | (parameters) | semmle.order | 0 |
+| test.py:15:1:15:12 | [Function] function test3(...) | test.py:16:5:16:16 | (StmtList) body | semmle.label | 4 |
+| test.py:15:1:15:12 | [Function] function test3(...) | test.py:16:5:16:16 | (StmtList) body | semmle.order | 4 |
+| test.py:16:5:16:16 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.label | 0 |
+| test.py:16:5:16:16 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.order | 0 |
+| test.py:16:5:16:16 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| test.py:16:5:16:16 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:5:16:5 | [Name] t | semmle.label | 1 |
+| test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:5:16:5 | [Name] t | semmle.order | 1 |
+| test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:9:16:16 | [Call] source() | semmle.label | 2 |
+| test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:9:16:16 | [Call] source() | semmle.order | 2 |
+| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.label | 1 |
+| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.order | 1 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.label | 1 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.order | 1 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:10:17:10 | [Name] t | semmle.label | 2 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:10:17:10 | [Name] t | semmle.order | 2 |
+| test.py:17:5:17:11 | [ExprStmt] SINK(t) | test.py:17:5:17:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:17:5:17:11 | [ExprStmt] SINK(t) | test.py:17:5:17:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.label | 2 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.order | 2 |
+| test.py:19:1:19:12 | [FunctionExpr] function test4(...) | test.py:19:1:19:12 | [Function] function test4(...) | semmle.label | 1 |
+| test.py:19:1:19:12 | [FunctionExpr] function test4(...) | test.py:19:1:19:12 | [Function] function test4(...) | semmle.order | 1 |
+| test.py:19:1:19:12 | [Function] function test4(...) | test.py:19:1:19:12 | (parameters) | semmle.label | 0 |
+| test.py:19:1:19:12 | [Function] function test4(...) | test.py:19:1:19:12 | (parameters) | semmle.order | 0 |
+| test.py:19:1:19:12 | [Function] function test4(...) | test.py:20:5:20:14 | (StmtList) body | semmle.label | 4 |
+| test.py:19:1:19:12 | [Function] function test4(...) | test.py:20:5:20:14 | (StmtList) body | semmle.order | 4 |
+| test.py:20:5:20:14 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:20:5:20:14 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:20:5:20:14 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.label | 1 |
+| test.py:20:5:20:14 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:5:20:5 | [Name] t | semmle.label | 1 |
+| test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:5:20:5 | [Name] t | semmle.order | 1 |
+| test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:9:20:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:9:20:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.label | 1 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.order | 1 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:10:21:10 | [Name] t | semmle.label | 2 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:10:21:10 | [Name] t | semmle.order | 2 |
+| test.py:21:5:21:11 | [ExprStmt] sink(t) | test.py:21:5:21:11 | [Call] sink(t) | semmle.label | 1 |
+| test.py:21:5:21:11 | [ExprStmt] sink(t) | test.py:21:5:21:11 | [Call] sink(t) | semmle.order | 1 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.label | 2 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.order | 2 |
+| test.py:23:1:23:12 | [FunctionExpr] function test5(...) | test.py:23:1:23:12 | [Function] function test5(...) | semmle.label | 1 |
+| test.py:23:1:23:12 | [FunctionExpr] function test5(...) | test.py:23:1:23:12 | [Function] function test5(...) | semmle.order | 1 |
+| test.py:23:1:23:12 | [Function] function test5(...) | test.py:23:1:23:12 | (parameters) | semmle.label | 0 |
+| test.py:23:1:23:12 | [Function] function test5(...) | test.py:23:1:23:12 | (parameters) | semmle.order | 0 |
+| test.py:23:1:23:12 | [Function] function test5(...) | test.py:24:5:24:16 | (StmtList) body | semmle.label | 4 |
+| test.py:23:1:23:12 | [Function] function test5(...) | test.py:24:5:24:16 | (StmtList) body | semmle.order | 4 |
+| test.py:24:5:24:16 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.label | 0 |
+| test.py:24:5:24:16 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.order | 0 |
+| test.py:24:5:24:16 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.label | 1 |
+| test.py:24:5:24:16 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:5:24:5 | [Name] t | semmle.label | 1 |
+| test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:5:24:5 | [Name] t | semmle.order | 1 |
+| test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:9:24:16 | [Call] source() | semmle.label | 2 |
+| test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:9:24:16 | [Call] source() | semmle.order | 2 |
+| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.label | 1 |
+| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.order | 1 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.label | 1 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.order | 1 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:10:25:10 | [Name] t | semmle.label | 2 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:10:25:10 | [Name] t | semmle.order | 2 |
+| test.py:25:5:25:11 | [ExprStmt] sink(t) | test.py:25:5:25:11 | [Call] sink(t) | semmle.label | 1 |
+| test.py:25:5:25:11 | [ExprStmt] sink(t) | test.py:25:5:25:11 | [Call] sink(t) | semmle.order | 1 |
+| test.py:27:1:27:16 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.label | 1 |
+| test.py:27:1:27:16 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.order | 1 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.label | 1 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.order | 1 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.label | 2 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.order | 2 |
+| test.py:27:1:27:16 | [FunctionExpr] function test6(...) | test.py:27:1:27:16 | [Function] function test6(...) | semmle.label | 1 |
+| test.py:27:1:27:16 | [FunctionExpr] function test6(...) | test.py:27:1:27:16 | [Function] function test6(...) | semmle.order | 1 |
+| test.py:27:1:27:16 | [Function] function test6(...) | test.py:27:1:27:16 | (parameters) | semmle.label | 0 |
+| test.py:27:1:27:16 | [Function] function test6(...) | test.py:27:1:27:16 | (parameters) | semmle.order | 0 |
+| test.py:27:1:27:16 | [Function] function test6(...) | test.py:28:5:28:12 | (StmtList) body | semmle.label | 5 |
+| test.py:27:1:27:16 | [Function] function test6(...) | test.py:28:5:28:12 | (StmtList) body | semmle.order | 5 |
+| test.py:28:5:28:12 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.label | 0 |
+| test.py:28:5:28:12 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.order | 0 |
+| test.py:28:5:28:12 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.label | 1 |
+| test.py:28:5:28:12 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.order | 1 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:28:8:28:11 | [Name] cond | semmle.label | 0 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:28:8:28:11 | [Name] cond | semmle.order | 0 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:29:9:29:18 | (StmtList) body | semmle.label | 2 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:29:9:29:18 | (StmtList) body | semmle.order | 2 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:31:9:31:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:28:5:28:12 | [If] if cond: | test.py:31:9:31:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:29:9:29:18 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| test.py:29:9:29:18 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:9:29:9 | [Name] t | semmle.label | 1 |
+| test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:9:29:9 | [Name] t | semmle.order | 1 |
+| test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:13:29:18 | [Str] Safe | semmle.label | 2 |
+| test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:13:29:18 | [Str] Safe | semmle.order | 2 |
+| test.py:31:9:31:18 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:31:9:31:18 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:9:31:9 | [Name] t | semmle.label | 1 |
+| test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:9:31:9 | [Name] t | semmle.order | 1 |
+| test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:13:31:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:13:31:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:32:5:32:12 | [If] if cond: | test.py:32:8:32:11 | [Name] cond | semmle.label | 0 |
+| test.py:32:5:32:12 | [If] if cond: | test.py:32:8:32:11 | [Name] cond | semmle.order | 0 |
+| test.py:32:5:32:12 | [If] if cond: | test.py:33:9:33:15 | (StmtList) body | semmle.label | 2 |
+| test.py:32:5:32:12 | [If] if cond: | test.py:33:9:33:15 | (StmtList) body | semmle.order | 2 |
+| test.py:33:9:33:15 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:33:9:33:15 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.label | 1 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.order | 1 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:14:33:14 | [Name] t | semmle.label | 2 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:14:33:14 | [Name] t | semmle.order | 2 |
+| test.py:33:9:33:15 | [ExprStmt] SINK(t) | test.py:33:9:33:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:33:9:33:15 | [ExprStmt] SINK(t) | test.py:33:9:33:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:35:1:35:16 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.label | 1 |
+| test.py:35:1:35:16 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.order | 1 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.label | 1 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.order | 1 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.label | 2 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.order | 2 |
+| test.py:35:1:35:16 | [FunctionExpr] function test7(...) | test.py:35:1:35:16 | [Function] function test7(...) | semmle.label | 1 |
+| test.py:35:1:35:16 | [FunctionExpr] function test7(...) | test.py:35:1:35:16 | [Function] function test7(...) | semmle.order | 1 |
+| test.py:35:1:35:16 | [Function] function test7(...) | test.py:35:1:35:16 | (parameters) | semmle.label | 0 |
+| test.py:35:1:35:16 | [Function] function test7(...) | test.py:35:1:35:16 | (parameters) | semmle.order | 0 |
+| test.py:35:1:35:16 | [Function] function test7(...) | test.py:36:5:36:12 | (StmtList) body | semmle.label | 5 |
+| test.py:35:1:35:16 | [Function] function test7(...) | test.py:36:5:36:12 | (StmtList) body | semmle.order | 5 |
+| test.py:36:5:36:12 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.label | 0 |
+| test.py:36:5:36:12 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.order | 0 |
+| test.py:36:5:36:12 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.label | 1 |
+| test.py:36:5:36:12 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.order | 1 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:36:8:36:11 | [Name] cond | semmle.label | 0 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:36:8:36:11 | [Name] cond | semmle.order | 0 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:37:9:37:18 | (StmtList) body | semmle.label | 2 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:37:9:37:18 | (StmtList) body | semmle.order | 2 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:39:9:39:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:36:5:36:12 | [If] if cond: | test.py:39:9:39:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:37:9:37:18 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:37:9:37:18 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:9:37:9 | [Name] t | semmle.label | 1 |
+| test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:9:37:9 | [Name] t | semmle.order | 1 |
+| test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:13:37:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:13:37:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:39:9:39:18 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| test.py:39:9:39:18 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:9:39:9 | [Name] t | semmle.label | 1 |
+| test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:9:39:9 | [Name] t | semmle.order | 1 |
+| test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:13:39:18 | [Str] Safe | semmle.label | 2 |
+| test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:13:39:18 | [Str] Safe | semmle.order | 2 |
+| test.py:40:5:40:12 | [If] if cond: | test.py:40:8:40:11 | [Name] cond | semmle.label | 0 |
+| test.py:40:5:40:12 | [If] if cond: | test.py:40:8:40:11 | [Name] cond | semmle.order | 0 |
+| test.py:40:5:40:12 | [If] if cond: | test.py:41:9:41:15 | (StmtList) body | semmle.label | 2 |
+| test.py:40:5:40:12 | [If] if cond: | test.py:41:9:41:15 | (StmtList) body | semmle.order | 2 |
+| test.py:41:9:41:15 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:41:9:41:15 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.label | 1 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.order | 1 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:14:41:14 | [Name] t | semmle.label | 2 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:14:41:14 | [Name] t | semmle.order | 2 |
+| test.py:41:9:41:15 | [ExprStmt] SINK(t) | test.py:41:9:41:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:41:9:41:15 | [ExprStmt] SINK(t) | test.py:41:9:41:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:43:1:43:17 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.label | 1 |
+| test.py:43:1:43:17 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.order | 1 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.label | 1 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.order | 1 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.label | 2 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.order | 2 |
+| test.py:43:1:43:17 | [FunctionExpr] function source2(...) | test.py:43:1:43:17 | [Function] function source2(...) | semmle.label | 1 |
+| test.py:43:1:43:17 | [FunctionExpr] function source2(...) | test.py:43:1:43:17 | [Function] function source2(...) | semmle.order | 1 |
+| test.py:43:1:43:17 | [Function] function source2(...) | test.py:43:1:43:17 | (parameters) | semmle.label | 0 |
+| test.py:43:1:43:17 | [Function] function source2(...) | test.py:43:1:43:17 | (parameters) | semmle.order | 0 |
+| test.py:43:1:43:17 | [Function] function source2(...) | test.py:44:5:44:22 | (StmtList) body | semmle.label | 4 |
+| test.py:43:1:43:17 | [Function] function source2(...) | test.py:44:5:44:22 | (StmtList) body | semmle.order | 4 |
+| test.py:44:5:44:22 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.label | 0 |
+| test.py:44:5:44:22 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.order | 0 |
+| test.py:44:5:44:22 | [Return] return source(arg) | test.py:44:12:44:22 | [Call] source(arg) | semmle.label | 1 |
+| test.py:44:5:44:22 | [Return] return source(arg) | test.py:44:12:44:22 | [Call] source(arg) | semmle.order | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.label | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.order | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:19:44:21 | [Name] arg | semmle.label | 2 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:19:44:21 | [Name] arg | semmle.order | 2 |
+| test.py:46:1:46:15 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.label | 1 |
+| test.py:46:1:46:15 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.order | 1 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.label | 1 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.order | 1 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.label | 2 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.order | 2 |
+| test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | test.py:46:1:46:15 | [Function] function sink2(...) | semmle.label | 1 |
+| test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | test.py:46:1:46:15 | [Function] function sink2(...) | semmle.order | 1 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:46:1:46:15 | (parameters) | semmle.label | 0 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:46:1:46:15 | (parameters) | semmle.order | 0 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:47:5:47:13 | (StmtList) body | semmle.label | 4 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:47:5:47:13 | (StmtList) body | semmle.order | 4 |
+| test.py:47:5:47:13 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.label | 0 |
+| test.py:47:5:47:13 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.order | 0 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.label | 1 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.order | 1 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:10:47:12 | [Name] arg | semmle.label | 2 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:10:47:12 | [Name] arg | semmle.order | 2 |
+| test.py:47:5:47:13 | [ExprStmt] sink(arg) | test.py:47:5:47:13 | [Call] sink(arg) | semmle.label | 1 |
+| test.py:47:5:47:13 | [ExprStmt] sink(arg) | test.py:47:5:47:13 | [Call] sink(arg) | semmle.order | 1 |
+| test.py:49:1:49:21 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.label | 1 |
+| test.py:49:1:49:21 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.order | 1 |
+| test.py:49:1:49:21 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.label | 2 |
+| test.py:49:1:49:21 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.order | 2 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.label | 1 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.order | 1 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.label | 2 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.order | 2 |
+| test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | test.py:49:1:49:21 | [Function] function sink3(...) | semmle.label | 1 |
+| test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | test.py:49:1:49:21 | [Function] function sink3(...) | semmle.order | 1 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:49:1:49:21 | (parameters) | semmle.label | 0 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:49:1:49:21 | (parameters) | semmle.order | 0 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:50:5:50:12 | (StmtList) body | semmle.label | 5 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:50:5:50:12 | (StmtList) body | semmle.order | 5 |
+| test.py:50:5:50:12 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.label | 0 |
+| test.py:50:5:50:12 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.order | 0 |
+| test.py:50:5:50:12 | [If] if cond: | test.py:50:8:50:11 | [Name] cond | semmle.label | 0 |
+| test.py:50:5:50:12 | [If] if cond: | test.py:50:8:50:11 | [Name] cond | semmle.order | 0 |
+| test.py:50:5:50:12 | [If] if cond: | test.py:51:9:51:17 | (StmtList) body | semmle.label | 2 |
+| test.py:50:5:50:12 | [If] if cond: | test.py:51:9:51:17 | (StmtList) body | semmle.order | 2 |
+| test.py:51:9:51:17 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.label | 0 |
+| test.py:51:9:51:17 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.order | 0 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.label | 1 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.order | 1 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:14:51:16 | [Name] arg | semmle.label | 2 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:14:51:16 | [Name] arg | semmle.order | 2 |
+| test.py:51:9:51:17 | [ExprStmt] sink(arg) | test.py:51:9:51:17 | [Call] sink(arg) | semmle.label | 1 |
+| test.py:51:9:51:17 | [ExprStmt] sink(arg) | test.py:51:9:51:17 | [Call] sink(arg) | semmle.order | 1 |
+| test.py:53:1:53:16 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.label | 1 |
+| test.py:53:1:53:16 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.order | 1 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.label | 1 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.order | 1 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.label | 2 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.order | 2 |
+| test.py:53:1:53:16 | [FunctionExpr] function test8(...) | test.py:53:1:53:16 | [Function] function test8(...) | semmle.label | 1 |
+| test.py:53:1:53:16 | [FunctionExpr] function test8(...) | test.py:53:1:53:16 | [Function] function test8(...) | semmle.order | 1 |
+| test.py:53:1:53:16 | [Function] function test8(...) | test.py:53:1:53:16 | (parameters) | semmle.label | 0 |
+| test.py:53:1:53:16 | [Function] function test8(...) | test.py:53:1:53:16 | (parameters) | semmle.order | 0 |
+| test.py:53:1:53:16 | [Function] function test8(...) | test.py:54:5:54:17 | (StmtList) body | semmle.label | 5 |
+| test.py:53:1:53:16 | [Function] function test8(...) | test.py:54:5:54:17 | (StmtList) body | semmle.order | 5 |
+| test.py:54:5:54:17 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.label | 0 |
+| test.py:54:5:54:17 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.order | 0 |
+| test.py:54:5:54:17 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.label | 1 |
+| test.py:54:5:54:17 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.order | 1 |
+| test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:5:54:5 | [Name] t | semmle.label | 1 |
+| test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:5:54:5 | [Name] t | semmle.order | 1 |
+| test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:9:54:17 | [Call] source2() | semmle.label | 2 |
+| test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:9:54:17 | [Call] source2() | semmle.order | 2 |
+| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.label | 1 |
+| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.order | 1 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.label | 1 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.order | 1 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:11:55:11 | [Name] t | semmle.label | 2 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:11:55:11 | [Name] t | semmle.order | 2 |
+| test.py:55:5:55:12 | [ExprStmt] sink2(t) | test.py:55:5:55:12 | [Call] sink2(t) | semmle.label | 1 |
+| test.py:55:5:55:12 | [ExprStmt] sink2(t) | test.py:55:5:55:12 | [Call] sink2(t) | semmle.order | 1 |
+| test.py:58:1:58:16 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.label | 1 |
+| test.py:58:1:58:16 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.order | 1 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.label | 1 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.order | 1 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.label | 2 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.order | 2 |
+| test.py:58:1:58:16 | [FunctionExpr] function test9(...) | test.py:58:1:58:16 | [Function] function test9(...) | semmle.label | 1 |
+| test.py:58:1:58:16 | [FunctionExpr] function test9(...) | test.py:58:1:58:16 | [Function] function test9(...) | semmle.order | 1 |
+| test.py:58:1:58:16 | [Function] function test9(...) | test.py:58:1:58:16 | (parameters) | semmle.label | 0 |
+| test.py:58:1:58:16 | [Function] function test9(...) | test.py:58:1:58:16 | (parameters) | semmle.order | 0 |
+| test.py:58:1:58:16 | [Function] function test9(...) | test.py:59:5:59:12 | (StmtList) body | semmle.label | 5 |
+| test.py:58:1:58:16 | [Function] function test9(...) | test.py:59:5:59:12 | (StmtList) body | semmle.order | 5 |
+| test.py:59:5:59:12 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.label | 0 |
+| test.py:59:5:59:12 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.order | 0 |
+| test.py:59:5:59:12 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
+| test.py:59:5:59:12 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:59:8:59:11 | [Name] cond | semmle.label | 0 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:59:8:59:11 | [Name] cond | semmle.order | 0 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:60:9:60:19 | (StmtList) body | semmle.label | 2 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:60:9:60:19 | (StmtList) body | semmle.order | 2 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:62:9:62:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:59:5:59:12 | [If] if cond: | test.py:62:9:62:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:60:9:60:19 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.label | 0 |
+| test.py:60:9:60:19 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.order | 0 |
+| test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:9:60:9 | [Name] t | semmle.label | 1 |
+| test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:9:60:9 | [Name] t | semmle.order | 1 |
+| test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:14:60:19 | [Str] Safe | semmle.label | 2 |
+| test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:14:60:19 | [Str] Safe | semmle.order | 2 |
+| test.py:62:9:62:18 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:62:9:62:18 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:9:62:9 | [Name] t | semmle.label | 1 |
+| test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:9:62:9 | [Name] t | semmle.order | 1 |
+| test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:13:62:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:13:62:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.label | 1 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.order | 1 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:11:63:14 | [Name] cond | semmle.label | 2 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:11:63:14 | [Name] cond | semmle.order | 2 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:17:63:17 | [Name] t | semmle.label | 3 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:17:63:17 | [Name] t | semmle.order | 3 |
+| test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | test.py:63:5:63:18 | [Call] sink3(cond, t) | semmle.label | 1 |
+| test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | test.py:63:5:63:18 | [Call] sink3(cond, t) | semmle.order | 1 |
+| test.py:65:1:65:17 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.label | 1 |
+| test.py:65:1:65:17 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.order | 1 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.label | 1 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.order | 1 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.label | 2 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.order | 2 |
+| test.py:65:1:65:17 | [FunctionExpr] function test10(...) | test.py:65:1:65:17 | [Function] function test10(...) | semmle.label | 1 |
+| test.py:65:1:65:17 | [FunctionExpr] function test10(...) | test.py:65:1:65:17 | [Function] function test10(...) | semmle.order | 1 |
+| test.py:65:1:65:17 | [Function] function test10(...) | test.py:65:1:65:17 | (parameters) | semmle.label | 0 |
+| test.py:65:1:65:17 | [Function] function test10(...) | test.py:65:1:65:17 | (parameters) | semmle.order | 0 |
+| test.py:65:1:65:17 | [Function] function test10(...) | test.py:66:5:66:12 | (StmtList) body | semmle.label | 5 |
+| test.py:65:1:65:17 | [Function] function test10(...) | test.py:66:5:66:12 | (StmtList) body | semmle.order | 5 |
+| test.py:66:5:66:12 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.label | 0 |
+| test.py:66:5:66:12 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.order | 0 |
+| test.py:66:5:66:12 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
+| test.py:66:5:66:12 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:66:8:66:11 | [Name] cond | semmle.label | 0 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:66:8:66:11 | [Name] cond | semmle.order | 0 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:67:9:67:18 | (StmtList) body | semmle.label | 2 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:67:9:67:18 | (StmtList) body | semmle.order | 2 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:69:9:69:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:66:5:66:12 | [If] if cond: | test.py:69:9:69:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:67:9:67:18 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:67:9:67:18 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:9:67:9 | [Name] t | semmle.label | 1 |
+| test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:9:67:9 | [Name] t | semmle.order | 1 |
+| test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:13:67:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:13:67:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:69:9:69:18 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| test.py:69:9:69:18 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:9:69:9 | [Name] t | semmle.label | 1 |
+| test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:9:69:9 | [Name] t | semmle.order | 1 |
+| test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:13:69:18 | [Str] Safe | semmle.label | 2 |
+| test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:13:69:18 | [Str] Safe | semmle.order | 2 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.label | 1 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.order | 1 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:11:70:14 | [Name] cond | semmle.label | 2 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:11:70:14 | [Name] cond | semmle.order | 2 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:17:70:17 | [Name] t | semmle.label | 3 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:17:70:17 | [Name] t | semmle.order | 3 |
+| test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | test.py:70:5:70:18 | [Call] sink3(cond, t) | semmle.label | 1 |
+| test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | test.py:70:5:70:18 | [Call] sink3(cond, t) | semmle.order | 1 |
+| test.py:72:1:72:13 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.label | 1 |
+| test.py:72:1:72:13 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.order | 1 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.label | 1 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.order | 1 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.label | 2 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.order | 2 |
+| test.py:72:1:72:13 | [FunctionExpr] function hub(...) | test.py:72:1:72:13 | [Function] function hub(...) | semmle.label | 1 |
+| test.py:72:1:72:13 | [FunctionExpr] function hub(...) | test.py:72:1:72:13 | [Function] function hub(...) | semmle.order | 1 |
+| test.py:72:1:72:13 | [Function] function hub(...) | test.py:72:1:72:13 | (parameters) | semmle.label | 0 |
+| test.py:72:1:72:13 | [Function] function hub(...) | test.py:72:1:72:13 | (parameters) | semmle.order | 0 |
+| test.py:72:1:72:13 | [Function] function hub(...) | test.py:73:5:73:14 | (StmtList) body | semmle.label | 4 |
+| test.py:72:1:72:13 | [Function] function hub(...) | test.py:73:5:73:14 | (StmtList) body | semmle.order | 4 |
+| test.py:73:5:73:14 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.label | 0 |
+| test.py:73:5:73:14 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.order | 0 |
+| test.py:73:5:73:14 | [Return] return arg | test.py:73:12:73:14 | [Name] arg | semmle.label | 1 |
+| test.py:73:5:73:14 | [Return] return arg | test.py:73:12:73:14 | [Name] arg | semmle.order | 1 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.label | 1 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.order | 1 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.label | 2 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.order | 2 |
+| test.py:75:1:75:13 | [FunctionExpr] function test11(...) | test.py:75:1:75:13 | [Function] function test11(...) | semmle.label | 1 |
+| test.py:75:1:75:13 | [FunctionExpr] function test11(...) | test.py:75:1:75:13 | [Function] function test11(...) | semmle.order | 1 |
+| test.py:75:1:75:13 | [Function] function test11(...) | test.py:75:1:75:13 | (parameters) | semmle.label | 0 |
+| test.py:75:1:75:13 | [Function] function test11(...) | test.py:75:1:75:13 | (parameters) | semmle.order | 0 |
+| test.py:75:1:75:13 | [Function] function test11(...) | test.py:76:5:76:14 | (StmtList) body | semmle.label | 5 |
+| test.py:75:1:75:13 | [Function] function test11(...) | test.py:76:5:76:14 | (StmtList) body | semmle.order | 5 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
+| test.py:76:5:76:14 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:5:76:5 | [Name] t | semmle.label | 1 |
+| test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:5:76:5 | [Name] t | semmle.order | 1 |
+| test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:9:76:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:9:76:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:5:77:5 | [Name] t | semmle.label | 1 |
+| test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:5:77:5 | [Name] t | semmle.order | 1 |
+| test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:9:77:14 | [Call] hub(t) | semmle.label | 2 |
+| test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:9:77:14 | [Call] hub(t) | semmle.order | 2 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.label | 1 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.order | 1 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:13:77:13 | [Name] t | semmle.label | 2 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:13:77:13 | [Name] t | semmle.order | 2 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.label | 1 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.order | 1 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:10:78:10 | [Name] t | semmle.label | 2 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:10:78:10 | [Name] t | semmle.order | 2 |
+| test.py:78:5:78:11 | [ExprStmt] SINK(t) | test.py:78:5:78:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:78:5:78:11 | [ExprStmt] SINK(t) | test.py:78:5:78:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.label | 1 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.order | 1 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.label | 2 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.order | 2 |
+| test.py:80:1:80:13 | [FunctionExpr] function test12(...) | test.py:80:1:80:13 | [Function] function test12(...) | semmle.label | 1 |
+| test.py:80:1:80:13 | [FunctionExpr] function test12(...) | test.py:80:1:80:13 | [Function] function test12(...) | semmle.order | 1 |
+| test.py:80:1:80:13 | [Function] function test12(...) | test.py:80:1:80:13 | (parameters) | semmle.label | 0 |
+| test.py:80:1:80:13 | [Function] function test12(...) | test.py:80:1:80:13 | (parameters) | semmle.order | 0 |
+| test.py:80:1:80:13 | [Function] function test12(...) | test.py:81:5:81:14 | (StmtList) body | semmle.label | 5 |
+| test.py:80:1:80:13 | [Function] function test12(...) | test.py:81:5:81:14 | (StmtList) body | semmle.order | 5 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.label | 0 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.order | 0 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
+| test.py:81:5:81:14 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:5:81:5 | [Name] t | semmle.label | 1 |
+| test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:5:81:5 | [Name] t | semmle.order | 1 |
+| test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:9:81:14 | [Str] safe | semmle.label | 2 |
+| test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:9:81:14 | [Str] safe | semmle.order | 2 |
+| test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:5:82:5 | [Name] t | semmle.label | 1 |
+| test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:5:82:5 | [Name] t | semmle.order | 1 |
+| test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:9:82:14 | [Call] hub(t) | semmle.label | 2 |
+| test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:9:82:14 | [Call] hub(t) | semmle.order | 2 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.label | 1 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.order | 1 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:13:82:13 | [Name] t | semmle.label | 2 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:13:82:13 | [Name] t | semmle.order | 2 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.label | 1 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.order | 1 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:10:83:10 | [Name] t | semmle.label | 2 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:10:83:10 | [Name] t | semmle.order | 2 |
+| test.py:83:5:83:11 | [ExprStmt] SINK(t) | test.py:83:5:83:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:83:5:83:11 | [ExprStmt] SINK(t) | test.py:83:5:83:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [ImportExpr]  | semmle.label | 1 |
+| test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [ImportExpr]  | semmle.order | 1 |
+| test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [Name] module | semmle.label | 1 |
+| test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [Name] module | semmle.order | 1 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.label | 1 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.order | 1 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.label | 2 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.order | 2 |
+| test.py:87:1:87:13 | [FunctionExpr] function test13(...) | test.py:87:1:87:13 | [Function] function test13(...) | semmle.label | 1 |
+| test.py:87:1:87:13 | [FunctionExpr] function test13(...) | test.py:87:1:87:13 | [Function] function test13(...) | semmle.order | 1 |
+| test.py:87:1:87:13 | [Function] function test13(...) | test.py:87:1:87:13 | (parameters) | semmle.label | 0 |
+| test.py:87:1:87:13 | [Function] function test13(...) | test.py:87:1:87:13 | (parameters) | semmle.order | 0 |
+| test.py:87:1:87:13 | [Function] function test13(...) | test.py:88:5:88:24 | (StmtList) body | semmle.label | 4 |
+| test.py:87:1:87:13 | [Function] function test13(...) | test.py:88:5:88:24 | (StmtList) body | semmle.order | 4 |
+| test.py:88:5:88:24 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.label | 0 |
+| test.py:88:5:88:24 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.order | 0 |
+| test.py:88:5:88:24 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| test.py:88:5:88:24 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:5:88:5 | [Name] t | semmle.label | 1 |
+| test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:5:88:5 | [Name] t | semmle.order | 1 |
+| test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.label | 2 |
+| test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.order | 2 |
+| test.py:88:9:88:24 | [Attribute] module.dangerous | test.py:88:9:88:14 | [Name] module | semmle.label | 1 |
+| test.py:88:9:88:24 | [Attribute] module.dangerous | test.py:88:9:88:14 | [Name] module | semmle.order | 1 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.label | 1 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.order | 1 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:10:89:10 | [Name] t | semmle.label | 2 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:10:89:10 | [Name] t | semmle.order | 2 |
+| test.py:89:5:89:11 | [ExprStmt] SINK(t) | test.py:89:5:89:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:89:5:89:11 | [ExprStmt] SINK(t) | test.py:89:5:89:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.label | 1 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.order | 1 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.label | 2 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.order | 2 |
+| test.py:91:1:91:13 | [FunctionExpr] function test14(...) | test.py:91:1:91:13 | [Function] function test14(...) | semmle.label | 1 |
+| test.py:91:1:91:13 | [FunctionExpr] function test14(...) | test.py:91:1:91:13 | [Function] function test14(...) | semmle.order | 1 |
+| test.py:91:1:91:13 | [Function] function test14(...) | test.py:91:1:91:13 | (parameters) | semmle.label | 0 |
+| test.py:91:1:91:13 | [Function] function test14(...) | test.py:91:1:91:13 | (parameters) | semmle.order | 0 |
+| test.py:91:1:91:13 | [Function] function test14(...) | test.py:92:5:92:19 | (StmtList) body | semmle.label | 4 |
+| test.py:91:1:91:13 | [Function] function test14(...) | test.py:92:5:92:19 | (StmtList) body | semmle.order | 4 |
+| test.py:92:5:92:19 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.label | 0 |
+| test.py:92:5:92:19 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.order | 0 |
+| test.py:92:5:92:19 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| test.py:92:5:92:19 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:5:92:5 | [Name] t | semmle.label | 1 |
+| test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:5:92:5 | [Name] t | semmle.order | 1 |
+| test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:9:92:19 | [Attribute] module.safe | semmle.label | 2 |
+| test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:9:92:19 | [Attribute] module.safe | semmle.order | 2 |
+| test.py:92:9:92:19 | [Attribute] module.safe | test.py:92:9:92:14 | [Name] module | semmle.label | 1 |
+| test.py:92:9:92:19 | [Attribute] module.safe | test.py:92:9:92:14 | [Name] module | semmle.order | 1 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.label | 1 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.order | 1 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:10:93:10 | [Name] t | semmle.label | 2 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:10:93:10 | [Name] t | semmle.order | 2 |
+| test.py:93:5:93:11 | [ExprStmt] SINK(t) | test.py:93:5:93:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:93:5:93:11 | [ExprStmt] SINK(t) | test.py:93:5:93:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.label | 1 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.order | 1 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.label | 2 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.order | 2 |
+| test.py:95:1:95:13 | [FunctionExpr] function test15(...) | test.py:95:1:95:13 | [Function] function test15(...) | semmle.label | 1 |
+| test.py:95:1:95:13 | [FunctionExpr] function test15(...) | test.py:95:1:95:13 | [Function] function test15(...) | semmle.order | 1 |
+| test.py:95:1:95:13 | [Function] function test15(...) | test.py:95:1:95:13 | (parameters) | semmle.label | 0 |
+| test.py:95:1:95:13 | [Function] function test15(...) | test.py:95:1:95:13 | (parameters) | semmle.order | 0 |
+| test.py:95:1:95:13 | [Function] function test15(...) | test.py:96:5:96:20 | (StmtList) body | semmle.label | 4 |
+| test.py:95:1:95:13 | [Function] function test15(...) | test.py:96:5:96:20 | (StmtList) body | semmle.order | 4 |
+| test.py:96:5:96:20 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.label | 0 |
+| test.py:96:5:96:20 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.order | 0 |
+| test.py:96:5:96:20 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| test.py:96:5:96:20 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:5:96:5 | [Name] t | semmle.label | 1 |
+| test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:5:96:5 | [Name] t | semmle.order | 1 |
+| test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.label | 2 |
+| test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.order | 2 |
+| test.py:96:9:96:20 | [Attribute] module.safe2 | test.py:96:9:96:14 | [Name] module | semmle.label | 1 |
+| test.py:96:9:96:20 | [Attribute] module.safe2 | test.py:96:9:96:14 | [Name] module | semmle.order | 1 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.label | 1 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.order | 1 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:10:97:10 | [Name] t | semmle.label | 2 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:10:97:10 | [Name] t | semmle.order | 2 |
+| test.py:97:5:97:11 | [ExprStmt] SINK(t) | test.py:97:5:97:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:97:5:97:11 | [ExprStmt] SINK(t) | test.py:97:5:97:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.label | 1 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.order | 1 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.label | 2 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.order | 2 |
+| test.py:99:1:99:13 | [FunctionExpr] function test16(...) | test.py:99:1:99:13 | [Function] function test16(...) | semmle.label | 1 |
+| test.py:99:1:99:13 | [FunctionExpr] function test16(...) | test.py:99:1:99:13 | [Function] function test16(...) | semmle.order | 1 |
+| test.py:99:1:99:13 | [Function] function test16(...) | test.py:99:1:99:13 | (parameters) | semmle.label | 0 |
+| test.py:99:1:99:13 | [Function] function test16(...) | test.py:99:1:99:13 | (parameters) | semmle.order | 0 |
+| test.py:99:1:99:13 | [Function] function test16(...) | test.py:100:5:100:31 | (StmtList) body | semmle.label | 4 |
+| test.py:99:1:99:13 | [Function] function test16(...) | test.py:100:5:100:31 | (StmtList) body | semmle.order | 4 |
+| test.py:100:5:100:31 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.label | 0 |
+| test.py:100:5:100:31 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.order | 0 |
+| test.py:100:5:100:31 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| test.py:100:5:100:31 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:5:100:5 | [Name] t | semmle.label | 1 |
+| test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:5:100:5 | [Name] t | semmle.order | 1 |
+| test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:9:100:31 | [Call] module.dangerous_func() | semmle.label | 2 |
+| test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:9:100:31 | [Call] module.dangerous_func() | semmle.order | 2 |
+| test.py:100:9:100:29 | [Attribute] module.dangerous_func | test.py:100:9:100:14 | [Name] module | semmle.label | 1 |
+| test.py:100:9:100:29 | [Attribute] module.dangerous_func | test.py:100:9:100:14 | [Name] module | semmle.order | 1 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.label | 1 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.order | 1 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.label | 1 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.order | 1 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:10:101:10 | [Name] t | semmle.label | 2 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:10:101:10 | [Name] t | semmle.order | 2 |
+| test.py:101:5:101:11 | [ExprStmt] SINK(t) | test.py:101:5:101:11 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:101:5:101:11 | [ExprStmt] SINK(t) | test.py:101:5:101:11 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:103:1:103:16 | [ClassDef] C = class C | test.py:103:1:103:16 | [ClassExpr] class C | semmle.label | 1 |
+| test.py:103:1:103:16 | [ClassDef] C = class C | test.py:103:1:103:16 | [ClassExpr] class C | semmle.order | 1 |
+| test.py:103:1:103:16 | [ClassDef] C = class C | test.py:103:7:103:7 | [Name] C | semmle.label | 2 |
+| test.py:103:1:103:16 | [ClassDef] C = class C | test.py:103:7:103:7 | [Name] C | semmle.order | 2 |
+| test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:1:103:16 | [Class] class C | semmle.label | 1 |
+| test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:1:103:16 | [Class] class C | semmle.order | 1 |
+| test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:9:103:14 | [Name] object | semmle.label | 2 |
+| test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:9:103:14 | [Name] object | semmle.order | 2 |
+| test.py:103:1:103:16 | [Class] class C | test.py:103:18:103:21 | (StmtList) body | semmle.label | 3 |
+| test.py:103:1:103:16 | [Class] class C | test.py:103:18:103:21 | (StmtList) body | semmle.order | 3 |
+| test.py:103:18:103:21 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.label | 0 |
+| test.py:103:18:103:21 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.order | 0 |
+| test.py:105:1:105:16 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.label | 1 |
+| test.py:105:1:105:16 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.order | 1 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.label | 1 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.order | 1 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.label | 2 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.order | 2 |
+| test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | test.py:105:1:105:16 | [Function] function x_sink(...) | semmle.label | 1 |
+| test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | test.py:105:1:105:16 | [Function] function x_sink(...) | semmle.order | 1 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:105:1:105:16 | (parameters) | semmle.label | 0 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:105:1:105:16 | (parameters) | semmle.order | 0 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:106:5:106:15 | (StmtList) body | semmle.label | 4 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:106:5:106:15 | (StmtList) body | semmle.order | 4 |
+| test.py:106:5:106:15 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.label | 0 |
+| test.py:106:5:106:15 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.order | 0 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.label | 1 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.order | 1 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.label | 2 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.order | 2 |
+| test.py:106:5:106:15 | [ExprStmt] SINK(...) | test.py:106:5:106:15 | [Call] SINK(...) | semmle.label | 1 |
+| test.py:106:5:106:15 | [ExprStmt] SINK(...) | test.py:106:5:106:15 | [Call] SINK(...) | semmle.order | 1 |
+| test.py:106:10:106:14 | [Attribute] arg.x | test.py:106:10:106:12 | [Name] arg | semmle.label | 1 |
+| test.py:106:10:106:14 | [Attribute] arg.x | test.py:106:10:106:12 | [Name] arg | semmle.order | 1 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.label | 1 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.order | 1 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.label | 2 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.order | 2 |
+| test.py:108:1:108:13 | [FunctionExpr] function test17(...) | test.py:108:1:108:13 | [Function] function test17(...) | semmle.label | 1 |
+| test.py:108:1:108:13 | [FunctionExpr] function test17(...) | test.py:108:1:108:13 | [Function] function test17(...) | semmle.order | 1 |
+| test.py:108:1:108:13 | [Function] function test17(...) | test.py:108:1:108:13 | (parameters) | semmle.label | 0 |
+| test.py:108:1:108:13 | [Function] function test17(...) | test.py:108:1:108:13 | (parameters) | semmle.order | 0 |
+| test.py:108:1:108:13 | [Function] function test17(...) | test.py:109:5:109:11 | (StmtList) body | semmle.label | 5 |
+| test.py:108:1:108:13 | [Function] function test17(...) | test.py:109:5:109:11 | (StmtList) body | semmle.order | 5 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.label | 0 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.order | 0 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.label | 2 |
+| test.py:109:5:109:11 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:5:109:5 | [Name] t | semmle.label | 1 |
+| test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:5:109:5 | [Name] t | semmle.order | 1 |
+| test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:9:109:11 | [Call] C() | semmle.label | 2 |
+| test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:9:109:11 | [Call] C() | semmle.order | 2 |
+| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.label | 1 |
+| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.order | 1 |
+| test.py:110:5:110:7 | [Attribute] t.x | test.py:110:5:110:5 | [Name] t | semmle.label | 1 |
+| test.py:110:5:110:7 | [Attribute] t.x | test.py:110:5:110:5 | [Name] t | semmle.order | 1 |
+| test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:5:110:7 | [Attribute] t.x | semmle.label | 1 |
+| test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:5:110:7 | [Attribute] t.x | semmle.order | 1 |
+| test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:11:110:26 | [Attribute] module.dangerous | semmle.label | 2 |
+| test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:11:110:26 | [Attribute] module.dangerous | semmle.order | 2 |
+| test.py:110:11:110:26 | [Attribute] module.dangerous | test.py:110:11:110:16 | [Name] module | semmle.label | 1 |
+| test.py:110:11:110:26 | [Attribute] module.dangerous | test.py:110:11:110:16 | [Name] module | semmle.order | 1 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.label | 1 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.order | 1 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:10:111:12 | [Attribute] t.x | semmle.label | 2 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:10:111:12 | [Attribute] t.x | semmle.order | 2 |
+| test.py:111:5:111:13 | [ExprStmt] SINK(...) | test.py:111:5:111:13 | [Call] SINK(...) | semmle.label | 1 |
+| test.py:111:5:111:13 | [ExprStmt] SINK(...) | test.py:111:5:111:13 | [Call] SINK(...) | semmle.order | 1 |
+| test.py:111:10:111:12 | [Attribute] t.x | test.py:111:10:111:10 | [Name] t | semmle.label | 1 |
+| test.py:111:10:111:12 | [Attribute] t.x | test.py:111:10:111:10 | [Name] t | semmle.order | 1 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.label | 1 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.order | 1 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.label | 2 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.order | 2 |
+| test.py:113:1:113:13 | [FunctionExpr] function test18(...) | test.py:113:1:113:13 | [Function] function test18(...) | semmle.label | 1 |
+| test.py:113:1:113:13 | [FunctionExpr] function test18(...) | test.py:113:1:113:13 | [Function] function test18(...) | semmle.order | 1 |
+| test.py:113:1:113:13 | [Function] function test18(...) | test.py:113:1:113:13 | (parameters) | semmle.label | 0 |
+| test.py:113:1:113:13 | [Function] function test18(...) | test.py:113:1:113:13 | (parameters) | semmle.order | 0 |
+| test.py:113:1:113:13 | [Function] function test18(...) | test.py:114:5:114:11 | (StmtList) body | semmle.label | 6 |
+| test.py:113:1:113:13 | [Function] function test18(...) | test.py:114:5:114:11 | (StmtList) body | semmle.order | 6 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.label | 0 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.order | 0 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.label | 2 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.order | 2 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.label | 3 |
+| test.py:114:5:114:11 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.order | 3 |
+| test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:5:114:5 | [Name] t | semmle.label | 1 |
+| test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:5:114:5 | [Name] t | semmle.order | 1 |
+| test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:9:114:11 | [Call] C() | semmle.label | 2 |
+| test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:9:114:11 | [Call] C() | semmle.order | 2 |
+| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.label | 1 |
+| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.order | 1 |
+| test.py:115:5:115:7 | [Attribute] t.x | test.py:115:5:115:5 | [Name] t | semmle.label | 1 |
+| test.py:115:5:115:7 | [Attribute] t.x | test.py:115:5:115:5 | [Name] t | semmle.order | 1 |
+| test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | test.py:115:5:115:7 | [Attribute] t.x | semmle.label | 1 |
+| test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | test.py:115:5:115:7 | [Attribute] t.x | semmle.order | 1 |
+| test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | test.py:115:11:115:26 | [Attribute] module.dangerous | semmle.label | 2 |
+| test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | test.py:115:11:115:26 | [Attribute] module.dangerous | semmle.order | 2 |
+| test.py:115:11:115:26 | [Attribute] module.dangerous | test.py:115:11:115:16 | [Name] module | semmle.label | 1 |
+| test.py:115:11:115:26 | [Attribute] module.dangerous | test.py:115:11:115:16 | [Name] module | semmle.order | 1 |
+| test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:5:116:5 | [Name] t | semmle.label | 1 |
+| test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:5:116:5 | [Name] t | semmle.order | 1 |
+| test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:9:116:14 | [Call] hub(t) | semmle.label | 2 |
+| test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:9:116:14 | [Call] hub(t) | semmle.order | 2 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.label | 1 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.order | 1 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:13:116:13 | [Name] t | semmle.label | 2 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:13:116:13 | [Name] t | semmle.order | 2 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.label | 1 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.order | 1 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:12:117:12 | [Name] t | semmle.label | 2 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:12:117:12 | [Name] t | semmle.order | 2 |
+| test.py:117:5:117:13 | [ExprStmt] x_sink(t) | test.py:117:5:117:13 | [Call] x_sink(t) | semmle.label | 1 |
+| test.py:117:5:117:13 | [ExprStmt] x_sink(t) | test.py:117:5:117:13 | [Call] x_sink(t) | semmle.order | 1 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.label | 1 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.order | 1 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.label | 2 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.order | 2 |
+| test.py:119:1:119:13 | [FunctionExpr] function test19(...) | test.py:119:1:119:13 | [Function] function test19(...) | semmle.label | 1 |
+| test.py:119:1:119:13 | [FunctionExpr] function test19(...) | test.py:119:1:119:13 | [Function] function test19(...) | semmle.order | 1 |
+| test.py:119:1:119:13 | [Function] function test19(...) | test.py:119:1:119:13 | (parameters) | semmle.label | 0 |
+| test.py:119:1:119:13 | [Function] function test19(...) | test.py:119:1:119:13 | (parameters) | semmle.order | 0 |
+| test.py:119:1:119:13 | [Function] function test19(...) | test.py:120:5:120:21 | (StmtList) body | semmle.label | 5 |
+| test.py:119:1:119:13 | [Function] function test19(...) | test.py:120:5:120:21 | (StmtList) body | semmle.order | 5 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.label | 1 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.order | 1 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 2 |
+| test.py:120:5:120:21 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 2 |
+| test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:5:120:5 | [Name] t | semmle.label | 1 |
+| test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:5:120:5 | [Name] t | semmle.order | 1 |
+| test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:9:120:21 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
+| test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:9:120:21 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
+| test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:5:121:5 | [Name] t | semmle.label | 1 |
+| test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:5:121:5 | [Name] t | semmle.order | 1 |
+| test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:9:121:30 | [Call] hub(...) | semmle.label | 2 |
+| test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:9:121:30 | [Call] hub(...) | semmle.order | 2 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.label | 1 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.order | 1 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.label | 2 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.order | 2 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.label | 1 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.order | 1 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:28:121:28 | [Name] t | semmle.label | 2 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:28:121:28 | [Name] t | semmle.order | 2 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.label | 1 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.order | 1 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:17:122:17 | [Name] t | semmle.label | 2 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:17:122:17 | [Name] t | semmle.order | 2 |
+| test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
+| test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
+| test.py:124:1:124:17 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.label | 1 |
+| test.py:124:1:124:17 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.order | 1 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.label | 1 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.order | 1 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.label | 2 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.order | 2 |
+| test.py:124:1:124:17 | [FunctionExpr] function test20(...) | test.py:124:1:124:17 | [Function] function test20(...) | semmle.label | 1 |
+| test.py:124:1:124:17 | [FunctionExpr] function test20(...) | test.py:124:1:124:17 | [Function] function test20(...) | semmle.order | 1 |
+| test.py:124:1:124:17 | [Function] function test20(...) | test.py:124:1:124:17 | (parameters) | semmle.label | 0 |
+| test.py:124:1:124:17 | [Function] function test20(...) | test.py:124:1:124:17 | (parameters) | semmle.order | 0 |
+| test.py:124:1:124:17 | [Function] function test20(...) | test.py:125:5:125:12 | (StmtList) body | semmle.label | 5 |
+| test.py:124:1:124:17 | [Function] function test20(...) | test.py:125:5:125:12 | (StmtList) body | semmle.order | 5 |
+| test.py:125:5:125:12 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.label | 0 |
+| test.py:125:5:125:12 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.order | 0 |
+| test.py:125:5:125:12 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.label | 1 |
+| test.py:125:5:125:12 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.order | 1 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:125:8:125:11 | [Name] cond | semmle.label | 0 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:125:8:125:11 | [Name] cond | semmle.order | 0 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:126:9:126:25 | (StmtList) body | semmle.label | 2 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:126:9:126:25 | (StmtList) body | semmle.order | 2 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:128:9:128:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:125:5:125:12 | [If] if cond: | test.py:128:9:128:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:126:9:126:25 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| test.py:126:9:126:25 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:9:126:9 | [Name] t | semmle.label | 1 |
+| test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:9:126:9 | [Name] t | semmle.order | 1 |
+| test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
+| test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
+| test.py:128:9:128:18 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:128:9:128:18 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:9:128:9 | [Name] t | semmle.label | 1 |
+| test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:9:128:9 | [Name] t | semmle.order | 1 |
+| test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:13:128:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:13:128:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:129:8:129:11 | [Name] cond | semmle.label | 0 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:129:8:129:11 | [Name] cond | semmle.order | 0 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:130:9:130:22 | (StmtList) body | semmle.label | 2 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:130:9:130:22 | (StmtList) body | semmle.order | 2 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:132:9:132:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:129:5:129:12 | [If] if cond: | test.py:132:9:132:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:130:9:130:22 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| test.py:130:9:130:22 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:21:130:21 | [Name] t | semmle.label | 2 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:21:130:21 | [Name] t | semmle.order | 2 |
+| test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
+| test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
+| test.py:132:9:132:15 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:132:9:132:15 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.label | 1 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.order | 1 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:14:132:14 | [Name] t | semmle.label | 2 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:14:132:14 | [Name] t | semmle.order | 2 |
+| test.py:132:9:132:15 | [ExprStmt] SINK(t) | test.py:132:9:132:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:132:9:132:15 | [ExprStmt] SINK(t) | test.py:132:9:132:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:134:1:134:17 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.label | 1 |
+| test.py:134:1:134:17 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.order | 1 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.label | 1 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.order | 1 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.label | 2 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.order | 2 |
+| test.py:134:1:134:17 | [FunctionExpr] function test21(...) | test.py:134:1:134:17 | [Function] function test21(...) | semmle.label | 1 |
+| test.py:134:1:134:17 | [FunctionExpr] function test21(...) | test.py:134:1:134:17 | [Function] function test21(...) | semmle.order | 1 |
+| test.py:134:1:134:17 | [Function] function test21(...) | test.py:134:1:134:17 | (parameters) | semmle.label | 0 |
+| test.py:134:1:134:17 | [Function] function test21(...) | test.py:134:1:134:17 | (parameters) | semmle.order | 0 |
+| test.py:134:1:134:17 | [Function] function test21(...) | test.py:135:5:135:12 | (StmtList) body | semmle.label | 5 |
+| test.py:134:1:134:17 | [Function] function test21(...) | test.py:135:5:135:12 | (StmtList) body | semmle.order | 5 |
+| test.py:135:5:135:12 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.label | 0 |
+| test.py:135:5:135:12 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.order | 0 |
+| test.py:135:5:135:12 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.label | 1 |
+| test.py:135:5:135:12 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.order | 1 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:135:8:135:11 | [Name] cond | semmle.label | 0 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:135:8:135:11 | [Name] cond | semmle.order | 0 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:136:9:136:25 | (StmtList) body | semmle.label | 2 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:136:9:136:25 | (StmtList) body | semmle.order | 2 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:138:9:138:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:135:5:135:12 | [If] if cond: | test.py:138:9:138:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:136:9:136:25 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| test.py:136:9:136:25 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:9:136:9 | [Name] t | semmle.label | 1 |
+| test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:9:136:9 | [Name] t | semmle.order | 1 |
+| test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
+| test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
+| test.py:138:9:138:18 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:138:9:138:18 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:9:138:9 | [Name] t | semmle.label | 1 |
+| test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:9:138:9 | [Name] t | semmle.order | 1 |
+| test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:13:138:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:13:138:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:139:5:139:16 | [If]  | test.py:139:8:139:15 | [UnaryExpr]  | semmle.label | 0 |
+| test.py:139:5:139:16 | [If]  | test.py:139:8:139:15 | [UnaryExpr]  | semmle.order | 0 |
+| test.py:139:5:139:16 | [If]  | test.py:140:9:140:22 | (StmtList) body | semmle.label | 2 |
+| test.py:139:5:139:16 | [If]  | test.py:140:9:140:22 | (StmtList) body | semmle.order | 2 |
+| test.py:139:5:139:16 | [If]  | test.py:142:9:142:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:139:5:139:16 | [If]  | test.py:142:9:142:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:139:8:139:15 | [UnaryExpr]  | test.py:139:12:139:15 | [Name] cond | semmle.label | 1 |
+| test.py:139:8:139:15 | [UnaryExpr]  | test.py:139:12:139:15 | [Name] cond | semmle.order | 1 |
+| test.py:140:9:140:22 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| test.py:140:9:140:22 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:21:140:21 | [Name] t | semmle.label | 2 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:21:140:21 | [Name] t | semmle.order | 2 |
+| test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
+| test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
+| test.py:142:9:142:15 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:142:9:142:15 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.label | 1 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.order | 1 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:14:142:14 | [Name] t | semmle.label | 2 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:14:142:14 | [Name] t | semmle.order | 2 |
+| test.py:142:9:142:15 | [ExprStmt] SINK(t) | test.py:142:9:142:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:142:9:142:15 | [ExprStmt] SINK(t) | test.py:142:9:142:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:144:1:144:17 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.label | 1 |
+| test.py:144:1:144:17 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.order | 1 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.label | 1 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.order | 1 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.label | 2 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.order | 2 |
+| test.py:144:1:144:17 | [FunctionExpr] function test22(...) | test.py:144:1:144:17 | [Function] function test22(...) | semmle.label | 1 |
+| test.py:144:1:144:17 | [FunctionExpr] function test22(...) | test.py:144:1:144:17 | [Function] function test22(...) | semmle.order | 1 |
+| test.py:144:1:144:17 | [Function] function test22(...) | test.py:144:1:144:17 | (parameters) | semmle.label | 0 |
+| test.py:144:1:144:17 | [Function] function test22(...) | test.py:144:1:144:17 | (parameters) | semmle.order | 0 |
+| test.py:144:1:144:17 | [Function] function test22(...) | test.py:145:5:145:12 | (StmtList) body | semmle.label | 6 |
+| test.py:144:1:144:17 | [Function] function test22(...) | test.py:145:5:145:12 | (StmtList) body | semmle.order | 6 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.label | 0 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.order | 0 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.label | 1 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.order | 1 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.label | 2 |
+| test.py:145:5:145:12 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.order | 2 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:145:8:145:11 | [Name] cond | semmle.label | 0 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:145:8:145:11 | [Name] cond | semmle.order | 0 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:146:9:146:25 | (StmtList) body | semmle.label | 2 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:146:9:146:25 | (StmtList) body | semmle.order | 2 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:148:9:148:18 | (StmtList) orelse | semmle.label | 3 |
+| test.py:145:5:145:12 | [If] if cond: | test.py:148:9:148:18 | (StmtList) orelse | semmle.order | 3 |
+| test.py:146:9:146:25 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| test.py:146:9:146:25 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:9:146:9 | [Name] t | semmle.label | 1 |
+| test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:9:146:9 | [Name] t | semmle.order | 1 |
+| test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
+| test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
+| test.py:148:9:148:18 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:148:9:148:18 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:9:148:9 | [Name] t | semmle.label | 1 |
+| test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:9:148:9 | [Name] t | semmle.order | 1 |
+| test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:13:148:18 | [Name] SOURCE | semmle.label | 2 |
+| test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:13:148:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:5:149:5 | [Name] t | semmle.label | 1 |
+| test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:5:149:5 | [Name] t | semmle.order | 1 |
+| test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | semmle.label | 2 |
+| test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | semmle.order | 2 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.label | 1 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.order | 1 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:24:149:24 | [Name] t | semmle.label | 2 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:24:149:24 | [Name] t | semmle.order | 2 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:150:8:150:11 | [Name] cond | semmle.label | 0 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:150:8:150:11 | [Name] cond | semmle.order | 0 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:151:9:151:22 | (StmtList) body | semmle.label | 2 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:151:9:151:22 | (StmtList) body | semmle.order | 2 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:153:9:153:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:150:5:150:12 | [If] if cond: | test.py:153:9:153:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:151:9:151:22 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| test.py:151:9:151:22 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:21:151:21 | [Name] t | semmle.label | 2 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:21:151:21 | [Name] t | semmle.order | 2 |
+| test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
+| test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
+| test.py:153:9:153:15 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:153:9:153:15 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.label | 1 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.order | 1 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:14:153:14 | [Name] t | semmle.label | 2 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:14:153:14 | [Name] t | semmle.order | 2 |
+| test.py:153:9:153:15 | [ExprStmt] SINK(t) | test.py:153:9:153:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:153:9:153:15 | [ExprStmt] SINK(t) | test.py:153:9:153:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:6:155:11 | [ImportExpr]  | semmle.label | 1 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:6:155:11 | [ImportExpr]  | semmle.order | 1 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:20:155:38 | [ImportMember]  | semmle.label | 2 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:20:155:38 | [ImportMember]  | semmle.order | 2 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:33:155:38 | [Name] unsafe | semmle.label | 3 |
+| test.py:155:1:155:38 | [Import] import unsafe | test.py:155:33:155:38 | [Name] unsafe | semmle.order | 3 |
+| test.py:155:20:155:38 | [ImportMember]  | test.py:155:6:155:11 | [ImportExpr]  | semmle.label | 1 |
+| test.py:155:20:155:38 | [ImportMember]  | test.py:155:6:155:11 | [ImportExpr]  | semmle.order | 1 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.label | 1 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.order | 1 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:6:156:11 | [Name] unsafe | semmle.label | 2 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:6:156:11 | [Name] unsafe | semmle.order | 2 |
+| test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | test.py:156:1:156:12 | [Call] SINK(unsafe) | semmle.label | 1 |
+| test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | test.py:156:1:156:12 | [Call] SINK(unsafe) | semmle.order | 1 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.label | 1 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.order | 1 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.label | 2 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.order | 2 |
+| test.py:158:1:158:13 | [FunctionExpr] function test23(...) | test.py:158:1:158:13 | [Function] function test23(...) | semmle.label | 1 |
+| test.py:158:1:158:13 | [FunctionExpr] function test23(...) | test.py:158:1:158:13 | [Function] function test23(...) | semmle.order | 1 |
+| test.py:158:1:158:13 | [Function] function test23(...) | test.py:158:1:158:13 | (parameters) | semmle.label | 0 |
+| test.py:158:1:158:13 | [Function] function test23(...) | test.py:158:1:158:13 | (parameters) | semmle.order | 0 |
+| test.py:158:1:158:13 | [Function] function test23(...) | test.py:159:5:159:21 | (StmtList) body | semmle.label | 3 |
+| test.py:158:1:158:13 | [Function] function test23(...) | test.py:159:5:159:21 | (StmtList) body | semmle.order | 3 |
+| test.py:159:5:159:21 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.label | 0 |
+| test.py:159:5:159:21 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.order | 0 |
+| test.py:159:5:159:21 | [With]  | test.py:159:10:159:15 | [Name] SOURCE | semmle.label | 1 |
+| test.py:159:5:159:21 | [With]  | test.py:159:10:159:15 | [Name] SOURCE | semmle.order | 1 |
+| test.py:159:5:159:21 | [With]  | test.py:159:20:159:20 | [Name] t | semmle.label | 2 |
+| test.py:159:5:159:21 | [With]  | test.py:159:20:159:20 | [Name] t | semmle.order | 2 |
+| test.py:159:5:159:21 | [With]  | test.py:160:9:160:15 | (StmtList) body | semmle.label | 5 |
+| test.py:159:5:159:21 | [With]  | test.py:160:9:160:15 | (StmtList) body | semmle.order | 5 |
+| test.py:160:9:160:15 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:160:9:160:15 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.label | 1 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.order | 1 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:14:160:14 | [Name] t | semmle.label | 2 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:14:160:14 | [Name] t | semmle.order | 2 |
+| test.py:160:9:160:15 | [ExprStmt] SINK(t) | test.py:160:9:160:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:160:9:160:15 | [ExprStmt] SINK(t) | test.py:160:9:160:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.label | 1 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.order | 1 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.label | 2 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.order | 2 |
+| test.py:162:1:162:13 | [FunctionExpr] function test24(...) | test.py:162:1:162:13 | [Function] function test24(...) | semmle.label | 1 |
+| test.py:162:1:162:13 | [FunctionExpr] function test24(...) | test.py:162:1:162:13 | [Function] function test24(...) | semmle.order | 1 |
+| test.py:162:1:162:13 | [Function] function test24(...) | test.py:162:1:162:13 | (parameters) | semmle.label | 0 |
+| test.py:162:1:162:13 | [Function] function test24(...) | test.py:162:1:162:13 | (parameters) | semmle.order | 0 |
+| test.py:162:1:162:13 | [Function] function test24(...) | test.py:163:5:163:14 | (StmtList) body | semmle.label | 5 |
+| test.py:162:1:162:13 | [Function] function test24(...) | test.py:163:5:163:14 | (StmtList) body | semmle.order | 5 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.label | 1 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.order | 1 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.label | 2 |
+| test.py:163:5:163:14 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.order | 2 |
+| test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:5:163:5 | [Name] s | semmle.label | 1 |
+| test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:5:163:5 | [Name] s | semmle.order | 1 |
+| test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:9:163:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:9:163:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.label | 1 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.order | 1 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:14:164:14 | [Name] s | semmle.label | 2 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:14:164:14 | [Name] s | semmle.order | 2 |
+| test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | test.py:164:5:164:15 | [Call] SANITIZE(s) | semmle.label | 1 |
+| test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | test.py:164:5:164:15 | [Call] SANITIZE(s) | semmle.order | 1 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.label | 1 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.order | 1 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:10:165:10 | [Name] s | semmle.label | 2 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:10:165:10 | [Name] s | semmle.order | 2 |
+| test.py:165:5:165:11 | [ExprStmt] SINK(s) | test.py:165:5:165:11 | [Call] SINK(s) | semmle.label | 1 |
+| test.py:165:5:165:11 | [ExprStmt] SINK(s) | test.py:165:5:165:11 | [Call] SINK(s) | semmle.order | 1 |
+| test.py:167:1:167:29 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.label | 1 |
+| test.py:167:1:167:29 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.order | 1 |
+| test.py:167:1:167:29 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.label | 2 |
+| test.py:167:1:167:29 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.order | 2 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.label | 1 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.order | 1 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.label | 2 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.order | 2 |
+| test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | test.py:167:1:167:29 | [Function] function test_update_extend(...) | semmle.label | 1 |
+| test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | test.py:167:1:167:29 | [Function] function test_update_extend(...) | semmle.order | 1 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:167:1:167:29 | (parameters) | semmle.label | 0 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:167:1:167:29 | (parameters) | semmle.order | 0 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:168:5:168:16 | (StmtList) body | semmle.label | 12 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:168:5:168:16 | (StmtList) body | semmle.order | 12 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.label | 0 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.order | 0 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.label | 1 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.order | 1 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.label | 2 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.order | 2 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.label | 3 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.order | 3 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.label | 4 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.order | 4 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.label | 5 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.order | 5 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.label | 6 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.order | 6 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.label | 7 |
+| test.py:168:5:168:16 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.order | 7 |
+| test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:5:168:5 | [Name] l | semmle.label | 1 |
+| test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:5:168:5 | [Name] l | semmle.order | 1 |
+| test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:9:168:16 | [List] [...] | semmle.label | 2 |
+| test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:9:168:16 | [List] [...] | semmle.order | 2 |
+| test.py:168:9:168:16 | [List] [...] | test.py:168:10:168:15 | [Name] SOURCE | semmle.label | 1 |
+| test.py:168:9:168:16 | [List] [...] | test.py:168:10:168:15 | [Name] SOURCE | semmle.order | 1 |
+| test.py:169:5:169:24 | [AssignStmt]  | test.py:169:5:169:5 | [Name] d | semmle.label | 1 |
+| test.py:169:5:169:24 | [AssignStmt]  | test.py:169:5:169:5 | [Name] d | semmle.order | 1 |
+| test.py:169:5:169:24 | [AssignStmt]  | test.py:169:9:169:24 | [Dict]  | semmle.label | 2 |
+| test.py:169:5:169:24 | [AssignStmt]  | test.py:169:9:169:24 | [Dict]  | semmle.order | 2 |
+| test.py:169:9:169:24 | [Dict]  | test.py:169:10:169:23 | [KeyValuePair]  | semmle.label | 1 |
+| test.py:169:9:169:24 | [Dict]  | test.py:169:10:169:23 | [KeyValuePair]  | semmle.order | 1 |
+| test.py:169:10:169:23 | [KeyValuePair]  | test.py:169:10:169:14 | [Str] key | semmle.label | 1 |
+| test.py:169:10:169:23 | [KeyValuePair]  | test.py:169:10:169:14 | [Str] key | semmle.order | 1 |
+| test.py:169:10:169:23 | [KeyValuePair]  | test.py:169:18:169:23 | [Name] SOURCE | semmle.label | 2 |
+| test.py:169:10:169:23 | [KeyValuePair]  | test.py:169:18:169:23 | [Name] SOURCE | semmle.order | 2 |
+| test.py:170:5:170:12 | [Attribute] x.extend | test.py:170:5:170:5 | [Name] x | semmle.label | 1 |
+| test.py:170:5:170:12 | [Attribute] x.extend | test.py:170:5:170:5 | [Name] x | semmle.order | 1 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.label | 1 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.order | 1 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:14:170:14 | [Name] l | semmle.label | 2 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:14:170:14 | [Name] l | semmle.order | 2 |
+| test.py:170:5:170:15 | [ExprStmt] x.extend(l) | test.py:170:5:170:15 | [Call] x.extend(l) | semmle.label | 1 |
+| test.py:170:5:170:15 | [ExprStmt] x.extend(l) | test.py:170:5:170:15 | [Call] x.extend(l) | semmle.order | 1 |
+| test.py:171:5:171:12 | [Attribute] y.update | test.py:171:5:171:5 | [Name] y | semmle.label | 1 |
+| test.py:171:5:171:12 | [Attribute] y.update | test.py:171:5:171:5 | [Name] y | semmle.order | 1 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.label | 1 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.order | 1 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:14:171:14 | [Name] d | semmle.label | 2 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:14:171:14 | [Name] d | semmle.order | 2 |
+| test.py:171:5:171:15 | [ExprStmt] y.update(d) | test.py:171:5:171:15 | [Call] y.update(d) | semmle.label | 1 |
+| test.py:171:5:171:15 | [ExprStmt] y.update(d) | test.py:171:5:171:15 | [Call] y.update(d) | semmle.order | 1 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.label | 1 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.order | 1 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.label | 2 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.order | 2 |
+| test.py:172:5:172:14 | [ExprStmt] SINK(...) | test.py:172:5:172:14 | [Call] SINK(...) | semmle.label | 1 |
+| test.py:172:5:172:14 | [ExprStmt] SINK(...) | test.py:172:5:172:14 | [Call] SINK(...) | semmle.order | 1 |
+| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:10:172:10 | [Name] x | semmle.label | 1 |
+| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:10:172:10 | [Name] x | semmle.order | 1 |
+| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.label | 2 |
+| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.order | 2 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.label | 1 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.order | 1 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.label | 2 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.order | 2 |
+| test.py:173:5:173:18 | [ExprStmt] SINK(...) | test.py:173:5:173:18 | [Call] SINK(...) | semmle.label | 1 |
+| test.py:173:5:173:18 | [ExprStmt] SINK(...) | test.py:173:5:173:18 | [Call] SINK(...) | semmle.order | 1 |
+| test.py:173:10:173:17 | [Subscript] y[key] | test.py:173:10:173:10 | [Name] y | semmle.label | 1 |
+| test.py:173:10:173:17 | [Subscript] y[key] | test.py:173:10:173:10 | [Name] y | semmle.order | 1 |
+| test.py:173:10:173:17 | [Subscript] y[key] | test.py:173:12:173:16 | [Str] key | semmle.label | 2 |
+| test.py:173:10:173:17 | [Subscript] y[key] | test.py:173:12:173:16 | [Str] key | semmle.order | 2 |
+| test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:5:174:6 | [Name] l2 | semmle.label | 1 |
+| test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:5:174:6 | [Name] l2 | semmle.order | 1 |
+| test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:10:174:16 | [Call] list(l) | semmle.label | 2 |
+| test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:10:174:16 | [Call] list(l) | semmle.order | 2 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.label | 1 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.order | 1 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:15:174:15 | [Name] l | semmle.label | 2 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:15:174:15 | [Name] l | semmle.order | 2 |
+| test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:5:175:6 | [Name] d2 | semmle.label | 1 |
+| test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:5:175:6 | [Name] d2 | semmle.order | 1 |
+| test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:10:175:16 | [Call] dict(d) | semmle.label | 2 |
+| test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:10:175:16 | [Call] dict(d) | semmle.order | 2 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.label | 1 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.order | 1 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:15:175:15 | [Name] d | semmle.label | 2 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:15:175:15 | [Name] d | semmle.order | 2 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.label | 1 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.order | 1 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.label | 2 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.order | 2 |
+| test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.label | 1 |
+| test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.order | 1 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:177:1:177:17 | (parameters) | semmle.label | 0 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:177:1:177:17 | (parameters) | semmle.order | 0 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:178:5:178:14 | (StmtList) body | semmle.label | 5 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:178:5:178:14 | (StmtList) body | semmle.order | 5 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.label | 1 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.order | 1 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.label | 2 |
+| test.py:178:5:178:14 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.order | 2 |
+| test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:5:178:5 | [Name] t | semmle.label | 1 |
+| test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:5:178:5 | [Name] t | semmle.order | 1 |
+| test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:9:178:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:9:178:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:179:5:179:9 | [If] if t: | test.py:179:8:179:8 | [Name] t | semmle.label | 0 |
+| test.py:179:5:179:9 | [If] if t: | test.py:179:8:179:8 | [Name] t | semmle.order | 0 |
+| test.py:179:5:179:9 | [If] if t: | test.py:180:9:180:15 | (StmtList) body | semmle.label | 2 |
+| test.py:179:5:179:9 | [If] if t: | test.py:180:9:180:15 | (StmtList) body | semmle.order | 2 |
+| test.py:179:5:179:9 | [If] if t: | test.py:182:9:182:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:179:5:179:9 | [If] if t: | test.py:182:9:182:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:180:9:180:15 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:180:9:180:15 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.label | 1 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.order | 1 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:14:180:14 | [Name] t | semmle.label | 2 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:14:180:14 | [Name] t | semmle.order | 2 |
+| test.py:180:9:180:15 | [ExprStmt] SINK(t) | test.py:180:9:180:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:180:9:180:15 | [ExprStmt] SINK(t) | test.py:180:9:180:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:182:9:182:15 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:182:9:182:15 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.label | 1 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.order | 1 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:14:182:14 | [Name] t | semmle.label | 2 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:14:182:14 | [Name] t | semmle.order | 2 |
+| test.py:182:9:182:15 | [ExprStmt] SINK(t) | test.py:182:9:182:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:182:9:182:15 | [ExprStmt] SINK(t) | test.py:182:9:182:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:183:5:183:13 | [If]  | test.py:183:8:183:12 | [UnaryExpr]  | semmle.label | 0 |
+| test.py:183:5:183:13 | [If]  | test.py:183:8:183:12 | [UnaryExpr]  | semmle.order | 0 |
+| test.py:183:5:183:13 | [If]  | test.py:184:9:184:15 | (StmtList) body | semmle.label | 2 |
+| test.py:183:5:183:13 | [If]  | test.py:184:9:184:15 | (StmtList) body | semmle.order | 2 |
+| test.py:183:5:183:13 | [If]  | test.py:186:9:186:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:183:5:183:13 | [If]  | test.py:186:9:186:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:183:8:183:12 | [UnaryExpr]  | test.py:183:12:183:12 | [Name] t | semmle.label | 1 |
+| test.py:183:8:183:12 | [UnaryExpr]  | test.py:183:12:183:12 | [Name] t | semmle.order | 1 |
+| test.py:184:9:184:15 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:184:9:184:15 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.label | 1 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.order | 1 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:14:184:14 | [Name] t | semmle.label | 2 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:14:184:14 | [Name] t | semmle.order | 2 |
+| test.py:184:9:184:15 | [ExprStmt] SINK(t) | test.py:184:9:184:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:184:9:184:15 | [ExprStmt] SINK(t) | test.py:184:9:184:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:186:9:186:15 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:186:9:186:15 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.label | 1 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.order | 1 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:14:186:14 | [Name] t | semmle.label | 2 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:14:186:14 | [Name] t | semmle.order | 2 |
+| test.py:186:9:186:15 | [ExprStmt] SINK(t) | test.py:186:9:186:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:186:9:186:15 | [ExprStmt] SINK(t) | test.py:186:9:186:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.label | 1 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.order | 1 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.label | 2 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.order | 2 |
+| test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.label | 1 |
+| test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.order | 1 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:188:1:188:22 | (parameters) | semmle.label | 0 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:188:1:188:22 | (parameters) | semmle.order | 0 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:189:5:189:14 | (StmtList) body | semmle.label | 5 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:189:5:189:14 | (StmtList) body | semmle.order | 5 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.label | 0 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.order | 0 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.label | 1 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.order | 1 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.label | 2 |
+| test.py:189:5:189:14 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.order | 2 |
+| test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:5:189:5 | [Name] t | semmle.label | 1 |
+| test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:5:189:5 | [Name] t | semmle.order | 1 |
+| test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:9:189:14 | [Name] FALSEY | semmle.label | 2 |
+| test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:9:189:14 | [Name] FALSEY | semmle.order | 2 |
+| test.py:190:5:190:13 | [If]  | test.py:190:8:190:12 | [UnaryExpr]  | semmle.label | 0 |
+| test.py:190:5:190:13 | [If]  | test.py:190:8:190:12 | [UnaryExpr]  | semmle.order | 0 |
+| test.py:190:5:190:13 | [If]  | test.py:191:9:191:14 | (StmtList) body | semmle.label | 2 |
+| test.py:190:5:190:13 | [If]  | test.py:191:9:191:14 | (StmtList) body | semmle.order | 2 |
+| test.py:190:8:190:12 | [UnaryExpr]  | test.py:190:12:190:12 | [Name] t | semmle.label | 1 |
+| test.py:190:8:190:12 | [UnaryExpr]  | test.py:190:12:190:12 | [Name] t | semmle.order | 1 |
+| test.py:191:9:191:14 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.label | 0 |
+| test.py:191:9:191:14 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.order | 0 |
+| test.py:192:5:192:5 | [ExprStmt] t | test.py:192:5:192:5 | [Name] t | semmle.label | 1 |
+| test.py:192:5:192:5 | [ExprStmt] t | test.py:192:5:192:5 | [Name] t | semmle.order | 1 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.label | 1 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.order | 1 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.label | 2 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.order | 2 |
+| test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.label | 1 |
+| test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.order | 1 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | (parameters) | semmle.label | 0 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | (parameters) | semmle.order | 0 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:195:5:195:14 | (StmtList) body | semmle.label | 4 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:195:5:195:14 | (StmtList) body | semmle.order | 4 |
+| test.py:195:5:195:14 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| test.py:195:5:195:14 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| test.py:195:5:195:14 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.label | 1 |
+| test.py:195:5:195:14 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.order | 1 |
+| test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:5:195:5 | [Name] t | semmle.label | 1 |
+| test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:5:195:5 | [Name] t | semmle.order | 1 |
+| test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:9:195:14 | [Name] SOURCE | semmle.label | 2 |
+| test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:9:195:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:196:8:196:25 | [Call] isinstance(str, t) | semmle.label | 0 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:196:8:196:25 | [Call] isinstance(str, t) | semmle.order | 0 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:197:9:197:15 | (StmtList) body | semmle.label | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:197:9:197:15 | (StmtList) body | semmle.order | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:199:9:199:15 | (StmtList) orelse | semmle.label | 3 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:199:9:199:15 | (StmtList) orelse | semmle.order | 3 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.label | 1 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.order | 1 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:19:196:19 | [Name] t | semmle.label | 2 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:19:196:19 | [Name] t | semmle.order | 2 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:22:196:24 | [Name] str | semmle.label | 3 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:22:196:24 | [Name] str | semmle.order | 3 |
+| test.py:197:9:197:15 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:197:9:197:15 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.label | 1 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.order | 1 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:14:197:14 | [Name] t | semmle.label | 2 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:14:197:14 | [Name] t | semmle.order | 2 |
+| test.py:197:9:197:15 | [ExprStmt] SINK(t) | test.py:197:9:197:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:197:9:197:15 | [ExprStmt] SINK(t) | test.py:197:9:197:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:199:9:199:15 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| test.py:199:9:199:15 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.label | 1 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.order | 1 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:14:199:14 | [Name] t | semmle.label | 2 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:14:199:14 | [Name] t | semmle.order | 2 |
+| test.py:199:9:199:15 | [ExprStmt] SINK(t) | test.py:199:9:199:15 | [Call] SINK(t) | semmle.label | 1 |
+| test.py:199:9:199:15 | [ExprStmt] SINK(t) | test.py:199:9:199:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.label | 1 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.order | 1 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.label | 2 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.order | 2 |
+| test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.label | 1 |
+| test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.order | 1 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:201:1:201:24 | (parameters) | semmle.label | 0 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:201:1:201:24 | (parameters) | semmle.order | 0 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:202:5:202:23 | (StmtList) body | semmle.label | 5 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:202:5:202:23 | (StmtList) body | semmle.order | 5 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.label | 0 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.order | 0 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.label | 1 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.order | 1 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.label | 2 |
+| test.py:202:5:202:23 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.order | 2 |
+| test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:5:202:5 | [Name] t | semmle.label | 1 |
+| test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:5:202:5 | [Name] t | semmle.order | 1 |
+| test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.label | 2 |
+| test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.order | 2 |
+| test.py:203:5:203:15 | [For]  | test.py:203:9:203:9 | [Name] i | semmle.label | 1 |
+| test.py:203:5:203:15 | [For]  | test.py:203:9:203:9 | [Name] i | semmle.order | 1 |
+| test.py:203:5:203:15 | [For]  | test.py:203:14:203:14 | [Name] t | semmle.label | 2 |
+| test.py:203:5:203:15 | [For]  | test.py:203:14:203:14 | [Name] t | semmle.order | 2 |
+| test.py:203:5:203:15 | [For]  | test.py:204:9:204:9 | (StmtList) body | semmle.label | 5 |
+| test.py:203:5:203:15 | [For]  | test.py:204:9:204:9 | (StmtList) body | semmle.order | 5 |
+| test.py:204:9:204:9 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.label | 0 |
+| test.py:204:9:204:9 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.order | 0 |
+| test.py:204:9:204:9 | [ExprStmt] i | test.py:204:9:204:9 | [Name] i | semmle.label | 1 |
+| test.py:204:9:204:9 | [ExprStmt] i | test.py:204:9:204:9 | [Name] i | semmle.order | 1 |
+| test.py:205:5:205:12 | [Return] return i | test.py:205:12:205:12 | [Name] i | semmle.label | 1 |
+| test.py:205:5:205:12 | [Return] return i | test.py:205:12:205:12 | [Name] i | semmle.order | 1 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.label | 1 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.order | 1 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.label | 2 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.order | 2 |
+| test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.label | 1 |
+| test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.order | 1 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:207:1:207:24 | (parameters) | semmle.label | 0 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:207:1:207:24 | (parameters) | semmle.order | 0 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:208:5:208:18 | (StmtList) body | semmle.label | 4 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:208:5:208:18 | (StmtList) body | semmle.order | 4 |
+| test.py:208:5:208:18 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.label | 0 |
+| test.py:208:5:208:18 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.order | 0 |
+| test.py:208:5:208:18 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.label | 1 |
+| test.py:208:5:208:18 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.order | 1 |
+| test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:5:208:7 | [Name] seq | semmle.label | 1 |
+| test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:5:208:7 | [Name] seq | semmle.order | 1 |
+| test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:11:208:18 | [List] [...] | semmle.label | 2 |
+| test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:11:208:18 | [List] [...] | semmle.order | 2 |
+| test.py:208:11:208:18 | [List] [...] | test.py:208:12:208:17 | [Name] SOURCE | semmle.label | 1 |
+| test.py:208:11:208:18 | [List] [...] | test.py:208:12:208:17 | [Name] SOURCE | semmle.order | 1 |
+| test.py:209:5:209:17 | [For]  | test.py:209:9:209:9 | [Name] i | semmle.label | 1 |
+| test.py:209:5:209:17 | [For]  | test.py:209:9:209:9 | [Name] i | semmle.order | 1 |
+| test.py:209:5:209:17 | [For]  | test.py:209:14:209:16 | [Name] seq | semmle.label | 2 |
+| test.py:209:5:209:17 | [For]  | test.py:209:14:209:16 | [Name] seq | semmle.order | 2 |
+| test.py:209:5:209:17 | [For]  | test.py:210:9:210:15 | (StmtList) body | semmle.label | 5 |
+| test.py:209:5:209:17 | [For]  | test.py:210:9:210:15 | (StmtList) body | semmle.order | 5 |
+| test.py:210:9:210:15 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.label | 0 |
+| test.py:210:9:210:15 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.order | 0 |
+| test.py:210:9:210:15 | [ExprStmt] yield i | test.py:210:9:210:15 | [Yield] yield i | semmle.label | 1 |
+| test.py:210:9:210:15 | [ExprStmt] yield i | test.py:210:9:210:15 | [Yield] yield i | semmle.order | 1 |
+| test.py:210:9:210:15 | [Yield] yield i | test.py:210:15:210:15 | [Name] i | semmle.label | 1 |
+| test.py:210:9:210:15 | [Yield] yield i | test.py:210:15:210:15 | [Name] i | semmle.order | 1 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.label | 1 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.order | 1 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.label | 2 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.order | 2 |
+| test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.label | 1 |
+| test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.order | 1 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:212:1:212:26 | (parameters) | semmle.label | 0 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:212:1:212:26 | (parameters) | semmle.order | 0 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:213:5:213:33 | (StmtList) body | semmle.label | 3 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:213:5:213:33 | (StmtList) body | semmle.order | 3 |
+| test.py:213:5:213:33 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.label | 0 |
+| test.py:213:5:213:33 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.order | 0 |
+| test.py:213:5:213:33 | [For]  | test.py:213:9:213:9 | [Name] x | semmle.label | 1 |
+| test.py:213:5:213:33 | [For]  | test.py:213:9:213:9 | [Name] x | semmle.order | 1 |
+| test.py:213:5:213:33 | [For]  | test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.label | 2 |
+| test.py:213:5:213:33 | [For]  | test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.order | 2 |
+| test.py:213:5:213:33 | [For]  | test.py:214:9:214:15 | (StmtList) body | semmle.label | 5 |
+| test.py:213:5:213:33 | [For]  | test.py:214:9:214:15 | (StmtList) body | semmle.order | 5 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.label | 1 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.order | 1 |
+| test.py:214:9:214:15 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.label | 0 |
+| test.py:214:9:214:15 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.order | 0 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.label | 1 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.order | 1 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:14:214:14 | [Name] x | semmle.label | 2 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:14:214:14 | [Name] x | semmle.order | 2 |
+| test.py:214:9:214:15 | [ExprStmt] SINK(x) | test.py:214:9:214:15 | [Call] SINK(x) | semmle.label | 1 |
+| test.py:214:9:214:15 | [ExprStmt] SINK(x) | test.py:214:9:214:15 | [Call] SINK(x) | semmle.order | 1 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.label | 1 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.order | 1 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.label | 2 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.order | 2 |
+| test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.label | 1 |
+| test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.order | 1 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:216:1:216:28 | (parameters) | semmle.label | 0 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:216:1:216:28 | (parameters) | semmle.order | 0 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:217:5:217:20 | (StmtList) body | semmle.label | 5 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:217:5:217:20 | (StmtList) body | semmle.order | 5 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.label | 1 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.order | 1 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
+| test.py:217:5:217:20 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:5:217:11 | [Name] tainted | semmle.label | 1 |
+| test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:5:217:11 | [Name] tainted | semmle.order | 1 |
+| test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:15:217:20 | [Name] SOURCE | semmle.label | 2 |
+| test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:15:217:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:218:8:218:24 | [Compare] tainted == ... | semmle.label | 0 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:218:8:218:24 | [Compare] tainted == ... | semmle.order | 0 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:219:9:219:21 | (StmtList) body | semmle.label | 2 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:219:9:219:21 | (StmtList) body | semmle.order | 2 |
+| test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:8:218:14 | [Name] tainted | semmle.label | 1 |
+| test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:8:218:14 | [Name] tainted | semmle.order | 1 |
+| test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:19:218:24 | [Str] safe | semmle.label | 2 |
+| test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:19:218:24 | [Str] safe | semmle.order | 2 |
+| test.py:219:9:219:21 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| test.py:219:9:219:21 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.label | 1 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.order | 1 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:14:219:20 | [Name] tainted | semmle.label | 2 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:14:219:20 | [Name] tainted | semmle.order | 2 |
+| test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.label | 1 |
+| test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.order | 1 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.label | 1 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.order | 1 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:10:220:16 | [Name] tainted | semmle.label | 2 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:10:220:16 | [Name] tainted | semmle.order | 2 |
+| test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.label | 1 |
+| test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.order | 1 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.label | 1 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.order | 1 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.label | 2 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.order | 2 |
+| test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.label | 1 |
+| test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.order | 1 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | (parameters) | semmle.label | 0 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | (parameters) | semmle.order | 0 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:223:5:223:20 | (StmtList) body | semmle.label | 5 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:223:5:223:20 | (StmtList) body | semmle.order | 5 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.label | 1 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.order | 1 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
+| test.py:223:5:223:20 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:5:223:11 | [Name] tainted | semmle.label | 1 |
+| test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:5:223:11 | [Name] tainted | semmle.order | 1 |
+| test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:15:223:20 | [Name] SOURCE | semmle.label | 2 |
+| test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:15:223:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:224:8:224:24 | [Compare] tainted != ... | semmle.label | 0 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:224:8:224:24 | [Compare] tainted != ... | semmle.order | 0 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:225:9:225:14 | (StmtList) body | semmle.label | 2 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:225:9:225:14 | (StmtList) body | semmle.order | 2 |
+| test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:8:224:14 | [Name] tainted | semmle.label | 1 |
+| test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:8:224:14 | [Name] tainted | semmle.order | 1 |
+| test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:19:224:24 | [Str] safe | semmle.label | 2 |
+| test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:19:224:24 | [Str] safe | semmle.order | 2 |
+| test.py:225:9:225:14 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.label | 0 |
+| test.py:225:9:225:14 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.order | 0 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.label | 1 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.order | 1 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:10:226:16 | [Name] tainted | semmle.label | 2 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:10:226:16 | [Name] tainted | semmle.order | 2 |
+| test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.label | 1 |
+| test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.order | 1 |
+| test.py:228:1:228:36 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.label | 1 |
+| test.py:228:1:228:36 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.order | 1 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.label | 1 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.order | 1 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.label | 2 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.order | 2 |
+| test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | semmle.label | 1 |
+| test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | semmle.order | 1 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | (parameters) | semmle.label | 0 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | (parameters) | semmle.order | 0 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:229:5:229:20 | (StmtList) body | semmle.label | 6 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:229:5:229:20 | (StmtList) body | semmle.order | 6 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.label | 1 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.order | 1 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.label | 2 |
+| test.py:229:5:229:20 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.order | 2 |
+| test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:5:229:11 | [Name] tainted | semmle.label | 1 |
+| test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:5:229:11 | [Name] tainted | semmle.order | 1 |
+| test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:15:229:20 | [Name] SOURCE | semmle.label | 2 |
+| test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:15:229:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:230:8:230:25 | [Compare] tainted == ... | semmle.label | 0 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:230:8:230:25 | [Compare] tainted == ... | semmle.order | 0 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:231:9:231:21 | (StmtList) body | semmle.label | 2 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:231:9:231:21 | (StmtList) body | semmle.order | 2 |
+| test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:8:230:14 | [Name] tainted | semmle.label | 1 |
+| test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:8:230:14 | [Name] tainted | semmle.order | 1 |
+| test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:19:230:25 | [Name] tainted | semmle.label | 2 |
+| test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:19:230:25 | [Name] tainted | semmle.order | 2 |
+| test.py:231:9:231:21 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| test.py:231:9:231:21 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.label | 1 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.order | 1 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:14:231:20 | [Name] tainted | semmle.label | 2 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:14:231:20 | [Name] tainted | semmle.order | 2 |
+| test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.label | 1 |
+| test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.order | 1 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:232:8:232:19 | [Compare] tainted == ... | semmle.label | 0 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:232:8:232:19 | [Compare] tainted == ... | semmle.order | 0 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:233:9:233:21 | (StmtList) body | semmle.label | 2 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:233:9:233:21 | (StmtList) body | semmle.order | 2 |
+| test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:8:232:14 | [Name] tainted | semmle.label | 1 |
+| test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:8:232:14 | [Name] tainted | semmle.order | 1 |
+| test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:19:232:19 | [Name] x | semmle.label | 2 |
+| test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:19:232:19 | [Name] x | semmle.order | 2 |
+| test.py:233:9:233:21 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| test.py:233:9:233:21 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.label | 1 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.order | 1 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:14:233:20 | [Name] tainted | semmle.label | 2 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:14:233:20 | [Name] tainted | semmle.order | 2 |
+| test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.label | 1 |
+| test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.order | 1 |
+graphProperties
+| semmle.graphKind | tree |

--- a/python/ql/test/library-tests/taint/general/printAst.expected
+++ b/python/ql/test/library-tests/taint/general/printAst.expected
@@ -1,14 +1,11 @@
 nodes
-| assignment.py:1:1:1:16 | (parameters) | semmle.label | (parameters) |
 | assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | semmle.label | [FunctionDef] test = function test(...) |
 | assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | semmle.order | 1 |
 | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.label | [FunctionExpr] function test(...) |
 | assignment.py:1:1:1:16 | [Function] function test(...) | semmle.label | [Function] function test(...) |
 | assignment.py:1:5:1:8 | [Name] test | semmle.label | [Name] test |
 | assignment.py:1:11:1:14 | [Parameter] args | semmle.label | [Parameter] args |
-| assignment.py:2:5:2:8 | (StmtList) body | semmle.label | (StmtList) body |
 | assignment.py:2:5:2:8 | [Pass] pass | semmle.label | [Pass] pass |
-| assignment.py:4:1:4:17 | (parameters) | semmle.label | (parameters) |
 | assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | semmle.label | [FunctionDef] swap_taint = function swap_taint(...) |
 | assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | semmle.order | 2 |
 | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.label | [FunctionExpr] function swap_taint(...) |
@@ -16,7 +13,6 @@ nodes
 | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.label | [Name] swap_taint |
 | assignment.py:5:5:5:5 | [Name] a | semmle.label | [Name] a |
 | assignment.py:5:5:5:8 | [Tuple]  | semmle.label | [Tuple]  |
-| assignment.py:5:5:5:25 | (StmtList) body | semmle.label | (StmtList) body |
 | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.label | [AssignStmt]  |
 | assignment.py:5:8:5:8 | [Name] b | semmle.label | [Name] b |
 | assignment.py:5:12:5:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
@@ -39,13 +35,11 @@ nodes
 | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.label | [ExprStmt] test(a, b) |
 | assignment.py:8:10:8:10 | [Name] a | semmle.label | [Name] a |
 | assignment.py:8:13:8:13 | [Name] b | semmle.label | [Name] b |
-| assignment.py:10:1:10:24 | (parameters) | semmle.label | (parameters) |
 | assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | semmle.label | [FunctionDef] nested_assignment = function nested_assignment(...) |
 | assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | semmle.order | 3 |
 | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.label | [FunctionExpr] function nested_assignment(...) |
 | assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.label | [Function] function nested_assignment(...) |
 | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.label | [Name] nested_assignment |
-| assignment.py:13:5:13:59 | (StmtList) body | semmle.label | (StmtList) body |
 | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.label | [AssignStmt]  |
 | assignment.py:13:6:13:21 | [Tuple]  | semmle.label | [Tuple]  |
 | assignment.py:13:7:13:8 | [Name] t1 | semmle.label | [Name] t1 |
@@ -72,8 +66,6 @@ nodes
 | carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | semmle.label | [Class] class ImplicitCarrier |
 | carrier.py:2:7:2:21 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
 | carrier.py:2:23:2:28 | [Name] object | semmle.label | [Name] object |
-| carrier.py:4:5:4:28 | (StmtList) body | semmle.label | (StmtList) body |
-| carrier.py:4:5:4:28 | (parameters) | semmle.label | (parameters) |
 | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.label | [FunctionDef] __init__ = function __init__(...) |
 | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.label | [FunctionExpr] function __init__(...) |
 | carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.label | [Function] function __init__(...) |
@@ -82,10 +74,8 @@ nodes
 | carrier.py:4:24:4:26 | [Parameter] arg | semmle.label | [Parameter] arg |
 | carrier.py:5:9:5:12 | [Name] self | semmle.label | [Name] self |
 | carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
-| carrier.py:5:9:5:23 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.label | [AssignStmt] self.attr = arg |
 | carrier.py:5:21:5:23 | [Name] arg | semmle.label | [Name] arg |
-| carrier.py:7:5:7:28 | (parameters) | semmle.label | (parameters) |
 | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.label | [FunctionDef] set_attr = function set_attr(...) |
 | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.label | [FunctionExpr] function set_attr(...) |
 | carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.label | [Function] function set_attr(...) |
@@ -94,37 +84,30 @@ nodes
 | carrier.py:7:24:7:26 | [Parameter] arg | semmle.label | [Parameter] arg |
 | carrier.py:8:9:8:12 | [Name] self | semmle.label | [Name] self |
 | carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
-| carrier.py:8:9:8:23 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.label | [AssignStmt] self.attr = arg |
 | carrier.py:8:21:8:23 | [Name] arg | semmle.label | [Name] arg |
-| carrier.py:10:5:10:23 | (parameters) | semmle.label | (parameters) |
 | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.label | [FunctionDef] get_attr = function get_attr(...) |
 | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.label | [FunctionExpr] function get_attr(...) |
 | carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.label | [Function] function get_attr(...) |
 | carrier.py:10:9:10:16 | [Name] get_attr | semmle.label | [Name] get_attr |
 | carrier.py:10:18:10:21 | [Parameter] self | semmle.label | [Parameter] self |
-| carrier.py:11:9:11:24 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.label | [Return] return self.attr |
 | carrier.py:11:16:11:19 | [Name] self | semmle.label | [Name] self |
 | carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.label | [Attribute] self.attr |
-| carrier.py:13:1:13:13 | (parameters) | semmle.label | (parameters) |
 | carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | semmle.label | [FunctionDef] hub = function hub(...) |
 | carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | semmle.order | 5 |
 | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.label | [FunctionExpr] function hub(...) |
 | carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.label | [Function] function hub(...) |
 | carrier.py:13:5:13:7 | [Name] hub | semmle.label | [Name] hub |
 | carrier.py:13:9:13:11 | [Parameter] arg | semmle.label | [Parameter] arg |
-| carrier.py:14:5:14:14 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:14:5:14:14 | [Return] return arg | semmle.label | [Return] return arg |
 | carrier.py:14:12:14:14 | [Name] arg | semmle.label | [Name] arg |
-| carrier.py:16:1:16:12 | (parameters) | semmle.label | (parameters) |
 | carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
 | carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 6 |
 | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
 | carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
 | carrier.py:16:5:16:9 | [Name] test1 | semmle.label | [Name] test1 |
 | carrier.py:17:5:17:5 | [Name] c | semmle.label | [Name] c |
-| carrier.py:17:5:17:31 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.label | [AssignStmt] c = ImplicitCarrier(SOURCE) |
 | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
 | carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.label | [Call] ImplicitCarrier(SOURCE) |
@@ -134,14 +117,12 @@ nodes
 | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
 | carrier.py:18:10:18:10 | [Name] c | semmle.label | [Name] c |
 | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.label | [Attribute] c.attr |
-| carrier.py:20:1:20:12 | (parameters) | semmle.label | (parameters) |
 | carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
 | carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 7 |
 | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
 | carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
 | carrier.py:20:5:20:9 | [Name] test2 | semmle.label | [Name] test2 |
 | carrier.py:21:5:21:5 | [Name] c | semmle.label | [Name] c |
-| carrier.py:21:5:21:28 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.label | [AssignStmt] c = TAINT_CARRIER_SOURCE |
 | carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.label | [Name] TAINT_CARRIER_SOURCE |
 | carrier.py:22:5:22:8 | [Name] SINK | semmle.label | [Name] SINK |
@@ -150,14 +131,12 @@ nodes
 | carrier.py:22:10:22:10 | [Name] c | semmle.label | [Name] c |
 | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.label | [Attribute] c.get_taint |
 | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.label | [Call] c.get_taint() |
-| carrier.py:24:1:24:12 | (parameters) | semmle.label | (parameters) |
 | carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
 | carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 8 |
 | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
 | carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
 | carrier.py:24:5:24:9 | [Name] test3 | semmle.label | [Name] test3 |
 | carrier.py:25:5:25:5 | [Name] c | semmle.label | [Name] c |
-| carrier.py:25:5:25:36 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.label | [AssignStmt] c = hub(...) |
 | carrier.py:25:9:25:11 | [Name] hub | semmle.label | [Name] hub |
 | carrier.py:25:9:25:36 | [Call] hub(...) | semmle.label | [Call] hub(...) |
@@ -170,14 +149,12 @@ nodes
 | carrier.py:26:10:26:10 | [Name] c | semmle.label | [Name] c |
 | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.label | [Attribute] c.get_attr |
 | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.label | [Call] c.get_attr() |
-| carrier.py:28:1:28:12 | (parameters) | semmle.label | (parameters) |
 | carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
 | carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 9 |
 | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
 | carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
 | carrier.py:28:5:28:9 | [Name] test4 | semmle.label | [Name] test4 |
 | carrier.py:29:5:29:5 | [Name] c | semmle.label | [Name] c |
-| carrier.py:29:5:29:33 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.label | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) |
 | carrier.py:29:9:29:11 | [Name] hub | semmle.label | [Name] hub |
 | carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.label | [Call] hub(TAINT_CARRIER_SOURCE) |
@@ -188,14 +165,12 @@ nodes
 | carrier.py:30:10:30:10 | [Name] c | semmle.label | [Name] c |
 | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.label | [Attribute] c.get_taint |
 | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.label | [Call] c.get_taint() |
-| carrier.py:32:1:32:12 | (parameters) | semmle.label | (parameters) |
 | carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
 | carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 10 |
 | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
 | carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
 | carrier.py:32:5:32:9 | [Name] test5 | semmle.label | [Name] test5 |
 | carrier.py:33:5:33:5 | [Name] c | semmle.label | [Name] c |
-| carrier.py:33:5:33:45 | (StmtList) body | semmle.label | (StmtList) body |
 | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) |
 | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.label | [Name] ImplicitCarrier |
 | carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) |
@@ -210,72 +185,60 @@ nodes
 | carrier.py:35:10:35:10 | [Name] x | semmle.label | [Name] x |
 | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.label | [Attribute] x.get_taint |
 | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.label | [Call] x.get_taint() |
-| deep.py:2:1:2:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | semmle.label | [FunctionDef] f1 = function f1(...) |
 | deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | semmle.order | 11 |
 | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.label | [FunctionExpr] function f1(...) |
 | deep.py:2:1:2:12 | [Function] function f1(...) | semmle.label | [Function] function f1(...) |
 | deep.py:2:5:2:6 | [Name] f1 | semmle.label | [Name] f1 |
 | deep.py:2:8:2:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:3:5:3:14 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:3:5:3:14 | [Return] return arg | semmle.label | [Return] return arg |
 | deep.py:3:12:3:14 | [Name] arg | semmle.label | [Name] arg |
-| deep.py:5:1:5:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | semmle.label | [FunctionDef] f2 = function f2(...) |
 | deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | semmle.order | 12 |
 | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.label | [FunctionExpr] function f2(...) |
 | deep.py:5:1:5:12 | [Function] function f2(...) | semmle.label | [Function] function f2(...) |
 | deep.py:5:5:5:6 | [Name] f2 | semmle.label | [Name] f2 |
 | deep.py:5:8:5:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:6:5:6:18 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.label | [Return] return f1(arg) |
 | deep.py:6:12:6:13 | [Name] f1 | semmle.label | [Name] f1 |
 | deep.py:6:12:6:18 | [Call] f1(arg) | semmle.label | [Call] f1(arg) |
 | deep.py:6:15:6:17 | [Name] arg | semmle.label | [Name] arg |
-| deep.py:8:1:8:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | semmle.label | [FunctionDef] f3 = function f3(...) |
 | deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | semmle.order | 13 |
 | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.label | [FunctionExpr] function f3(...) |
 | deep.py:8:1:8:12 | [Function] function f3(...) | semmle.label | [Function] function f3(...) |
 | deep.py:8:5:8:6 | [Name] f3 | semmle.label | [Name] f3 |
 | deep.py:8:8:8:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:9:5:9:18 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.label | [Return] return f2(arg) |
 | deep.py:9:12:9:13 | [Name] f2 | semmle.label | [Name] f2 |
 | deep.py:9:12:9:18 | [Call] f2(arg) | semmle.label | [Call] f2(arg) |
 | deep.py:9:15:9:17 | [Name] arg | semmle.label | [Name] arg |
-| deep.py:11:1:11:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | semmle.label | [FunctionDef] f4 = function f4(...) |
 | deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | semmle.order | 14 |
 | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.label | [FunctionExpr] function f4(...) |
 | deep.py:11:1:11:12 | [Function] function f4(...) | semmle.label | [Function] function f4(...) |
 | deep.py:11:5:11:6 | [Name] f4 | semmle.label | [Name] f4 |
 | deep.py:11:8:11:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:12:5:12:18 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.label | [Return] return f3(arg) |
 | deep.py:12:12:12:13 | [Name] f3 | semmle.label | [Name] f3 |
 | deep.py:12:12:12:18 | [Call] f3(arg) | semmle.label | [Call] f3(arg) |
 | deep.py:12:15:12:17 | [Name] arg | semmle.label | [Name] arg |
-| deep.py:14:1:14:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | semmle.label | [FunctionDef] f5 = function f5(...) |
 | deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | semmle.order | 15 |
 | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.label | [FunctionExpr] function f5(...) |
 | deep.py:14:1:14:12 | [Function] function f5(...) | semmle.label | [Function] function f5(...) |
 | deep.py:14:5:14:6 | [Name] f5 | semmle.label | [Name] f5 |
 | deep.py:14:8:14:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:15:5:15:18 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.label | [Return] return f4(arg) |
 | deep.py:15:12:15:13 | [Name] f4 | semmle.label | [Name] f4 |
 | deep.py:15:12:15:18 | [Call] f4(arg) | semmle.label | [Call] f4(arg) |
 | deep.py:15:15:15:17 | [Name] arg | semmle.label | [Name] arg |
-| deep.py:17:1:17:12 | (parameters) | semmle.label | (parameters) |
 | deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | semmle.label | [FunctionDef] f6 = function f6(...) |
 | deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | semmle.order | 16 |
 | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.label | [FunctionExpr] function f6(...) |
 | deep.py:17:1:17:12 | [Function] function f6(...) | semmle.label | [Function] function f6(...) |
 | deep.py:17:5:17:6 | [Name] f6 | semmle.label | [Name] f6 |
 | deep.py:17:8:17:10 | [Parameter] arg | semmle.label | [Parameter] arg |
-| deep.py:18:5:18:18 | (StmtList) body | semmle.label | (StmtList) body |
 | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.label | [Return] return f5(arg) |
 | deep.py:18:12:18:13 | [Name] f5 | semmle.label | [Name] f5 |
 | deep.py:18:12:18:18 | [Call] f5(arg) | semmle.label | [Call] f5(arg) |
@@ -289,6 +252,317 @@ nodes
 | deep.py:22:1:22:1 | [ExprStmt] x | semmle.label | [ExprStmt] x |
 | deep.py:22:1:22:1 | [ExprStmt] x | semmle.order | 18 |
 | deep.py:22:1:22:1 | [Name] x | semmle.label | [Name] x |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) body | semmle.label | (StmtList) body |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (StmtList) orelse | semmle.label | (StmtList) orelse |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (arguments) | semmle.label | (arguments) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
+| file://:0:0:0:0 | (parameters) | semmle.label | (parameters) |
 | module.py:3:1:3:9 | [Name] dangerous | semmle.label | [Name] dangerous |
 | module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | semmle.label | [AssignStmt] dangerous = SOURCE |
 | module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | semmle.order | 19 |
@@ -297,13 +571,11 @@ nodes
 | module.py:4:1:4:13 | [AssignStmt] safe = safe | semmle.label | [AssignStmt] safe = safe |
 | module.py:4:1:4:13 | [AssignStmt] safe = safe | semmle.order | 20 |
 | module.py:4:8:4:13 | [Str] safe | semmle.label | [Str] safe |
-| module.py:6:1:6:21 | (parameters) | semmle.label | (parameters) |
 | module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | semmle.label | [FunctionDef] dangerous_func = function dangerous_func(...) |
 | module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | semmle.order | 21 |
 | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.label | [FunctionExpr] function dangerous_func(...) |
 | module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.label | [Function] function dangerous_func(...) |
 | module.py:6:5:6:18 | [Name] dangerous_func | semmle.label | [Name] dangerous_func |
-| module.py:7:5:7:17 | (StmtList) body | semmle.label | (StmtList) body |
 | module.py:7:5:7:17 | [Return] return SOURCE | semmle.label | [Return] return SOURCE |
 | module.py:7:12:7:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | module.py:10:1:10:5 | [Name] safe2 | semmle.label | [Name] safe2 |
@@ -314,66 +586,54 @@ nodes
 | module.py:11:1:11:14 | [AssignStmt] safe2 = safe | semmle.label | [AssignStmt] safe2 = safe |
 | module.py:11:1:11:14 | [AssignStmt] safe2 = safe | semmle.order | 23 |
 | module.py:11:9:11:14 | [Str] safe | semmle.label | [Str] safe |
-| rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | semmle.label | [FunctionDef] rock = function rock(...) |
 | rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | semmle.order | 24 |
 | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.label | [FunctionExpr] function rock(...) |
 | rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.label | [Function] function rock(...) |
 | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.label | [Name] rock |
 | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.label | [Parameter] arg |
-| rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.label | [ExprStmt] SCISSORS are vulnerable |
 | rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.label | [Str] SCISSORS are vulnerable |
-| rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | semmle.label | [FunctionDef] paper = function paper(...) |
 | rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | semmle.order | 25 |
 | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.label | [FunctionExpr] function paper(...) |
 | rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.label | [Function] function paper(...) |
 | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.label | [Name] paper |
 | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.label | [Parameter] arg |
-| rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.label | [ExprStmt] ROCK is vulnerable |
 | rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.label | [Str] ROCK is vulnerable |
-| rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | semmle.label | [FunctionDef] scissors = function scissors(...) |
 | rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | semmle.order | 26 |
 | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.label | [FunctionExpr] function scissors(...) |
 | rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.label | [Function] function scissors(...) |
 | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.label | [Name] scissors |
 | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.label | [Parameter] arg |
-| rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.label | [ExprStmt] PAPER is vulnerable |
 | rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.label | [Str] PAPER is vulnerable |
-| rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
 | rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 27 |
 | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
 | rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
 | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.label | [Name] test1 |
 | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.label | [Name] rock |
-| rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.label | [Call] rock(SCISSORS) |
 | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.label | [ExprStmt] rock(SCISSORS) |
 | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.label | [Name] SCISSORS |
-| rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
 | rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 28 |
 | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
 | rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
 | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.label | [Name] test2 |
 | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.label | [Name] paper |
-| rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.label | [Call] paper(ROCK) |
 | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.label | [ExprStmt] paper(ROCK) |
 | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.label | [Name] ROCK |
-| rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
 | rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 29 |
 | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
 | rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
 | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.label | [Name] test3 |
 | rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.label | [Name] x |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.label | [AssignStmt] x = ROCK |
 | rockpaperscissors.py:19:9:19:12 | [Name] ROCK | semmle.label | [Name] ROCK |
 | rockpaperscissors.py:20:5:20:5 | [Name] y | semmle.label | [Name] y |
@@ -385,14 +645,12 @@ nodes
 | rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.label | [Call] scissors(y) |
 | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.label | [ExprStmt] scissors(y) |
 | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.label | [Name] y |
-| rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
 | rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 30 |
 | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
 | rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
 | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.label | [Name] test4 |
 | rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.label | [Name] x |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.label | [AssignStmt] x = ROCK |
 | rockpaperscissors.py:24:9:24:12 | [Name] ROCK | semmle.label | [Name] ROCK |
 | rockpaperscissors.py:25:5:25:5 | [Name] y | semmle.label | [Name] y |
@@ -406,14 +664,12 @@ nodes
 | rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.label | [Call] scissors(y) |
 | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.label | [ExprStmt] scissors(y) |
 | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.label | [Name] y |
-| rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.label | (parameters) |
 | rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
 | rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 31 |
 | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
 | rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
 | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.label | [Name] test5 |
 | rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.label | [Name] x |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.label | (StmtList) body |
 | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.label | [AssignStmt] x = SCISSORS |
 | rockpaperscissors.py:29:9:29:16 | [Name] SCISSORS | semmle.label | [Name] SCISSORS |
 | rockpaperscissors.py:30:5:30:5 | [Name] y | semmle.label | [Name] y |
@@ -429,32 +685,26 @@ nodes
 | rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.label | [Call] paper(y) |
 | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.label | [ExprStmt] paper(y) |
 | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.label | [Name] y |
-| sanitizer.py:3:1:3:22 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | semmle.label | [FunctionDef] isEscapedSql = function isEscapedSql(...) |
 | sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | semmle.order | 32 |
 | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.label | [FunctionExpr] function isEscapedSql(...) |
 | sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.label | [Function] function isEscapedSql(...) |
 | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.label | [Name] isEscapedSql |
 | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.label | [Parameter] arg |
-| sanitizer.py:3:24:3:27 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.label | [Pass] pass |
-| sanitizer.py:5:1:5:24 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | semmle.label | [FunctionDef] isValidCommand = function isValidCommand(...) |
 | sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | semmle.order | 33 |
 | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.label | [FunctionExpr] function isValidCommand(...) |
 | sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.label | [Function] function isValidCommand(...) |
 | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.label | [Name] isValidCommand |
 | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.label | [Parameter] arg |
-| sanitizer.py:5:26:5:29 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.label | [Pass] pass |
-| sanitizer.py:8:1:8:18 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | semmle.label | [FunctionDef] sql_inject1 = function sql_inject1(...) |
 | sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | semmle.order | 34 |
 | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.label | [FunctionExpr] function sql_inject1(...) |
 | sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.label | [Function] function sql_inject1(...) |
 | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.label | [Name] sql_inject1 |
 | sanitizer.py:9:5:9:5 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:9:5:9:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
 | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.label | [Name] user_input |
 | sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.label | [Call] user_input() |
@@ -463,23 +713,19 @@ nodes
 | sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.label | [Call] isEscapedSql(x) |
 | sanitizer.py:10:21:10:21 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.label | [Name] sql_query |
-| sanitizer.py:11:9:11:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
 | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
 | sanitizer.py:11:19:11:19 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.label | [Name] sql_query |
-| sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
 | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
 | sanitizer.py:13:19:13:19 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:15:1:15:22 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | semmle.label | [FunctionDef] command_inject1 = function command_inject1(...) |
 | sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | semmle.order | 35 |
 | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.label | [FunctionExpr] function command_inject1(...) |
 | sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.label | [Function] function command_inject1(...) |
 | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.label | [Name] command_inject1 |
 | sanitizer.py:16:5:16:5 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:16:5:16:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
 | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.label | [Name] user_input |
 | sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.label | [Call] user_input() |
@@ -488,23 +734,19 @@ nodes
 | sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.label | [Call] isValidCommand(x) |
 | sanitizer.py:17:23:17:23 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.label | [Name] os_command |
-| sanitizer.py:18:9:18:21 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
 | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
 | sanitizer.py:18:20:18:20 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.label | [Name] os_command |
-| sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
 | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
 | sanitizer.py:20:20:20:20 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:23:1:23:18 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | semmle.label | [FunctionDef] sql_inject2 = function sql_inject2(...) |
 | sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | semmle.order | 36 |
 | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.label | [FunctionExpr] function sql_inject2(...) |
 | sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.label | [Function] function sql_inject2(...) |
 | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.label | [Name] sql_inject2 |
 | sanitizer.py:24:5:24:5 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:24:5:24:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
 | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.label | [Name] user_input |
 | sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.label | [Call] user_input() |
@@ -513,23 +755,19 @@ nodes
 | sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.label | [Call] notASanitizer(x) |
 | sanitizer.py:25:22:25:22 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.label | [Name] sql_query |
-| sanitizer.py:26:9:26:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
 | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
 | sanitizer.py:26:19:26:19 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.label | [Name] sql_query |
-| sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.label | [Call] sql_query(x) |
 | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.label | [ExprStmt] sql_query(x) |
 | sanitizer.py:28:19:28:19 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:30:1:30:22 | (parameters) | semmle.label | (parameters) |
 | sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | semmle.label | [FunctionDef] command_inject2 = function command_inject2(...) |
 | sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | semmle.order | 37 |
 | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.label | [FunctionExpr] function command_inject2(...) |
 | sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.label | [Function] function command_inject2(...) |
 | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.label | [Name] command_inject2 |
 | sanitizer.py:31:5:31:5 | [Name] x | semmle.label | [Name] x |
-| sanitizer.py:31:5:31:20 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.label | [AssignStmt] x = user_input() |
 | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.label | [Name] user_input |
 | sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.label | [Call] user_input() |
@@ -538,50 +776,41 @@ nodes
 | sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.label | [Call] notASanitizer(x) |
 | sanitizer.py:32:22:32:22 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.label | [Name] os_command |
-| sanitizer.py:33:9:33:21 | (StmtList) body | semmle.label | (StmtList) body |
 | sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
 | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
 | sanitizer.py:33:20:33:20 | [Name] x | semmle.label | [Name] x |
 | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.label | [Name] os_command |
-| sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.label | [Call] os_command(x) |
 | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.label | [ExprStmt] os_command(x) |
 | sanitizer.py:35:20:35:20 | [Name] x | semmle.label | [Name] x |
-| test.py:2:1:2:12 | (parameters) | semmle.label | (parameters) |
 | test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | semmle.label | [FunctionDef] test1 = function test1(...) |
 | test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | semmle.order | 38 |
 | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.label | [FunctionExpr] function test1(...) |
 | test.py:2:1:2:12 | [Function] function test1(...) | semmle.label | [Function] function test1(...) |
 | test.py:2:5:2:9 | [Name] test1 | semmle.label | [Name] test1 |
 | test.py:3:5:3:8 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:3:5:3:16 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.label | [Call] SINK(SOURCE) |
 | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.label | [ExprStmt] SINK(SOURCE) |
 | test.py:3:10:3:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
-| test.py:5:1:5:12 | (parameters) | semmle.label | (parameters) |
 | test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | semmle.label | [FunctionDef] test2 = function test2(...) |
 | test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | semmle.order | 39 |
 | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.label | [FunctionExpr] function test2(...) |
 | test.py:5:1:5:12 | [Function] function test2(...) | semmle.label | [Function] function test2(...) |
 | test.py:5:5:5:9 | [Name] test2 | semmle.label | [Name] test2 |
 | test.py:6:5:6:5 | [Name] s | semmle.label | [Name] s |
-| test.py:6:5:6:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.label | [AssignStmt] s = SOURCE |
 | test.py:6:9:6:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:7:5:7:8 | [Name] SINK | semmle.label | [Name] SINK |
 | test.py:7:5:7:11 | [Call] SINK(s) | semmle.label | [Call] SINK(s) |
 | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.label | [ExprStmt] SINK(s) |
 | test.py:7:10:7:10 | [Name] s | semmle.label | [Name] s |
-| test.py:9:1:9:13 | (parameters) | semmle.label | (parameters) |
 | test.py:9:1:9:13 | [FunctionDef] source = function source(...) | semmle.label | [FunctionDef] source = function source(...) |
 | test.py:9:1:9:13 | [FunctionDef] source = function source(...) | semmle.order | 40 |
 | test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.label | [FunctionExpr] function source(...) |
 | test.py:9:1:9:13 | [Function] function source(...) | semmle.label | [Function] function source(...) |
 | test.py:9:5:9:10 | [Name] source | semmle.label | [Name] source |
-| test.py:10:5:10:17 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:10:5:10:17 | [Return] return SOURCE | semmle.label | [Return] return SOURCE |
 | test.py:10:12:10:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
-| test.py:12:1:12:14 | (parameters) | semmle.label | (parameters) |
 | test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | semmle.label | [FunctionDef] sink = function sink(...) |
 | test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | semmle.order | 41 |
 | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.label | [FunctionExpr] function sink(...) |
@@ -589,18 +818,15 @@ nodes
 | test.py:12:5:12:8 | [Name] sink | semmle.label | [Name] sink |
 | test.py:12:10:12:12 | [Parameter] arg | semmle.label | [Parameter] arg |
 | test.py:13:5:13:8 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:13:5:13:13 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:13:5:13:13 | [Call] SINK(arg) | semmle.label | [Call] SINK(arg) |
 | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.label | [ExprStmt] SINK(arg) |
 | test.py:13:10:13:12 | [Name] arg | semmle.label | [Name] arg |
-| test.py:15:1:15:12 | (parameters) | semmle.label | (parameters) |
 | test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | semmle.label | [FunctionDef] test3 = function test3(...) |
 | test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | semmle.order | 42 |
 | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.label | [FunctionExpr] function test3(...) |
 | test.py:15:1:15:12 | [Function] function test3(...) | semmle.label | [Function] function test3(...) |
 | test.py:15:5:15:9 | [Name] test3 | semmle.label | [Name] test3 |
 | test.py:16:5:16:5 | [Name] t | semmle.label | [Name] t |
-| test.py:16:5:16:16 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.label | [AssignStmt] t = source() |
 | test.py:16:9:16:14 | [Name] source | semmle.label | [Name] source |
 | test.py:16:9:16:16 | [Call] source() | semmle.label | [Call] source() |
@@ -608,28 +834,24 @@ nodes
 | test.py:17:5:17:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:17:10:17:10 | [Name] t | semmle.label | [Name] t |
-| test.py:19:1:19:12 | (parameters) | semmle.label | (parameters) |
 | test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | semmle.label | [FunctionDef] test4 = function test4(...) |
 | test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | semmle.order | 43 |
 | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.label | [FunctionExpr] function test4(...) |
 | test.py:19:1:19:12 | [Function] function test4(...) | semmle.label | [Function] function test4(...) |
 | test.py:19:5:19:9 | [Name] test4 | semmle.label | [Name] test4 |
 | test.py:20:5:20:5 | [Name] t | semmle.label | [Name] t |
-| test.py:20:5:20:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:20:9:20:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:21:5:21:8 | [Name] sink | semmle.label | [Name] sink |
 | test.py:21:5:21:11 | [Call] sink(t) | semmle.label | [Call] sink(t) |
 | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.label | [ExprStmt] sink(t) |
 | test.py:21:10:21:10 | [Name] t | semmle.label | [Name] t |
-| test.py:23:1:23:12 | (parameters) | semmle.label | (parameters) |
 | test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | semmle.label | [FunctionDef] test5 = function test5(...) |
 | test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | semmle.order | 44 |
 | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.label | [FunctionExpr] function test5(...) |
 | test.py:23:1:23:12 | [Function] function test5(...) | semmle.label | [Function] function test5(...) |
 | test.py:23:5:23:9 | [Name] test5 | semmle.label | [Name] test5 |
 | test.py:24:5:24:5 | [Name] t | semmle.label | [Name] t |
-| test.py:24:5:24:16 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.label | [AssignStmt] t = source() |
 | test.py:24:9:24:14 | [Name] source | semmle.label | [Name] source |
 | test.py:24:9:24:16 | [Call] source() | semmle.label | [Call] source() |
@@ -637,69 +859,56 @@ nodes
 | test.py:25:5:25:11 | [Call] sink(t) | semmle.label | [Call] sink(t) |
 | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.label | [ExprStmt] sink(t) |
 | test.py:25:10:25:10 | [Name] t | semmle.label | [Name] t |
-| test.py:27:1:27:16 | (parameters) | semmle.label | (parameters) |
 | test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | semmle.label | [FunctionDef] test6 = function test6(...) |
 | test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | semmle.order | 45 |
 | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.label | [FunctionExpr] function test6(...) |
 | test.py:27:1:27:16 | [Function] function test6(...) | semmle.label | [Function] function test6(...) |
 | test.py:27:5:27:9 | [Name] test6 | semmle.label | [Name] test6 |
 | test.py:27:11:27:14 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:28:5:28:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:28:5:28:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:28:8:28:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:29:9:29:9 | [Name] t | semmle.label | [Name] t |
-| test.py:29:9:29:18 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
 | test.py:29:13:29:18 | [Str] Safe | semmle.label | [Str] Safe |
 | test.py:31:9:31:9 | [Name] t | semmle.label | [Name] t |
-| test.py:31:9:31:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:31:13:31:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:32:5:32:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:32:8:32:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:33:9:33:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:33:9:33:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:33:9:33:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:33:14:33:14 | [Name] t | semmle.label | [Name] t |
-| test.py:35:1:35:16 | (parameters) | semmle.label | (parameters) |
 | test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | semmle.label | [FunctionDef] test7 = function test7(...) |
 | test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | semmle.order | 46 |
 | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.label | [FunctionExpr] function test7(...) |
 | test.py:35:1:35:16 | [Function] function test7(...) | semmle.label | [Function] function test7(...) |
 | test.py:35:5:35:9 | [Name] test7 | semmle.label | [Name] test7 |
 | test.py:35:11:35:14 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:36:5:36:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:36:5:36:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:36:8:36:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:37:9:37:9 | [Name] t | semmle.label | [Name] t |
-| test.py:37:9:37:18 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:37:13:37:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:39:9:39:9 | [Name] t | semmle.label | [Name] t |
-| test.py:39:9:39:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
 | test.py:39:13:39:18 | [Str] Safe | semmle.label | [Str] Safe |
 | test.py:40:5:40:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:40:8:40:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:41:9:41:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:41:9:41:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:41:9:41:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:41:14:41:14 | [Name] t | semmle.label | [Name] t |
-| test.py:43:1:43:17 | (parameters) | semmle.label | (parameters) |
 | test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | semmle.label | [FunctionDef] source2 = function source2(...) |
 | test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | semmle.order | 47 |
 | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.label | [FunctionExpr] function source2(...) |
 | test.py:43:1:43:17 | [Function] function source2(...) | semmle.label | [Function] function source2(...) |
 | test.py:43:5:43:11 | [Name] source2 | semmle.label | [Name] source2 |
 | test.py:43:13:43:15 | [Parameter] arg | semmle.label | [Parameter] arg |
-| test.py:44:5:44:22 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:44:5:44:22 | [Return] return source(arg) | semmle.label | [Return] return source(arg) |
 | test.py:44:12:44:17 | [Name] source | semmle.label | [Name] source |
 | test.py:44:12:44:22 | [Call] source(arg) | semmle.label | [Call] source(arg) |
 | test.py:44:19:44:21 | [Name] arg | semmle.label | [Name] arg |
-| test.py:46:1:46:15 | (parameters) | semmle.label | (parameters) |
 | test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | semmle.label | [FunctionDef] sink2 = function sink2(...) |
 | test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | semmle.order | 48 |
 | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.label | [FunctionExpr] function sink2(...) |
@@ -707,11 +916,9 @@ nodes
 | test.py:46:5:46:9 | [Name] sink2 | semmle.label | [Name] sink2 |
 | test.py:46:11:46:13 | [Parameter] arg | semmle.label | [Parameter] arg |
 | test.py:47:5:47:8 | [Name] sink | semmle.label | [Name] sink |
-| test.py:47:5:47:13 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:47:5:47:13 | [Call] sink(arg) | semmle.label | [Call] sink(arg) |
 | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.label | [ExprStmt] sink(arg) |
 | test.py:47:10:47:12 | [Name] arg | semmle.label | [Name] arg |
-| test.py:49:1:49:21 | (parameters) | semmle.label | (parameters) |
 | test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | semmle.label | [FunctionDef] sink3 = function sink3(...) |
 | test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | semmle.order | 49 |
 | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.label | [FunctionExpr] function sink3(...) |
@@ -719,15 +926,12 @@ nodes
 | test.py:49:5:49:9 | [Name] sink3 | semmle.label | [Name] sink3 |
 | test.py:49:11:49:14 | [Parameter] cond | semmle.label | [Parameter] cond |
 | test.py:49:17:49:19 | [Parameter] arg | semmle.label | [Parameter] arg |
-| test.py:50:5:50:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:50:5:50:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:50:8:50:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:51:9:51:12 | [Name] sink | semmle.label | [Name] sink |
-| test.py:51:9:51:17 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:51:9:51:17 | [Call] sink(arg) | semmle.label | [Call] sink(arg) |
 | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.label | [ExprStmt] sink(arg) |
 | test.py:51:14:51:16 | [Name] arg | semmle.label | [Name] arg |
-| test.py:53:1:53:16 | (parameters) | semmle.label | (parameters) |
 | test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | semmle.label | [FunctionDef] test8 = function test8(...) |
 | test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | semmle.order | 50 |
 | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.label | [FunctionExpr] function test8(...) |
@@ -735,7 +939,6 @@ nodes
 | test.py:53:5:53:9 | [Name] test8 | semmle.label | [Name] test8 |
 | test.py:53:11:53:14 | [Parameter] cond | semmle.label | [Parameter] cond |
 | test.py:54:5:54:5 | [Name] t | semmle.label | [Name] t |
-| test.py:54:5:54:17 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.label | [AssignStmt] t = source2() |
 | test.py:54:9:54:15 | [Name] source2 | semmle.label | [Name] source2 |
 | test.py:54:9:54:17 | [Call] source2() | semmle.label | [Call] source2() |
@@ -743,22 +946,18 @@ nodes
 | test.py:55:5:55:12 | [Call] sink2(t) | semmle.label | [Call] sink2(t) |
 | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.label | [ExprStmt] sink2(t) |
 | test.py:55:11:55:11 | [Name] t | semmle.label | [Name] t |
-| test.py:58:1:58:16 | (parameters) | semmle.label | (parameters) |
 | test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | semmle.label | [FunctionDef] test9 = function test9(...) |
 | test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | semmle.order | 51 |
 | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.label | [FunctionExpr] function test9(...) |
 | test.py:58:1:58:16 | [Function] function test9(...) | semmle.label | [Function] function test9(...) |
 | test.py:58:5:58:9 | [Name] test9 | semmle.label | [Name] test9 |
 | test.py:58:11:58:14 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:59:5:59:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:59:5:59:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:59:8:59:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:60:9:60:9 | [Name] t | semmle.label | [Name] t |
-| test.py:60:9:60:19 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
 | test.py:60:14:60:19 | [Str] Safe | semmle.label | [Str] Safe |
 | test.py:62:9:62:9 | [Name] t | semmle.label | [Name] t |
-| test.py:62:9:62:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:62:13:62:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:63:5:63:9 | [Name] sink3 | semmle.label | [Name] sink3 |
@@ -766,22 +965,18 @@ nodes
 | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.label | [ExprStmt] sink3(cond, t) |
 | test.py:63:11:63:14 | [Name] cond | semmle.label | [Name] cond |
 | test.py:63:17:63:17 | [Name] t | semmle.label | [Name] t |
-| test.py:65:1:65:17 | (parameters) | semmle.label | (parameters) |
 | test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | semmle.label | [FunctionDef] test10 = function test10(...) |
 | test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | semmle.order | 52 |
 | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.label | [FunctionExpr] function test10(...) |
 | test.py:65:1:65:17 | [Function] function test10(...) | semmle.label | [Function] function test10(...) |
 | test.py:65:5:65:10 | [Name] test10 | semmle.label | [Name] test10 |
 | test.py:65:12:65:15 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:66:5:66:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:66:5:66:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:66:8:66:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:67:9:67:9 | [Name] t | semmle.label | [Name] t |
-| test.py:67:9:67:18 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:67:13:67:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:69:9:69:9 | [Name] t | semmle.label | [Name] t |
-| test.py:69:9:69:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.label | [AssignStmt] t = Safe |
 | test.py:69:13:69:18 | [Str] Safe | semmle.label | [Str] Safe |
 | test.py:70:5:70:9 | [Name] sink3 | semmle.label | [Name] sink3 |
@@ -789,24 +984,20 @@ nodes
 | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.label | [ExprStmt] sink3(cond, t) |
 | test.py:70:11:70:14 | [Name] cond | semmle.label | [Name] cond |
 | test.py:70:17:70:17 | [Name] t | semmle.label | [Name] t |
-| test.py:72:1:72:13 | (parameters) | semmle.label | (parameters) |
 | test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | semmle.label | [FunctionDef] hub = function hub(...) |
 | test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | semmle.order | 53 |
 | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.label | [FunctionExpr] function hub(...) |
 | test.py:72:1:72:13 | [Function] function hub(...) | semmle.label | [Function] function hub(...) |
 | test.py:72:5:72:7 | [Name] hub | semmle.label | [Name] hub |
 | test.py:72:9:72:11 | [Parameter] arg | semmle.label | [Parameter] arg |
-| test.py:73:5:73:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:73:5:73:14 | [Return] return arg | semmle.label | [Return] return arg |
 | test.py:73:12:73:14 | [Name] arg | semmle.label | [Name] arg |
-| test.py:75:1:75:13 | (parameters) | semmle.label | (parameters) |
 | test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | semmle.label | [FunctionDef] test11 = function test11(...) |
 | test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | semmle.order | 54 |
 | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.label | [FunctionExpr] function test11(...) |
 | test.py:75:1:75:13 | [Function] function test11(...) | semmle.label | [Function] function test11(...) |
 | test.py:75:5:75:10 | [Name] test11 | semmle.label | [Name] test11 |
 | test.py:76:5:76:5 | [Name] t | semmle.label | [Name] t |
-| test.py:76:5:76:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:76:9:76:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:77:5:77:5 | [Name] t | semmle.label | [Name] t |
@@ -818,14 +1009,12 @@ nodes
 | test.py:78:5:78:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:78:10:78:10 | [Name] t | semmle.label | [Name] t |
-| test.py:80:1:80:13 | (parameters) | semmle.label | (parameters) |
 | test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | semmle.label | [FunctionDef] test12 = function test12(...) |
 | test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | semmle.order | 55 |
 | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.label | [FunctionExpr] function test12(...) |
 | test.py:80:1:80:13 | [Function] function test12(...) | semmle.label | [Function] function test12(...) |
 | test.py:80:5:80:10 | [Name] test12 | semmle.label | [Name] test12 |
 | test.py:81:5:81:5 | [Name] t | semmle.label | [Name] t |
-| test.py:81:5:81:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.label | [AssignStmt] t = safe |
 | test.py:81:9:81:14 | [Str] safe | semmle.label | [Str] safe |
 | test.py:82:5:82:5 | [Name] t | semmle.label | [Name] t |
@@ -841,14 +1030,12 @@ nodes
 | test.py:85:1:85:13 | [Import] import module | semmle.order | 56 |
 | test.py:85:8:85:13 | [ImportExpr]  | semmle.label | [ImportExpr]  |
 | test.py:85:8:85:13 | [Name] module | semmle.label | [Name] module |
-| test.py:87:1:87:13 | (parameters) | semmle.label | (parameters) |
 | test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | semmle.label | [FunctionDef] test13 = function test13(...) |
 | test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | semmle.order | 57 |
 | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.label | [FunctionExpr] function test13(...) |
 | test.py:87:1:87:13 | [Function] function test13(...) | semmle.label | [Function] function test13(...) |
 | test.py:87:5:87:10 | [Name] test13 | semmle.label | [Name] test13 |
 | test.py:88:5:88:5 | [Name] t | semmle.label | [Name] t |
-| test.py:88:5:88:24 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.label | [AssignStmt] t = module.dangerous |
 | test.py:88:9:88:14 | [Name] module | semmle.label | [Name] module |
 | test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.label | [Attribute] module.dangerous |
@@ -856,14 +1043,12 @@ nodes
 | test.py:89:5:89:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:89:10:89:10 | [Name] t | semmle.label | [Name] t |
-| test.py:91:1:91:13 | (parameters) | semmle.label | (parameters) |
 | test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | semmle.label | [FunctionDef] test14 = function test14(...) |
 | test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | semmle.order | 58 |
 | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.label | [FunctionExpr] function test14(...) |
 | test.py:91:1:91:13 | [Function] function test14(...) | semmle.label | [Function] function test14(...) |
 | test.py:91:5:91:10 | [Name] test14 | semmle.label | [Name] test14 |
 | test.py:92:5:92:5 | [Name] t | semmle.label | [Name] t |
-| test.py:92:5:92:19 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.label | [AssignStmt] t = module.safe |
 | test.py:92:9:92:14 | [Name] module | semmle.label | [Name] module |
 | test.py:92:9:92:19 | [Attribute] module.safe | semmle.label | [Attribute] module.safe |
@@ -871,14 +1056,12 @@ nodes
 | test.py:93:5:93:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:93:10:93:10 | [Name] t | semmle.label | [Name] t |
-| test.py:95:1:95:13 | (parameters) | semmle.label | (parameters) |
 | test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | semmle.label | [FunctionDef] test15 = function test15(...) |
 | test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | semmle.order | 59 |
 | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.label | [FunctionExpr] function test15(...) |
 | test.py:95:1:95:13 | [Function] function test15(...) | semmle.label | [Function] function test15(...) |
 | test.py:95:5:95:10 | [Name] test15 | semmle.label | [Name] test15 |
 | test.py:96:5:96:5 | [Name] t | semmle.label | [Name] t |
-| test.py:96:5:96:20 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.label | [AssignStmt] t = module.safe2 |
 | test.py:96:9:96:14 | [Name] module | semmle.label | [Name] module |
 | test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.label | [Attribute] module.safe2 |
@@ -886,14 +1069,12 @@ nodes
 | test.py:97:5:97:11 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:97:10:97:10 | [Name] t | semmle.label | [Name] t |
-| test.py:99:1:99:13 | (parameters) | semmle.label | (parameters) |
 | test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | semmle.label | [FunctionDef] test16 = function test16(...) |
 | test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | semmle.order | 60 |
 | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.label | [FunctionExpr] function test16(...) |
 | test.py:99:1:99:13 | [Function] function test16(...) | semmle.label | [Function] function test16(...) |
 | test.py:99:5:99:10 | [Name] test16 | semmle.label | [Name] test16 |
 | test.py:100:5:100:5 | [Name] t | semmle.label | [Name] t |
-| test.py:100:5:100:31 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.label | [AssignStmt] t = module.dangerous_func() |
 | test.py:100:9:100:14 | [Name] module | semmle.label | [Name] module |
 | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.label | [Attribute] module.dangerous_func |
@@ -908,9 +1089,7 @@ nodes
 | test.py:103:1:103:16 | [Class] class C | semmle.label | [Class] class C |
 | test.py:103:7:103:7 | [Name] C | semmle.label | [Name] C |
 | test.py:103:9:103:14 | [Name] object | semmle.label | [Name] object |
-| test.py:103:18:103:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:103:18:103:21 | [Pass] pass | semmle.label | [Pass] pass |
-| test.py:105:1:105:16 | (parameters) | semmle.label | (parameters) |
 | test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | semmle.label | [FunctionDef] x_sink = function x_sink(...) |
 | test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | semmle.order | 62 |
 | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.label | [FunctionExpr] function x_sink(...) |
@@ -918,19 +1097,16 @@ nodes
 | test.py:105:5:105:10 | [Name] x_sink | semmle.label | [Name] x_sink |
 | test.py:105:12:105:14 | [Parameter] arg | semmle.label | [Parameter] arg |
 | test.py:106:5:106:8 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:106:5:106:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:106:5:106:15 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
 | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
 | test.py:106:10:106:12 | [Name] arg | semmle.label | [Name] arg |
 | test.py:106:10:106:14 | [Attribute] arg.x | semmle.label | [Attribute] arg.x |
-| test.py:108:1:108:13 | (parameters) | semmle.label | (parameters) |
 | test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | semmle.label | [FunctionDef] test17 = function test17(...) |
 | test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | semmle.order | 63 |
 | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.label | [FunctionExpr] function test17(...) |
 | test.py:108:1:108:13 | [Function] function test17(...) | semmle.label | [Function] function test17(...) |
 | test.py:108:5:108:10 | [Name] test17 | semmle.label | [Name] test17 |
 | test.py:109:5:109:5 | [Name] t | semmle.label | [Name] t |
-| test.py:109:5:109:11 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.label | [AssignStmt] t = C() |
 | test.py:109:9:109:9 | [Name] C | semmle.label | [Name] C |
 | test.py:109:9:109:11 | [Call] C() | semmle.label | [Call] C() |
@@ -944,14 +1120,12 @@ nodes
 | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
 | test.py:111:10:111:10 | [Name] t | semmle.label | [Name] t |
 | test.py:111:10:111:12 | [Attribute] t.x | semmle.label | [Attribute] t.x |
-| test.py:113:1:113:13 | (parameters) | semmle.label | (parameters) |
 | test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | semmle.label | [FunctionDef] test18 = function test18(...) |
 | test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | semmle.order | 64 |
 | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.label | [FunctionExpr] function test18(...) |
 | test.py:113:1:113:13 | [Function] function test18(...) | semmle.label | [Function] function test18(...) |
 | test.py:113:5:113:10 | [Name] test18 | semmle.label | [Name] test18 |
 | test.py:114:5:114:5 | [Name] t | semmle.label | [Name] t |
-| test.py:114:5:114:11 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.label | [AssignStmt] t = C() |
 | test.py:114:9:114:9 | [Name] C | semmle.label | [Name] C |
 | test.py:114:9:114:11 | [Call] C() | semmle.label | [Call] C() |
@@ -969,14 +1143,12 @@ nodes
 | test.py:117:5:117:13 | [Call] x_sink(t) | semmle.label | [Call] x_sink(t) |
 | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.label | [ExprStmt] x_sink(t) |
 | test.py:117:12:117:12 | [Name] t | semmle.label | [Name] t |
-| test.py:119:1:119:13 | (parameters) | semmle.label | (parameters) |
 | test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | semmle.label | [FunctionDef] test19 = function test19(...) |
 | test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | semmle.order | 65 |
 | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.label | [FunctionExpr] function test19(...) |
 | test.py:119:1:119:13 | [Function] function test19(...) | semmle.label | [Function] function test19(...) |
 | test.py:119:5:119:10 | [Name] test19 | semmle.label | [Name] test19 |
 | test.py:120:5:120:5 | [Name] t | semmle.label | [Name] t |
-| test.py:120:5:120:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
 | test.py:120:9:120:21 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
 | test.py:121:5:121:5 | [Name] t | semmle.label | [Name] t |
@@ -990,83 +1162,67 @@ nodes
 | test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
 | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
 | test.py:122:17:122:17 | [Name] t | semmle.label | [Name] t |
-| test.py:124:1:124:17 | (parameters) | semmle.label | (parameters) |
 | test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | semmle.label | [FunctionDef] test20 = function test20(...) |
 | test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | semmle.order | 66 |
 | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.label | [FunctionExpr] function test20(...) |
 | test.py:124:1:124:17 | [Function] function test20(...) | semmle.label | [Function] function test20(...) |
 | test.py:124:5:124:10 | [Name] test20 | semmle.label | [Name] test20 |
 | test.py:124:12:124:15 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:125:5:125:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:125:5:125:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:125:8:125:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:126:9:126:9 | [Name] t | semmle.label | [Name] t |
-| test.py:126:9:126:25 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
 | test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
 | test.py:128:9:128:9 | [Name] t | semmle.label | [Name] t |
-| test.py:128:9:128:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:128:13:128:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:129:5:129:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:129:8:129:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
-| test.py:130:9:130:22 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
 | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
 | test.py:130:21:130:21 | [Name] t | semmle.label | [Name] t |
 | test.py:132:9:132:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:132:9:132:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:132:9:132:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:132:14:132:14 | [Name] t | semmle.label | [Name] t |
-| test.py:134:1:134:17 | (parameters) | semmle.label | (parameters) |
 | test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | semmle.label | [FunctionDef] test21 = function test21(...) |
 | test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | semmle.order | 67 |
 | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.label | [FunctionExpr] function test21(...) |
 | test.py:134:1:134:17 | [Function] function test21(...) | semmle.label | [Function] function test21(...) |
 | test.py:134:5:134:10 | [Name] test21 | semmle.label | [Name] test21 |
 | test.py:134:12:134:15 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:135:5:135:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:135:5:135:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:135:8:135:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:136:9:136:9 | [Name] t | semmle.label | [Name] t |
-| test.py:136:9:136:25 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
 | test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
 | test.py:138:9:138:9 | [Name] t | semmle.label | [Name] t |
-| test.py:138:9:138:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:138:13:138:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:139:5:139:16 | [If]  | semmle.label | [If]  |
 | test.py:139:8:139:15 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
 | test.py:139:12:139:15 | [Name] cond | semmle.label | [Name] cond |
 | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
-| test.py:140:9:140:22 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
 | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
 | test.py:140:21:140:21 | [Name] t | semmle.label | [Name] t |
 | test.py:142:9:142:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:142:9:142:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:142:9:142:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:142:14:142:14 | [Name] t | semmle.label | [Name] t |
-| test.py:144:1:144:17 | (parameters) | semmle.label | (parameters) |
 | test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | semmle.label | [FunctionDef] test22 = function test22(...) |
 | test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | semmle.order | 68 |
 | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.label | [FunctionExpr] function test22(...) |
 | test.py:144:1:144:17 | [Function] function test22(...) | semmle.label | [Function] function test22(...) |
 | test.py:144:5:144:10 | [Name] test22 | semmle.label | [Name] test22 |
 | test.py:144:12:144:15 | [Parameter] cond | semmle.label | [Parameter] cond |
-| test.py:145:5:145:12 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:145:5:145:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:145:8:145:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:146:9:146:9 | [Name] t | semmle.label | [Name] t |
-| test.py:146:9:146:25 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | [AssignStmt] t = CUSTOM_SOURCE |
 | test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.label | [Name] CUSTOM_SOURCE |
 | test.py:148:9:148:9 | [Name] t | semmle.label | [Name] t |
-| test.py:148:9:148:18 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:148:13:148:18 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:149:5:149:5 | [Name] t | semmle.label | [Name] t |
@@ -1077,12 +1233,10 @@ nodes
 | test.py:150:5:150:12 | [If] if cond: | semmle.label | [If] if cond: |
 | test.py:150:8:150:11 | [Name] cond | semmle.label | [Name] cond |
 | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.label | [Name] CUSTOM_SINK |
-| test.py:151:9:151:22 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.label | [Call] CUSTOM_SINK(t) |
 | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | [ExprStmt] CUSTOM_SINK(t) |
 | test.py:151:21:151:21 | [Name] t | semmle.label | [Name] t |
 | test.py:153:9:153:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:153:9:153:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:153:9:153:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:153:14:153:14 | [Name] t | semmle.label | [Name] t |
@@ -1096,29 +1250,24 @@ nodes
 | test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | semmle.label | [ExprStmt] SINK(unsafe) |
 | test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | semmle.order | 70 |
 | test.py:156:6:156:11 | [Name] unsafe | semmle.label | [Name] unsafe |
-| test.py:158:1:158:13 | (parameters) | semmle.label | (parameters) |
 | test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | semmle.label | [FunctionDef] test23 = function test23(...) |
 | test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | semmle.order | 71 |
 | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.label | [FunctionExpr] function test23(...) |
 | test.py:158:1:158:13 | [Function] function test23(...) | semmle.label | [Function] function test23(...) |
 | test.py:158:5:158:10 | [Name] test23 | semmle.label | [Name] test23 |
-| test.py:159:5:159:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:159:5:159:21 | [With]  | semmle.label | [With]  |
 | test.py:159:10:159:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:159:20:159:20 | [Name] t | semmle.label | [Name] t |
 | test.py:160:9:160:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:160:9:160:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:160:9:160:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:160:14:160:14 | [Name] t | semmle.label | [Name] t |
-| test.py:162:1:162:13 | (parameters) | semmle.label | (parameters) |
 | test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | semmle.label | [FunctionDef] test24 = function test24(...) |
 | test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | semmle.order | 72 |
 | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.label | [FunctionExpr] function test24(...) |
 | test.py:162:1:162:13 | [Function] function test24(...) | semmle.label | [Function] function test24(...) |
 | test.py:162:5:162:10 | [Name] test24 | semmle.label | [Name] test24 |
 | test.py:163:5:163:5 | [Name] s | semmle.label | [Name] s |
-| test.py:163:5:163:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.label | [AssignStmt] s = SOURCE |
 | test.py:163:9:163:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:164:5:164:12 | [Name] SANITIZE | semmle.label | [Name] SANITIZE |
@@ -1129,7 +1278,6 @@ nodes
 | test.py:165:5:165:11 | [Call] SINK(s) | semmle.label | [Call] SINK(s) |
 | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.label | [ExprStmt] SINK(s) |
 | test.py:165:10:165:10 | [Name] s | semmle.label | [Name] s |
-| test.py:167:1:167:29 | (parameters) | semmle.label | (parameters) |
 | test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | semmle.label | [FunctionDef] test_update_extend = function test_update_extend(...) |
 | test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | semmle.order | 73 |
 | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.label | [FunctionExpr] function test_update_extend(...) |
@@ -1138,7 +1286,6 @@ nodes
 | test.py:167:24:167:24 | [Parameter] x | semmle.label | [Parameter] x |
 | test.py:167:27:167:27 | [Parameter] y | semmle.label | [Parameter] y |
 | test.py:168:5:168:5 | [Name] l | semmle.label | [Name] l |
-| test.py:168:5:168:16 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.label | [AssignStmt] l = [...] |
 | test.py:168:9:168:16 | [List] [...] | semmle.label | [List] [...] |
 | test.py:168:10:168:15 | [Name] SOURCE | semmle.label | [Name] SOURCE |
@@ -1162,8 +1309,8 @@ nodes
 | test.py:172:5:172:14 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
 | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
 | test.py:172:10:172:10 | [Name] x | semmle.label | [Name] x |
-| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.label | [Subscript] x[IntegerLiteral] |
-| test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.label | [IntegerLiteral] IntegerLiteral |
+| test.py:172:10:172:13 | [Subscript] x[0] | semmle.label | [Subscript] x[0] |
+| test.py:172:12:172:12 | [IntegerLiteral] 0 | semmle.label | [IntegerLiteral] 0 |
 | test.py:173:5:173:8 | [Name] SINK | semmle.label | [Name] SINK |
 | test.py:173:5:173:18 | [Call] SINK(...) | semmle.label | [Call] SINK(...) |
 | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.label | [ExprStmt] SINK(...) |
@@ -1180,25 +1327,21 @@ nodes
 | test.py:175:10:175:13 | [Name] dict | semmle.label | [Name] dict |
 | test.py:175:10:175:16 | [Call] dict(d) | semmle.label | [Call] dict(d) |
 | test.py:175:15:175:15 | [Name] d | semmle.label | [Name] d |
-| test.py:177:1:177:17 | (parameters) | semmle.label | (parameters) |
 | test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | semmle.label | [FunctionDef] test_truth = function test_truth(...) |
 | test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | semmle.order | 74 |
 | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.label | [FunctionExpr] function test_truth(...) |
 | test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.label | [Function] function test_truth(...) |
 | test.py:177:5:177:14 | [Name] test_truth | semmle.label | [Name] test_truth |
 | test.py:178:5:178:5 | [Name] t | semmle.label | [Name] t |
-| test.py:178:5:178:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:178:9:178:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:179:5:179:9 | [If] if t: | semmle.label | [If] if t: |
 | test.py:179:8:179:8 | [Name] t | semmle.label | [Name] t |
 | test.py:180:9:180:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:180:9:180:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:180:9:180:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:180:14:180:14 | [Name] t | semmle.label | [Name] t |
 | test.py:182:9:182:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:182:9:182:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:182:9:182:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:182:14:182:14 | [Name] t | semmle.label | [Name] t |
@@ -1206,40 +1349,33 @@ nodes
 | test.py:183:8:183:12 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
 | test.py:183:12:183:12 | [Name] t | semmle.label | [Name] t |
 | test.py:184:9:184:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:184:9:184:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:184:9:184:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:184:14:184:14 | [Name] t | semmle.label | [Name] t |
 | test.py:186:9:186:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:186:9:186:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:186:9:186:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:186:14:186:14 | [Name] t | semmle.label | [Name] t |
-| test.py:188:1:188:22 | (parameters) | semmle.label | (parameters) |
 | test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | semmle.label | [FunctionDef] test_early_exit = function test_early_exit(...) |
 | test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | semmle.order | 75 |
 | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.label | [FunctionExpr] function test_early_exit(...) |
 | test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.label | [Function] function test_early_exit(...) |
 | test.py:188:5:188:19 | [Name] test_early_exit | semmle.label | [Name] test_early_exit |
 | test.py:189:5:189:5 | [Name] t | semmle.label | [Name] t |
-| test.py:189:5:189:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.label | [AssignStmt] t = FALSEY |
 | test.py:189:9:189:14 | [Name] FALSEY | semmle.label | [Name] FALSEY |
 | test.py:190:5:190:13 | [If]  | semmle.label | [If]  |
 | test.py:190:8:190:12 | [UnaryExpr]  | semmle.label | [UnaryExpr]  |
 | test.py:190:12:190:12 | [Name] t | semmle.label | [Name] t |
-| test.py:191:9:191:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:191:9:191:14 | [Return]  | semmle.label | [Return]  |
 | test.py:192:5:192:5 | [ExprStmt] t | semmle.label | [ExprStmt] t |
 | test.py:192:5:192:5 | [Name] t | semmle.label | [Name] t |
-| test.py:194:1:194:41 | (parameters) | semmle.label | (parameters) |
 | test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | semmle.label | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) |
 | test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | semmle.order | 76 |
 | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.label | [FunctionExpr] function flow_through_type_test_if_no_class(...) |
 | test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.label | [Function] function flow_through_type_test_if_no_class(...) |
 | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.label | [Name] flow_through_type_test_if_no_class |
 | test.py:195:5:195:5 | [Name] t | semmle.label | [Name] t |
-| test.py:195:5:195:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.label | [AssignStmt] t = SOURCE |
 | test.py:195:9:195:14 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.label | [If] if isinstance(str, t): |
@@ -1248,75 +1384,62 @@ nodes
 | test.py:196:19:196:19 | [Name] t | semmle.label | [Name] t |
 | test.py:196:22:196:24 | [Name] str | semmle.label | [Name] str |
 | test.py:197:9:197:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:197:9:197:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:197:9:197:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:197:14:197:14 | [Name] t | semmle.label | [Name] t |
 | test.py:199:9:199:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:199:9:199:15 | (StmtList) orelse | semmle.label | (StmtList) orelse |
 | test.py:199:9:199:15 | [Call] SINK(t) | semmle.label | [Call] SINK(t) |
 | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.label | [ExprStmt] SINK(t) |
 | test.py:199:14:199:14 | [Name] t | semmle.label | [Name] t |
-| test.py:201:1:201:24 | (parameters) | semmle.label | (parameters) |
 | test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | semmle.label | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) |
 | test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | semmle.order | 77 |
 | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.label | [FunctionExpr] function flow_in_iteration(...) |
 | test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.label | [Function] function flow_in_iteration(...) |
 | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.label | [Name] flow_in_iteration |
 | test.py:202:5:202:5 | [Name] t | semmle.label | [Name] t |
-| test.py:202:5:202:23 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.label | [AssignStmt] t = ITERABLE_SOURCE |
 | test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.label | [Name] ITERABLE_SOURCE |
 | test.py:203:5:203:15 | [For]  | semmle.label | [For]  |
 | test.py:203:9:203:9 | [Name] i | semmle.label | [Name] i |
 | test.py:203:14:203:14 | [Name] t | semmle.label | [Name] t |
-| test.py:204:9:204:9 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:204:9:204:9 | [ExprStmt] i | semmle.label | [ExprStmt] i |
 | test.py:204:9:204:9 | [Name] i | semmle.label | [Name] i |
 | test.py:205:5:205:12 | [Return] return i | semmle.label | [Return] return i |
 | test.py:205:12:205:12 | [Name] i | semmle.label | [Name] i |
-| test.py:207:1:207:24 | (parameters) | semmle.label | (parameters) |
 | test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | semmle.label | [FunctionDef] flow_in_generator = function flow_in_generator(...) |
 | test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | semmle.order | 78 |
 | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.label | [FunctionExpr] function flow_in_generator(...) |
 | test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.label | [Function] function flow_in_generator(...) |
 | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.label | [Name] flow_in_generator |
 | test.py:208:5:208:7 | [Name] seq | semmle.label | [Name] seq |
-| test.py:208:5:208:18 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.label | [AssignStmt] seq = [...] |
 | test.py:208:11:208:18 | [List] [...] | semmle.label | [List] [...] |
 | test.py:208:12:208:17 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:209:5:209:17 | [For]  | semmle.label | [For]  |
 | test.py:209:9:209:9 | [Name] i | semmle.label | [Name] i |
 | test.py:209:14:209:16 | [Name] seq | semmle.label | [Name] seq |
-| test.py:210:9:210:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.label | [ExprStmt] yield i |
 | test.py:210:9:210:15 | [Yield] yield i | semmle.label | [Yield] yield i |
 | test.py:210:15:210:15 | [Name] i | semmle.label | [Name] i |
-| test.py:212:1:212:26 | (parameters) | semmle.label | (parameters) |
 | test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | semmle.label | [FunctionDef] flow_from_generator = function flow_from_generator(...) |
 | test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | semmle.order | 79 |
 | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.label | [FunctionExpr] function flow_from_generator(...) |
 | test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.label | [Function] function flow_from_generator(...) |
 | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.label | [Name] flow_from_generator |
-| test.py:213:5:213:33 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:213:5:213:33 | [For]  | semmle.label | [For]  |
 | test.py:213:9:213:9 | [Name] x | semmle.label | [Name] x |
 | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.label | [Name] flow_in_generator |
 | test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.label | [Call] flow_in_generator() |
 | test.py:214:9:214:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:214:9:214:15 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:214:9:214:15 | [Call] SINK(x) | semmle.label | [Call] SINK(x) |
 | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.label | [ExprStmt] SINK(x) |
 | test.py:214:14:214:14 | [Name] x | semmle.label | [Name] x |
-| test.py:216:1:216:28 | (parameters) | semmle.label | (parameters) |
 | test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | semmle.label | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) |
 | test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | semmle.order | 80 |
 | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.label | [FunctionExpr] function const_eq_clears_taint(...) |
 | test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.label | [Function] function const_eq_clears_taint(...) |
 | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.label | [Name] const_eq_clears_taint |
 | test.py:217:5:217:11 | [Name] tainted | semmle.label | [Name] tainted |
-| test.py:217:5:217:20 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
 | test.py:217:15:217:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.label | [If] if tainted == ...: |
@@ -1324,7 +1447,6 @@ nodes
 | test.py:218:8:218:24 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
 | test.py:218:19:218:24 | [Str] safe | semmle.label | [Str] safe |
 | test.py:219:9:219:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:219:9:219:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
 | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
 | test.py:219:14:219:20 | [Name] tainted | semmle.label | [Name] tainted |
@@ -1332,27 +1454,23 @@ nodes
 | test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
 | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
 | test.py:220:10:220:16 | [Name] tainted | semmle.label | [Name] tainted |
-| test.py:222:1:222:29 | (parameters) | semmle.label | (parameters) |
 | test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | semmle.label | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) |
 | test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | semmle.order | 81 |
 | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.label | [FunctionExpr] function const_eq_clears_taint2(...) |
 | test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.label | [Function] function const_eq_clears_taint2(...) |
 | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.label | [Name] const_eq_clears_taint2 |
 | test.py:223:5:223:11 | [Name] tainted | semmle.label | [Name] tainted |
-| test.py:223:5:223:20 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
 | test.py:223:15:223:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.label | [If] if tainted != ...: |
 | test.py:224:8:224:14 | [Name] tainted | semmle.label | [Name] tainted |
 | test.py:224:8:224:24 | [Compare] tainted != ... | semmle.label | [Compare] tainted != ... |
 | test.py:224:19:224:24 | [Str] safe | semmle.label | [Str] safe |
-| test.py:225:9:225:14 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:225:9:225:14 | [Return]  | semmle.label | [Return]  |
 | test.py:226:5:226:8 | [Name] SINK | semmle.label | [Name] SINK |
 | test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
 | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
 | test.py:226:10:226:16 | [Name] tainted | semmle.label | [Name] tainted |
-| test.py:228:1:228:36 | (parameters) | semmle.label | (parameters) |
 | test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | semmle.label | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) |
 | test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | semmle.order | 82 |
 | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.label | [FunctionExpr] function non_const_eq_preserves_taint(...) |
@@ -1360,7 +1478,6 @@ nodes
 | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.label | [Name] non_const_eq_preserves_taint |
 | test.py:228:34:228:34 | [Parameter] x | semmle.label | [Parameter] x |
 | test.py:229:5:229:11 | [Name] tainted | semmle.label | [Name] tainted |
-| test.py:229:5:229:20 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.label | [AssignStmt] tainted = SOURCE |
 | test.py:229:15:229:20 | [Name] SOURCE | semmle.label | [Name] SOURCE |
 | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.label | [If] if tainted == ...: |
@@ -1368,7 +1485,6 @@ nodes
 | test.py:230:8:230:25 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
 | test.py:230:19:230:25 | [Name] tainted | semmle.label | [Name] tainted |
 | test.py:231:9:231:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:231:9:231:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
 | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
 | test.py:231:14:231:20 | [Name] tainted | semmle.label | [Name] tainted |
@@ -1377,47 +1493,34 @@ nodes
 | test.py:232:8:232:19 | [Compare] tainted == ... | semmle.label | [Compare] tainted == ... |
 | test.py:232:19:232:19 | [Name] x | semmle.label | [Name] x |
 | test.py:233:9:233:12 | [Name] SINK | semmle.label | [Name] SINK |
-| test.py:233:9:233:21 | (StmtList) body | semmle.label | (StmtList) body |
 | test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.label | [Call] SINK(tainted) |
 | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.label | [ExprStmt] SINK(tainted) |
 | test.py:233:14:233:20 | [Name] tainted | semmle.label | [Name] tainted |
 edges
-| assignment.py:1:1:1:16 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.label | 1 |
-| assignment.py:1:1:1:16 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.order | 1 |
 | assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.label | 1 |
 | assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | semmle.order | 1 |
-| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.label | 2 |
-| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.order | 2 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.label | 0 |
+| assignment.py:1:1:1:16 | [FunctionDef] test = function test(...) | assignment.py:1:5:1:8 | [Name] test | semmle.order | 0 |
 | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | assignment.py:1:1:1:16 | [Function] function test(...) | semmle.label | 1 |
 | assignment.py:1:1:1:16 | [FunctionExpr] function test(...) | assignment.py:1:1:1:16 | [Function] function test(...) | semmle.order | 1 |
-| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:1:1:1:16 | (parameters) | semmle.label | 0 |
-| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:1:1:1:16 | (parameters) | semmle.order | 0 |
-| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:2:5:2:8 | (StmtList) body | semmle.label | 4 |
-| assignment.py:1:1:1:16 | [Function] function test(...) | assignment.py:2:5:2:8 | (StmtList) body | semmle.order | 4 |
-| assignment.py:2:5:2:8 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.label | 0 |
-| assignment.py:2:5:2:8 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.order | 0 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| assignment.py:1:1:1:16 | [Function] function test(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.label | 1 |
 | assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | semmle.order | 1 |
-| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.label | 2 |
-| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.order | 2 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.label | 0 |
+| assignment.py:4:1:4:17 | [FunctionDef] swap_taint = function swap_taint(...) | assignment.py:4:5:4:14 | [Name] swap_taint | semmle.order | 0 |
 | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | assignment.py:4:1:4:17 | [Function] function swap_taint(...) | semmle.label | 1 |
 | assignment.py:4:1:4:17 | [FunctionExpr] function swap_taint(...) | assignment.py:4:1:4:17 | [Function] function swap_taint(...) | semmle.order | 1 |
-| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:4:1:4:17 | (parameters) | semmle.label | 0 |
-| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:4:1:4:17 | (parameters) | semmle.order | 0 |
-| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:5:5:5:25 | (StmtList) body | semmle.label | 6 |
-| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | assignment.py:5:5:5:25 | (StmtList) body | semmle.order | 6 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 6 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 6 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| assignment.py:4:1:4:17 | [Function] function swap_taint(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:5:5:5 | [Name] a | semmle.label | 1 |
 | assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:5:5:5 | [Name] a | semmle.order | 1 |
 | assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:8:5:8 | [Name] b | semmle.label | 2 |
 | assignment.py:5:5:5:8 | [Tuple]  | assignment.py:5:8:5:8 | [Name] b | semmle.order | 2 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.label | 0 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.order | 0 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.label | 1 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.order | 1 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.label | 2 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.order | 2 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.label | 3 |
-| assignment.py:5:5:5:25 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.order | 3 |
 | assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:5:5:8 | [Tuple]  | semmle.label | 1 |
 | assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:5:5:8 | [Tuple]  | semmle.order | 1 |
 | assignment.py:5:5:5:25 | [AssignStmt]  | assignment.py:5:12:5:25 | [Tuple]  | semmle.label | 2 |
@@ -1426,12 +1529,10 @@ edges
 | assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:12:5:17 | [Name] SOURCE | semmle.order | 1 |
 | assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:20:5:25 | [Str] safe | semmle.label | 2 |
 | assignment.py:5:12:5:25 | [Tuple]  | assignment.py:5:20:5:25 | [Str] safe | semmle.order | 2 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.label | 1 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.order | 1 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:10:6:10 | [Name] a | semmle.label | 2 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:10:6:10 | [Name] a | semmle.order | 2 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:13:6:13 | [Name] b | semmle.label | 3 |
-| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:13:6:13 | [Name] b | semmle.order | 3 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.label | 0 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | assignment.py:6:5:6:8 | [Name] test | semmle.order | 0 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| assignment.py:6:5:6:14 | [Call] test(a, b) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | assignment.py:6:5:6:14 | [Call] test(a, b) | semmle.label | 1 |
 | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | assignment.py:6:5:6:14 | [Call] test(a, b) | semmle.order | 1 |
 | assignment.py:7:5:7:8 | [Tuple]  | assignment.py:7:5:7:5 | [Name] a | semmle.label | 1 |
@@ -1446,28 +1547,22 @@ edges
 | assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:12:7:12 | [Name] b | semmle.order | 1 |
 | assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:15:7:15 | [Name] a | semmle.label | 2 |
 | assignment.py:7:12:7:15 | [Tuple]  | assignment.py:7:15:7:15 | [Name] a | semmle.order | 2 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.label | 1 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.order | 1 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:10:8:10 | [Name] a | semmle.label | 2 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:10:8:10 | [Name] a | semmle.order | 2 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:13:8:13 | [Name] b | semmle.label | 3 |
-| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:13:8:13 | [Name] b | semmle.order | 3 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.label | 0 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | assignment.py:8:5:8:8 | [Name] test | semmle.order | 0 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| assignment.py:8:5:8:14 | [Call] test(a, b) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | assignment.py:8:5:8:14 | [Call] test(a, b) | semmle.label | 1 |
 | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | assignment.py:8:5:8:14 | [Call] test(a, b) | semmle.order | 1 |
 | assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.label | 1 |
 | assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | semmle.order | 1 |
-| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.label | 2 |
-| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.order | 2 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.label | 0 |
+| assignment.py:10:1:10:24 | [FunctionDef] nested_assignment = function nested_assignment(...) | assignment.py:10:5:10:21 | [Name] nested_assignment | semmle.order | 0 |
 | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.label | 1 |
 | assignment.py:10:1:10:24 | [FunctionExpr] function nested_assignment(...) | assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | semmle.order | 1 |
-| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:10:1:10:24 | (parameters) | semmle.label | 0 |
-| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:10:1:10:24 | (parameters) | semmle.order | 0 |
-| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:13:5:13:59 | (StmtList) body | semmle.label | 4 |
-| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | assignment.py:13:5:13:59 | (StmtList) body | semmle.order | 4 |
-| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.label | 0 |
-| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.order | 0 |
-| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.label | 1 |
-| assignment.py:13:5:13:59 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.order | 1 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| assignment.py:10:1:10:24 | [Function] function nested_assignment(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:6:13:21 | [Tuple]  | semmle.label | 1 |
 | assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:6:13:21 | [Tuple]  | semmle.order | 1 |
 | assignment.py:13:5:13:59 | [AssignStmt]  | assignment.py:13:27:13:58 | [Tuple]  | semmle.label | 2 |
@@ -1492,16 +1587,10 @@ edges
 | assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:28:13:33 | [Name] SOURCE | semmle.order | 1 |
 | assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:36:13:41 | [Str] safe | semmle.label | 2 |
 | assignment.py:13:28:13:41 | [Tuple]  | assignment.py:13:36:13:41 | [Str] safe | semmle.order | 2 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.label | 1 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.order | 1 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:10:14:11 | [Name] t1 | semmle.label | 2 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:10:14:11 | [Name] t1 | semmle.order | 2 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:14:14:15 | [Name] s1 | semmle.label | 3 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:14:14:15 | [Name] s1 | semmle.order | 3 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:18:14:19 | [Name] t2 | semmle.label | 4 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:18:14:19 | [Name] t2 | semmle.order | 4 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:22:14:23 | [Name] s2 | semmle.label | 5 |
-| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:22:14:23 | [Name] s2 | semmle.order | 5 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.label | 0 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | assignment.py:14:5:14:8 | [Name] test | semmle.order | 0 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | semmle.label | 1 |
 | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | assignment.py:14:5:14:24 | [Call] test(s1, s2, t1, t2) | semmle.order | 1 |
 | carrier.py:2:1:2:30 | [ClassDef] ImplicitCarrier = class ImplicitCarrier | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | semmle.label | 1 |
@@ -1512,384 +1601,992 @@ edges
 | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | semmle.order | 1 |
 | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:23:2:28 | [Name] object | semmle.label | 2 |
 | carrier.py:2:1:2:30 | [ClassExpr] class ImplicitCarrier | carrier.py:2:23:2:28 | [Name] object | semmle.order | 2 |
-| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | carrier.py:4:5:4:28 | (StmtList) body | semmle.label | 5 |
-| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | carrier.py:4:5:4:28 | (StmtList) body | semmle.order | 5 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.label | 0 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.order | 0 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.label | 1 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.order | 1 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.label | 2 |
-| carrier.py:4:5:4:28 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.order | 2 |
-| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.label | 1 |
-| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.order | 1 |
-| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.label | 2 |
-| carrier.py:4:5:4:28 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.order | 2 |
+| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| carrier.py:2:1:2:30 | [Class] class ImplicitCarrier | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
 | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.label | 1 |
 | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | semmle.order | 1 |
-| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.label | 2 |
-| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.order | 2 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.label | 0 |
+| carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | carrier.py:4:9:4:16 | [Name] __init__ | semmle.order | 0 |
 | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.label | 1 |
 | carrier.py:4:5:4:28 | [FunctionExpr] function __init__(...) | carrier.py:4:5:4:28 | [Function] function __init__(...) | semmle.order | 1 |
-| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:4:5:4:28 | (parameters) | semmle.label | 0 |
-| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:4:5:4:28 | (parameters) | semmle.order | 0 |
-| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:5:9:5:23 | (StmtList) body | semmle.label | 5 |
-| carrier.py:4:5:4:28 | [Function] function __init__(...) | carrier.py:5:9:5:23 | (StmtList) body | semmle.order | 5 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:4:5:4:28 | [Function] function __init__(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:5:9:5:17 | [Attribute] self.attr | carrier.py:5:9:5:12 | [Name] self | semmle.label | 1 |
 | carrier.py:5:9:5:17 | [Attribute] self.attr | carrier.py:5:9:5:12 | [Name] self | semmle.order | 1 |
-| carrier.py:5:9:5:23 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
-| carrier.py:5:9:5:23 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
 | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.label | 1 |
 | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:9:5:17 | [Attribute] self.attr | semmle.order | 1 |
 | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:21:5:23 | [Name] arg | semmle.label | 2 |
 | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | carrier.py:5:21:5:23 | [Name] arg | semmle.order | 2 |
-| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.label | 1 |
-| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.order | 1 |
-| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.label | 2 |
-| carrier.py:7:5:7:28 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.order | 2 |
 | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.label | 1 |
 | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | semmle.order | 1 |
-| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.label | 2 |
-| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.order | 2 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.label | 0 |
+| carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | carrier.py:7:9:7:16 | [Name] set_attr | semmle.order | 0 |
 | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.label | 1 |
 | carrier.py:7:5:7:28 | [FunctionExpr] function set_attr(...) | carrier.py:7:5:7:28 | [Function] function set_attr(...) | semmle.order | 1 |
-| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:7:5:7:28 | (parameters) | semmle.label | 0 |
-| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:7:5:7:28 | (parameters) | semmle.order | 0 |
-| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:8:9:8:23 | (StmtList) body | semmle.label | 5 |
-| carrier.py:7:5:7:28 | [Function] function set_attr(...) | carrier.py:8:9:8:23 | (StmtList) body | semmle.order | 5 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:7:5:7:28 | [Function] function set_attr(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:8:9:8:17 | [Attribute] self.attr | carrier.py:8:9:8:12 | [Name] self | semmle.label | 1 |
 | carrier.py:8:9:8:17 | [Attribute] self.attr | carrier.py:8:9:8:12 | [Name] self | semmle.order | 1 |
-| carrier.py:8:9:8:23 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
-| carrier.py:8:9:8:23 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
 | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.label | 1 |
 | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:9:8:17 | [Attribute] self.attr | semmle.order | 1 |
 | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:21:8:23 | [Name] arg | semmle.label | 2 |
 | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | carrier.py:8:21:8:23 | [Name] arg | semmle.order | 2 |
-| carrier.py:10:5:10:23 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.label | 1 |
-| carrier.py:10:5:10:23 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.order | 1 |
 | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.label | 1 |
 | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | semmle.order | 1 |
-| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.label | 2 |
-| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.order | 2 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.label | 0 |
+| carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | carrier.py:10:9:10:16 | [Name] get_attr | semmle.order | 0 |
 | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.label | 1 |
 | carrier.py:10:5:10:23 | [FunctionExpr] function get_attr(...) | carrier.py:10:5:10:23 | [Function] function get_attr(...) | semmle.order | 1 |
-| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:10:5:10:23 | (parameters) | semmle.label | 0 |
-| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:10:5:10:23 | (parameters) | semmle.order | 0 |
-| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:11:9:11:24 | (StmtList) body | semmle.label | 4 |
-| carrier.py:10:5:10:23 | [Function] function get_attr(...) | carrier.py:11:9:11:24 | (StmtList) body | semmle.order | 4 |
-| carrier.py:11:9:11:24 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.label | 0 |
-| carrier.py:11:9:11:24 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.order | 0 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:10:5:10:23 | [Function] function get_attr(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:11:9:11:24 | [Return] return self.attr | carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.label | 1 |
 | carrier.py:11:9:11:24 | [Return] return self.attr | carrier.py:11:16:11:24 | [Attribute] self.attr | semmle.order | 1 |
 | carrier.py:11:16:11:24 | [Attribute] self.attr | carrier.py:11:16:11:19 | [Name] self | semmle.label | 1 |
 | carrier.py:11:16:11:24 | [Attribute] self.attr | carrier.py:11:16:11:19 | [Name] self | semmle.order | 1 |
-| carrier.py:13:1:13:13 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.label | 1 |
-| carrier.py:13:1:13:13 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.order | 1 |
 | carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.label | 1 |
 | carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | semmle.order | 1 |
-| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.label | 2 |
-| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.order | 2 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.label | 0 |
+| carrier.py:13:1:13:13 | [FunctionDef] hub = function hub(...) | carrier.py:13:5:13:7 | [Name] hub | semmle.order | 0 |
 | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.label | 1 |
 | carrier.py:13:1:13:13 | [FunctionExpr] function hub(...) | carrier.py:13:1:13:13 | [Function] function hub(...) | semmle.order | 1 |
-| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:13:1:13:13 | (parameters) | semmle.label | 0 |
-| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:13:1:13:13 | (parameters) | semmle.order | 0 |
-| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:14:5:14:14 | (StmtList) body | semmle.label | 4 |
-| carrier.py:13:1:13:13 | [Function] function hub(...) | carrier.py:14:5:14:14 | (StmtList) body | semmle.order | 4 |
-| carrier.py:14:5:14:14 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.label | 0 |
-| carrier.py:14:5:14:14 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.order | 0 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:13:1:13:13 | [Function] function hub(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:14:5:14:14 | [Return] return arg | carrier.py:14:12:14:14 | [Name] arg | semmle.label | 1 |
 | carrier.py:14:5:14:14 | [Return] return arg | carrier.py:14:12:14:14 | [Name] arg | semmle.order | 1 |
 | carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
 | carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
-| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.label | 2 |
-| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.order | 2 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.label | 0 |
+| carrier.py:16:1:16:12 | [FunctionDef] test1 = function test1(...) | carrier.py:16:5:16:9 | [Name] test1 | semmle.order | 0 |
 | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.label | 1 |
 | carrier.py:16:1:16:12 | [FunctionExpr] function test1(...) | carrier.py:16:1:16:12 | [Function] function test1(...) | semmle.order | 1 |
-| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:16:1:16:12 | (parameters) | semmle.label | 0 |
-| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:16:1:16:12 | (parameters) | semmle.order | 0 |
-| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:17:5:17:31 | (StmtList) body | semmle.label | 4 |
-| carrier.py:16:1:16:12 | [Function] function test1(...) | carrier.py:17:5:17:31 | (StmtList) body | semmle.order | 4 |
-| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.label | 0 |
-| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.order | 0 |
-| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.label | 1 |
-| carrier.py:17:5:17:31 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:16:1:16:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:5:17:5 | [Name] c | semmle.label | 1 |
 | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:5:17:5 | [Name] c | semmle.order | 1 |
 | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.label | 2 |
 | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | semmle.order | 2 |
-| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.label | 1 |
-| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.order | 1 |
-| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.label | 2 |
-| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.order | 2 |
-| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.label | 1 |
-| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.order | 1 |
-| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.label | 2 |
-| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.order | 2 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.label | 0 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | carrier.py:17:9:17:23 | [Name] ImplicitCarrier | semmle.order | 0 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:17:9:17:31 | [Call] ImplicitCarrier(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.label | 0 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | carrier.py:18:5:18:8 | [Name] SINK | semmle.order | 0 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:18:5:18:16 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | carrier.py:18:5:18:16 | [Call] SINK(...) | semmle.label | 1 |
 | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | carrier.py:18:5:18:16 | [Call] SINK(...) | semmle.order | 1 |
 | carrier.py:18:10:18:15 | [Attribute] c.attr | carrier.py:18:10:18:10 | [Name] c | semmle.label | 1 |
 | carrier.py:18:10:18:15 | [Attribute] c.attr | carrier.py:18:10:18:10 | [Name] c | semmle.order | 1 |
 | carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
 | carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
-| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.label | 2 |
-| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.order | 2 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.label | 0 |
+| carrier.py:20:1:20:12 | [FunctionDef] test2 = function test2(...) | carrier.py:20:5:20:9 | [Name] test2 | semmle.order | 0 |
 | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.label | 1 |
 | carrier.py:20:1:20:12 | [FunctionExpr] function test2(...) | carrier.py:20:1:20:12 | [Function] function test2(...) | semmle.order | 1 |
-| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:20:1:20:12 | (parameters) | semmle.label | 0 |
-| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:20:1:20:12 | (parameters) | semmle.order | 0 |
-| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:21:5:21:28 | (StmtList) body | semmle.label | 4 |
-| carrier.py:20:1:20:12 | [Function] function test2(...) | carrier.py:21:5:21:28 | (StmtList) body | semmle.order | 4 |
-| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.label | 0 |
-| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.order | 0 |
-| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
-| carrier.py:21:5:21:28 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:20:1:20:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:5:21:5 | [Name] c | semmle.label | 1 |
 | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:5:21:5 | [Name] c | semmle.order | 1 |
 | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
 | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | carrier.py:21:9:21:28 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
-| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.label | 1 |
-| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.order | 1 |
-| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.label | 2 |
-| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.order | 2 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.label | 0 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | carrier.py:22:5:22:8 | [Name] SINK | semmle.order | 0 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:22:5:22:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | carrier.py:22:5:22:23 | [Call] SINK(...) | semmle.label | 1 |
 | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | carrier.py:22:5:22:23 | [Call] SINK(...) | semmle.order | 1 |
 | carrier.py:22:10:22:20 | [Attribute] c.get_taint | carrier.py:22:10:22:10 | [Name] c | semmle.label | 1 |
 | carrier.py:22:10:22:20 | [Attribute] c.get_taint | carrier.py:22:10:22:10 | [Name] c | semmle.order | 1 |
-| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.label | 1 |
-| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.order | 1 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.label | 0 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | carrier.py:22:10:22:20 | [Attribute] c.get_taint | semmle.order | 0 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:22:10:22:22 | [Call] c.get_taint() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
 | carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
-| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.label | 2 |
-| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.order | 2 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.label | 0 |
+| carrier.py:24:1:24:12 | [FunctionDef] test3 = function test3(...) | carrier.py:24:5:24:9 | [Name] test3 | semmle.order | 0 |
 | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.label | 1 |
 | carrier.py:24:1:24:12 | [FunctionExpr] function test3(...) | carrier.py:24:1:24:12 | [Function] function test3(...) | semmle.order | 1 |
-| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:24:1:24:12 | (parameters) | semmle.label | 0 |
-| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:24:1:24:12 | (parameters) | semmle.order | 0 |
-| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:25:5:25:36 | (StmtList) body | semmle.label | 4 |
-| carrier.py:24:1:24:12 | [Function] function test3(...) | carrier.py:25:5:25:36 | (StmtList) body | semmle.order | 4 |
-| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.label | 0 |
-| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.order | 0 |
-| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.label | 1 |
-| carrier.py:25:5:25:36 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:24:1:24:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:5:25:5 | [Name] c | semmle.label | 1 |
 | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:5:25:5 | [Name] c | semmle.order | 1 |
 | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:9:25:36 | [Call] hub(...) | semmle.label | 2 |
 | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | carrier.py:25:9:25:36 | [Call] hub(...) | semmle.order | 2 |
-| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.label | 1 |
-| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.order | 1 |
-| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.label | 2 |
-| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.order | 2 |
-| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.label | 1 |
-| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.order | 1 |
-| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.label | 2 |
-| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.order | 2 |
-| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.label | 1 |
-| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.order | 1 |
-| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.label | 2 |
-| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.order | 2 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.label | 0 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | carrier.py:25:9:25:11 | [Name] hub | semmle.order | 0 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:25:9:25:36 | [Call] hub(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.label | 0 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | carrier.py:25:13:25:27 | [Name] ImplicitCarrier | semmle.order | 0 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.label | 0 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | carrier.py:26:5:26:8 | [Name] SINK | semmle.order | 0 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:26:5:26:22 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | carrier.py:26:5:26:22 | [Call] SINK(...) | semmle.label | 1 |
 | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | carrier.py:26:5:26:22 | [Call] SINK(...) | semmle.order | 1 |
 | carrier.py:26:10:26:19 | [Attribute] c.get_attr | carrier.py:26:10:26:10 | [Name] c | semmle.label | 1 |
 | carrier.py:26:10:26:19 | [Attribute] c.get_attr | carrier.py:26:10:26:10 | [Name] c | semmle.order | 1 |
-| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.label | 1 |
-| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.order | 1 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.label | 0 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | carrier.py:26:10:26:19 | [Attribute] c.get_attr | semmle.order | 0 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:26:10:26:21 | [Call] c.get_attr() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
 | carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
-| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.label | 2 |
-| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.order | 2 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.label | 0 |
+| carrier.py:28:1:28:12 | [FunctionDef] test4 = function test4(...) | carrier.py:28:5:28:9 | [Name] test4 | semmle.order | 0 |
 | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.label | 1 |
 | carrier.py:28:1:28:12 | [FunctionExpr] function test4(...) | carrier.py:28:1:28:12 | [Function] function test4(...) | semmle.order | 1 |
-| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:28:1:28:12 | (parameters) | semmle.label | 0 |
-| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:28:1:28:12 | (parameters) | semmle.order | 0 |
-| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:29:5:29:33 | (StmtList) body | semmle.label | 4 |
-| carrier.py:28:1:28:12 | [Function] function test4(...) | carrier.py:29:5:29:33 | (StmtList) body | semmle.order | 4 |
-| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
-| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
-| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
-| carrier.py:29:5:29:33 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:28:1:28:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:5:29:5 | [Name] c | semmle.label | 1 |
 | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:5:29:5 | [Name] c | semmle.order | 1 |
 | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.label | 2 |
 | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | semmle.order | 2 |
-| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.label | 1 |
-| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.order | 1 |
-| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
-| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
-| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.label | 1 |
-| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.order | 1 |
-| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.label | 2 |
-| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.order | 2 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.label | 0 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | carrier.py:29:9:29:11 | [Name] hub | semmle.order | 0 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:29:9:29:33 | [Call] hub(TAINT_CARRIER_SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.label | 0 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | carrier.py:30:5:30:8 | [Name] SINK | semmle.order | 0 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:30:5:30:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | carrier.py:30:5:30:23 | [Call] SINK(...) | semmle.label | 1 |
 | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | carrier.py:30:5:30:23 | [Call] SINK(...) | semmle.order | 1 |
 | carrier.py:30:10:30:20 | [Attribute] c.get_taint | carrier.py:30:10:30:10 | [Name] c | semmle.label | 1 |
 | carrier.py:30:10:30:20 | [Attribute] c.get_taint | carrier.py:30:10:30:10 | [Name] c | semmle.order | 1 |
-| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.label | 1 |
-| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.order | 1 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.label | 0 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | carrier.py:30:10:30:20 | [Attribute] c.get_taint | semmle.order | 0 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:30:10:30:22 | [Call] c.get_taint() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
 | carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
-| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.label | 2 |
-| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.order | 2 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.label | 0 |
+| carrier.py:32:1:32:12 | [FunctionDef] test5 = function test5(...) | carrier.py:32:5:32:9 | [Name] test5 | semmle.order | 0 |
 | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.label | 1 |
 | carrier.py:32:1:32:12 | [FunctionExpr] function test5(...) | carrier.py:32:1:32:12 | [Function] function test5(...) | semmle.order | 1 |
-| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:32:1:32:12 | (parameters) | semmle.label | 0 |
-| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:32:1:32:12 | (parameters) | semmle.order | 0 |
-| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:33:5:33:45 | (StmtList) body | semmle.label | 5 |
-| carrier.py:32:1:32:12 | [Function] function test5(...) | carrier.py:33:5:33:45 | (StmtList) body | semmle.order | 5 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.label | 1 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.order | 1 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.label | 2 |
-| carrier.py:33:5:33:45 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| carrier.py:32:1:32:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:5:33:5 | [Name] c | semmle.label | 1 |
 | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:5:33:5 | [Name] c | semmle.order | 1 |
 | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | 2 |
 | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.order | 2 |
-| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.label | 1 |
-| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.order | 1 |
-| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
-| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.label | 0 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | carrier.py:33:9:33:23 | [Name] ImplicitCarrier | semmle.order | 0 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:33:9:33:45 | [Call] ImplicitCarrier(TAINT_CARRIER_SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:5:34:5 | [Name] x | semmle.label | 1 |
 | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:5:34:5 | [Name] x | semmle.order | 1 |
 | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:9:34:14 | [Attribute] c.attr | semmle.label | 2 |
 | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | carrier.py:34:9:34:14 | [Attribute] c.attr | semmle.order | 2 |
 | carrier.py:34:9:34:14 | [Attribute] c.attr | carrier.py:34:9:34:9 | [Name] c | semmle.label | 1 |
 | carrier.py:34:9:34:14 | [Attribute] c.attr | carrier.py:34:9:34:9 | [Name] c | semmle.order | 1 |
-| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.label | 1 |
-| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.order | 1 |
-| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.label | 2 |
-| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.order | 2 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.label | 0 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | carrier.py:35:5:35:8 | [Name] SINK | semmle.order | 0 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:35:5:35:23 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | carrier.py:35:5:35:23 | [Call] SINK(...) | semmle.label | 1 |
 | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | carrier.py:35:5:35:23 | [Call] SINK(...) | semmle.order | 1 |
 | carrier.py:35:10:35:20 | [Attribute] x.get_taint | carrier.py:35:10:35:10 | [Name] x | semmle.label | 1 |
 | carrier.py:35:10:35:20 | [Attribute] x.get_taint | carrier.py:35:10:35:10 | [Name] x | semmle.order | 1 |
-| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.label | 1 |
-| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.order | 1 |
-| deep.py:2:1:2:12 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:2:1:2:12 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.order | 1 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.label | 0 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | carrier.py:35:10:35:20 | [Attribute] x.get_taint | semmle.order | 0 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| carrier.py:35:10:35:22 | [Call] x.get_taint() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.label | 1 |
 | deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | semmle.order | 1 |
-| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.label | 2 |
-| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.order | 2 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.label | 0 |
+| deep.py:2:1:2:12 | [FunctionDef] f1 = function f1(...) | deep.py:2:5:2:6 | [Name] f1 | semmle.order | 0 |
 | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | deep.py:2:1:2:12 | [Function] function f1(...) | semmle.label | 1 |
 | deep.py:2:1:2:12 | [FunctionExpr] function f1(...) | deep.py:2:1:2:12 | [Function] function f1(...) | semmle.order | 1 |
-| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:2:1:2:12 | (parameters) | semmle.label | 0 |
-| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:2:1:2:12 | (parameters) | semmle.order | 0 |
-| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:3:5:3:14 | (StmtList) body | semmle.label | 4 |
-| deep.py:2:1:2:12 | [Function] function f1(...) | deep.py:3:5:3:14 | (StmtList) body | semmle.order | 4 |
-| deep.py:3:5:3:14 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.label | 0 |
-| deep.py:3:5:3:14 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.order | 0 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:2:1:2:12 | [Function] function f1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:3:5:3:14 | [Return] return arg | deep.py:3:12:3:14 | [Name] arg | semmle.label | 1 |
 | deep.py:3:5:3:14 | [Return] return arg | deep.py:3:12:3:14 | [Name] arg | semmle.order | 1 |
-| deep.py:5:1:5:12 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:5:1:5:12 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.order | 1 |
 | deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.label | 1 |
 | deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | semmle.order | 1 |
-| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.label | 2 |
-| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.order | 2 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.label | 0 |
+| deep.py:5:1:5:12 | [FunctionDef] f2 = function f2(...) | deep.py:5:5:5:6 | [Name] f2 | semmle.order | 0 |
 | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | deep.py:5:1:5:12 | [Function] function f2(...) | semmle.label | 1 |
 | deep.py:5:1:5:12 | [FunctionExpr] function f2(...) | deep.py:5:1:5:12 | [Function] function f2(...) | semmle.order | 1 |
-| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:5:1:5:12 | (parameters) | semmle.label | 0 |
-| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:5:1:5:12 | (parameters) | semmle.order | 0 |
-| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:6:5:6:18 | (StmtList) body | semmle.label | 4 |
-| deep.py:5:1:5:12 | [Function] function f2(...) | deep.py:6:5:6:18 | (StmtList) body | semmle.order | 4 |
-| deep.py:6:5:6:18 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.label | 0 |
-| deep.py:6:5:6:18 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.order | 0 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:5:1:5:12 | [Function] function f2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:6:5:6:18 | [Return] return f1(arg) | deep.py:6:12:6:18 | [Call] f1(arg) | semmle.label | 1 |
 | deep.py:6:5:6:18 | [Return] return f1(arg) | deep.py:6:12:6:18 | [Call] f1(arg) | semmle.order | 1 |
-| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.label | 1 |
-| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.order | 1 |
-| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:15:6:17 | [Name] arg | semmle.label | 2 |
-| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:15:6:17 | [Name] arg | semmle.order | 2 |
-| deep.py:8:1:8:12 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:8:1:8:12 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.label | 0 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | deep.py:6:12:6:13 | [Name] f1 | semmle.order | 0 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:6:12:6:18 | [Call] f1(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.label | 1 |
 | deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | semmle.order | 1 |
-| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.label | 2 |
-| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.order | 2 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.label | 0 |
+| deep.py:8:1:8:12 | [FunctionDef] f3 = function f3(...) | deep.py:8:5:8:6 | [Name] f3 | semmle.order | 0 |
 | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | deep.py:8:1:8:12 | [Function] function f3(...) | semmle.label | 1 |
 | deep.py:8:1:8:12 | [FunctionExpr] function f3(...) | deep.py:8:1:8:12 | [Function] function f3(...) | semmle.order | 1 |
-| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:8:1:8:12 | (parameters) | semmle.label | 0 |
-| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:8:1:8:12 | (parameters) | semmle.order | 0 |
-| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:9:5:9:18 | (StmtList) body | semmle.label | 4 |
-| deep.py:8:1:8:12 | [Function] function f3(...) | deep.py:9:5:9:18 | (StmtList) body | semmle.order | 4 |
-| deep.py:9:5:9:18 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.label | 0 |
-| deep.py:9:5:9:18 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.order | 0 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:8:1:8:12 | [Function] function f3(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:9:5:9:18 | [Return] return f2(arg) | deep.py:9:12:9:18 | [Call] f2(arg) | semmle.label | 1 |
 | deep.py:9:5:9:18 | [Return] return f2(arg) | deep.py:9:12:9:18 | [Call] f2(arg) | semmle.order | 1 |
-| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.label | 1 |
-| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.order | 1 |
-| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:15:9:17 | [Name] arg | semmle.label | 2 |
-| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:15:9:17 | [Name] arg | semmle.order | 2 |
-| deep.py:11:1:11:12 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:11:1:11:12 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.label | 0 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | deep.py:9:12:9:13 | [Name] f2 | semmle.order | 0 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:9:12:9:18 | [Call] f2(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.label | 1 |
 | deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | semmle.order | 1 |
-| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.label | 2 |
-| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.order | 2 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.label | 0 |
+| deep.py:11:1:11:12 | [FunctionDef] f4 = function f4(...) | deep.py:11:5:11:6 | [Name] f4 | semmle.order | 0 |
 | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | deep.py:11:1:11:12 | [Function] function f4(...) | semmle.label | 1 |
 | deep.py:11:1:11:12 | [FunctionExpr] function f4(...) | deep.py:11:1:11:12 | [Function] function f4(...) | semmle.order | 1 |
-| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:11:1:11:12 | (parameters) | semmle.label | 0 |
-| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:11:1:11:12 | (parameters) | semmle.order | 0 |
-| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:12:5:12:18 | (StmtList) body | semmle.label | 4 |
-| deep.py:11:1:11:12 | [Function] function f4(...) | deep.py:12:5:12:18 | (StmtList) body | semmle.order | 4 |
-| deep.py:12:5:12:18 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.label | 0 |
-| deep.py:12:5:12:18 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.order | 0 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:11:1:11:12 | [Function] function f4(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:12:5:12:18 | [Return] return f3(arg) | deep.py:12:12:12:18 | [Call] f3(arg) | semmle.label | 1 |
 | deep.py:12:5:12:18 | [Return] return f3(arg) | deep.py:12:12:12:18 | [Call] f3(arg) | semmle.order | 1 |
-| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.label | 1 |
-| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.order | 1 |
-| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:15:12:17 | [Name] arg | semmle.label | 2 |
-| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:15:12:17 | [Name] arg | semmle.order | 2 |
-| deep.py:14:1:14:12 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:14:1:14:12 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.label | 0 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | deep.py:12:12:12:13 | [Name] f3 | semmle.order | 0 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:12:12:12:18 | [Call] f3(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.label | 1 |
 | deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | semmle.order | 1 |
-| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.label | 2 |
-| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.order | 2 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.label | 0 |
+| deep.py:14:1:14:12 | [FunctionDef] f5 = function f5(...) | deep.py:14:5:14:6 | [Name] f5 | semmle.order | 0 |
 | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | deep.py:14:1:14:12 | [Function] function f5(...) | semmle.label | 1 |
 | deep.py:14:1:14:12 | [FunctionExpr] function f5(...) | deep.py:14:1:14:12 | [Function] function f5(...) | semmle.order | 1 |
-| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:14:1:14:12 | (parameters) | semmle.label | 0 |
-| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:14:1:14:12 | (parameters) | semmle.order | 0 |
-| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:15:5:15:18 | (StmtList) body | semmle.label | 4 |
-| deep.py:14:1:14:12 | [Function] function f5(...) | deep.py:15:5:15:18 | (StmtList) body | semmle.order | 4 |
-| deep.py:15:5:15:18 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.label | 0 |
-| deep.py:15:5:15:18 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.order | 0 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:14:1:14:12 | [Function] function f5(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:15:5:15:18 | [Return] return f4(arg) | deep.py:15:12:15:18 | [Call] f4(arg) | semmle.label | 1 |
 | deep.py:15:5:15:18 | [Return] return f4(arg) | deep.py:15:12:15:18 | [Call] f4(arg) | semmle.order | 1 |
-| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.label | 1 |
-| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.order | 1 |
-| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:15:15:17 | [Name] arg | semmle.label | 2 |
-| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:15:15:17 | [Name] arg | semmle.order | 2 |
-| deep.py:17:1:17:12 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.label | 1 |
-| deep.py:17:1:17:12 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.order | 1 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.label | 0 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | deep.py:15:12:15:13 | [Name] f4 | semmle.order | 0 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:15:12:15:18 | [Call] f4(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.label | 1 |
 | deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | semmle.order | 1 |
-| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.label | 2 |
-| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.order | 2 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.label | 0 |
+| deep.py:17:1:17:12 | [FunctionDef] f6 = function f6(...) | deep.py:17:5:17:6 | [Name] f6 | semmle.order | 0 |
 | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | deep.py:17:1:17:12 | [Function] function f6(...) | semmle.label | 1 |
 | deep.py:17:1:17:12 | [FunctionExpr] function f6(...) | deep.py:17:1:17:12 | [Function] function f6(...) | semmle.order | 1 |
-| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:17:1:17:12 | (parameters) | semmle.label | 0 |
-| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:17:1:17:12 | (parameters) | semmle.order | 0 |
-| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:18:5:18:18 | (StmtList) body | semmle.label | 4 |
-| deep.py:17:1:17:12 | [Function] function f6(...) | deep.py:18:5:18:18 | (StmtList) body | semmle.order | 4 |
-| deep.py:18:5:18:18 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.label | 0 |
-| deep.py:18:5:18:18 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.order | 0 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| deep.py:17:1:17:12 | [Function] function f6(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | deep.py:18:5:18:18 | [Return] return f5(arg) | deep.py:18:12:18:18 | [Call] f5(arg) | semmle.label | 1 |
 | deep.py:18:5:18:18 | [Return] return f5(arg) | deep.py:18:12:18:18 | [Call] f5(arg) | semmle.order | 1 |
-| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.label | 1 |
-| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.order | 1 |
-| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:15:18:17 | [Name] arg | semmle.label | 2 |
-| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:15:18:17 | [Name] arg | semmle.order | 2 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.label | 0 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | deep.py:18:12:18:13 | [Name] f5 | semmle.order | 0 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:18:12:18:18 | [Call] f5(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:1:20:1 | [Name] x | semmle.label | 1 |
 | deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:1:20:1 | [Name] x | semmle.order | 1 |
 | deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:5:20:14 | [Call] f6(SOURCE) | semmle.label | 2 |
 | deep.py:20:1:20:14 | [AssignStmt] x = f6(SOURCE) | deep.py:20:5:20:14 | [Call] f6(SOURCE) | semmle.order | 2 |
-| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.label | 1 |
-| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.order | 1 |
-| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.label | 2 |
-| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.order | 2 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.label | 0 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | deep.py:20:5:20:6 | [Name] f6 | semmle.order | 0 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| deep.py:20:5:20:14 | [Call] f6(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
 | deep.py:22:1:22:1 | [ExprStmt] x | deep.py:22:1:22:1 | [Name] x | semmle.label | 1 |
 | deep.py:22:1:22:1 | [ExprStmt] x | deep.py:22:1:22:1 | [Name] x | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:2:5:2:8 | [Pass] pass | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:5:5:5:25 | [AssignStmt]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:6:5:6:14 | [ExprStmt] test(a, b) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:7:5:7:15 | [AssignStmt]  | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.label | 3 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:8:5:8:14 | [ExprStmt] test(a, b) | semmle.order | 3 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:13:5:13:59 | [AssignStmt]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | assignment.py:14:5:14:24 | [ExprStmt] test(s1, s2, t1, t2) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:4:5:4:28 | [FunctionDef] __init__ = function __init__(...) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:5:9:5:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:7:5:7:28 | [FunctionDef] set_attr = function set_attr(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:8:9:8:23 | [AssignStmt] self.attr = arg | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:10:5:10:23 | [FunctionDef] get_attr = function get_attr(...) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:11:9:11:24 | [Return] return self.attr | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:14:5:14:14 | [Return] return arg | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:17:5:17:31 | [AssignStmt] c = ImplicitCarrier(SOURCE) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:18:5:18:16 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:21:5:21:28 | [AssignStmt] c = TAINT_CARRIER_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:22:5:22:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:25:5:25:36 | [AssignStmt] c = hub(...) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:26:5:26:22 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:29:5:29:33 | [AssignStmt] c = hub(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:30:5:30:23 | [ExprStmt] SINK(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:33:5:33:45 | [AssignStmt] c = ImplicitCarrier(TAINT_CARRIER_SOURCE) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:34:5:34:14 | [AssignStmt] x = c.attr | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | carrier.py:35:5:35:23 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:3:5:3:14 | [Return] return arg | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:6:5:6:18 | [Return] return f1(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:9:5:9:18 | [Return] return f2(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:12:5:12:18 | [Return] return f3(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:15:5:15:18 | [Return] return f4(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | deep.py:18:5:18:18 | [Return] return f5(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.label | 3 |
+| file://:0:0:0:0 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.order | 3 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.label | 3 |
+| file://:0:0:0:0 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.order | 3 |
+| file://:0:0:0:0 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.label | 3 |
+| file://:0:0:0:0 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.order | 3 |
+| file://:0:0:0:0 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.label | 4 |
+| file://:0:0:0:0 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.order | 4 |
+| file://:0:0:0:0 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.label | 5 |
+| file://:0:0:0:0 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.order | 5 |
+| file://:0:0:0:0 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.label | 6 |
+| file://:0:0:0:0 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.order | 6 |
+| file://:0:0:0:0 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.label | 7 |
+| file://:0:0:0:0 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.order | 7 |
+| file://:0:0:0:0 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.label | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.order | 1 |
+| file://:0:0:0:0 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.label | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.order | 2 |
+| file://:0:0:0:0 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
+| file://:0:0:0:0 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
+| file://:0:0:0:0 | (arguments) | assignment.py:6:10:6:10 | [Name] a | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:6:10:6:10 | [Name] a | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:6:13:6:13 | [Name] b | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:6:13:6:13 | [Name] b | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:8:10:8:10 | [Name] a | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:8:10:8:10 | [Name] a | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:8:13:8:13 | [Name] b | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:8:13:8:13 | [Name] b | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:10:14:11 | [Name] t1 | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:10:14:11 | [Name] t1 | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:14:14:15 | [Name] s1 | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:14:14:15 | [Name] s1 | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:18:14:19 | [Name] t2 | semmle.label | 4 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:18:14:19 | [Name] t2 | semmle.order | 4 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:22:14:23 | [Name] s2 | semmle.label | 5 |
+| file://:0:0:0:0 | (arguments) | assignment.py:14:22:14:23 | [Name] s2 | semmle.order | 5 |
+| file://:0:0:0:0 | (arguments) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:17:25:17:30 | [Name] SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:18:10:18:15 | [Attribute] c.attr | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:22:10:22:22 | [Call] c.get_taint() | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:25:13:25:35 | [Call] ImplicitCarrier(SOURCE) | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:25:29:25:34 | [Name] SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:26:10:26:21 | [Call] c.get_attr() | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:29:13:29:32 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:30:10:30:22 | [Call] c.get_taint() | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:33:25:33:44 | [Name] TAINT_CARRIER_SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | carrier.py:35:10:35:22 | [Call] x.get_taint() | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:6:15:6:17 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:6:15:6:17 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:9:15:9:17 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:9:15:9:17 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:12:15:12:17 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:12:15:12:17 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:15:15:15:17 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:15:15:15:17 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:18:15:18:17 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:18:15:18:17 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | deep.py:20:8:20:13 | [Name] SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:10:21:10:21 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:10:21:10:21 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:11:19:11:19 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:11:19:11:19 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:13:19:13:19 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:13:19:13:19 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:17:23:17:23 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:17:23:17:23 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:18:20:18:20 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:18:20:18:20 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:20:20:20:20 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:20:20:20:20 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:25:22:25:22 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:25:22:25:22 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:26:19:26:19 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:26:19:26:19 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:28:19:28:19 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:28:19:28:19 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:32:22:32:22 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:32:22:32:22 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:33:20:33:20 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:33:20:33:20 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:35:20:35:20 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | sanitizer.py:35:20:35:20 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:3:10:3:15 | [Name] SOURCE | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:3:10:3:15 | [Name] SOURCE | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:7:10:7:10 | [Name] s | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:7:10:7:10 | [Name] s | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:13:10:13:12 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:13:10:13:12 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:17:10:17:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:17:10:17:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:21:10:21:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:21:10:21:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:25:10:25:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:25:10:25:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:33:14:33:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:33:14:33:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:41:14:41:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:41:14:41:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:44:19:44:21 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:44:19:44:21 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:47:10:47:12 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:47:10:47:12 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:51:14:51:16 | [Name] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:51:14:51:16 | [Name] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:55:11:55:11 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:55:11:55:11 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:63:11:63:14 | [Name] cond | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:63:11:63:14 | [Name] cond | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:63:17:63:17 | [Name] t | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:63:17:63:17 | [Name] t | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:70:11:70:14 | [Name] cond | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:70:11:70:14 | [Name] cond | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:70:17:70:17 | [Name] t | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:70:17:70:17 | [Name] t | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:77:13:77:13 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:77:13:77:13 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:78:10:78:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:78:10:78:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:82:13:82:13 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:82:13:82:13 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:83:10:83:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:83:10:83:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:89:10:89:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:89:10:89:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:93:10:93:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:93:10:93:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:97:10:97:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:97:10:97:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:101:10:101:10 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:101:10:101:10 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:111:10:111:12 | [Attribute] t.x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:111:10:111:12 | [Attribute] t.x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:116:13:116:13 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:116:13:116:13 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:117:12:117:12 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:117:12:117:12 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:121:28:121:28 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:121:28:121:28 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:122:17:122:17 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:122:17:122:17 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:130:21:130:21 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:130:21:130:21 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:132:14:132:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:132:14:132:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:140:21:140:21 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:140:21:140:21 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:142:14:142:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:142:14:142:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:149:24:149:24 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:149:24:149:24 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:151:21:151:21 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:151:21:151:21 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:153:14:153:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:153:14:153:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:156:6:156:11 | [Name] unsafe | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:156:6:156:11 | [Name] unsafe | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:160:14:160:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:160:14:160:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:164:14:164:14 | [Name] s | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:164:14:164:14 | [Name] s | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:165:10:165:10 | [Name] s | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:165:10:165:10 | [Name] s | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:170:14:170:14 | [Name] l | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:170:14:170:14 | [Name] l | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:171:14:171:14 | [Name] d | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:171:14:171:14 | [Name] d | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:172:10:172:13 | [Subscript] x[0] | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:172:10:172:13 | [Subscript] x[0] | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:174:15:174:15 | [Name] l | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:174:15:174:15 | [Name] l | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:175:15:175:15 | [Name] d | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:175:15:175:15 | [Name] d | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:180:14:180:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:180:14:180:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:182:14:182:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:182:14:182:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:184:14:184:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:184:14:184:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:186:14:186:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:186:14:186:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:196:19:196:19 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:196:19:196:19 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:196:22:196:24 | [Name] str | semmle.label | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:196:22:196:24 | [Name] str | semmle.order | 3 |
+| file://:0:0:0:0 | (arguments) | test.py:197:14:197:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:197:14:197:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:199:14:199:14 | [Name] t | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:199:14:199:14 | [Name] t | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:214:14:214:14 | [Name] x | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:214:14:214:14 | [Name] x | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:219:14:219:20 | [Name] tainted | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:219:14:219:20 | [Name] tainted | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:220:10:220:16 | [Name] tainted | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:220:10:220:16 | [Name] tainted | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:226:10:226:16 | [Name] tainted | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:226:10:226:16 | [Name] tainted | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:231:14:231:20 | [Name] tainted | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:231:14:231:20 | [Name] tainted | semmle.order | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:233:14:233:20 | [Name] tainted | semmle.label | 2 |
+| file://:0:0:0:0 | (arguments) | test.py:233:14:233:20 | [Name] tainted | semmle.order | 2 |
+| file://:0:0:0:0 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | assignment.py:1:11:1:14 | [Parameter] args | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:4:18:4:21 | [Parameter] self | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (parameters) | carrier.py:4:24:4:26 | [Parameter] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:7:18:7:21 | [Parameter] self | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (parameters) | carrier.py:7:24:7:26 | [Parameter] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:10:18:10:21 | [Parameter] self | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | carrier.py:13:9:13:11 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:2:8:2:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:5:8:5:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:8:8:8:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:11:8:11:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:14:8:14:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | deep.py:17:8:17:10 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.label | 2 |
+| file://:0:0:0:0 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.order | 2 |
+| file://:0:0:0:0 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.order | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.label | 2 |
+| file://:0:0:0:0 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.order | 2 |
+| file://:0:0:0:0 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.label | 1 |
+| file://:0:0:0:0 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.order | 1 |
 | module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:1:3:9 | [Name] dangerous | semmle.label | 1 |
 | module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:1:3:9 | [Name] dangerous | semmle.order | 1 |
 | module.py:3:1:3:18 | [AssignStmt] dangerous = SOURCE | module.py:3:13:3:18 | [Name] SOURCE | semmle.label | 2 |
@@ -1900,16 +2597,14 @@ edges
 | module.py:4:1:4:13 | [AssignStmt] safe = safe | module.py:4:8:4:13 | [Str] safe | semmle.order | 2 |
 | module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.label | 1 |
 | module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | semmle.order | 1 |
-| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.label | 2 |
-| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.order | 2 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.label | 0 |
+| module.py:6:1:6:21 | [FunctionDef] dangerous_func = function dangerous_func(...) | module.py:6:5:6:18 | [Name] dangerous_func | semmle.order | 0 |
 | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.label | 1 |
 | module.py:6:1:6:21 | [FunctionExpr] function dangerous_func(...) | module.py:6:1:6:21 | [Function] function dangerous_func(...) | semmle.order | 1 |
-| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:6:1:6:21 | (parameters) | semmle.label | 0 |
-| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:6:1:6:21 | (parameters) | semmle.order | 0 |
-| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:7:5:7:17 | (StmtList) body | semmle.label | 3 |
-| module.py:6:1:6:21 | [Function] function dangerous_func(...) | module.py:7:5:7:17 | (StmtList) body | semmle.order | 3 |
-| module.py:7:5:7:17 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.label | 0 |
-| module.py:7:5:7:17 | (StmtList) body | module.py:7:5:7:17 | [Return] return SOURCE | semmle.order | 0 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| module.py:6:1:6:21 | [Function] function dangerous_func(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | module.py:7:5:7:17 | [Return] return SOURCE | module.py:7:12:7:17 | [Name] SOURCE | semmle.label | 1 |
 | module.py:7:5:7:17 | [Return] return SOURCE | module.py:7:12:7:17 | [Name] SOURCE | semmle.order | 1 |
 | module.py:10:1:10:14 | [AssignStmt] safe2 = SOURCE | module.py:10:1:10:5 | [Name] safe2 | semmle.label | 1 |
@@ -1920,106 +2615,84 @@ edges
 | module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:1:11:5 | [Name] safe2 | semmle.order | 1 |
 | module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:9:11:14 | [Str] safe | semmle.label | 2 |
 | module.py:11:1:11:14 | [AssignStmt] safe2 = safe | module.py:11:9:11:14 | [Str] safe | semmle.order | 2 |
-| rockpaperscissors.py:3:1:3:14 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.label | 1 |
-| rockpaperscissors.py:3:1:3:14 | (parameters) | rockpaperscissors.py:3:10:3:12 | [Parameter] arg | semmle.order | 1 |
 | rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.label | 1 |
 | rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | semmle.order | 1 |
-| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.label | 2 |
-| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.order | 2 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.label | 0 |
+| rockpaperscissors.py:3:1:3:14 | [FunctionDef] rock = function rock(...) | rockpaperscissors.py:3:5:3:8 | [Name] rock | semmle.order | 0 |
 | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.label | 1 |
 | rockpaperscissors.py:3:1:3:14 | [FunctionExpr] function rock(...) | rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | semmle.order | 1 |
-| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:3:1:3:14 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.label | 4 |
-| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | rockpaperscissors.py:4:5:4:29 | (StmtList) body | semmle.order | 4 |
-| rockpaperscissors.py:4:5:4:29 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.label | 0 |
-| rockpaperscissors.py:4:5:4:29 | (StmtList) body | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:3:1:3:14 | [Function] function rock(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.label | 1 |
 | rockpaperscissors.py:4:5:4:29 | [ExprStmt] SCISSORS are vulnerable | rockpaperscissors.py:4:5:4:29 | [Str] SCISSORS are vulnerable | semmle.order | 1 |
-| rockpaperscissors.py:6:1:6:15 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.label | 1 |
-| rockpaperscissors.py:6:1:6:15 | (parameters) | rockpaperscissors.py:6:11:6:13 | [Parameter] arg | semmle.order | 1 |
 | rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.label | 1 |
 | rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | semmle.order | 1 |
-| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.label | 2 |
-| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.order | 2 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.label | 0 |
+| rockpaperscissors.py:6:1:6:15 | [FunctionDef] paper = function paper(...) | rockpaperscissors.py:6:5:6:9 | [Name] paper | semmle.order | 0 |
 | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.label | 1 |
 | rockpaperscissors.py:6:1:6:15 | [FunctionExpr] function paper(...) | rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | semmle.order | 1 |
-| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:6:1:6:15 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.label | 4 |
-| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | rockpaperscissors.py:7:5:7:24 | (StmtList) body | semmle.order | 4 |
-| rockpaperscissors.py:7:5:7:24 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.label | 0 |
-| rockpaperscissors.py:7:5:7:24 | (StmtList) body | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:6:1:6:15 | [Function] function paper(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.label | 1 |
 | rockpaperscissors.py:7:5:7:24 | [ExprStmt] ROCK is vulnerable | rockpaperscissors.py:7:5:7:24 | [Str] ROCK is vulnerable | semmle.order | 1 |
-| rockpaperscissors.py:9:1:9:18 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.label | 1 |
-| rockpaperscissors.py:9:1:9:18 | (parameters) | rockpaperscissors.py:9:14:9:16 | [Parameter] arg | semmle.order | 1 |
 | rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.label | 1 |
 | rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | semmle.order | 1 |
-| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.label | 2 |
-| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.order | 2 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.label | 0 |
+| rockpaperscissors.py:9:1:9:18 | [FunctionDef] scissors = function scissors(...) | rockpaperscissors.py:9:5:9:12 | [Name] scissors | semmle.order | 0 |
 | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.label | 1 |
 | rockpaperscissors.py:9:1:9:18 | [FunctionExpr] function scissors(...) | rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | semmle.order | 1 |
-| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:9:1:9:18 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.label | 4 |
-| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | rockpaperscissors.py:10:5:10:25 | (StmtList) body | semmle.order | 4 |
-| rockpaperscissors.py:10:5:10:25 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.label | 0 |
-| rockpaperscissors.py:10:5:10:25 | (StmtList) body | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | semmle.order | 0 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:9:1:9:18 | [Function] function scissors(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.label | 1 |
 | rockpaperscissors.py:10:5:10:25 | [ExprStmt] PAPER is vulnerable | rockpaperscissors.py:10:5:10:25 | [Str] PAPER is vulnerable | semmle.order | 1 |
 | rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
 | rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
-| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.label | 2 |
-| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.order | 2 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.label | 0 |
+| rockpaperscissors.py:12:1:12:12 | [FunctionDef] test1 = function test1(...) | rockpaperscissors.py:12:5:12:9 | [Name] test1 | semmle.order | 0 |
 | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.label | 1 |
 | rockpaperscissors.py:12:1:12:12 | [FunctionExpr] function test1(...) | rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | semmle.order | 1 |
-| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:12:1:12:12 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.label | 3 |
-| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | rockpaperscissors.py:13:5:13:18 | (StmtList) body | semmle.order | 3 |
-| rockpaperscissors.py:13:5:13:18 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.label | 0 |
-| rockpaperscissors.py:13:5:13:18 | (StmtList) body | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | semmle.order | 0 |
-| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.label | 1 |
-| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.order | 1 |
-| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.label | 2 |
-| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:10:13:17 | [Name] SCISSORS | semmle.order | 2 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:12:1:12:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.label | 0 |
+| rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | rockpaperscissors.py:13:5:13:8 | [Name] rock | semmle.order | 0 |
 | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.label | 1 |
 | rockpaperscissors.py:13:5:13:18 | [ExprStmt] rock(SCISSORS) | rockpaperscissors.py:13:5:13:18 | [Call] rock(SCISSORS) | semmle.order | 1 |
 | rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
 | rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
-| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.label | 2 |
-| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.order | 2 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.label | 0 |
+| rockpaperscissors.py:15:1:15:12 | [FunctionDef] test2 = function test2(...) | rockpaperscissors.py:15:5:15:9 | [Name] test2 | semmle.order | 0 |
 | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.label | 1 |
 | rockpaperscissors.py:15:1:15:12 | [FunctionExpr] function test2(...) | rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | semmle.order | 1 |
-| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:15:1:15:12 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.label | 3 |
-| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | rockpaperscissors.py:16:5:16:15 | (StmtList) body | semmle.order | 3 |
-| rockpaperscissors.py:16:5:16:15 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.label | 0 |
-| rockpaperscissors.py:16:5:16:15 | (StmtList) body | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | semmle.order | 0 |
-| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.label | 1 |
-| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.order | 1 |
-| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.label | 2 |
-| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:11:16:14 | [Name] ROCK | semmle.order | 2 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:15:1:15:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.label | 0 |
+| rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | rockpaperscissors.py:16:5:16:9 | [Name] paper | semmle.order | 0 |
 | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.label | 1 |
 | rockpaperscissors.py:16:5:16:15 | [ExprStmt] paper(ROCK) | rockpaperscissors.py:16:5:16:15 | [Call] paper(ROCK) | semmle.order | 1 |
 | rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
 | rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
-| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.label | 2 |
-| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.order | 2 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.label | 0 |
+| rockpaperscissors.py:18:1:18:12 | [FunctionDef] test3 = function test3(...) | rockpaperscissors.py:18:5:18:9 | [Name] test3 | semmle.order | 0 |
 | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.label | 1 |
 | rockpaperscissors.py:18:1:18:12 | [FunctionExpr] function test3(...) | rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | semmle.order | 1 |
-| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:18:1:18:12 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.label | 5 |
-| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | rockpaperscissors.py:19:5:19:12 | (StmtList) body | semmle.order | 5 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
-| rockpaperscissors.py:19:5:19:12 | (StmtList) body | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:18:1:18:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:5:19:5 | [Name] x | semmle.order | 1 |
 | rockpaperscissors.py:19:5:19:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:19:9:19:12 | [Name] ROCK | semmle.label | 2 |
@@ -2030,30 +2703,26 @@ edges
 | rockpaperscissors.py:20:5:20:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | semmle.order | 2 |
 | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | rockpaperscissors.py:20:9:20:9 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | rockpaperscissors.py:20:9:20:9 | [Name] x | semmle.order | 1 |
-| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.label | 1 |
-| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.order | 1 |
-| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.label | 1 |
-| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.order | 1 |
-| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.label | 2 |
-| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:14:21:14 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.label | 0 |
+| rockpaperscissors.py:20:9:20:16 | [Call] x.prev() | rockpaperscissors.py:20:9:20:14 | [Attribute] x.prev | semmle.order | 0 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.label | 0 |
+| rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | rockpaperscissors.py:21:5:21:12 | [Name] scissors | semmle.order | 0 |
 | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.label | 1 |
 | rockpaperscissors.py:21:5:21:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:21:5:21:15 | [Call] scissors(y) | semmle.order | 1 |
 | rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
 | rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
-| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.label | 2 |
-| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.order | 2 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.label | 0 |
+| rockpaperscissors.py:23:1:23:12 | [FunctionDef] test4 = function test4(...) | rockpaperscissors.py:23:5:23:9 | [Name] test4 | semmle.order | 0 |
 | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.label | 1 |
 | rockpaperscissors.py:23:1:23:12 | [FunctionExpr] function test4(...) | rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | semmle.order | 1 |
-| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:23:1:23:12 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.label | 5 |
-| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | rockpaperscissors.py:24:5:24:12 | (StmtList) body | semmle.order | 5 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.label | 0 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | semmle.order | 0 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.label | 1 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | semmle.order | 1 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.label | 2 |
-| rockpaperscissors.py:24:5:24:12 | (StmtList) body | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | semmle.order | 2 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:23:1:23:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:5:24:5 | [Name] x | semmle.order | 1 |
 | rockpaperscissors.py:24:5:24:12 | [AssignStmt] x = ROCK | rockpaperscissors.py:24:9:24:12 | [Name] ROCK | semmle.label | 2 |
@@ -2064,36 +2733,32 @@ edges
 | rockpaperscissors.py:25:5:25:23 | [AssignStmt] y = (...).prev() | rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | semmle.order | 2 |
 | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | rockpaperscissors.py:25:9:25:9 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | rockpaperscissors.py:25:9:25:9 | [Name] x | semmle.order | 1 |
-| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.label | 1 |
-| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.label | 0 |
+| rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | rockpaperscissors.py:25:9:25:14 | [Attribute] x.prev | semmle.order | 0 |
 | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | semmle.label | 1 |
 | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | rockpaperscissors.py:25:9:25:16 | [Call] x.prev() | semmle.order | 1 |
-| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.label | 1 |
-| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.order | 1 |
-| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.label | 1 |
-| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.order | 1 |
-| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.label | 2 |
-| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:14:26:14 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.label | 0 |
+| rockpaperscissors.py:25:9:25:23 | [Call] (...).prev() | rockpaperscissors.py:25:9:25:21 | [Attribute] (...).prev | semmle.order | 0 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.label | 0 |
+| rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | rockpaperscissors.py:26:5:26:12 | [Name] scissors | semmle.order | 0 |
 | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.label | 1 |
 | rockpaperscissors.py:26:5:26:15 | [ExprStmt] scissors(y) | rockpaperscissors.py:26:5:26:15 | [Call] scissors(y) | semmle.order | 1 |
 | rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
 | rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
-| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.label | 2 |
-| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.order | 2 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.label | 0 |
+| rockpaperscissors.py:28:1:28:12 | [FunctionDef] test5 = function test5(...) | rockpaperscissors.py:28:5:28:9 | [Name] test5 | semmle.order | 0 |
 | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.label | 1 |
 | rockpaperscissors.py:28:1:28:12 | [FunctionExpr] function test5(...) | rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | semmle.order | 1 |
-| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.label | 0 |
-| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:28:1:28:12 | (parameters) | semmle.order | 0 |
-| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.label | 6 |
-| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | rockpaperscissors.py:29:5:29:16 | (StmtList) body | semmle.order | 6 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.label | 0 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | semmle.order | 0 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.label | 1 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | semmle.order | 1 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.label | 2 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | semmle.order | 2 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.label | 3 |
-| rockpaperscissors.py:29:5:29:16 | (StmtList) body | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | semmle.order | 3 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 6 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 6 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| rockpaperscissors.py:28:1:28:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:5:29:5 | [Name] x | semmle.order | 1 |
 | rockpaperscissors.py:29:5:29:16 | [AssignStmt] x = SCISSORS | rockpaperscissors.py:29:9:29:16 | [Name] SCISSORS | semmle.label | 2 |
@@ -2104,688 +2769,560 @@ edges
 | rockpaperscissors.py:30:5:30:16 | [AssignStmt] y = x.prev() | rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | semmle.order | 2 |
 | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | rockpaperscissors.py:30:9:30:9 | [Name] x | semmle.label | 1 |
 | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | rockpaperscissors.py:30:9:30:9 | [Name] x | semmle.order | 1 |
-| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.label | 1 |
-| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.order | 1 |
-| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.label | 1 |
-| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.order | 1 |
-| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.label | 2 |
-| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:11:31:11 | [Name] x | semmle.order | 2 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.label | 0 |
+| rockpaperscissors.py:30:9:30:16 | [Call] x.prev() | rockpaperscissors.py:30:9:30:14 | [Attribute] x.prev | semmle.order | 0 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.label | 0 |
+| rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | rockpaperscissors.py:31:5:31:9 | [Name] paper | semmle.order | 0 |
 | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | semmle.label | 1 |
 | rockpaperscissors.py:31:5:31:12 | [ExprStmt] paper(x) | rockpaperscissors.py:31:5:31:12 | [Call] paper(x) | semmle.order | 1 |
-| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.label | 1 |
-| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.order | 1 |
-| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.label | 2 |
-| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:11:32:11 | [Name] y | semmle.order | 2 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.label | 0 |
+| rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | rockpaperscissors.py:32:5:32:9 | [Name] paper | semmle.order | 0 |
 | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.label | 1 |
 | rockpaperscissors.py:32:5:32:12 | [ExprStmt] paper(y) | rockpaperscissors.py:32:5:32:12 | [Call] paper(y) | semmle.order | 1 |
-| sanitizer.py:3:1:3:22 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.label | 1 |
-| sanitizer.py:3:1:3:22 | (parameters) | sanitizer.py:3:18:3:20 | [Parameter] arg | semmle.order | 1 |
 | sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.label | 1 |
 | sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | semmle.order | 1 |
-| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.label | 2 |
-| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.order | 2 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.label | 0 |
+| sanitizer.py:3:1:3:22 | [FunctionDef] isEscapedSql = function isEscapedSql(...) | sanitizer.py:3:5:3:16 | [Name] isEscapedSql | semmle.order | 0 |
 | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.label | 1 |
 | sanitizer.py:3:1:3:22 | [FunctionExpr] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | semmle.order | 1 |
-| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | (parameters) | semmle.label | 0 |
-| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:1:3:22 | (parameters) | semmle.order | 0 |
-| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:24:3:27 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | sanitizer.py:3:24:3:27 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:3:24:3:27 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.label | 0 |
-| sanitizer.py:3:24:3:27 | (StmtList) body | sanitizer.py:3:24:3:27 | [Pass] pass | semmle.order | 0 |
-| sanitizer.py:5:1:5:24 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.label | 1 |
-| sanitizer.py:5:1:5:24 | (parameters) | sanitizer.py:5:20:5:22 | [Parameter] arg | semmle.order | 1 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:3:1:3:22 | [Function] function isEscapedSql(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.label | 1 |
 | sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | semmle.order | 1 |
-| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.label | 2 |
-| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.order | 2 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.label | 0 |
+| sanitizer.py:5:1:5:24 | [FunctionDef] isValidCommand = function isValidCommand(...) | sanitizer.py:5:5:5:18 | [Name] isValidCommand | semmle.order | 0 |
 | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.label | 1 |
 | sanitizer.py:5:1:5:24 | [FunctionExpr] function isValidCommand(...) | sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | semmle.order | 1 |
-| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:1:5:24 | (parameters) | semmle.label | 0 |
-| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:1:5:24 | (parameters) | semmle.order | 0 |
-| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:26:5:29 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | sanitizer.py:5:26:5:29 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:5:26:5:29 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.label | 0 |
-| sanitizer.py:5:26:5:29 | (StmtList) body | sanitizer.py:5:26:5:29 | [Pass] pass | semmle.order | 0 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:5:1:5:24 | [Function] function isValidCommand(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.label | 1 |
 | sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | semmle.order | 1 |
-| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.label | 2 |
-| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.order | 2 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.label | 0 |
+| sanitizer.py:8:1:8:18 | [FunctionDef] sql_inject1 = function sql_inject1(...) | sanitizer.py:8:5:8:15 | [Name] sql_inject1 | semmle.order | 0 |
 | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.label | 1 |
 | sanitizer.py:8:1:8:18 | [FunctionExpr] function sql_inject1(...) | sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | semmle.order | 1 |
-| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:8:1:8:18 | (parameters) | semmle.label | 0 |
-| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:8:1:8:18 | (parameters) | semmle.order | 0 |
-| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:9:5:9:20 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | sanitizer.py:9:5:9:20 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
-| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
-| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.label | 1 |
-| sanitizer.py:9:5:9:20 | (StmtList) body | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | semmle.order | 1 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:8:1:8:18 | [Function] function sql_inject1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:5:9:5 | [Name] x | semmle.label | 1 |
 | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:5:9:5 | [Name] x | semmle.order | 1 |
 | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.label | 2 |
 | sanitizer.py:9:5:9:20 | [AssignStmt] x = user_input() | sanitizer.py:9:9:9:20 | [Call] user_input() | semmle.order | 2 |
-| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.label | 1 |
-| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.label | 0 |
+| sanitizer.py:9:9:9:20 | [Call] user_input() | sanitizer.py:9:9:9:18 | [Name] user_input | semmle.order | 0 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.label | 0 |
 | sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | semmle.order | 0 |
-| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:11:9:11:20 | (StmtList) body | semmle.label | 2 |
-| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:11:9:11:20 | (StmtList) body | semmle.order | 2 |
-| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.label | 3 |
-| sanitizer.py:10:5:10:23 | [If] if isEscapedSql(x): | sanitizer.py:13:9:13:20 | (StmtList) orelse | semmle.order | 3 |
-| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.label | 1 |
-| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.order | 1 |
-| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:21:10:21 | [Name] x | semmle.label | 2 |
-| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:21:10:21 | [Name] x | semmle.order | 2 |
-| sanitizer.py:11:9:11:20 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
-| sanitizer.py:11:9:11:20 | (StmtList) body | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
-| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.label | 1 |
-| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.order | 1 |
-| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:19:11:19 | [Name] x | semmle.label | 2 |
-| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:19:11:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.label | 0 |
+| sanitizer.py:10:8:10:22 | [Call] isEscapedSql(x) | sanitizer.py:10:8:10:19 | [Name] isEscapedSql | semmle.order | 0 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.label | 0 |
+| sanitizer.py:11:9:11:20 | [Call] sql_query(x) | sanitizer.py:11:9:11:17 | [Name] sql_query | semmle.order | 0 |
 | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.label | 1 |
 | sanitizer.py:11:9:11:20 | [ExprStmt] sql_query(x) | sanitizer.py:11:9:11:20 | [Call] sql_query(x) | semmle.order | 1 |
-| sanitizer.py:13:9:13:20 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
-| sanitizer.py:13:9:13:20 | (StmtList) orelse | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
-| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.label | 1 |
-| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.order | 1 |
-| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:19:13:19 | [Name] x | semmle.label | 2 |
-| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:19:13:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.label | 0 |
+| sanitizer.py:13:9:13:20 | [Call] sql_query(x) | sanitizer.py:13:9:13:17 | [Name] sql_query | semmle.order | 0 |
 | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.label | 1 |
 | sanitizer.py:13:9:13:20 | [ExprStmt] sql_query(x) | sanitizer.py:13:9:13:20 | [Call] sql_query(x) | semmle.order | 1 |
 | sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.label | 1 |
 | sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | semmle.order | 1 |
-| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.label | 2 |
-| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.order | 2 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.label | 0 |
+| sanitizer.py:15:1:15:22 | [FunctionDef] command_inject1 = function command_inject1(...) | sanitizer.py:15:5:15:19 | [Name] command_inject1 | semmle.order | 0 |
 | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.label | 1 |
 | sanitizer.py:15:1:15:22 | [FunctionExpr] function command_inject1(...) | sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | semmle.order | 1 |
-| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:15:1:15:22 | (parameters) | semmle.label | 0 |
-| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:15:1:15:22 | (parameters) | semmle.order | 0 |
-| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:16:5:16:20 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | sanitizer.py:16:5:16:20 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
-| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
-| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.label | 1 |
-| sanitizer.py:16:5:16:20 | (StmtList) body | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | semmle.order | 1 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:15:1:15:22 | [Function] function command_inject1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:5:16:5 | [Name] x | semmle.label | 1 |
 | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:5:16:5 | [Name] x | semmle.order | 1 |
 | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.label | 2 |
 | sanitizer.py:16:5:16:20 | [AssignStmt] x = user_input() | sanitizer.py:16:9:16:20 | [Call] user_input() | semmle.order | 2 |
-| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.label | 1 |
-| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.label | 0 |
+| sanitizer.py:16:9:16:20 | [Call] user_input() | sanitizer.py:16:9:16:18 | [Name] user_input | semmle.order | 0 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.label | 0 |
 | sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | semmle.order | 0 |
-| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:18:9:18:21 | (StmtList) body | semmle.label | 2 |
-| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:18:9:18:21 | (StmtList) body | semmle.order | 2 |
-| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.label | 3 |
-| sanitizer.py:17:5:17:25 | [If] if isValidCommand(x): | sanitizer.py:20:9:20:21 | (StmtList) orelse | semmle.order | 3 |
-| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.label | 1 |
-| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.order | 1 |
-| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:23:17:23 | [Name] x | semmle.label | 2 |
-| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:23:17:23 | [Name] x | semmle.order | 2 |
-| sanitizer.py:18:9:18:21 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
-| sanitizer.py:18:9:18:21 | (StmtList) body | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
-| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.label | 1 |
-| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.order | 1 |
-| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:20:18:20 | [Name] x | semmle.label | 2 |
-| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:20:18:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.label | 0 |
+| sanitizer.py:17:8:17:24 | [Call] isValidCommand(x) | sanitizer.py:17:8:17:21 | [Name] isValidCommand | semmle.order | 0 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.label | 0 |
+| sanitizer.py:18:9:18:21 | [Call] os_command(x) | sanitizer.py:18:9:18:18 | [Name] os_command | semmle.order | 0 |
 | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.label | 1 |
 | sanitizer.py:18:9:18:21 | [ExprStmt] os_command(x) | sanitizer.py:18:9:18:21 | [Call] os_command(x) | semmle.order | 1 |
-| sanitizer.py:20:9:20:21 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
-| sanitizer.py:20:9:20:21 | (StmtList) orelse | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
-| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.label | 1 |
-| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.order | 1 |
-| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:20:20:20 | [Name] x | semmle.label | 2 |
-| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:20:20:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.label | 0 |
+| sanitizer.py:20:9:20:21 | [Call] os_command(x) | sanitizer.py:20:9:20:18 | [Name] os_command | semmle.order | 0 |
 | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.label | 1 |
 | sanitizer.py:20:9:20:21 | [ExprStmt] os_command(x) | sanitizer.py:20:9:20:21 | [Call] os_command(x) | semmle.order | 1 |
 | sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.label | 1 |
 | sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | semmle.order | 1 |
-| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.label | 2 |
-| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.order | 2 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.label | 0 |
+| sanitizer.py:23:1:23:18 | [FunctionDef] sql_inject2 = function sql_inject2(...) | sanitizer.py:23:5:23:15 | [Name] sql_inject2 | semmle.order | 0 |
 | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.label | 1 |
 | sanitizer.py:23:1:23:18 | [FunctionExpr] function sql_inject2(...) | sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | semmle.order | 1 |
-| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:23:1:23:18 | (parameters) | semmle.label | 0 |
-| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:23:1:23:18 | (parameters) | semmle.order | 0 |
-| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:24:5:24:20 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | sanitizer.py:24:5:24:20 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
-| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
-| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.label | 1 |
-| sanitizer.py:24:5:24:20 | (StmtList) body | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:23:1:23:18 | [Function] function sql_inject2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:5:24:5 | [Name] x | semmle.label | 1 |
 | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:5:24:5 | [Name] x | semmle.order | 1 |
 | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.label | 2 |
 | sanitizer.py:24:5:24:20 | [AssignStmt] x = user_input() | sanitizer.py:24:9:24:20 | [Call] user_input() | semmle.order | 2 |
-| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.label | 1 |
-| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.label | 0 |
+| sanitizer.py:24:9:24:20 | [Call] user_input() | sanitizer.py:24:9:24:18 | [Name] user_input | semmle.order | 0 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.label | 0 |
 | sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | semmle.order | 0 |
-| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:26:9:26:20 | (StmtList) body | semmle.label | 2 |
-| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:26:9:26:20 | (StmtList) body | semmle.order | 2 |
-| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.label | 3 |
-| sanitizer.py:25:5:25:24 | [If] if notASanitizer(x): | sanitizer.py:28:9:28:20 | (StmtList) orelse | semmle.order | 3 |
-| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.label | 1 |
-| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.order | 1 |
-| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:22:25:22 | [Name] x | semmle.label | 2 |
-| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:22:25:22 | [Name] x | semmle.order | 2 |
-| sanitizer.py:26:9:26:20 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
-| sanitizer.py:26:9:26:20 | (StmtList) body | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
-| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.label | 1 |
-| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.order | 1 |
-| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:19:26:19 | [Name] x | semmle.label | 2 |
-| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:19:26:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.label | 0 |
+| sanitizer.py:25:8:25:23 | [Call] notASanitizer(x) | sanitizer.py:25:8:25:20 | [Name] notASanitizer | semmle.order | 0 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.label | 0 |
+| sanitizer.py:26:9:26:20 | [Call] sql_query(x) | sanitizer.py:26:9:26:17 | [Name] sql_query | semmle.order | 0 |
 | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.label | 1 |
 | sanitizer.py:26:9:26:20 | [ExprStmt] sql_query(x) | sanitizer.py:26:9:26:20 | [Call] sql_query(x) | semmle.order | 1 |
-| sanitizer.py:28:9:28:20 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.label | 0 |
-| sanitizer.py:28:9:28:20 | (StmtList) orelse | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | semmle.order | 0 |
-| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.label | 1 |
-| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.order | 1 |
-| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:19:28:19 | [Name] x | semmle.label | 2 |
-| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:19:28:19 | [Name] x | semmle.order | 2 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.label | 0 |
+| sanitizer.py:28:9:28:20 | [Call] sql_query(x) | sanitizer.py:28:9:28:17 | [Name] sql_query | semmle.order | 0 |
 | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.label | 1 |
 | sanitizer.py:28:9:28:20 | [ExprStmt] sql_query(x) | sanitizer.py:28:9:28:20 | [Call] sql_query(x) | semmle.order | 1 |
 | sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.label | 1 |
 | sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | semmle.order | 1 |
-| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.label | 2 |
-| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.order | 2 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.label | 0 |
+| sanitizer.py:30:1:30:22 | [FunctionDef] command_inject2 = function command_inject2(...) | sanitizer.py:30:5:30:19 | [Name] command_inject2 | semmle.order | 0 |
 | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.label | 1 |
 | sanitizer.py:30:1:30:22 | [FunctionExpr] function command_inject2(...) | sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | semmle.order | 1 |
-| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:30:1:30:22 | (parameters) | semmle.label | 0 |
-| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:30:1:30:22 | (parameters) | semmle.order | 0 |
-| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:31:5:31:20 | (StmtList) body | semmle.label | 4 |
-| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | sanitizer.py:31:5:31:20 | (StmtList) body | semmle.order | 4 |
-| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.label | 0 |
-| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | semmle.order | 0 |
-| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.label | 1 |
-| sanitizer.py:31:5:31:20 | (StmtList) body | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | semmle.order | 1 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| sanitizer.py:30:1:30:22 | [Function] function command_inject2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:5:31:5 | [Name] x | semmle.label | 1 |
 | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:5:31:5 | [Name] x | semmle.order | 1 |
 | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.label | 2 |
 | sanitizer.py:31:5:31:20 | [AssignStmt] x = user_input() | sanitizer.py:31:9:31:20 | [Call] user_input() | semmle.order | 2 |
-| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.label | 1 |
-| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.order | 1 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.label | 0 |
+| sanitizer.py:31:9:31:20 | [Call] user_input() | sanitizer.py:31:9:31:18 | [Name] user_input | semmle.order | 0 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.label | 0 |
 | sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | semmle.order | 0 |
-| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:33:9:33:21 | (StmtList) body | semmle.label | 2 |
-| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:33:9:33:21 | (StmtList) body | semmle.order | 2 |
-| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.label | 3 |
-| sanitizer.py:32:5:32:24 | [If] if notASanitizer(x): | sanitizer.py:35:9:35:21 | (StmtList) orelse | semmle.order | 3 |
-| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.label | 1 |
-| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.order | 1 |
-| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:22:32:22 | [Name] x | semmle.label | 2 |
-| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:22:32:22 | [Name] x | semmle.order | 2 |
-| sanitizer.py:33:9:33:21 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
-| sanitizer.py:33:9:33:21 | (StmtList) body | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
-| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.label | 1 |
-| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.order | 1 |
-| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:20:33:20 | [Name] x | semmle.label | 2 |
-| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:20:33:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.label | 0 |
+| sanitizer.py:32:8:32:23 | [Call] notASanitizer(x) | sanitizer.py:32:8:32:20 | [Name] notASanitizer | semmle.order | 0 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.label | 0 |
+| sanitizer.py:33:9:33:21 | [Call] os_command(x) | sanitizer.py:33:9:33:18 | [Name] os_command | semmle.order | 0 |
 | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.label | 1 |
 | sanitizer.py:33:9:33:21 | [ExprStmt] os_command(x) | sanitizer.py:33:9:33:21 | [Call] os_command(x) | semmle.order | 1 |
-| sanitizer.py:35:9:35:21 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.label | 0 |
-| sanitizer.py:35:9:35:21 | (StmtList) orelse | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | semmle.order | 0 |
-| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.label | 1 |
-| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.order | 1 |
-| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:20:35:20 | [Name] x | semmle.label | 2 |
-| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:20:35:20 | [Name] x | semmle.order | 2 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.label | 0 |
+| sanitizer.py:35:9:35:21 | [Call] os_command(x) | sanitizer.py:35:9:35:18 | [Name] os_command | semmle.order | 0 |
 | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.label | 1 |
 | sanitizer.py:35:9:35:21 | [ExprStmt] os_command(x) | sanitizer.py:35:9:35:21 | [Call] os_command(x) | semmle.order | 1 |
 | test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.label | 1 |
 | test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | semmle.order | 1 |
-| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.label | 2 |
-| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.order | 2 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.label | 0 |
+| test.py:2:1:2:12 | [FunctionDef] test1 = function test1(...) | test.py:2:5:2:9 | [Name] test1 | semmle.order | 0 |
 | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | test.py:2:1:2:12 | [Function] function test1(...) | semmle.label | 1 |
 | test.py:2:1:2:12 | [FunctionExpr] function test1(...) | test.py:2:1:2:12 | [Function] function test1(...) | semmle.order | 1 |
-| test.py:2:1:2:12 | [Function] function test1(...) | test.py:2:1:2:12 | (parameters) | semmle.label | 0 |
-| test.py:2:1:2:12 | [Function] function test1(...) | test.py:2:1:2:12 | (parameters) | semmle.order | 0 |
-| test.py:2:1:2:12 | [Function] function test1(...) | test.py:3:5:3:16 | (StmtList) body | semmle.label | 3 |
-| test.py:2:1:2:12 | [Function] function test1(...) | test.py:3:5:3:16 | (StmtList) body | semmle.order | 3 |
-| test.py:3:5:3:16 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.label | 0 |
-| test.py:3:5:3:16 | (StmtList) body | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | semmle.order | 0 |
-| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.label | 1 |
-| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.order | 1 |
-| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:10:3:15 | [Name] SOURCE | semmle.label | 2 |
-| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:10:3:15 | [Name] SOURCE | semmle.order | 2 |
+| test.py:2:1:2:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| test.py:2:1:2:12 | [Function] function test1(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| test.py:2:1:2:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:2:1:2:12 | [Function] function test1(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.label | 0 |
+| test.py:3:5:3:16 | [Call] SINK(SOURCE) | test.py:3:5:3:8 | [Name] SINK | semmle.order | 0 |
 | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.label | 1 |
 | test.py:3:5:3:16 | [ExprStmt] SINK(SOURCE) | test.py:3:5:3:16 | [Call] SINK(SOURCE) | semmle.order | 1 |
 | test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.label | 1 |
 | test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | semmle.order | 1 |
-| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.label | 2 |
-| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.order | 2 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.label | 0 |
+| test.py:5:1:5:12 | [FunctionDef] test2 = function test2(...) | test.py:5:5:5:9 | [Name] test2 | semmle.order | 0 |
 | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | test.py:5:1:5:12 | [Function] function test2(...) | semmle.label | 1 |
 | test.py:5:1:5:12 | [FunctionExpr] function test2(...) | test.py:5:1:5:12 | [Function] function test2(...) | semmle.order | 1 |
-| test.py:5:1:5:12 | [Function] function test2(...) | test.py:5:1:5:12 | (parameters) | semmle.label | 0 |
-| test.py:5:1:5:12 | [Function] function test2(...) | test.py:5:1:5:12 | (parameters) | semmle.order | 0 |
-| test.py:5:1:5:12 | [Function] function test2(...) | test.py:6:5:6:14 | (StmtList) body | semmle.label | 4 |
-| test.py:5:1:5:12 | [Function] function test2(...) | test.py:6:5:6:14 | (StmtList) body | semmle.order | 4 |
-| test.py:6:5:6:14 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
-| test.py:6:5:6:14 | (StmtList) body | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
-| test.py:6:5:6:14 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.label | 1 |
-| test.py:6:5:6:14 | (StmtList) body | test.py:7:5:7:11 | [ExprStmt] SINK(s) | semmle.order | 1 |
+| test.py:5:1:5:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:5:1:5:12 | [Function] function test2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:5:1:5:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:5:1:5:12 | [Function] function test2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:5:6:5 | [Name] s | semmle.label | 1 |
 | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:5:6:5 | [Name] s | semmle.order | 1 |
 | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:9:6:14 | [Name] SOURCE | semmle.label | 2 |
 | test.py:6:5:6:14 | [AssignStmt] s = SOURCE | test.py:6:9:6:14 | [Name] SOURCE | semmle.order | 2 |
-| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.label | 1 |
-| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.order | 1 |
-| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:10:7:10 | [Name] s | semmle.label | 2 |
-| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:10:7:10 | [Name] s | semmle.order | 2 |
+| test.py:7:5:7:11 | [Call] SINK(s) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:7:5:7:11 | [Call] SINK(s) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.label | 0 |
+| test.py:7:5:7:11 | [Call] SINK(s) | test.py:7:5:7:8 | [Name] SINK | semmle.order | 0 |
 | test.py:7:5:7:11 | [ExprStmt] SINK(s) | test.py:7:5:7:11 | [Call] SINK(s) | semmle.label | 1 |
 | test.py:7:5:7:11 | [ExprStmt] SINK(s) | test.py:7:5:7:11 | [Call] SINK(s) | semmle.order | 1 |
 | test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.label | 1 |
 | test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:1:9:13 | [FunctionExpr] function source(...) | semmle.order | 1 |
-| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.label | 2 |
-| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.order | 2 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.label | 0 |
+| test.py:9:1:9:13 | [FunctionDef] source = function source(...) | test.py:9:5:9:10 | [Name] source | semmle.order | 0 |
 | test.py:9:1:9:13 | [FunctionExpr] function source(...) | test.py:9:1:9:13 | [Function] function source(...) | semmle.label | 1 |
 | test.py:9:1:9:13 | [FunctionExpr] function source(...) | test.py:9:1:9:13 | [Function] function source(...) | semmle.order | 1 |
-| test.py:9:1:9:13 | [Function] function source(...) | test.py:9:1:9:13 | (parameters) | semmle.label | 0 |
-| test.py:9:1:9:13 | [Function] function source(...) | test.py:9:1:9:13 | (parameters) | semmle.order | 0 |
-| test.py:9:1:9:13 | [Function] function source(...) | test.py:10:5:10:17 | (StmtList) body | semmle.label | 3 |
-| test.py:9:1:9:13 | [Function] function source(...) | test.py:10:5:10:17 | (StmtList) body | semmle.order | 3 |
-| test.py:10:5:10:17 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.label | 0 |
-| test.py:10:5:10:17 | (StmtList) body | test.py:10:5:10:17 | [Return] return SOURCE | semmle.order | 0 |
+| test.py:9:1:9:13 | [Function] function source(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| test.py:9:1:9:13 | [Function] function source(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| test.py:9:1:9:13 | [Function] function source(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:9:1:9:13 | [Function] function source(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:10:5:10:17 | [Return] return SOURCE | test.py:10:12:10:17 | [Name] SOURCE | semmle.label | 1 |
 | test.py:10:5:10:17 | [Return] return SOURCE | test.py:10:12:10:17 | [Name] SOURCE | semmle.order | 1 |
-| test.py:12:1:12:14 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.label | 1 |
-| test.py:12:1:12:14 | (parameters) | test.py:12:10:12:12 | [Parameter] arg | semmle.order | 1 |
 | test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.label | 1 |
 | test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | semmle.order | 1 |
-| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.label | 2 |
-| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.order | 2 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.label | 0 |
+| test.py:12:1:12:14 | [FunctionDef] sink = function sink(...) | test.py:12:5:12:8 | [Name] sink | semmle.order | 0 |
 | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | test.py:12:1:12:14 | [Function] function sink(...) | semmle.label | 1 |
 | test.py:12:1:12:14 | [FunctionExpr] function sink(...) | test.py:12:1:12:14 | [Function] function sink(...) | semmle.order | 1 |
-| test.py:12:1:12:14 | [Function] function sink(...) | test.py:12:1:12:14 | (parameters) | semmle.label | 0 |
-| test.py:12:1:12:14 | [Function] function sink(...) | test.py:12:1:12:14 | (parameters) | semmle.order | 0 |
-| test.py:12:1:12:14 | [Function] function sink(...) | test.py:13:5:13:13 | (StmtList) body | semmle.label | 4 |
-| test.py:12:1:12:14 | [Function] function sink(...) | test.py:13:5:13:13 | (StmtList) body | semmle.order | 4 |
-| test.py:13:5:13:13 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.label | 0 |
-| test.py:13:5:13:13 | (StmtList) body | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | semmle.order | 0 |
-| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.label | 1 |
-| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.order | 1 |
-| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:10:13:12 | [Name] arg | semmle.label | 2 |
-| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:10:13:12 | [Name] arg | semmle.order | 2 |
+| test.py:12:1:12:14 | [Function] function sink(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:12:1:12:14 | [Function] function sink(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:12:1:12:14 | [Function] function sink(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:12:1:12:14 | [Function] function sink(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.label | 0 |
+| test.py:13:5:13:13 | [Call] SINK(arg) | test.py:13:5:13:8 | [Name] SINK | semmle.order | 0 |
 | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | test.py:13:5:13:13 | [Call] SINK(arg) | semmle.label | 1 |
 | test.py:13:5:13:13 | [ExprStmt] SINK(arg) | test.py:13:5:13:13 | [Call] SINK(arg) | semmle.order | 1 |
 | test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.label | 1 |
 | test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | semmle.order | 1 |
-| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.label | 2 |
-| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.order | 2 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.label | 0 |
+| test.py:15:1:15:12 | [FunctionDef] test3 = function test3(...) | test.py:15:5:15:9 | [Name] test3 | semmle.order | 0 |
 | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | test.py:15:1:15:12 | [Function] function test3(...) | semmle.label | 1 |
 | test.py:15:1:15:12 | [FunctionExpr] function test3(...) | test.py:15:1:15:12 | [Function] function test3(...) | semmle.order | 1 |
-| test.py:15:1:15:12 | [Function] function test3(...) | test.py:15:1:15:12 | (parameters) | semmle.label | 0 |
-| test.py:15:1:15:12 | [Function] function test3(...) | test.py:15:1:15:12 | (parameters) | semmle.order | 0 |
-| test.py:15:1:15:12 | [Function] function test3(...) | test.py:16:5:16:16 | (StmtList) body | semmle.label | 4 |
-| test.py:15:1:15:12 | [Function] function test3(...) | test.py:16:5:16:16 | (StmtList) body | semmle.order | 4 |
-| test.py:16:5:16:16 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.label | 0 |
-| test.py:16:5:16:16 | (StmtList) body | test.py:16:5:16:16 | [AssignStmt] t = source() | semmle.order | 0 |
-| test.py:16:5:16:16 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
-| test.py:16:5:16:16 | (StmtList) body | test.py:17:5:17:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:15:1:15:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:15:1:15:12 | [Function] function test3(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:15:1:15:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:15:1:15:12 | [Function] function test3(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:5:16:5 | [Name] t | semmle.label | 1 |
 | test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:5:16:5 | [Name] t | semmle.order | 1 |
 | test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:9:16:16 | [Call] source() | semmle.label | 2 |
 | test.py:16:5:16:16 | [AssignStmt] t = source() | test.py:16:9:16:16 | [Call] source() | semmle.order | 2 |
-| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.label | 1 |
-| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.order | 1 |
-| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.label | 1 |
-| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.order | 1 |
-| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:10:17:10 | [Name] t | semmle.label | 2 |
-| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:10:17:10 | [Name] t | semmle.order | 2 |
+| test.py:16:9:16:16 | [Call] source() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:16:9:16:16 | [Call] source() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.label | 0 |
+| test.py:16:9:16:16 | [Call] source() | test.py:16:9:16:14 | [Name] source | semmle.order | 0 |
+| test.py:17:5:17:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:17:5:17:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.label | 0 |
+| test.py:17:5:17:11 | [Call] SINK(t) | test.py:17:5:17:8 | [Name] SINK | semmle.order | 0 |
 | test.py:17:5:17:11 | [ExprStmt] SINK(t) | test.py:17:5:17:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:17:5:17:11 | [ExprStmt] SINK(t) | test.py:17:5:17:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.label | 1 |
 | test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | semmle.order | 1 |
-| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.label | 2 |
-| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.order | 2 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.label | 0 |
+| test.py:19:1:19:12 | [FunctionDef] test4 = function test4(...) | test.py:19:5:19:9 | [Name] test4 | semmle.order | 0 |
 | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | test.py:19:1:19:12 | [Function] function test4(...) | semmle.label | 1 |
 | test.py:19:1:19:12 | [FunctionExpr] function test4(...) | test.py:19:1:19:12 | [Function] function test4(...) | semmle.order | 1 |
-| test.py:19:1:19:12 | [Function] function test4(...) | test.py:19:1:19:12 | (parameters) | semmle.label | 0 |
-| test.py:19:1:19:12 | [Function] function test4(...) | test.py:19:1:19:12 | (parameters) | semmle.order | 0 |
-| test.py:19:1:19:12 | [Function] function test4(...) | test.py:20:5:20:14 | (StmtList) body | semmle.label | 4 |
-| test.py:19:1:19:12 | [Function] function test4(...) | test.py:20:5:20:14 | (StmtList) body | semmle.order | 4 |
-| test.py:20:5:20:14 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:20:5:20:14 | (StmtList) body | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
-| test.py:20:5:20:14 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.label | 1 |
-| test.py:20:5:20:14 | (StmtList) body | test.py:21:5:21:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| test.py:19:1:19:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:19:1:19:12 | [Function] function test4(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:19:1:19:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:19:1:19:12 | [Function] function test4(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:5:20:5 | [Name] t | semmle.label | 1 |
 | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:5:20:5 | [Name] t | semmle.order | 1 |
 | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:9:20:14 | [Name] SOURCE | semmle.label | 2 |
 | test.py:20:5:20:14 | [AssignStmt] t = SOURCE | test.py:20:9:20:14 | [Name] SOURCE | semmle.order | 2 |
-| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.label | 1 |
-| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.order | 1 |
-| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:10:21:10 | [Name] t | semmle.label | 2 |
-| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:10:21:10 | [Name] t | semmle.order | 2 |
+| test.py:21:5:21:11 | [Call] sink(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:21:5:21:11 | [Call] sink(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.label | 0 |
+| test.py:21:5:21:11 | [Call] sink(t) | test.py:21:5:21:8 | [Name] sink | semmle.order | 0 |
 | test.py:21:5:21:11 | [ExprStmt] sink(t) | test.py:21:5:21:11 | [Call] sink(t) | semmle.label | 1 |
 | test.py:21:5:21:11 | [ExprStmt] sink(t) | test.py:21:5:21:11 | [Call] sink(t) | semmle.order | 1 |
 | test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.label | 1 |
 | test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | semmle.order | 1 |
-| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.label | 2 |
-| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.order | 2 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.label | 0 |
+| test.py:23:1:23:12 | [FunctionDef] test5 = function test5(...) | test.py:23:5:23:9 | [Name] test5 | semmle.order | 0 |
 | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | test.py:23:1:23:12 | [Function] function test5(...) | semmle.label | 1 |
 | test.py:23:1:23:12 | [FunctionExpr] function test5(...) | test.py:23:1:23:12 | [Function] function test5(...) | semmle.order | 1 |
-| test.py:23:1:23:12 | [Function] function test5(...) | test.py:23:1:23:12 | (parameters) | semmle.label | 0 |
-| test.py:23:1:23:12 | [Function] function test5(...) | test.py:23:1:23:12 | (parameters) | semmle.order | 0 |
-| test.py:23:1:23:12 | [Function] function test5(...) | test.py:24:5:24:16 | (StmtList) body | semmle.label | 4 |
-| test.py:23:1:23:12 | [Function] function test5(...) | test.py:24:5:24:16 | (StmtList) body | semmle.order | 4 |
-| test.py:24:5:24:16 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.label | 0 |
-| test.py:24:5:24:16 | (StmtList) body | test.py:24:5:24:16 | [AssignStmt] t = source() | semmle.order | 0 |
-| test.py:24:5:24:16 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.label | 1 |
-| test.py:24:5:24:16 | (StmtList) body | test.py:25:5:25:11 | [ExprStmt] sink(t) | semmle.order | 1 |
+| test.py:23:1:23:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:23:1:23:12 | [Function] function test5(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:23:1:23:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:23:1:23:12 | [Function] function test5(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:5:24:5 | [Name] t | semmle.label | 1 |
 | test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:5:24:5 | [Name] t | semmle.order | 1 |
 | test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:9:24:16 | [Call] source() | semmle.label | 2 |
 | test.py:24:5:24:16 | [AssignStmt] t = source() | test.py:24:9:24:16 | [Call] source() | semmle.order | 2 |
-| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.label | 1 |
-| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.order | 1 |
-| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.label | 1 |
-| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.order | 1 |
-| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:10:25:10 | [Name] t | semmle.label | 2 |
-| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:10:25:10 | [Name] t | semmle.order | 2 |
+| test.py:24:9:24:16 | [Call] source() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:24:9:24:16 | [Call] source() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.label | 0 |
+| test.py:24:9:24:16 | [Call] source() | test.py:24:9:24:14 | [Name] source | semmle.order | 0 |
+| test.py:25:5:25:11 | [Call] sink(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:25:5:25:11 | [Call] sink(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.label | 0 |
+| test.py:25:5:25:11 | [Call] sink(t) | test.py:25:5:25:8 | [Name] sink | semmle.order | 0 |
 | test.py:25:5:25:11 | [ExprStmt] sink(t) | test.py:25:5:25:11 | [Call] sink(t) | semmle.label | 1 |
 | test.py:25:5:25:11 | [ExprStmt] sink(t) | test.py:25:5:25:11 | [Call] sink(t) | semmle.order | 1 |
-| test.py:27:1:27:16 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.label | 1 |
-| test.py:27:1:27:16 | (parameters) | test.py:27:11:27:14 | [Parameter] cond | semmle.order | 1 |
 | test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.label | 1 |
 | test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | semmle.order | 1 |
-| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.label | 2 |
-| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.order | 2 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.label | 0 |
+| test.py:27:1:27:16 | [FunctionDef] test6 = function test6(...) | test.py:27:5:27:9 | [Name] test6 | semmle.order | 0 |
 | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | test.py:27:1:27:16 | [Function] function test6(...) | semmle.label | 1 |
 | test.py:27:1:27:16 | [FunctionExpr] function test6(...) | test.py:27:1:27:16 | [Function] function test6(...) | semmle.order | 1 |
-| test.py:27:1:27:16 | [Function] function test6(...) | test.py:27:1:27:16 | (parameters) | semmle.label | 0 |
-| test.py:27:1:27:16 | [Function] function test6(...) | test.py:27:1:27:16 | (parameters) | semmle.order | 0 |
-| test.py:27:1:27:16 | [Function] function test6(...) | test.py:28:5:28:12 | (StmtList) body | semmle.label | 5 |
-| test.py:27:1:27:16 | [Function] function test6(...) | test.py:28:5:28:12 | (StmtList) body | semmle.order | 5 |
-| test.py:28:5:28:12 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.label | 0 |
-| test.py:28:5:28:12 | (StmtList) body | test.py:28:5:28:12 | [If] if cond: | semmle.order | 0 |
-| test.py:28:5:28:12 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.label | 1 |
-| test.py:28:5:28:12 | (StmtList) body | test.py:32:5:32:12 | [If] if cond: | semmle.order | 1 |
+| test.py:27:1:27:16 | [Function] function test6(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:27:1:27:16 | [Function] function test6(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:27:1:27:16 | [Function] function test6(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:27:1:27:16 | [Function] function test6(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:28:5:28:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:28:5:28:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:28:5:28:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:28:5:28:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:28:5:28:12 | [If] if cond: | test.py:28:8:28:11 | [Name] cond | semmle.label | 0 |
 | test.py:28:5:28:12 | [If] if cond: | test.py:28:8:28:11 | [Name] cond | semmle.order | 0 |
-| test.py:28:5:28:12 | [If] if cond: | test.py:29:9:29:18 | (StmtList) body | semmle.label | 2 |
-| test.py:28:5:28:12 | [If] if cond: | test.py:29:9:29:18 | (StmtList) body | semmle.order | 2 |
-| test.py:28:5:28:12 | [If] if cond: | test.py:31:9:31:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:28:5:28:12 | [If] if cond: | test.py:31:9:31:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:29:9:29:18 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.label | 0 |
-| test.py:29:9:29:18 | (StmtList) body | test.py:29:9:29:18 | [AssignStmt] t = Safe | semmle.order | 0 |
 | test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:9:29:9 | [Name] t | semmle.label | 1 |
 | test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:9:29:9 | [Name] t | semmle.order | 1 |
 | test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:13:29:18 | [Str] Safe | semmle.label | 2 |
 | test.py:29:9:29:18 | [AssignStmt] t = Safe | test.py:29:13:29:18 | [Str] Safe | semmle.order | 2 |
-| test.py:31:9:31:18 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:31:9:31:18 | (StmtList) orelse | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:9:31:9 | [Name] t | semmle.label | 1 |
 | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:9:31:9 | [Name] t | semmle.order | 1 |
 | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:13:31:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:31:9:31:18 | [AssignStmt] t = SOURCE | test.py:31:13:31:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:32:5:32:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:32:5:32:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:32:5:32:12 | [If] if cond: | test.py:32:8:32:11 | [Name] cond | semmle.label | 0 |
 | test.py:32:5:32:12 | [If] if cond: | test.py:32:8:32:11 | [Name] cond | semmle.order | 0 |
-| test.py:32:5:32:12 | [If] if cond: | test.py:33:9:33:15 | (StmtList) body | semmle.label | 2 |
-| test.py:32:5:32:12 | [If] if cond: | test.py:33:9:33:15 | (StmtList) body | semmle.order | 2 |
-| test.py:33:9:33:15 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:33:9:33:15 | (StmtList) body | test.py:33:9:33:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.label | 1 |
-| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.order | 1 |
-| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:14:33:14 | [Name] t | semmle.label | 2 |
-| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:14:33:14 | [Name] t | semmle.order | 2 |
+| test.py:33:9:33:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:33:9:33:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.label | 0 |
+| test.py:33:9:33:15 | [Call] SINK(t) | test.py:33:9:33:12 | [Name] SINK | semmle.order | 0 |
 | test.py:33:9:33:15 | [ExprStmt] SINK(t) | test.py:33:9:33:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:33:9:33:15 | [ExprStmt] SINK(t) | test.py:33:9:33:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:35:1:35:16 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.label | 1 |
-| test.py:35:1:35:16 | (parameters) | test.py:35:11:35:14 | [Parameter] cond | semmle.order | 1 |
 | test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.label | 1 |
 | test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | semmle.order | 1 |
-| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.label | 2 |
-| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.order | 2 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.label | 0 |
+| test.py:35:1:35:16 | [FunctionDef] test7 = function test7(...) | test.py:35:5:35:9 | [Name] test7 | semmle.order | 0 |
 | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | test.py:35:1:35:16 | [Function] function test7(...) | semmle.label | 1 |
 | test.py:35:1:35:16 | [FunctionExpr] function test7(...) | test.py:35:1:35:16 | [Function] function test7(...) | semmle.order | 1 |
-| test.py:35:1:35:16 | [Function] function test7(...) | test.py:35:1:35:16 | (parameters) | semmle.label | 0 |
-| test.py:35:1:35:16 | [Function] function test7(...) | test.py:35:1:35:16 | (parameters) | semmle.order | 0 |
-| test.py:35:1:35:16 | [Function] function test7(...) | test.py:36:5:36:12 | (StmtList) body | semmle.label | 5 |
-| test.py:35:1:35:16 | [Function] function test7(...) | test.py:36:5:36:12 | (StmtList) body | semmle.order | 5 |
-| test.py:36:5:36:12 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.label | 0 |
-| test.py:36:5:36:12 | (StmtList) body | test.py:36:5:36:12 | [If] if cond: | semmle.order | 0 |
-| test.py:36:5:36:12 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.label | 1 |
-| test.py:36:5:36:12 | (StmtList) body | test.py:40:5:40:12 | [If] if cond: | semmle.order | 1 |
+| test.py:35:1:35:16 | [Function] function test7(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:35:1:35:16 | [Function] function test7(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:35:1:35:16 | [Function] function test7(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:35:1:35:16 | [Function] function test7(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:36:5:36:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:36:5:36:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:36:5:36:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:36:5:36:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:36:5:36:12 | [If] if cond: | test.py:36:8:36:11 | [Name] cond | semmle.label | 0 |
 | test.py:36:5:36:12 | [If] if cond: | test.py:36:8:36:11 | [Name] cond | semmle.order | 0 |
-| test.py:36:5:36:12 | [If] if cond: | test.py:37:9:37:18 | (StmtList) body | semmle.label | 2 |
-| test.py:36:5:36:12 | [If] if cond: | test.py:37:9:37:18 | (StmtList) body | semmle.order | 2 |
-| test.py:36:5:36:12 | [If] if cond: | test.py:39:9:39:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:36:5:36:12 | [If] if cond: | test.py:39:9:39:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:37:9:37:18 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:37:9:37:18 | (StmtList) body | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:9:37:9 | [Name] t | semmle.label | 1 |
 | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:9:37:9 | [Name] t | semmle.order | 1 |
 | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:13:37:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:37:9:37:18 | [AssignStmt] t = SOURCE | test.py:37:13:37:18 | [Name] SOURCE | semmle.order | 2 |
-| test.py:39:9:39:18 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.label | 0 |
-| test.py:39:9:39:18 | (StmtList) orelse | test.py:39:9:39:18 | [AssignStmt] t = Safe | semmle.order | 0 |
 | test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:9:39:9 | [Name] t | semmle.label | 1 |
 | test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:9:39:9 | [Name] t | semmle.order | 1 |
 | test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:13:39:18 | [Str] Safe | semmle.label | 2 |
 | test.py:39:9:39:18 | [AssignStmt] t = Safe | test.py:39:13:39:18 | [Str] Safe | semmle.order | 2 |
+| test.py:40:5:40:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:40:5:40:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:40:5:40:12 | [If] if cond: | test.py:40:8:40:11 | [Name] cond | semmle.label | 0 |
 | test.py:40:5:40:12 | [If] if cond: | test.py:40:8:40:11 | [Name] cond | semmle.order | 0 |
-| test.py:40:5:40:12 | [If] if cond: | test.py:41:9:41:15 | (StmtList) body | semmle.label | 2 |
-| test.py:40:5:40:12 | [If] if cond: | test.py:41:9:41:15 | (StmtList) body | semmle.order | 2 |
-| test.py:41:9:41:15 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:41:9:41:15 | (StmtList) body | test.py:41:9:41:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.label | 1 |
-| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.order | 1 |
-| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:14:41:14 | [Name] t | semmle.label | 2 |
-| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:14:41:14 | [Name] t | semmle.order | 2 |
+| test.py:41:9:41:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:41:9:41:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.label | 0 |
+| test.py:41:9:41:15 | [Call] SINK(t) | test.py:41:9:41:12 | [Name] SINK | semmle.order | 0 |
 | test.py:41:9:41:15 | [ExprStmt] SINK(t) | test.py:41:9:41:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:41:9:41:15 | [ExprStmt] SINK(t) | test.py:41:9:41:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:43:1:43:17 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.label | 1 |
-| test.py:43:1:43:17 | (parameters) | test.py:43:13:43:15 | [Parameter] arg | semmle.order | 1 |
 | test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.label | 1 |
 | test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | semmle.order | 1 |
-| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.label | 2 |
-| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.order | 2 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.label | 0 |
+| test.py:43:1:43:17 | [FunctionDef] source2 = function source2(...) | test.py:43:5:43:11 | [Name] source2 | semmle.order | 0 |
 | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | test.py:43:1:43:17 | [Function] function source2(...) | semmle.label | 1 |
 | test.py:43:1:43:17 | [FunctionExpr] function source2(...) | test.py:43:1:43:17 | [Function] function source2(...) | semmle.order | 1 |
-| test.py:43:1:43:17 | [Function] function source2(...) | test.py:43:1:43:17 | (parameters) | semmle.label | 0 |
-| test.py:43:1:43:17 | [Function] function source2(...) | test.py:43:1:43:17 | (parameters) | semmle.order | 0 |
-| test.py:43:1:43:17 | [Function] function source2(...) | test.py:44:5:44:22 | (StmtList) body | semmle.label | 4 |
-| test.py:43:1:43:17 | [Function] function source2(...) | test.py:44:5:44:22 | (StmtList) body | semmle.order | 4 |
-| test.py:44:5:44:22 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.label | 0 |
-| test.py:44:5:44:22 | (StmtList) body | test.py:44:5:44:22 | [Return] return source(arg) | semmle.order | 0 |
+| test.py:43:1:43:17 | [Function] function source2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:43:1:43:17 | [Function] function source2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:43:1:43:17 | [Function] function source2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:43:1:43:17 | [Function] function source2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:44:5:44:22 | [Return] return source(arg) | test.py:44:12:44:22 | [Call] source(arg) | semmle.label | 1 |
 | test.py:44:5:44:22 | [Return] return source(arg) | test.py:44:12:44:22 | [Call] source(arg) | semmle.order | 1 |
-| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.label | 1 |
-| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.order | 1 |
-| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:19:44:21 | [Name] arg | semmle.label | 2 |
-| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:19:44:21 | [Name] arg | semmle.order | 2 |
-| test.py:46:1:46:15 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.label | 1 |
-| test.py:46:1:46:15 | (parameters) | test.py:46:11:46:13 | [Parameter] arg | semmle.order | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.label | 0 |
+| test.py:44:12:44:22 | [Call] source(arg) | test.py:44:12:44:17 | [Name] source | semmle.order | 0 |
 | test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.label | 1 |
 | test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | semmle.order | 1 |
-| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.label | 2 |
-| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.order | 2 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.label | 0 |
+| test.py:46:1:46:15 | [FunctionDef] sink2 = function sink2(...) | test.py:46:5:46:9 | [Name] sink2 | semmle.order | 0 |
 | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | test.py:46:1:46:15 | [Function] function sink2(...) | semmle.label | 1 |
 | test.py:46:1:46:15 | [FunctionExpr] function sink2(...) | test.py:46:1:46:15 | [Function] function sink2(...) | semmle.order | 1 |
-| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:46:1:46:15 | (parameters) | semmle.label | 0 |
-| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:46:1:46:15 | (parameters) | semmle.order | 0 |
-| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:47:5:47:13 | (StmtList) body | semmle.label | 4 |
-| test.py:46:1:46:15 | [Function] function sink2(...) | test.py:47:5:47:13 | (StmtList) body | semmle.order | 4 |
-| test.py:47:5:47:13 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.label | 0 |
-| test.py:47:5:47:13 | (StmtList) body | test.py:47:5:47:13 | [ExprStmt] sink(arg) | semmle.order | 0 |
-| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.label | 1 |
-| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.order | 1 |
-| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:10:47:12 | [Name] arg | semmle.label | 2 |
-| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:10:47:12 | [Name] arg | semmle.order | 2 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:46:1:46:15 | [Function] function sink2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:47:5:47:13 | [Call] sink(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:47:5:47:13 | [Call] sink(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.label | 0 |
+| test.py:47:5:47:13 | [Call] sink(arg) | test.py:47:5:47:8 | [Name] sink | semmle.order | 0 |
 | test.py:47:5:47:13 | [ExprStmt] sink(arg) | test.py:47:5:47:13 | [Call] sink(arg) | semmle.label | 1 |
 | test.py:47:5:47:13 | [ExprStmt] sink(arg) | test.py:47:5:47:13 | [Call] sink(arg) | semmle.order | 1 |
-| test.py:49:1:49:21 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.label | 1 |
-| test.py:49:1:49:21 | (parameters) | test.py:49:11:49:14 | [Parameter] cond | semmle.order | 1 |
-| test.py:49:1:49:21 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.label | 2 |
-| test.py:49:1:49:21 | (parameters) | test.py:49:17:49:19 | [Parameter] arg | semmle.order | 2 |
 | test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.label | 1 |
 | test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | semmle.order | 1 |
-| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.label | 2 |
-| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.order | 2 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.label | 0 |
+| test.py:49:1:49:21 | [FunctionDef] sink3 = function sink3(...) | test.py:49:5:49:9 | [Name] sink3 | semmle.order | 0 |
 | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | test.py:49:1:49:21 | [Function] function sink3(...) | semmle.label | 1 |
 | test.py:49:1:49:21 | [FunctionExpr] function sink3(...) | test.py:49:1:49:21 | [Function] function sink3(...) | semmle.order | 1 |
-| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:49:1:49:21 | (parameters) | semmle.label | 0 |
-| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:49:1:49:21 | (parameters) | semmle.order | 0 |
-| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:50:5:50:12 | (StmtList) body | semmle.label | 5 |
-| test.py:49:1:49:21 | [Function] function sink3(...) | test.py:50:5:50:12 | (StmtList) body | semmle.order | 5 |
-| test.py:50:5:50:12 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.label | 0 |
-| test.py:50:5:50:12 | (StmtList) body | test.py:50:5:50:12 | [If] if cond: | semmle.order | 0 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:49:1:49:21 | [Function] function sink3(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:50:5:50:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:50:5:50:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:50:5:50:12 | [If] if cond: | test.py:50:8:50:11 | [Name] cond | semmle.label | 0 |
 | test.py:50:5:50:12 | [If] if cond: | test.py:50:8:50:11 | [Name] cond | semmle.order | 0 |
-| test.py:50:5:50:12 | [If] if cond: | test.py:51:9:51:17 | (StmtList) body | semmle.label | 2 |
-| test.py:50:5:50:12 | [If] if cond: | test.py:51:9:51:17 | (StmtList) body | semmle.order | 2 |
-| test.py:51:9:51:17 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.label | 0 |
-| test.py:51:9:51:17 | (StmtList) body | test.py:51:9:51:17 | [ExprStmt] sink(arg) | semmle.order | 0 |
-| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.label | 1 |
-| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.order | 1 |
-| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:14:51:16 | [Name] arg | semmle.label | 2 |
-| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:14:51:16 | [Name] arg | semmle.order | 2 |
+| test.py:51:9:51:17 | [Call] sink(arg) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:51:9:51:17 | [Call] sink(arg) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.label | 0 |
+| test.py:51:9:51:17 | [Call] sink(arg) | test.py:51:9:51:12 | [Name] sink | semmle.order | 0 |
 | test.py:51:9:51:17 | [ExprStmt] sink(arg) | test.py:51:9:51:17 | [Call] sink(arg) | semmle.label | 1 |
 | test.py:51:9:51:17 | [ExprStmt] sink(arg) | test.py:51:9:51:17 | [Call] sink(arg) | semmle.order | 1 |
-| test.py:53:1:53:16 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.label | 1 |
-| test.py:53:1:53:16 | (parameters) | test.py:53:11:53:14 | [Parameter] cond | semmle.order | 1 |
 | test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.label | 1 |
 | test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | semmle.order | 1 |
-| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.label | 2 |
-| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.order | 2 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.label | 0 |
+| test.py:53:1:53:16 | [FunctionDef] test8 = function test8(...) | test.py:53:5:53:9 | [Name] test8 | semmle.order | 0 |
 | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | test.py:53:1:53:16 | [Function] function test8(...) | semmle.label | 1 |
 | test.py:53:1:53:16 | [FunctionExpr] function test8(...) | test.py:53:1:53:16 | [Function] function test8(...) | semmle.order | 1 |
-| test.py:53:1:53:16 | [Function] function test8(...) | test.py:53:1:53:16 | (parameters) | semmle.label | 0 |
-| test.py:53:1:53:16 | [Function] function test8(...) | test.py:53:1:53:16 | (parameters) | semmle.order | 0 |
-| test.py:53:1:53:16 | [Function] function test8(...) | test.py:54:5:54:17 | (StmtList) body | semmle.label | 5 |
-| test.py:53:1:53:16 | [Function] function test8(...) | test.py:54:5:54:17 | (StmtList) body | semmle.order | 5 |
-| test.py:54:5:54:17 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.label | 0 |
-| test.py:54:5:54:17 | (StmtList) body | test.py:54:5:54:17 | [AssignStmt] t = source2() | semmle.order | 0 |
-| test.py:54:5:54:17 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.label | 1 |
-| test.py:54:5:54:17 | (StmtList) body | test.py:55:5:55:12 | [ExprStmt] sink2(t) | semmle.order | 1 |
+| test.py:53:1:53:16 | [Function] function test8(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:53:1:53:16 | [Function] function test8(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:53:1:53:16 | [Function] function test8(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:53:1:53:16 | [Function] function test8(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:5:54:5 | [Name] t | semmle.label | 1 |
 | test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:5:54:5 | [Name] t | semmle.order | 1 |
 | test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:9:54:17 | [Call] source2() | semmle.label | 2 |
 | test.py:54:5:54:17 | [AssignStmt] t = source2() | test.py:54:9:54:17 | [Call] source2() | semmle.order | 2 |
-| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.label | 1 |
-| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.order | 1 |
-| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.label | 1 |
-| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.order | 1 |
-| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:11:55:11 | [Name] t | semmle.label | 2 |
-| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:11:55:11 | [Name] t | semmle.order | 2 |
+| test.py:54:9:54:17 | [Call] source2() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:54:9:54:17 | [Call] source2() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.label | 0 |
+| test.py:54:9:54:17 | [Call] source2() | test.py:54:9:54:15 | [Name] source2 | semmle.order | 0 |
+| test.py:55:5:55:12 | [Call] sink2(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:55:5:55:12 | [Call] sink2(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.label | 0 |
+| test.py:55:5:55:12 | [Call] sink2(t) | test.py:55:5:55:9 | [Name] sink2 | semmle.order | 0 |
 | test.py:55:5:55:12 | [ExprStmt] sink2(t) | test.py:55:5:55:12 | [Call] sink2(t) | semmle.label | 1 |
 | test.py:55:5:55:12 | [ExprStmt] sink2(t) | test.py:55:5:55:12 | [Call] sink2(t) | semmle.order | 1 |
-| test.py:58:1:58:16 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.label | 1 |
-| test.py:58:1:58:16 | (parameters) | test.py:58:11:58:14 | [Parameter] cond | semmle.order | 1 |
 | test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.label | 1 |
 | test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | semmle.order | 1 |
-| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.label | 2 |
-| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.order | 2 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.label | 0 |
+| test.py:58:1:58:16 | [FunctionDef] test9 = function test9(...) | test.py:58:5:58:9 | [Name] test9 | semmle.order | 0 |
 | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | test.py:58:1:58:16 | [Function] function test9(...) | semmle.label | 1 |
 | test.py:58:1:58:16 | [FunctionExpr] function test9(...) | test.py:58:1:58:16 | [Function] function test9(...) | semmle.order | 1 |
-| test.py:58:1:58:16 | [Function] function test9(...) | test.py:58:1:58:16 | (parameters) | semmle.label | 0 |
-| test.py:58:1:58:16 | [Function] function test9(...) | test.py:58:1:58:16 | (parameters) | semmle.order | 0 |
-| test.py:58:1:58:16 | [Function] function test9(...) | test.py:59:5:59:12 | (StmtList) body | semmle.label | 5 |
-| test.py:58:1:58:16 | [Function] function test9(...) | test.py:59:5:59:12 | (StmtList) body | semmle.order | 5 |
-| test.py:59:5:59:12 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.label | 0 |
-| test.py:59:5:59:12 | (StmtList) body | test.py:59:5:59:12 | [If] if cond: | semmle.order | 0 |
-| test.py:59:5:59:12 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
-| test.py:59:5:59:12 | (StmtList) body | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| test.py:58:1:58:16 | [Function] function test9(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:58:1:58:16 | [Function] function test9(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:58:1:58:16 | [Function] function test9(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:58:1:58:16 | [Function] function test9(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:59:5:59:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:59:5:59:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:59:5:59:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:59:5:59:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:59:5:59:12 | [If] if cond: | test.py:59:8:59:11 | [Name] cond | semmle.label | 0 |
 | test.py:59:5:59:12 | [If] if cond: | test.py:59:8:59:11 | [Name] cond | semmle.order | 0 |
-| test.py:59:5:59:12 | [If] if cond: | test.py:60:9:60:19 | (StmtList) body | semmle.label | 2 |
-| test.py:59:5:59:12 | [If] if cond: | test.py:60:9:60:19 | (StmtList) body | semmle.order | 2 |
-| test.py:59:5:59:12 | [If] if cond: | test.py:62:9:62:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:59:5:59:12 | [If] if cond: | test.py:62:9:62:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:60:9:60:19 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.label | 0 |
-| test.py:60:9:60:19 | (StmtList) body | test.py:60:9:60:19 | [AssignStmt] t = Safe | semmle.order | 0 |
 | test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:9:60:9 | [Name] t | semmle.label | 1 |
 | test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:9:60:9 | [Name] t | semmle.order | 1 |
 | test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:14:60:19 | [Str] Safe | semmle.label | 2 |
 | test.py:60:9:60:19 | [AssignStmt] t = Safe | test.py:60:14:60:19 | [Str] Safe | semmle.order | 2 |
-| test.py:62:9:62:18 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:62:9:62:18 | (StmtList) orelse | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:9:62:9 | [Name] t | semmle.label | 1 |
 | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:9:62:9 | [Name] t | semmle.order | 1 |
 | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:13:62:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:62:9:62:18 | [AssignStmt] t = SOURCE | test.py:62:13:62:18 | [Name] SOURCE | semmle.order | 2 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.label | 1 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.order | 1 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:11:63:14 | [Name] cond | semmle.label | 2 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:11:63:14 | [Name] cond | semmle.order | 2 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:17:63:17 | [Name] t | semmle.label | 3 |
-| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:17:63:17 | [Name] t | semmle.order | 3 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.label | 0 |
+| test.py:63:5:63:18 | [Call] sink3(cond, t) | test.py:63:5:63:9 | [Name] sink3 | semmle.order | 0 |
 | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | test.py:63:5:63:18 | [Call] sink3(cond, t) | semmle.label | 1 |
 | test.py:63:5:63:18 | [ExprStmt] sink3(cond, t) | test.py:63:5:63:18 | [Call] sink3(cond, t) | semmle.order | 1 |
-| test.py:65:1:65:17 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.label | 1 |
-| test.py:65:1:65:17 | (parameters) | test.py:65:12:65:15 | [Parameter] cond | semmle.order | 1 |
 | test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.label | 1 |
 | test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | semmle.order | 1 |
-| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.label | 2 |
-| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.order | 2 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.label | 0 |
+| test.py:65:1:65:17 | [FunctionDef] test10 = function test10(...) | test.py:65:5:65:10 | [Name] test10 | semmle.order | 0 |
 | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | test.py:65:1:65:17 | [Function] function test10(...) | semmle.label | 1 |
 | test.py:65:1:65:17 | [FunctionExpr] function test10(...) | test.py:65:1:65:17 | [Function] function test10(...) | semmle.order | 1 |
-| test.py:65:1:65:17 | [Function] function test10(...) | test.py:65:1:65:17 | (parameters) | semmle.label | 0 |
-| test.py:65:1:65:17 | [Function] function test10(...) | test.py:65:1:65:17 | (parameters) | semmle.order | 0 |
-| test.py:65:1:65:17 | [Function] function test10(...) | test.py:66:5:66:12 | (StmtList) body | semmle.label | 5 |
-| test.py:65:1:65:17 | [Function] function test10(...) | test.py:66:5:66:12 | (StmtList) body | semmle.order | 5 |
-| test.py:66:5:66:12 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.label | 0 |
-| test.py:66:5:66:12 | (StmtList) body | test.py:66:5:66:12 | [If] if cond: | semmle.order | 0 |
-| test.py:66:5:66:12 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.label | 1 |
-| test.py:66:5:66:12 | (StmtList) body | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | semmle.order | 1 |
+| test.py:65:1:65:17 | [Function] function test10(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:65:1:65:17 | [Function] function test10(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:65:1:65:17 | [Function] function test10(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:65:1:65:17 | [Function] function test10(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:66:5:66:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:66:5:66:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:66:5:66:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:66:5:66:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:66:5:66:12 | [If] if cond: | test.py:66:8:66:11 | [Name] cond | semmle.label | 0 |
 | test.py:66:5:66:12 | [If] if cond: | test.py:66:8:66:11 | [Name] cond | semmle.order | 0 |
-| test.py:66:5:66:12 | [If] if cond: | test.py:67:9:67:18 | (StmtList) body | semmle.label | 2 |
-| test.py:66:5:66:12 | [If] if cond: | test.py:67:9:67:18 | (StmtList) body | semmle.order | 2 |
-| test.py:66:5:66:12 | [If] if cond: | test.py:69:9:69:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:66:5:66:12 | [If] if cond: | test.py:69:9:69:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:67:9:67:18 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:67:9:67:18 | (StmtList) body | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:9:67:9 | [Name] t | semmle.label | 1 |
 | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:9:67:9 | [Name] t | semmle.order | 1 |
 | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:13:67:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:67:9:67:18 | [AssignStmt] t = SOURCE | test.py:67:13:67:18 | [Name] SOURCE | semmle.order | 2 |
-| test.py:69:9:69:18 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.label | 0 |
-| test.py:69:9:69:18 | (StmtList) orelse | test.py:69:9:69:18 | [AssignStmt] t = Safe | semmle.order | 0 |
 | test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:9:69:9 | [Name] t | semmle.label | 1 |
 | test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:9:69:9 | [Name] t | semmle.order | 1 |
 | test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:13:69:18 | [Str] Safe | semmle.label | 2 |
 | test.py:69:9:69:18 | [AssignStmt] t = Safe | test.py:69:13:69:18 | [Str] Safe | semmle.order | 2 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.label | 1 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.order | 1 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:11:70:14 | [Name] cond | semmle.label | 2 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:11:70:14 | [Name] cond | semmle.order | 2 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:17:70:17 | [Name] t | semmle.label | 3 |
-| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:17:70:17 | [Name] t | semmle.order | 3 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.label | 0 |
+| test.py:70:5:70:18 | [Call] sink3(cond, t) | test.py:70:5:70:9 | [Name] sink3 | semmle.order | 0 |
 | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | test.py:70:5:70:18 | [Call] sink3(cond, t) | semmle.label | 1 |
 | test.py:70:5:70:18 | [ExprStmt] sink3(cond, t) | test.py:70:5:70:18 | [Call] sink3(cond, t) | semmle.order | 1 |
-| test.py:72:1:72:13 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.label | 1 |
-| test.py:72:1:72:13 | (parameters) | test.py:72:9:72:11 | [Parameter] arg | semmle.order | 1 |
 | test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.label | 1 |
 | test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | semmle.order | 1 |
-| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.label | 2 |
-| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.order | 2 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.label | 0 |
+| test.py:72:1:72:13 | [FunctionDef] hub = function hub(...) | test.py:72:5:72:7 | [Name] hub | semmle.order | 0 |
 | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | test.py:72:1:72:13 | [Function] function hub(...) | semmle.label | 1 |
 | test.py:72:1:72:13 | [FunctionExpr] function hub(...) | test.py:72:1:72:13 | [Function] function hub(...) | semmle.order | 1 |
-| test.py:72:1:72:13 | [Function] function hub(...) | test.py:72:1:72:13 | (parameters) | semmle.label | 0 |
-| test.py:72:1:72:13 | [Function] function hub(...) | test.py:72:1:72:13 | (parameters) | semmle.order | 0 |
-| test.py:72:1:72:13 | [Function] function hub(...) | test.py:73:5:73:14 | (StmtList) body | semmle.label | 4 |
-| test.py:72:1:72:13 | [Function] function hub(...) | test.py:73:5:73:14 | (StmtList) body | semmle.order | 4 |
-| test.py:73:5:73:14 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.label | 0 |
-| test.py:73:5:73:14 | (StmtList) body | test.py:73:5:73:14 | [Return] return arg | semmle.order | 0 |
+| test.py:72:1:72:13 | [Function] function hub(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:72:1:72:13 | [Function] function hub(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:72:1:72:13 | [Function] function hub(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:72:1:72:13 | [Function] function hub(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:73:5:73:14 | [Return] return arg | test.py:73:12:73:14 | [Name] arg | semmle.label | 1 |
 | test.py:73:5:73:14 | [Return] return arg | test.py:73:12:73:14 | [Name] arg | semmle.order | 1 |
 | test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.label | 1 |
 | test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | semmle.order | 1 |
-| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.label | 2 |
-| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.order | 2 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.label | 0 |
+| test.py:75:1:75:13 | [FunctionDef] test11 = function test11(...) | test.py:75:5:75:10 | [Name] test11 | semmle.order | 0 |
 | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | test.py:75:1:75:13 | [Function] function test11(...) | semmle.label | 1 |
 | test.py:75:1:75:13 | [FunctionExpr] function test11(...) | test.py:75:1:75:13 | [Function] function test11(...) | semmle.order | 1 |
-| test.py:75:1:75:13 | [Function] function test11(...) | test.py:75:1:75:13 | (parameters) | semmle.label | 0 |
-| test.py:75:1:75:13 | [Function] function test11(...) | test.py:75:1:75:13 | (parameters) | semmle.order | 0 |
-| test.py:75:1:75:13 | [Function] function test11(...) | test.py:76:5:76:14 | (StmtList) body | semmle.label | 5 |
-| test.py:75:1:75:13 | [Function] function test11(...) | test.py:76:5:76:14 | (StmtList) body | semmle.order | 5 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
-| test.py:76:5:76:14 | (StmtList) body | test.py:78:5:78:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| test.py:75:1:75:13 | [Function] function test11(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:75:1:75:13 | [Function] function test11(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:75:1:75:13 | [Function] function test11(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:75:1:75:13 | [Function] function test11(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:5:76:5 | [Name] t | semmle.label | 1 |
 | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:5:76:5 | [Name] t | semmle.order | 1 |
 | test.py:76:5:76:14 | [AssignStmt] t = SOURCE | test.py:76:9:76:14 | [Name] SOURCE | semmle.label | 2 |
@@ -2794,32 +3331,26 @@ edges
 | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:5:77:5 | [Name] t | semmle.order | 1 |
 | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:9:77:14 | [Call] hub(t) | semmle.label | 2 |
 | test.py:77:5:77:14 | [AssignStmt] t = hub(t) | test.py:77:9:77:14 | [Call] hub(t) | semmle.order | 2 |
-| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.label | 1 |
-| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.order | 1 |
-| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:13:77:13 | [Name] t | semmle.label | 2 |
-| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:13:77:13 | [Name] t | semmle.order | 2 |
-| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.label | 1 |
-| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.order | 1 |
-| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:10:78:10 | [Name] t | semmle.label | 2 |
-| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:10:78:10 | [Name] t | semmle.order | 2 |
+| test.py:77:9:77:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:77:9:77:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.label | 0 |
+| test.py:77:9:77:14 | [Call] hub(t) | test.py:77:9:77:11 | [Name] hub | semmle.order | 0 |
+| test.py:78:5:78:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:78:5:78:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.label | 0 |
+| test.py:78:5:78:11 | [Call] SINK(t) | test.py:78:5:78:8 | [Name] SINK | semmle.order | 0 |
 | test.py:78:5:78:11 | [ExprStmt] SINK(t) | test.py:78:5:78:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:78:5:78:11 | [ExprStmt] SINK(t) | test.py:78:5:78:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.label | 1 |
 | test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | semmle.order | 1 |
-| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.label | 2 |
-| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.order | 2 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.label | 0 |
+| test.py:80:1:80:13 | [FunctionDef] test12 = function test12(...) | test.py:80:5:80:10 | [Name] test12 | semmle.order | 0 |
 | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | test.py:80:1:80:13 | [Function] function test12(...) | semmle.label | 1 |
 | test.py:80:1:80:13 | [FunctionExpr] function test12(...) | test.py:80:1:80:13 | [Function] function test12(...) | semmle.order | 1 |
-| test.py:80:1:80:13 | [Function] function test12(...) | test.py:80:1:80:13 | (parameters) | semmle.label | 0 |
-| test.py:80:1:80:13 | [Function] function test12(...) | test.py:80:1:80:13 | (parameters) | semmle.order | 0 |
-| test.py:80:1:80:13 | [Function] function test12(...) | test.py:81:5:81:14 | (StmtList) body | semmle.label | 5 |
-| test.py:80:1:80:13 | [Function] function test12(...) | test.py:81:5:81:14 | (StmtList) body | semmle.order | 5 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.label | 0 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:81:5:81:14 | [AssignStmt] t = safe | semmle.order | 0 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.label | 1 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | semmle.order | 1 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.label | 2 |
-| test.py:81:5:81:14 | (StmtList) body | test.py:83:5:83:11 | [ExprStmt] SINK(t) | semmle.order | 2 |
+| test.py:80:1:80:13 | [Function] function test12(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:80:1:80:13 | [Function] function test12(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:80:1:80:13 | [Function] function test12(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:80:1:80:13 | [Function] function test12(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:5:81:5 | [Name] t | semmle.label | 1 |
 | test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:5:81:5 | [Name] t | semmle.order | 1 |
 | test.py:81:5:81:14 | [AssignStmt] t = safe | test.py:81:9:81:14 | [Str] safe | semmle.label | 2 |
@@ -2828,14 +3359,14 @@ edges
 | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:5:82:5 | [Name] t | semmle.order | 1 |
 | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:9:82:14 | [Call] hub(t) | semmle.label | 2 |
 | test.py:82:5:82:14 | [AssignStmt] t = hub(t) | test.py:82:9:82:14 | [Call] hub(t) | semmle.order | 2 |
-| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.label | 1 |
-| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.order | 1 |
-| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:13:82:13 | [Name] t | semmle.label | 2 |
-| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:13:82:13 | [Name] t | semmle.order | 2 |
-| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.label | 1 |
-| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.order | 1 |
-| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:10:83:10 | [Name] t | semmle.label | 2 |
-| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:10:83:10 | [Name] t | semmle.order | 2 |
+| test.py:82:9:82:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:82:9:82:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.label | 0 |
+| test.py:82:9:82:14 | [Call] hub(t) | test.py:82:9:82:11 | [Name] hub | semmle.order | 0 |
+| test.py:83:5:83:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:83:5:83:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.label | 0 |
+| test.py:83:5:83:11 | [Call] SINK(t) | test.py:83:5:83:8 | [Name] SINK | semmle.order | 0 |
 | test.py:83:5:83:11 | [ExprStmt] SINK(t) | test.py:83:5:83:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:83:5:83:11 | [ExprStmt] SINK(t) | test.py:83:5:83:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [ImportExpr]  | semmle.label | 1 |
@@ -2844,108 +3375,94 @@ edges
 | test.py:85:1:85:13 | [Import] import module | test.py:85:8:85:13 | [Name] module | semmle.order | 1 |
 | test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.label | 1 |
 | test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | semmle.order | 1 |
-| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.label | 2 |
-| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.order | 2 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.label | 0 |
+| test.py:87:1:87:13 | [FunctionDef] test13 = function test13(...) | test.py:87:5:87:10 | [Name] test13 | semmle.order | 0 |
 | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | test.py:87:1:87:13 | [Function] function test13(...) | semmle.label | 1 |
 | test.py:87:1:87:13 | [FunctionExpr] function test13(...) | test.py:87:1:87:13 | [Function] function test13(...) | semmle.order | 1 |
-| test.py:87:1:87:13 | [Function] function test13(...) | test.py:87:1:87:13 | (parameters) | semmle.label | 0 |
-| test.py:87:1:87:13 | [Function] function test13(...) | test.py:87:1:87:13 | (parameters) | semmle.order | 0 |
-| test.py:87:1:87:13 | [Function] function test13(...) | test.py:88:5:88:24 | (StmtList) body | semmle.label | 4 |
-| test.py:87:1:87:13 | [Function] function test13(...) | test.py:88:5:88:24 | (StmtList) body | semmle.order | 4 |
-| test.py:88:5:88:24 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.label | 0 |
-| test.py:88:5:88:24 | (StmtList) body | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | semmle.order | 0 |
-| test.py:88:5:88:24 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
-| test.py:88:5:88:24 | (StmtList) body | test.py:89:5:89:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:87:1:87:13 | [Function] function test13(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:87:1:87:13 | [Function] function test13(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:87:1:87:13 | [Function] function test13(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:87:1:87:13 | [Function] function test13(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:5:88:5 | [Name] t | semmle.label | 1 |
 | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:5:88:5 | [Name] t | semmle.order | 1 |
 | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.label | 2 |
 | test.py:88:5:88:24 | [AssignStmt] t = module.dangerous | test.py:88:9:88:24 | [Attribute] module.dangerous | semmle.order | 2 |
 | test.py:88:9:88:24 | [Attribute] module.dangerous | test.py:88:9:88:14 | [Name] module | semmle.label | 1 |
 | test.py:88:9:88:24 | [Attribute] module.dangerous | test.py:88:9:88:14 | [Name] module | semmle.order | 1 |
-| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.label | 1 |
-| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.order | 1 |
-| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:10:89:10 | [Name] t | semmle.label | 2 |
-| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:10:89:10 | [Name] t | semmle.order | 2 |
+| test.py:89:5:89:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:89:5:89:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.label | 0 |
+| test.py:89:5:89:11 | [Call] SINK(t) | test.py:89:5:89:8 | [Name] SINK | semmle.order | 0 |
 | test.py:89:5:89:11 | [ExprStmt] SINK(t) | test.py:89:5:89:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:89:5:89:11 | [ExprStmt] SINK(t) | test.py:89:5:89:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.label | 1 |
 | test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | semmle.order | 1 |
-| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.label | 2 |
-| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.order | 2 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.label | 0 |
+| test.py:91:1:91:13 | [FunctionDef] test14 = function test14(...) | test.py:91:5:91:10 | [Name] test14 | semmle.order | 0 |
 | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | test.py:91:1:91:13 | [Function] function test14(...) | semmle.label | 1 |
 | test.py:91:1:91:13 | [FunctionExpr] function test14(...) | test.py:91:1:91:13 | [Function] function test14(...) | semmle.order | 1 |
-| test.py:91:1:91:13 | [Function] function test14(...) | test.py:91:1:91:13 | (parameters) | semmle.label | 0 |
-| test.py:91:1:91:13 | [Function] function test14(...) | test.py:91:1:91:13 | (parameters) | semmle.order | 0 |
-| test.py:91:1:91:13 | [Function] function test14(...) | test.py:92:5:92:19 | (StmtList) body | semmle.label | 4 |
-| test.py:91:1:91:13 | [Function] function test14(...) | test.py:92:5:92:19 | (StmtList) body | semmle.order | 4 |
-| test.py:92:5:92:19 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.label | 0 |
-| test.py:92:5:92:19 | (StmtList) body | test.py:92:5:92:19 | [AssignStmt] t = module.safe | semmle.order | 0 |
-| test.py:92:5:92:19 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
-| test.py:92:5:92:19 | (StmtList) body | test.py:93:5:93:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:91:1:91:13 | [Function] function test14(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:91:1:91:13 | [Function] function test14(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:91:1:91:13 | [Function] function test14(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:91:1:91:13 | [Function] function test14(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:5:92:5 | [Name] t | semmle.label | 1 |
 | test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:5:92:5 | [Name] t | semmle.order | 1 |
 | test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:9:92:19 | [Attribute] module.safe | semmle.label | 2 |
 | test.py:92:5:92:19 | [AssignStmt] t = module.safe | test.py:92:9:92:19 | [Attribute] module.safe | semmle.order | 2 |
 | test.py:92:9:92:19 | [Attribute] module.safe | test.py:92:9:92:14 | [Name] module | semmle.label | 1 |
 | test.py:92:9:92:19 | [Attribute] module.safe | test.py:92:9:92:14 | [Name] module | semmle.order | 1 |
-| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.label | 1 |
-| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.order | 1 |
-| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:10:93:10 | [Name] t | semmle.label | 2 |
-| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:10:93:10 | [Name] t | semmle.order | 2 |
+| test.py:93:5:93:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:93:5:93:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.label | 0 |
+| test.py:93:5:93:11 | [Call] SINK(t) | test.py:93:5:93:8 | [Name] SINK | semmle.order | 0 |
 | test.py:93:5:93:11 | [ExprStmt] SINK(t) | test.py:93:5:93:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:93:5:93:11 | [ExprStmt] SINK(t) | test.py:93:5:93:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.label | 1 |
 | test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | semmle.order | 1 |
-| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.label | 2 |
-| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.order | 2 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.label | 0 |
+| test.py:95:1:95:13 | [FunctionDef] test15 = function test15(...) | test.py:95:5:95:10 | [Name] test15 | semmle.order | 0 |
 | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | test.py:95:1:95:13 | [Function] function test15(...) | semmle.label | 1 |
 | test.py:95:1:95:13 | [FunctionExpr] function test15(...) | test.py:95:1:95:13 | [Function] function test15(...) | semmle.order | 1 |
-| test.py:95:1:95:13 | [Function] function test15(...) | test.py:95:1:95:13 | (parameters) | semmle.label | 0 |
-| test.py:95:1:95:13 | [Function] function test15(...) | test.py:95:1:95:13 | (parameters) | semmle.order | 0 |
-| test.py:95:1:95:13 | [Function] function test15(...) | test.py:96:5:96:20 | (StmtList) body | semmle.label | 4 |
-| test.py:95:1:95:13 | [Function] function test15(...) | test.py:96:5:96:20 | (StmtList) body | semmle.order | 4 |
-| test.py:96:5:96:20 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.label | 0 |
-| test.py:96:5:96:20 | (StmtList) body | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | semmle.order | 0 |
-| test.py:96:5:96:20 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
-| test.py:96:5:96:20 | (StmtList) body | test.py:97:5:97:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:95:1:95:13 | [Function] function test15(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:95:1:95:13 | [Function] function test15(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:95:1:95:13 | [Function] function test15(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:95:1:95:13 | [Function] function test15(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:5:96:5 | [Name] t | semmle.label | 1 |
 | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:5:96:5 | [Name] t | semmle.order | 1 |
 | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.label | 2 |
 | test.py:96:5:96:20 | [AssignStmt] t = module.safe2 | test.py:96:9:96:20 | [Attribute] module.safe2 | semmle.order | 2 |
 | test.py:96:9:96:20 | [Attribute] module.safe2 | test.py:96:9:96:14 | [Name] module | semmle.label | 1 |
 | test.py:96:9:96:20 | [Attribute] module.safe2 | test.py:96:9:96:14 | [Name] module | semmle.order | 1 |
-| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.label | 1 |
-| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.order | 1 |
-| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:10:97:10 | [Name] t | semmle.label | 2 |
-| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:10:97:10 | [Name] t | semmle.order | 2 |
+| test.py:97:5:97:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:97:5:97:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.label | 0 |
+| test.py:97:5:97:11 | [Call] SINK(t) | test.py:97:5:97:8 | [Name] SINK | semmle.order | 0 |
 | test.py:97:5:97:11 | [ExprStmt] SINK(t) | test.py:97:5:97:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:97:5:97:11 | [ExprStmt] SINK(t) | test.py:97:5:97:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.label | 1 |
 | test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | semmle.order | 1 |
-| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.label | 2 |
-| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.order | 2 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.label | 0 |
+| test.py:99:1:99:13 | [FunctionDef] test16 = function test16(...) | test.py:99:5:99:10 | [Name] test16 | semmle.order | 0 |
 | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | test.py:99:1:99:13 | [Function] function test16(...) | semmle.label | 1 |
 | test.py:99:1:99:13 | [FunctionExpr] function test16(...) | test.py:99:1:99:13 | [Function] function test16(...) | semmle.order | 1 |
-| test.py:99:1:99:13 | [Function] function test16(...) | test.py:99:1:99:13 | (parameters) | semmle.label | 0 |
-| test.py:99:1:99:13 | [Function] function test16(...) | test.py:99:1:99:13 | (parameters) | semmle.order | 0 |
-| test.py:99:1:99:13 | [Function] function test16(...) | test.py:100:5:100:31 | (StmtList) body | semmle.label | 4 |
-| test.py:99:1:99:13 | [Function] function test16(...) | test.py:100:5:100:31 | (StmtList) body | semmle.order | 4 |
-| test.py:100:5:100:31 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.label | 0 |
-| test.py:100:5:100:31 | (StmtList) body | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | semmle.order | 0 |
-| test.py:100:5:100:31 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.label | 1 |
-| test.py:100:5:100:31 | (StmtList) body | test.py:101:5:101:11 | [ExprStmt] SINK(t) | semmle.order | 1 |
+| test.py:99:1:99:13 | [Function] function test16(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:99:1:99:13 | [Function] function test16(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:99:1:99:13 | [Function] function test16(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:99:1:99:13 | [Function] function test16(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:5:100:5 | [Name] t | semmle.label | 1 |
 | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:5:100:5 | [Name] t | semmle.order | 1 |
 | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:9:100:31 | [Call] module.dangerous_func() | semmle.label | 2 |
 | test.py:100:5:100:31 | [AssignStmt] t = module.dangerous_func() | test.py:100:9:100:31 | [Call] module.dangerous_func() | semmle.order | 2 |
 | test.py:100:9:100:29 | [Attribute] module.dangerous_func | test.py:100:9:100:14 | [Name] module | semmle.label | 1 |
 | test.py:100:9:100:29 | [Attribute] module.dangerous_func | test.py:100:9:100:14 | [Name] module | semmle.order | 1 |
-| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.label | 1 |
-| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.order | 1 |
-| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.label | 1 |
-| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.order | 1 |
-| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:10:101:10 | [Name] t | semmle.label | 2 |
-| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:10:101:10 | [Name] t | semmle.order | 2 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.label | 0 |
+| test.py:100:9:100:31 | [Call] module.dangerous_func() | test.py:100:9:100:29 | [Attribute] module.dangerous_func | semmle.order | 0 |
+| test.py:101:5:101:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:101:5:101:11 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.label | 0 |
+| test.py:101:5:101:11 | [Call] SINK(t) | test.py:101:5:101:8 | [Name] SINK | semmle.order | 0 |
 | test.py:101:5:101:11 | [ExprStmt] SINK(t) | test.py:101:5:101:11 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:101:5:101:11 | [ExprStmt] SINK(t) | test.py:101:5:101:11 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:103:1:103:16 | [ClassDef] C = class C | test.py:103:1:103:16 | [ClassExpr] class C | semmle.label | 1 |
@@ -2956,54 +3473,44 @@ edges
 | test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:1:103:16 | [Class] class C | semmle.order | 1 |
 | test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:9:103:14 | [Name] object | semmle.label | 2 |
 | test.py:103:1:103:16 | [ClassExpr] class C | test.py:103:9:103:14 | [Name] object | semmle.order | 2 |
-| test.py:103:1:103:16 | [Class] class C | test.py:103:18:103:21 | (StmtList) body | semmle.label | 3 |
-| test.py:103:1:103:16 | [Class] class C | test.py:103:18:103:21 | (StmtList) body | semmle.order | 3 |
-| test.py:103:18:103:21 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.label | 0 |
-| test.py:103:18:103:21 | (StmtList) body | test.py:103:18:103:21 | [Pass] pass | semmle.order | 0 |
-| test.py:105:1:105:16 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.label | 1 |
-| test.py:105:1:105:16 | (parameters) | test.py:105:12:105:14 | [Parameter] arg | semmle.order | 1 |
+| test.py:103:1:103:16 | [Class] class C | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| test.py:103:1:103:16 | [Class] class C | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
 | test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.label | 1 |
 | test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | semmle.order | 1 |
-| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.label | 2 |
-| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.order | 2 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.label | 0 |
+| test.py:105:1:105:16 | [FunctionDef] x_sink = function x_sink(...) | test.py:105:5:105:10 | [Name] x_sink | semmle.order | 0 |
 | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | test.py:105:1:105:16 | [Function] function x_sink(...) | semmle.label | 1 |
 | test.py:105:1:105:16 | [FunctionExpr] function x_sink(...) | test.py:105:1:105:16 | [Function] function x_sink(...) | semmle.order | 1 |
-| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:105:1:105:16 | (parameters) | semmle.label | 0 |
-| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:105:1:105:16 | (parameters) | semmle.order | 0 |
-| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:106:5:106:15 | (StmtList) body | semmle.label | 4 |
-| test.py:105:1:105:16 | [Function] function x_sink(...) | test.py:106:5:106:15 | (StmtList) body | semmle.order | 4 |
-| test.py:106:5:106:15 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.label | 0 |
-| test.py:106:5:106:15 | (StmtList) body | test.py:106:5:106:15 | [ExprStmt] SINK(...) | semmle.order | 0 |
-| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.label | 1 |
-| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.order | 1 |
-| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.label | 2 |
-| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:10:106:14 | [Attribute] arg.x | semmle.order | 2 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:105:1:105:16 | [Function] function x_sink(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:106:5:106:15 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:106:5:106:15 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.label | 0 |
+| test.py:106:5:106:15 | [Call] SINK(...) | test.py:106:5:106:8 | [Name] SINK | semmle.order | 0 |
 | test.py:106:5:106:15 | [ExprStmt] SINK(...) | test.py:106:5:106:15 | [Call] SINK(...) | semmle.label | 1 |
 | test.py:106:5:106:15 | [ExprStmt] SINK(...) | test.py:106:5:106:15 | [Call] SINK(...) | semmle.order | 1 |
 | test.py:106:10:106:14 | [Attribute] arg.x | test.py:106:10:106:12 | [Name] arg | semmle.label | 1 |
 | test.py:106:10:106:14 | [Attribute] arg.x | test.py:106:10:106:12 | [Name] arg | semmle.order | 1 |
 | test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.label | 1 |
 | test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | semmle.order | 1 |
-| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.label | 2 |
-| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.order | 2 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.label | 0 |
+| test.py:108:1:108:13 | [FunctionDef] test17 = function test17(...) | test.py:108:5:108:10 | [Name] test17 | semmle.order | 0 |
 | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | test.py:108:1:108:13 | [Function] function test17(...) | semmle.label | 1 |
 | test.py:108:1:108:13 | [FunctionExpr] function test17(...) | test.py:108:1:108:13 | [Function] function test17(...) | semmle.order | 1 |
-| test.py:108:1:108:13 | [Function] function test17(...) | test.py:108:1:108:13 | (parameters) | semmle.label | 0 |
-| test.py:108:1:108:13 | [Function] function test17(...) | test.py:108:1:108:13 | (parameters) | semmle.order | 0 |
-| test.py:108:1:108:13 | [Function] function test17(...) | test.py:109:5:109:11 | (StmtList) body | semmle.label | 5 |
-| test.py:108:1:108:13 | [Function] function test17(...) | test.py:109:5:109:11 | (StmtList) body | semmle.order | 5 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.label | 0 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:109:5:109:11 | [AssignStmt] t = C() | semmle.order | 0 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.label | 2 |
-| test.py:109:5:109:11 | (StmtList) body | test.py:111:5:111:13 | [ExprStmt] SINK(...) | semmle.order | 2 |
+| test.py:108:1:108:13 | [Function] function test17(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:108:1:108:13 | [Function] function test17(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:108:1:108:13 | [Function] function test17(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:108:1:108:13 | [Function] function test17(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:5:109:5 | [Name] t | semmle.label | 1 |
 | test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:5:109:5 | [Name] t | semmle.order | 1 |
 | test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:9:109:11 | [Call] C() | semmle.label | 2 |
 | test.py:109:5:109:11 | [AssignStmt] t = C() | test.py:109:9:109:11 | [Call] C() | semmle.order | 2 |
-| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.label | 1 |
-| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.order | 1 |
+| test.py:109:9:109:11 | [Call] C() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:109:9:109:11 | [Call] C() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.label | 0 |
+| test.py:109:9:109:11 | [Call] C() | test.py:109:9:109:9 | [Name] C | semmle.order | 0 |
 | test.py:110:5:110:7 | [Attribute] t.x | test.py:110:5:110:5 | [Name] t | semmle.label | 1 |
 | test.py:110:5:110:7 | [Attribute] t.x | test.py:110:5:110:5 | [Name] t | semmle.order | 1 |
 | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:5:110:7 | [Attribute] t.x | semmle.label | 1 |
@@ -3012,38 +3519,32 @@ edges
 | test.py:110:5:110:26 | [AssignStmt] t.x = module.dangerous | test.py:110:11:110:26 | [Attribute] module.dangerous | semmle.order | 2 |
 | test.py:110:11:110:26 | [Attribute] module.dangerous | test.py:110:11:110:16 | [Name] module | semmle.label | 1 |
 | test.py:110:11:110:26 | [Attribute] module.dangerous | test.py:110:11:110:16 | [Name] module | semmle.order | 1 |
-| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.label | 1 |
-| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.order | 1 |
-| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:10:111:12 | [Attribute] t.x | semmle.label | 2 |
-| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:10:111:12 | [Attribute] t.x | semmle.order | 2 |
+| test.py:111:5:111:13 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:111:5:111:13 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.label | 0 |
+| test.py:111:5:111:13 | [Call] SINK(...) | test.py:111:5:111:8 | [Name] SINK | semmle.order | 0 |
 | test.py:111:5:111:13 | [ExprStmt] SINK(...) | test.py:111:5:111:13 | [Call] SINK(...) | semmle.label | 1 |
 | test.py:111:5:111:13 | [ExprStmt] SINK(...) | test.py:111:5:111:13 | [Call] SINK(...) | semmle.order | 1 |
 | test.py:111:10:111:12 | [Attribute] t.x | test.py:111:10:111:10 | [Name] t | semmle.label | 1 |
 | test.py:111:10:111:12 | [Attribute] t.x | test.py:111:10:111:10 | [Name] t | semmle.order | 1 |
 | test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.label | 1 |
 | test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | semmle.order | 1 |
-| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.label | 2 |
-| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.order | 2 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.label | 0 |
+| test.py:113:1:113:13 | [FunctionDef] test18 = function test18(...) | test.py:113:5:113:10 | [Name] test18 | semmle.order | 0 |
 | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | test.py:113:1:113:13 | [Function] function test18(...) | semmle.label | 1 |
 | test.py:113:1:113:13 | [FunctionExpr] function test18(...) | test.py:113:1:113:13 | [Function] function test18(...) | semmle.order | 1 |
-| test.py:113:1:113:13 | [Function] function test18(...) | test.py:113:1:113:13 | (parameters) | semmle.label | 0 |
-| test.py:113:1:113:13 | [Function] function test18(...) | test.py:113:1:113:13 | (parameters) | semmle.order | 0 |
-| test.py:113:1:113:13 | [Function] function test18(...) | test.py:114:5:114:11 | (StmtList) body | semmle.label | 6 |
-| test.py:113:1:113:13 | [Function] function test18(...) | test.py:114:5:114:11 | (StmtList) body | semmle.order | 6 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.label | 0 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:114:5:114:11 | [AssignStmt] t = C() | semmle.order | 0 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.label | 1 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | semmle.order | 1 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.label | 2 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | semmle.order | 2 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.label | 3 |
-| test.py:114:5:114:11 | (StmtList) body | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | semmle.order | 3 |
+| test.py:113:1:113:13 | [Function] function test18(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 6 |
+| test.py:113:1:113:13 | [Function] function test18(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 6 |
+| test.py:113:1:113:13 | [Function] function test18(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:113:1:113:13 | [Function] function test18(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:5:114:5 | [Name] t | semmle.label | 1 |
 | test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:5:114:5 | [Name] t | semmle.order | 1 |
 | test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:9:114:11 | [Call] C() | semmle.label | 2 |
 | test.py:114:5:114:11 | [AssignStmt] t = C() | test.py:114:9:114:11 | [Call] C() | semmle.order | 2 |
-| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.label | 1 |
-| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.order | 1 |
+| test.py:114:9:114:11 | [Call] C() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:114:9:114:11 | [Call] C() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.label | 0 |
+| test.py:114:9:114:11 | [Call] C() | test.py:114:9:114:9 | [Name] C | semmle.order | 0 |
 | test.py:115:5:115:7 | [Attribute] t.x | test.py:115:5:115:5 | [Name] t | semmle.label | 1 |
 | test.py:115:5:115:7 | [Attribute] t.x | test.py:115:5:115:5 | [Name] t | semmle.order | 1 |
 | test.py:115:5:115:26 | [AssignStmt] t.x = module.dangerous | test.py:115:5:115:7 | [Attribute] t.x | semmle.label | 1 |
@@ -3056,32 +3557,26 @@ edges
 | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:5:116:5 | [Name] t | semmle.order | 1 |
 | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:9:116:14 | [Call] hub(t) | semmle.label | 2 |
 | test.py:116:5:116:14 | [AssignStmt] t = hub(t) | test.py:116:9:116:14 | [Call] hub(t) | semmle.order | 2 |
-| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.label | 1 |
-| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.order | 1 |
-| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:13:116:13 | [Name] t | semmle.label | 2 |
-| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:13:116:13 | [Name] t | semmle.order | 2 |
-| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.label | 1 |
-| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.order | 1 |
-| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:12:117:12 | [Name] t | semmle.label | 2 |
-| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:12:117:12 | [Name] t | semmle.order | 2 |
+| test.py:116:9:116:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:116:9:116:14 | [Call] hub(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.label | 0 |
+| test.py:116:9:116:14 | [Call] hub(t) | test.py:116:9:116:11 | [Name] hub | semmle.order | 0 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.label | 0 |
+| test.py:117:5:117:13 | [Call] x_sink(t) | test.py:117:5:117:10 | [Name] x_sink | semmle.order | 0 |
 | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | test.py:117:5:117:13 | [Call] x_sink(t) | semmle.label | 1 |
 | test.py:117:5:117:13 | [ExprStmt] x_sink(t) | test.py:117:5:117:13 | [Call] x_sink(t) | semmle.order | 1 |
 | test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.label | 1 |
 | test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | semmle.order | 1 |
-| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.label | 2 |
-| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.order | 2 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.label | 0 |
+| test.py:119:1:119:13 | [FunctionDef] test19 = function test19(...) | test.py:119:5:119:10 | [Name] test19 | semmle.order | 0 |
 | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | test.py:119:1:119:13 | [Function] function test19(...) | semmle.label | 1 |
 | test.py:119:1:119:13 | [FunctionExpr] function test19(...) | test.py:119:1:119:13 | [Function] function test19(...) | semmle.order | 1 |
-| test.py:119:1:119:13 | [Function] function test19(...) | test.py:119:1:119:13 | (parameters) | semmle.label | 0 |
-| test.py:119:1:119:13 | [Function] function test19(...) | test.py:119:1:119:13 | (parameters) | semmle.order | 0 |
-| test.py:119:1:119:13 | [Function] function test19(...) | test.py:120:5:120:21 | (StmtList) body | semmle.label | 5 |
-| test.py:119:1:119:13 | [Function] function test19(...) | test.py:120:5:120:21 | (StmtList) body | semmle.order | 5 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.label | 1 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | semmle.order | 1 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 2 |
-| test.py:120:5:120:21 | (StmtList) body | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 2 |
+| test.py:119:1:119:13 | [Function] function test19(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:119:1:119:13 | [Function] function test19(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:119:1:119:13 | [Function] function test19(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:119:1:119:13 | [Function] function test19(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:5:120:5 | [Name] t | semmle.label | 1 |
 | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:5:120:5 | [Name] t | semmle.order | 1 |
 | test.py:120:5:120:21 | [AssignStmt] t = CUSTOM_SOURCE | test.py:120:9:120:21 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
@@ -3090,166 +3585,126 @@ edges
 | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:5:121:5 | [Name] t | semmle.order | 1 |
 | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:9:121:30 | [Call] hub(...) | semmle.label | 2 |
 | test.py:121:5:121:30 | [AssignStmt] t = hub(...) | test.py:121:9:121:30 | [Call] hub(...) | semmle.order | 2 |
-| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.label | 1 |
-| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.order | 1 |
-| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.label | 2 |
-| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | semmle.order | 2 |
-| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.label | 1 |
-| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.order | 1 |
-| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:28:121:28 | [Name] t | semmle.label | 2 |
-| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:28:121:28 | [Name] t | semmle.order | 2 |
-| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.label | 1 |
-| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.order | 1 |
-| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:17:122:17 | [Name] t | semmle.label | 2 |
-| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:17:122:17 | [Name] t | semmle.order | 2 |
+| test.py:121:9:121:30 | [Call] hub(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:121:9:121:30 | [Call] hub(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.label | 0 |
+| test.py:121:9:121:30 | [Call] hub(...) | test.py:121:9:121:11 | [Name] hub | semmle.order | 0 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.label | 0 |
+| test.py:121:13:121:29 | [Call] TAINT_FROM_ARG(t) | test.py:121:13:121:26 | [Name] TAINT_FROM_ARG | semmle.order | 0 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.label | 0 |
+| test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | test.py:122:5:122:15 | [Name] CUSTOM_SINK | semmle.order | 0 |
 | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
 | test.py:122:5:122:18 | [ExprStmt] CUSTOM_SINK(t) | test.py:122:5:122:18 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
-| test.py:124:1:124:17 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.label | 1 |
-| test.py:124:1:124:17 | (parameters) | test.py:124:12:124:15 | [Parameter] cond | semmle.order | 1 |
 | test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.label | 1 |
 | test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | semmle.order | 1 |
-| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.label | 2 |
-| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.order | 2 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.label | 0 |
+| test.py:124:1:124:17 | [FunctionDef] test20 = function test20(...) | test.py:124:5:124:10 | [Name] test20 | semmle.order | 0 |
 | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | test.py:124:1:124:17 | [Function] function test20(...) | semmle.label | 1 |
 | test.py:124:1:124:17 | [FunctionExpr] function test20(...) | test.py:124:1:124:17 | [Function] function test20(...) | semmle.order | 1 |
-| test.py:124:1:124:17 | [Function] function test20(...) | test.py:124:1:124:17 | (parameters) | semmle.label | 0 |
-| test.py:124:1:124:17 | [Function] function test20(...) | test.py:124:1:124:17 | (parameters) | semmle.order | 0 |
-| test.py:124:1:124:17 | [Function] function test20(...) | test.py:125:5:125:12 | (StmtList) body | semmle.label | 5 |
-| test.py:124:1:124:17 | [Function] function test20(...) | test.py:125:5:125:12 | (StmtList) body | semmle.order | 5 |
-| test.py:125:5:125:12 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.label | 0 |
-| test.py:125:5:125:12 | (StmtList) body | test.py:125:5:125:12 | [If] if cond: | semmle.order | 0 |
-| test.py:125:5:125:12 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.label | 1 |
-| test.py:125:5:125:12 | (StmtList) body | test.py:129:5:129:12 | [If] if cond: | semmle.order | 1 |
+| test.py:124:1:124:17 | [Function] function test20(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:124:1:124:17 | [Function] function test20(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:124:1:124:17 | [Function] function test20(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:124:1:124:17 | [Function] function test20(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:125:5:125:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:125:5:125:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:125:5:125:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:125:5:125:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:125:5:125:12 | [If] if cond: | test.py:125:8:125:11 | [Name] cond | semmle.label | 0 |
 | test.py:125:5:125:12 | [If] if cond: | test.py:125:8:125:11 | [Name] cond | semmle.order | 0 |
-| test.py:125:5:125:12 | [If] if cond: | test.py:126:9:126:25 | (StmtList) body | semmle.label | 2 |
-| test.py:125:5:125:12 | [If] if cond: | test.py:126:9:126:25 | (StmtList) body | semmle.order | 2 |
-| test.py:125:5:125:12 | [If] if cond: | test.py:128:9:128:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:125:5:125:12 | [If] if cond: | test.py:128:9:128:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:126:9:126:25 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
-| test.py:126:9:126:25 | (StmtList) body | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
 | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:9:126:9 | [Name] t | semmle.label | 1 |
 | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:9:126:9 | [Name] t | semmle.order | 1 |
 | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
 | test.py:126:9:126:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:126:13:126:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
-| test.py:128:9:128:18 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:128:9:128:18 | (StmtList) orelse | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:9:128:9 | [Name] t | semmle.label | 1 |
 | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:9:128:9 | [Name] t | semmle.order | 1 |
 | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:13:128:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:128:9:128:18 | [AssignStmt] t = SOURCE | test.py:128:13:128:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:129:5:129:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:129:5:129:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:129:5:129:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:129:5:129:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:129:5:129:12 | [If] if cond: | test.py:129:8:129:11 | [Name] cond | semmle.label | 0 |
 | test.py:129:5:129:12 | [If] if cond: | test.py:129:8:129:11 | [Name] cond | semmle.order | 0 |
-| test.py:129:5:129:12 | [If] if cond: | test.py:130:9:130:22 | (StmtList) body | semmle.label | 2 |
-| test.py:129:5:129:12 | [If] if cond: | test.py:130:9:130:22 | (StmtList) body | semmle.order | 2 |
-| test.py:129:5:129:12 | [If] if cond: | test.py:132:9:132:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:129:5:129:12 | [If] if cond: | test.py:132:9:132:15 | (StmtList) orelse | semmle.order | 3 |
-| test.py:130:9:130:22 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
-| test.py:130:9:130:22 | (StmtList) body | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
-| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
-| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
-| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:21:130:21 | [Name] t | semmle.label | 2 |
-| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:21:130:21 | [Name] t | semmle.order | 2 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.label | 0 |
+| test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | test.py:130:9:130:19 | [Name] CUSTOM_SINK | semmle.order | 0 |
 | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
 | test.py:130:9:130:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:130:9:130:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
-| test.py:132:9:132:15 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:132:9:132:15 | (StmtList) orelse | test.py:132:9:132:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.label | 1 |
-| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.order | 1 |
-| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:14:132:14 | [Name] t | semmle.label | 2 |
-| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:14:132:14 | [Name] t | semmle.order | 2 |
+| test.py:132:9:132:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:132:9:132:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.label | 0 |
+| test.py:132:9:132:15 | [Call] SINK(t) | test.py:132:9:132:12 | [Name] SINK | semmle.order | 0 |
 | test.py:132:9:132:15 | [ExprStmt] SINK(t) | test.py:132:9:132:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:132:9:132:15 | [ExprStmt] SINK(t) | test.py:132:9:132:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:134:1:134:17 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.label | 1 |
-| test.py:134:1:134:17 | (parameters) | test.py:134:12:134:15 | [Parameter] cond | semmle.order | 1 |
 | test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.label | 1 |
 | test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | semmle.order | 1 |
-| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.label | 2 |
-| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.order | 2 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.label | 0 |
+| test.py:134:1:134:17 | [FunctionDef] test21 = function test21(...) | test.py:134:5:134:10 | [Name] test21 | semmle.order | 0 |
 | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | test.py:134:1:134:17 | [Function] function test21(...) | semmle.label | 1 |
 | test.py:134:1:134:17 | [FunctionExpr] function test21(...) | test.py:134:1:134:17 | [Function] function test21(...) | semmle.order | 1 |
-| test.py:134:1:134:17 | [Function] function test21(...) | test.py:134:1:134:17 | (parameters) | semmle.label | 0 |
-| test.py:134:1:134:17 | [Function] function test21(...) | test.py:134:1:134:17 | (parameters) | semmle.order | 0 |
-| test.py:134:1:134:17 | [Function] function test21(...) | test.py:135:5:135:12 | (StmtList) body | semmle.label | 5 |
-| test.py:134:1:134:17 | [Function] function test21(...) | test.py:135:5:135:12 | (StmtList) body | semmle.order | 5 |
-| test.py:135:5:135:12 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.label | 0 |
-| test.py:135:5:135:12 | (StmtList) body | test.py:135:5:135:12 | [If] if cond: | semmle.order | 0 |
-| test.py:135:5:135:12 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.label | 1 |
-| test.py:135:5:135:12 | (StmtList) body | test.py:139:5:139:16 | [If]  | semmle.order | 1 |
+| test.py:134:1:134:17 | [Function] function test21(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:134:1:134:17 | [Function] function test21(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:134:1:134:17 | [Function] function test21(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:134:1:134:17 | [Function] function test21(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:135:5:135:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:135:5:135:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:135:5:135:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:135:5:135:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:135:5:135:12 | [If] if cond: | test.py:135:8:135:11 | [Name] cond | semmle.label | 0 |
 | test.py:135:5:135:12 | [If] if cond: | test.py:135:8:135:11 | [Name] cond | semmle.order | 0 |
-| test.py:135:5:135:12 | [If] if cond: | test.py:136:9:136:25 | (StmtList) body | semmle.label | 2 |
-| test.py:135:5:135:12 | [If] if cond: | test.py:136:9:136:25 | (StmtList) body | semmle.order | 2 |
-| test.py:135:5:135:12 | [If] if cond: | test.py:138:9:138:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:135:5:135:12 | [If] if cond: | test.py:138:9:138:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:136:9:136:25 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
-| test.py:136:9:136:25 | (StmtList) body | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
 | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:9:136:9 | [Name] t | semmle.label | 1 |
 | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:9:136:9 | [Name] t | semmle.order | 1 |
 | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
 | test.py:136:9:136:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:136:13:136:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
-| test.py:138:9:138:18 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:138:9:138:18 | (StmtList) orelse | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:9:138:9 | [Name] t | semmle.label | 1 |
 | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:9:138:9 | [Name] t | semmle.order | 1 |
 | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:13:138:18 | [Name] SOURCE | semmle.label | 2 |
 | test.py:138:9:138:18 | [AssignStmt] t = SOURCE | test.py:138:13:138:18 | [Name] SOURCE | semmle.order | 2 |
+| test.py:139:5:139:16 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:139:5:139:16 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:139:5:139:16 | [If]  | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:139:5:139:16 | [If]  | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:139:5:139:16 | [If]  | test.py:139:8:139:15 | [UnaryExpr]  | semmle.label | 0 |
 | test.py:139:5:139:16 | [If]  | test.py:139:8:139:15 | [UnaryExpr]  | semmle.order | 0 |
-| test.py:139:5:139:16 | [If]  | test.py:140:9:140:22 | (StmtList) body | semmle.label | 2 |
-| test.py:139:5:139:16 | [If]  | test.py:140:9:140:22 | (StmtList) body | semmle.order | 2 |
-| test.py:139:5:139:16 | [If]  | test.py:142:9:142:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:139:5:139:16 | [If]  | test.py:142:9:142:15 | (StmtList) orelse | semmle.order | 3 |
 | test.py:139:8:139:15 | [UnaryExpr]  | test.py:139:12:139:15 | [Name] cond | semmle.label | 1 |
 | test.py:139:8:139:15 | [UnaryExpr]  | test.py:139:12:139:15 | [Name] cond | semmle.order | 1 |
-| test.py:140:9:140:22 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
-| test.py:140:9:140:22 | (StmtList) body | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
-| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
-| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
-| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:21:140:21 | [Name] t | semmle.label | 2 |
-| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:21:140:21 | [Name] t | semmle.order | 2 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.label | 0 |
+| test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | test.py:140:9:140:19 | [Name] CUSTOM_SINK | semmle.order | 0 |
 | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
 | test.py:140:9:140:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:140:9:140:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
-| test.py:142:9:142:15 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:142:9:142:15 | (StmtList) orelse | test.py:142:9:142:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.label | 1 |
-| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.order | 1 |
-| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:14:142:14 | [Name] t | semmle.label | 2 |
-| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:14:142:14 | [Name] t | semmle.order | 2 |
+| test.py:142:9:142:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:142:9:142:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.label | 0 |
+| test.py:142:9:142:15 | [Call] SINK(t) | test.py:142:9:142:12 | [Name] SINK | semmle.order | 0 |
 | test.py:142:9:142:15 | [ExprStmt] SINK(t) | test.py:142:9:142:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:142:9:142:15 | [ExprStmt] SINK(t) | test.py:142:9:142:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:144:1:144:17 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.label | 1 |
-| test.py:144:1:144:17 | (parameters) | test.py:144:12:144:15 | [Parameter] cond | semmle.order | 1 |
 | test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.label | 1 |
 | test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | semmle.order | 1 |
-| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.label | 2 |
-| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.order | 2 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.label | 0 |
+| test.py:144:1:144:17 | [FunctionDef] test22 = function test22(...) | test.py:144:5:144:10 | [Name] test22 | semmle.order | 0 |
 | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | test.py:144:1:144:17 | [Function] function test22(...) | semmle.label | 1 |
 | test.py:144:1:144:17 | [FunctionExpr] function test22(...) | test.py:144:1:144:17 | [Function] function test22(...) | semmle.order | 1 |
-| test.py:144:1:144:17 | [Function] function test22(...) | test.py:144:1:144:17 | (parameters) | semmle.label | 0 |
-| test.py:144:1:144:17 | [Function] function test22(...) | test.py:144:1:144:17 | (parameters) | semmle.order | 0 |
-| test.py:144:1:144:17 | [Function] function test22(...) | test.py:145:5:145:12 | (StmtList) body | semmle.label | 6 |
-| test.py:144:1:144:17 | [Function] function test22(...) | test.py:145:5:145:12 | (StmtList) body | semmle.order | 6 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.label | 0 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:145:5:145:12 | [If] if cond: | semmle.order | 0 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.label | 1 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | semmle.order | 1 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.label | 2 |
-| test.py:145:5:145:12 | (StmtList) body | test.py:150:5:150:12 | [If] if cond: | semmle.order | 2 |
+| test.py:144:1:144:17 | [Function] function test22(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 6 |
+| test.py:144:1:144:17 | [Function] function test22(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 6 |
+| test.py:144:1:144:17 | [Function] function test22(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:144:1:144:17 | [Function] function test22(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:145:5:145:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:145:5:145:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:145:5:145:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:145:5:145:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:145:5:145:12 | [If] if cond: | test.py:145:8:145:11 | [Name] cond | semmle.label | 0 |
 | test.py:145:5:145:12 | [If] if cond: | test.py:145:8:145:11 | [Name] cond | semmle.order | 0 |
-| test.py:145:5:145:12 | [If] if cond: | test.py:146:9:146:25 | (StmtList) body | semmle.label | 2 |
-| test.py:145:5:145:12 | [If] if cond: | test.py:146:9:146:25 | (StmtList) body | semmle.order | 2 |
-| test.py:145:5:145:12 | [If] if cond: | test.py:148:9:148:18 | (StmtList) orelse | semmle.label | 3 |
-| test.py:145:5:145:12 | [If] if cond: | test.py:148:9:148:18 | (StmtList) orelse | semmle.order | 3 |
-| test.py:146:9:146:25 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.label | 0 |
-| test.py:146:9:146:25 | (StmtList) body | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | semmle.order | 0 |
 | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:9:146:9 | [Name] t | semmle.label | 1 |
 | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:9:146:9 | [Name] t | semmle.order | 1 |
 | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.label | 2 |
 | test.py:146:9:146:25 | [AssignStmt] t = CUSTOM_SOURCE | test.py:146:13:146:25 | [Name] CUSTOM_SOURCE | semmle.order | 2 |
-| test.py:148:9:148:18 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:148:9:148:18 | (StmtList) orelse | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | semmle.order | 0 |
 | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:9:148:9 | [Name] t | semmle.label | 1 |
 | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:9:148:9 | [Name] t | semmle.order | 1 |
 | test.py:148:9:148:18 | [AssignStmt] t = SOURCE | test.py:148:13:148:18 | [Name] SOURCE | semmle.label | 2 |
@@ -3258,30 +3713,26 @@ edges
 | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:5:149:5 | [Name] t | semmle.order | 1 |
 | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | semmle.label | 2 |
 | test.py:149:5:149:25 | [AssignStmt] t = TAINT_FROM_ARG(t) | test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | semmle.order | 2 |
-| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.label | 1 |
-| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.order | 1 |
-| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:24:149:24 | [Name] t | semmle.label | 2 |
-| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:24:149:24 | [Name] t | semmle.order | 2 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.label | 0 |
+| test.py:149:9:149:25 | [Call] TAINT_FROM_ARG(t) | test.py:149:9:149:22 | [Name] TAINT_FROM_ARG | semmle.order | 0 |
+| test.py:150:5:150:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:150:5:150:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:150:5:150:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:150:5:150:12 | [If] if cond: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:150:5:150:12 | [If] if cond: | test.py:150:8:150:11 | [Name] cond | semmle.label | 0 |
 | test.py:150:5:150:12 | [If] if cond: | test.py:150:8:150:11 | [Name] cond | semmle.order | 0 |
-| test.py:150:5:150:12 | [If] if cond: | test.py:151:9:151:22 | (StmtList) body | semmle.label | 2 |
-| test.py:150:5:150:12 | [If] if cond: | test.py:151:9:151:22 | (StmtList) body | semmle.order | 2 |
-| test.py:150:5:150:12 | [If] if cond: | test.py:153:9:153:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:150:5:150:12 | [If] if cond: | test.py:153:9:153:15 | (StmtList) orelse | semmle.order | 3 |
-| test.py:151:9:151:22 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.label | 0 |
-| test.py:151:9:151:22 | (StmtList) body | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | semmle.order | 0 |
-| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.label | 1 |
-| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.order | 1 |
-| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:21:151:21 | [Name] t | semmle.label | 2 |
-| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:21:151:21 | [Name] t | semmle.order | 2 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.label | 0 |
+| test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | test.py:151:9:151:19 | [Name] CUSTOM_SINK | semmle.order | 0 |
 | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.label | 1 |
 | test.py:151:9:151:22 | [ExprStmt] CUSTOM_SINK(t) | test.py:151:9:151:22 | [Call] CUSTOM_SINK(t) | semmle.order | 1 |
-| test.py:153:9:153:15 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:153:9:153:15 | (StmtList) orelse | test.py:153:9:153:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.label | 1 |
-| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.order | 1 |
-| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:14:153:14 | [Name] t | semmle.label | 2 |
-| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:14:153:14 | [Name] t | semmle.order | 2 |
+| test.py:153:9:153:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:153:9:153:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.label | 0 |
+| test.py:153:9:153:15 | [Call] SINK(t) | test.py:153:9:153:12 | [Name] SINK | semmle.order | 0 |
 | test.py:153:9:153:15 | [ExprStmt] SINK(t) | test.py:153:9:153:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:153:9:153:15 | [ExprStmt] SINK(t) | test.py:153:9:153:15 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:155:1:155:38 | [Import] import unsafe | test.py:155:6:155:11 | [ImportExpr]  | semmle.label | 1 |
@@ -3292,100 +3743,70 @@ edges
 | test.py:155:1:155:38 | [Import] import unsafe | test.py:155:33:155:38 | [Name] unsafe | semmle.order | 3 |
 | test.py:155:20:155:38 | [ImportMember]  | test.py:155:6:155:11 | [ImportExpr]  | semmle.label | 1 |
 | test.py:155:20:155:38 | [ImportMember]  | test.py:155:6:155:11 | [ImportExpr]  | semmle.order | 1 |
-| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.label | 1 |
-| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.order | 1 |
-| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:6:156:11 | [Name] unsafe | semmle.label | 2 |
-| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:6:156:11 | [Name] unsafe | semmle.order | 2 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.label | 0 |
+| test.py:156:1:156:12 | [Call] SINK(unsafe) | test.py:156:1:156:4 | [Name] SINK | semmle.order | 0 |
 | test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | test.py:156:1:156:12 | [Call] SINK(unsafe) | semmle.label | 1 |
 | test.py:156:1:156:12 | [ExprStmt] SINK(unsafe) | test.py:156:1:156:12 | [Call] SINK(unsafe) | semmle.order | 1 |
 | test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.label | 1 |
 | test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | semmle.order | 1 |
-| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.label | 2 |
-| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.order | 2 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.label | 0 |
+| test.py:158:1:158:13 | [FunctionDef] test23 = function test23(...) | test.py:158:5:158:10 | [Name] test23 | semmle.order | 0 |
 | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | test.py:158:1:158:13 | [Function] function test23(...) | semmle.label | 1 |
 | test.py:158:1:158:13 | [FunctionExpr] function test23(...) | test.py:158:1:158:13 | [Function] function test23(...) | semmle.order | 1 |
-| test.py:158:1:158:13 | [Function] function test23(...) | test.py:158:1:158:13 | (parameters) | semmle.label | 0 |
-| test.py:158:1:158:13 | [Function] function test23(...) | test.py:158:1:158:13 | (parameters) | semmle.order | 0 |
-| test.py:158:1:158:13 | [Function] function test23(...) | test.py:159:5:159:21 | (StmtList) body | semmle.label | 3 |
-| test.py:158:1:158:13 | [Function] function test23(...) | test.py:159:5:159:21 | (StmtList) body | semmle.order | 3 |
-| test.py:159:5:159:21 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.label | 0 |
-| test.py:159:5:159:21 | (StmtList) body | test.py:159:5:159:21 | [With]  | semmle.order | 0 |
+| test.py:158:1:158:13 | [Function] function test23(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| test.py:158:1:158:13 | [Function] function test23(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| test.py:158:1:158:13 | [Function] function test23(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:158:1:158:13 | [Function] function test23(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:159:5:159:21 | [With]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:159:5:159:21 | [With]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
 | test.py:159:5:159:21 | [With]  | test.py:159:10:159:15 | [Name] SOURCE | semmle.label | 1 |
 | test.py:159:5:159:21 | [With]  | test.py:159:10:159:15 | [Name] SOURCE | semmle.order | 1 |
 | test.py:159:5:159:21 | [With]  | test.py:159:20:159:20 | [Name] t | semmle.label | 2 |
 | test.py:159:5:159:21 | [With]  | test.py:159:20:159:20 | [Name] t | semmle.order | 2 |
-| test.py:159:5:159:21 | [With]  | test.py:160:9:160:15 | (StmtList) body | semmle.label | 5 |
-| test.py:159:5:159:21 | [With]  | test.py:160:9:160:15 | (StmtList) body | semmle.order | 5 |
-| test.py:160:9:160:15 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:160:9:160:15 | (StmtList) body | test.py:160:9:160:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.label | 1 |
-| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.order | 1 |
-| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:14:160:14 | [Name] t | semmle.label | 2 |
-| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:14:160:14 | [Name] t | semmle.order | 2 |
+| test.py:160:9:160:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:160:9:160:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.label | 0 |
+| test.py:160:9:160:15 | [Call] SINK(t) | test.py:160:9:160:12 | [Name] SINK | semmle.order | 0 |
 | test.py:160:9:160:15 | [ExprStmt] SINK(t) | test.py:160:9:160:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:160:9:160:15 | [ExprStmt] SINK(t) | test.py:160:9:160:15 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.label | 1 |
 | test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | semmle.order | 1 |
-| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.label | 2 |
-| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.order | 2 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.label | 0 |
+| test.py:162:1:162:13 | [FunctionDef] test24 = function test24(...) | test.py:162:5:162:10 | [Name] test24 | semmle.order | 0 |
 | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | test.py:162:1:162:13 | [Function] function test24(...) | semmle.label | 1 |
 | test.py:162:1:162:13 | [FunctionExpr] function test24(...) | test.py:162:1:162:13 | [Function] function test24(...) | semmle.order | 1 |
-| test.py:162:1:162:13 | [Function] function test24(...) | test.py:162:1:162:13 | (parameters) | semmle.label | 0 |
-| test.py:162:1:162:13 | [Function] function test24(...) | test.py:162:1:162:13 | (parameters) | semmle.order | 0 |
-| test.py:162:1:162:13 | [Function] function test24(...) | test.py:163:5:163:14 | (StmtList) body | semmle.label | 5 |
-| test.py:162:1:162:13 | [Function] function test24(...) | test.py:163:5:163:14 | (StmtList) body | semmle.order | 5 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.label | 0 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | semmle.order | 0 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.label | 1 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | semmle.order | 1 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.label | 2 |
-| test.py:163:5:163:14 | (StmtList) body | test.py:165:5:165:11 | [ExprStmt] SINK(s) | semmle.order | 2 |
+| test.py:162:1:162:13 | [Function] function test24(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:162:1:162:13 | [Function] function test24(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:162:1:162:13 | [Function] function test24(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:162:1:162:13 | [Function] function test24(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:5:163:5 | [Name] s | semmle.label | 1 |
 | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:5:163:5 | [Name] s | semmle.order | 1 |
 | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:9:163:14 | [Name] SOURCE | semmle.label | 2 |
 | test.py:163:5:163:14 | [AssignStmt] s = SOURCE | test.py:163:9:163:14 | [Name] SOURCE | semmle.order | 2 |
-| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.label | 1 |
-| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.order | 1 |
-| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:14:164:14 | [Name] s | semmle.label | 2 |
-| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:14:164:14 | [Name] s | semmle.order | 2 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.label | 0 |
+| test.py:164:5:164:15 | [Call] SANITIZE(s) | test.py:164:5:164:12 | [Name] SANITIZE | semmle.order | 0 |
 | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | test.py:164:5:164:15 | [Call] SANITIZE(s) | semmle.label | 1 |
 | test.py:164:5:164:15 | [ExprStmt] SANITIZE(s) | test.py:164:5:164:15 | [Call] SANITIZE(s) | semmle.order | 1 |
-| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.label | 1 |
-| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.order | 1 |
-| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:10:165:10 | [Name] s | semmle.label | 2 |
-| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:10:165:10 | [Name] s | semmle.order | 2 |
+| test.py:165:5:165:11 | [Call] SINK(s) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:165:5:165:11 | [Call] SINK(s) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.label | 0 |
+| test.py:165:5:165:11 | [Call] SINK(s) | test.py:165:5:165:8 | [Name] SINK | semmle.order | 0 |
 | test.py:165:5:165:11 | [ExprStmt] SINK(s) | test.py:165:5:165:11 | [Call] SINK(s) | semmle.label | 1 |
 | test.py:165:5:165:11 | [ExprStmt] SINK(s) | test.py:165:5:165:11 | [Call] SINK(s) | semmle.order | 1 |
-| test.py:167:1:167:29 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.label | 1 |
-| test.py:167:1:167:29 | (parameters) | test.py:167:24:167:24 | [Parameter] x | semmle.order | 1 |
-| test.py:167:1:167:29 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.label | 2 |
-| test.py:167:1:167:29 | (parameters) | test.py:167:27:167:27 | [Parameter] y | semmle.order | 2 |
 | test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.label | 1 |
 | test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | semmle.order | 1 |
-| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.label | 2 |
-| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.order | 2 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.label | 0 |
+| test.py:167:1:167:29 | [FunctionDef] test_update_extend = function test_update_extend(...) | test.py:167:5:167:22 | [Name] test_update_extend | semmle.order | 0 |
 | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | test.py:167:1:167:29 | [Function] function test_update_extend(...) | semmle.label | 1 |
 | test.py:167:1:167:29 | [FunctionExpr] function test_update_extend(...) | test.py:167:1:167:29 | [Function] function test_update_extend(...) | semmle.order | 1 |
-| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:167:1:167:29 | (parameters) | semmle.label | 0 |
-| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:167:1:167:29 | (parameters) | semmle.order | 0 |
-| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:168:5:168:16 | (StmtList) body | semmle.label | 12 |
-| test.py:167:1:167:29 | [Function] function test_update_extend(...) | test.py:168:5:168:16 | (StmtList) body | semmle.order | 12 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.label | 0 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:168:5:168:16 | [AssignStmt] l = [...] | semmle.order | 0 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.label | 1 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:169:5:169:24 | [AssignStmt]  | semmle.order | 1 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.label | 2 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | semmle.order | 2 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.label | 3 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:171:5:171:15 | [ExprStmt] y.update(d) | semmle.order | 3 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.label | 4 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:172:5:172:14 | [ExprStmt] SINK(...) | semmle.order | 4 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.label | 5 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:173:5:173:18 | [ExprStmt] SINK(...) | semmle.order | 5 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.label | 6 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | semmle.order | 6 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.label | 7 |
-| test.py:168:5:168:16 | (StmtList) body | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | semmle.order | 7 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 12 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 12 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:167:1:167:29 | [Function] function test_update_extend(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:5:168:5 | [Name] l | semmle.label | 1 |
 | test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:5:168:5 | [Name] l | semmle.order | 1 |
 | test.py:168:5:168:16 | [AssignStmt] l = [...] | test.py:168:9:168:16 | [List] [...] | semmle.label | 2 |
@@ -3404,34 +3825,34 @@ edges
 | test.py:169:10:169:23 | [KeyValuePair]  | test.py:169:18:169:23 | [Name] SOURCE | semmle.order | 2 |
 | test.py:170:5:170:12 | [Attribute] x.extend | test.py:170:5:170:5 | [Name] x | semmle.label | 1 |
 | test.py:170:5:170:12 | [Attribute] x.extend | test.py:170:5:170:5 | [Name] x | semmle.order | 1 |
-| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.label | 1 |
-| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.order | 1 |
-| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:14:170:14 | [Name] l | semmle.label | 2 |
-| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:14:170:14 | [Name] l | semmle.order | 2 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.label | 0 |
+| test.py:170:5:170:15 | [Call] x.extend(l) | test.py:170:5:170:12 | [Attribute] x.extend | semmle.order | 0 |
 | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | test.py:170:5:170:15 | [Call] x.extend(l) | semmle.label | 1 |
 | test.py:170:5:170:15 | [ExprStmt] x.extend(l) | test.py:170:5:170:15 | [Call] x.extend(l) | semmle.order | 1 |
 | test.py:171:5:171:12 | [Attribute] y.update | test.py:171:5:171:5 | [Name] y | semmle.label | 1 |
 | test.py:171:5:171:12 | [Attribute] y.update | test.py:171:5:171:5 | [Name] y | semmle.order | 1 |
-| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.label | 1 |
-| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.order | 1 |
-| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:14:171:14 | [Name] d | semmle.label | 2 |
-| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:14:171:14 | [Name] d | semmle.order | 2 |
+| test.py:171:5:171:15 | [Call] y.update(d) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:171:5:171:15 | [Call] y.update(d) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.label | 0 |
+| test.py:171:5:171:15 | [Call] y.update(d) | test.py:171:5:171:12 | [Attribute] y.update | semmle.order | 0 |
 | test.py:171:5:171:15 | [ExprStmt] y.update(d) | test.py:171:5:171:15 | [Call] y.update(d) | semmle.label | 1 |
 | test.py:171:5:171:15 | [ExprStmt] y.update(d) | test.py:171:5:171:15 | [Call] y.update(d) | semmle.order | 1 |
-| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.label | 1 |
-| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.order | 1 |
-| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.label | 2 |
-| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | semmle.order | 2 |
+| test.py:172:5:172:14 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:172:5:172:14 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.label | 0 |
+| test.py:172:5:172:14 | [Call] SINK(...) | test.py:172:5:172:8 | [Name] SINK | semmle.order | 0 |
 | test.py:172:5:172:14 | [ExprStmt] SINK(...) | test.py:172:5:172:14 | [Call] SINK(...) | semmle.label | 1 |
 | test.py:172:5:172:14 | [ExprStmt] SINK(...) | test.py:172:5:172:14 | [Call] SINK(...) | semmle.order | 1 |
-| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:10:172:10 | [Name] x | semmle.label | 1 |
-| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:10:172:10 | [Name] x | semmle.order | 1 |
-| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.label | 2 |
-| test.py:172:10:172:13 | [Subscript] x[IntegerLiteral] | test.py:172:12:172:12 | [IntegerLiteral] IntegerLiteral | semmle.order | 2 |
-| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.label | 1 |
-| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.order | 1 |
-| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.label | 2 |
-| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:10:173:17 | [Subscript] y[key] | semmle.order | 2 |
+| test.py:172:10:172:13 | [Subscript] x[0] | test.py:172:10:172:10 | [Name] x | semmle.label | 1 |
+| test.py:172:10:172:13 | [Subscript] x[0] | test.py:172:10:172:10 | [Name] x | semmle.order | 1 |
+| test.py:172:10:172:13 | [Subscript] x[0] | test.py:172:12:172:12 | [IntegerLiteral] 0 | semmle.label | 2 |
+| test.py:172:10:172:13 | [Subscript] x[0] | test.py:172:12:172:12 | [IntegerLiteral] 0 | semmle.order | 2 |
+| test.py:173:5:173:18 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:173:5:173:18 | [Call] SINK(...) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.label | 0 |
+| test.py:173:5:173:18 | [Call] SINK(...) | test.py:173:5:173:8 | [Name] SINK | semmle.order | 0 |
 | test.py:173:5:173:18 | [ExprStmt] SINK(...) | test.py:173:5:173:18 | [Call] SINK(...) | semmle.label | 1 |
 | test.py:173:5:173:18 | [ExprStmt] SINK(...) | test.py:173:5:173:18 | [Call] SINK(...) | semmle.order | 1 |
 | test.py:173:10:173:17 | [Subscript] y[key] | test.py:173:10:173:10 | [Name] y | semmle.label | 1 |
@@ -3442,382 +3863,306 @@ edges
 | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:5:174:6 | [Name] l2 | semmle.order | 1 |
 | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:10:174:16 | [Call] list(l) | semmle.label | 2 |
 | test.py:174:5:174:16 | [AssignStmt] l2 = list(l) | test.py:174:10:174:16 | [Call] list(l) | semmle.order | 2 |
-| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.label | 1 |
-| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.order | 1 |
-| test.py:174:10:174:16 | [Call] list(l) | test.py:174:15:174:15 | [Name] l | semmle.label | 2 |
-| test.py:174:10:174:16 | [Call] list(l) | test.py:174:15:174:15 | [Name] l | semmle.order | 2 |
+| test.py:174:10:174:16 | [Call] list(l) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:174:10:174:16 | [Call] list(l) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.label | 0 |
+| test.py:174:10:174:16 | [Call] list(l) | test.py:174:10:174:13 | [Name] list | semmle.order | 0 |
 | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:5:175:6 | [Name] d2 | semmle.label | 1 |
 | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:5:175:6 | [Name] d2 | semmle.order | 1 |
 | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:10:175:16 | [Call] dict(d) | semmle.label | 2 |
 | test.py:175:5:175:16 | [AssignStmt] d2 = dict(d) | test.py:175:10:175:16 | [Call] dict(d) | semmle.order | 2 |
-| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.label | 1 |
-| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.order | 1 |
-| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:15:175:15 | [Name] d | semmle.label | 2 |
-| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:15:175:15 | [Name] d | semmle.order | 2 |
+| test.py:175:10:175:16 | [Call] dict(d) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:175:10:175:16 | [Call] dict(d) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.label | 0 |
+| test.py:175:10:175:16 | [Call] dict(d) | test.py:175:10:175:13 | [Name] dict | semmle.order | 0 |
 | test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.label | 1 |
 | test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | semmle.order | 1 |
-| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.label | 2 |
-| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.order | 2 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.label | 0 |
+| test.py:177:1:177:17 | [FunctionDef] test_truth = function test_truth(...) | test.py:177:5:177:14 | [Name] test_truth | semmle.order | 0 |
 | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.label | 1 |
 | test.py:177:1:177:17 | [FunctionExpr] function test_truth(...) | test.py:177:1:177:17 | [Function] function test_truth(...) | semmle.order | 1 |
-| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:177:1:177:17 | (parameters) | semmle.label | 0 |
-| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:177:1:177:17 | (parameters) | semmle.order | 0 |
-| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:178:5:178:14 | (StmtList) body | semmle.label | 5 |
-| test.py:177:1:177:17 | [Function] function test_truth(...) | test.py:178:5:178:14 | (StmtList) body | semmle.order | 5 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.label | 1 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:179:5:179:9 | [If] if t: | semmle.order | 1 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.label | 2 |
-| test.py:178:5:178:14 | (StmtList) body | test.py:183:5:183:13 | [If]  | semmle.order | 2 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:177:1:177:17 | [Function] function test_truth(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:5:178:5 | [Name] t | semmle.label | 1 |
 | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:5:178:5 | [Name] t | semmle.order | 1 |
 | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:9:178:14 | [Name] SOURCE | semmle.label | 2 |
 | test.py:178:5:178:14 | [AssignStmt] t = SOURCE | test.py:178:9:178:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:179:5:179:9 | [If] if t: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:179:5:179:9 | [If] if t: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:179:5:179:9 | [If] if t: | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:179:5:179:9 | [If] if t: | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:179:5:179:9 | [If] if t: | test.py:179:8:179:8 | [Name] t | semmle.label | 0 |
 | test.py:179:5:179:9 | [If] if t: | test.py:179:8:179:8 | [Name] t | semmle.order | 0 |
-| test.py:179:5:179:9 | [If] if t: | test.py:180:9:180:15 | (StmtList) body | semmle.label | 2 |
-| test.py:179:5:179:9 | [If] if t: | test.py:180:9:180:15 | (StmtList) body | semmle.order | 2 |
-| test.py:179:5:179:9 | [If] if t: | test.py:182:9:182:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:179:5:179:9 | [If] if t: | test.py:182:9:182:15 | (StmtList) orelse | semmle.order | 3 |
-| test.py:180:9:180:15 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:180:9:180:15 | (StmtList) body | test.py:180:9:180:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.label | 1 |
-| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.order | 1 |
-| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:14:180:14 | [Name] t | semmle.label | 2 |
-| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:14:180:14 | [Name] t | semmle.order | 2 |
+| test.py:180:9:180:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:180:9:180:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.label | 0 |
+| test.py:180:9:180:15 | [Call] SINK(t) | test.py:180:9:180:12 | [Name] SINK | semmle.order | 0 |
 | test.py:180:9:180:15 | [ExprStmt] SINK(t) | test.py:180:9:180:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:180:9:180:15 | [ExprStmt] SINK(t) | test.py:180:9:180:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:182:9:182:15 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:182:9:182:15 | (StmtList) orelse | test.py:182:9:182:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.label | 1 |
-| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.order | 1 |
-| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:14:182:14 | [Name] t | semmle.label | 2 |
-| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:14:182:14 | [Name] t | semmle.order | 2 |
+| test.py:182:9:182:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:182:9:182:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.label | 0 |
+| test.py:182:9:182:15 | [Call] SINK(t) | test.py:182:9:182:12 | [Name] SINK | semmle.order | 0 |
 | test.py:182:9:182:15 | [ExprStmt] SINK(t) | test.py:182:9:182:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:182:9:182:15 | [ExprStmt] SINK(t) | test.py:182:9:182:15 | [Call] SINK(t) | semmle.order | 1 |
+| test.py:183:5:183:13 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:183:5:183:13 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:183:5:183:13 | [If]  | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:183:5:183:13 | [If]  | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:183:5:183:13 | [If]  | test.py:183:8:183:12 | [UnaryExpr]  | semmle.label | 0 |
 | test.py:183:5:183:13 | [If]  | test.py:183:8:183:12 | [UnaryExpr]  | semmle.order | 0 |
-| test.py:183:5:183:13 | [If]  | test.py:184:9:184:15 | (StmtList) body | semmle.label | 2 |
-| test.py:183:5:183:13 | [If]  | test.py:184:9:184:15 | (StmtList) body | semmle.order | 2 |
-| test.py:183:5:183:13 | [If]  | test.py:186:9:186:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:183:5:183:13 | [If]  | test.py:186:9:186:15 | (StmtList) orelse | semmle.order | 3 |
 | test.py:183:8:183:12 | [UnaryExpr]  | test.py:183:12:183:12 | [Name] t | semmle.label | 1 |
 | test.py:183:8:183:12 | [UnaryExpr]  | test.py:183:12:183:12 | [Name] t | semmle.order | 1 |
-| test.py:184:9:184:15 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:184:9:184:15 | (StmtList) body | test.py:184:9:184:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.label | 1 |
-| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.order | 1 |
-| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:14:184:14 | [Name] t | semmle.label | 2 |
-| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:14:184:14 | [Name] t | semmle.order | 2 |
+| test.py:184:9:184:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:184:9:184:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.label | 0 |
+| test.py:184:9:184:15 | [Call] SINK(t) | test.py:184:9:184:12 | [Name] SINK | semmle.order | 0 |
 | test.py:184:9:184:15 | [ExprStmt] SINK(t) | test.py:184:9:184:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:184:9:184:15 | [ExprStmt] SINK(t) | test.py:184:9:184:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:186:9:186:15 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:186:9:186:15 | (StmtList) orelse | test.py:186:9:186:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.label | 1 |
-| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.order | 1 |
-| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:14:186:14 | [Name] t | semmle.label | 2 |
-| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:14:186:14 | [Name] t | semmle.order | 2 |
+| test.py:186:9:186:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:186:9:186:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.label | 0 |
+| test.py:186:9:186:15 | [Call] SINK(t) | test.py:186:9:186:12 | [Name] SINK | semmle.order | 0 |
 | test.py:186:9:186:15 | [ExprStmt] SINK(t) | test.py:186:9:186:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:186:9:186:15 | [ExprStmt] SINK(t) | test.py:186:9:186:15 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.label | 1 |
 | test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | semmle.order | 1 |
-| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.label | 2 |
-| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.order | 2 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.label | 0 |
+| test.py:188:1:188:22 | [FunctionDef] test_early_exit = function test_early_exit(...) | test.py:188:5:188:19 | [Name] test_early_exit | semmle.order | 0 |
 | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.label | 1 |
 | test.py:188:1:188:22 | [FunctionExpr] function test_early_exit(...) | test.py:188:1:188:22 | [Function] function test_early_exit(...) | semmle.order | 1 |
-| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:188:1:188:22 | (parameters) | semmle.label | 0 |
-| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:188:1:188:22 | (parameters) | semmle.order | 0 |
-| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:189:5:189:14 | (StmtList) body | semmle.label | 5 |
-| test.py:188:1:188:22 | [Function] function test_early_exit(...) | test.py:189:5:189:14 | (StmtList) body | semmle.order | 5 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.label | 0 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | semmle.order | 0 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.label | 1 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:190:5:190:13 | [If]  | semmle.order | 1 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.label | 2 |
-| test.py:189:5:189:14 | (StmtList) body | test.py:192:5:192:5 | [ExprStmt] t | semmle.order | 2 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:188:1:188:22 | [Function] function test_early_exit(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:5:189:5 | [Name] t | semmle.label | 1 |
 | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:5:189:5 | [Name] t | semmle.order | 1 |
 | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:9:189:14 | [Name] FALSEY | semmle.label | 2 |
 | test.py:189:5:189:14 | [AssignStmt] t = FALSEY | test.py:189:9:189:14 | [Name] FALSEY | semmle.order | 2 |
+| test.py:190:5:190:13 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:190:5:190:13 | [If]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:190:5:190:13 | [If]  | test.py:190:8:190:12 | [UnaryExpr]  | semmle.label | 0 |
 | test.py:190:5:190:13 | [If]  | test.py:190:8:190:12 | [UnaryExpr]  | semmle.order | 0 |
-| test.py:190:5:190:13 | [If]  | test.py:191:9:191:14 | (StmtList) body | semmle.label | 2 |
-| test.py:190:5:190:13 | [If]  | test.py:191:9:191:14 | (StmtList) body | semmle.order | 2 |
 | test.py:190:8:190:12 | [UnaryExpr]  | test.py:190:12:190:12 | [Name] t | semmle.label | 1 |
 | test.py:190:8:190:12 | [UnaryExpr]  | test.py:190:12:190:12 | [Name] t | semmle.order | 1 |
-| test.py:191:9:191:14 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.label | 0 |
-| test.py:191:9:191:14 | (StmtList) body | test.py:191:9:191:14 | [Return]  | semmle.order | 0 |
 | test.py:192:5:192:5 | [ExprStmt] t | test.py:192:5:192:5 | [Name] t | semmle.label | 1 |
 | test.py:192:5:192:5 | [ExprStmt] t | test.py:192:5:192:5 | [Name] t | semmle.order | 1 |
 | test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.label | 1 |
 | test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | semmle.order | 1 |
-| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.label | 2 |
-| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.order | 2 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.label | 0 |
+| test.py:194:1:194:41 | [FunctionDef] flow_through_type_test_if_no_class = function flow_through_type_test_if_no_class(...) | test.py:194:5:194:38 | [Name] flow_through_type_test_if_no_class | semmle.order | 0 |
 | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.label | 1 |
 | test.py:194:1:194:41 | [FunctionExpr] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | semmle.order | 1 |
-| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | (parameters) | semmle.label | 0 |
-| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:194:1:194:41 | (parameters) | semmle.order | 0 |
-| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:195:5:195:14 | (StmtList) body | semmle.label | 4 |
-| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | test.py:195:5:195:14 | (StmtList) body | semmle.order | 4 |
-| test.py:195:5:195:14 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.label | 0 |
-| test.py:195:5:195:14 | (StmtList) body | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | semmle.order | 0 |
-| test.py:195:5:195:14 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.label | 1 |
-| test.py:195:5:195:14 | (StmtList) body | test.py:196:5:196:26 | [If] if isinstance(str, t): | semmle.order | 1 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:194:1:194:41 | [Function] function flow_through_type_test_if_no_class(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:5:195:5 | [Name] t | semmle.label | 1 |
 | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:5:195:5 | [Name] t | semmle.order | 1 |
 | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:9:195:14 | [Name] SOURCE | semmle.label | 2 |
 | test.py:195:5:195:14 | [AssignStmt] t = SOURCE | test.py:195:9:195:14 | [Name] SOURCE | semmle.order | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | file://:0:0:0:0 | (StmtList) orelse | semmle.label | 3 |
+| test.py:196:5:196:26 | [If] if isinstance(str, t): | file://:0:0:0:0 | (StmtList) orelse | semmle.order | 3 |
 | test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:196:8:196:25 | [Call] isinstance(str, t) | semmle.label | 0 |
 | test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:196:8:196:25 | [Call] isinstance(str, t) | semmle.order | 0 |
-| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:197:9:197:15 | (StmtList) body | semmle.label | 2 |
-| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:197:9:197:15 | (StmtList) body | semmle.order | 2 |
-| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:199:9:199:15 | (StmtList) orelse | semmle.label | 3 |
-| test.py:196:5:196:26 | [If] if isinstance(str, t): | test.py:199:9:199:15 | (StmtList) orelse | semmle.order | 3 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.label | 1 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.order | 1 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:19:196:19 | [Name] t | semmle.label | 2 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:19:196:19 | [Name] t | semmle.order | 2 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:22:196:24 | [Name] str | semmle.label | 3 |
-| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:22:196:24 | [Name] str | semmle.order | 3 |
-| test.py:197:9:197:15 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:197:9:197:15 | (StmtList) body | test.py:197:9:197:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.label | 1 |
-| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.order | 1 |
-| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:14:197:14 | [Name] t | semmle.label | 2 |
-| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:14:197:14 | [Name] t | semmle.order | 2 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.label | 0 |
+| test.py:196:8:196:25 | [Call] isinstance(str, t) | test.py:196:8:196:17 | [Name] isinstance | semmle.order | 0 |
+| test.py:197:9:197:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:197:9:197:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.label | 0 |
+| test.py:197:9:197:15 | [Call] SINK(t) | test.py:197:9:197:12 | [Name] SINK | semmle.order | 0 |
 | test.py:197:9:197:15 | [ExprStmt] SINK(t) | test.py:197:9:197:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:197:9:197:15 | [ExprStmt] SINK(t) | test.py:197:9:197:15 | [Call] SINK(t) | semmle.order | 1 |
-| test.py:199:9:199:15 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.label | 0 |
-| test.py:199:9:199:15 | (StmtList) orelse | test.py:199:9:199:15 | [ExprStmt] SINK(t) | semmle.order | 0 |
-| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.label | 1 |
-| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.order | 1 |
-| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:14:199:14 | [Name] t | semmle.label | 2 |
-| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:14:199:14 | [Name] t | semmle.order | 2 |
+| test.py:199:9:199:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:199:9:199:15 | [Call] SINK(t) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.label | 0 |
+| test.py:199:9:199:15 | [Call] SINK(t) | test.py:199:9:199:12 | [Name] SINK | semmle.order | 0 |
 | test.py:199:9:199:15 | [ExprStmt] SINK(t) | test.py:199:9:199:15 | [Call] SINK(t) | semmle.label | 1 |
 | test.py:199:9:199:15 | [ExprStmt] SINK(t) | test.py:199:9:199:15 | [Call] SINK(t) | semmle.order | 1 |
 | test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.label | 1 |
 | test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | semmle.order | 1 |
-| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.label | 2 |
-| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.order | 2 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.label | 0 |
+| test.py:201:1:201:24 | [FunctionDef] flow_in_iteration = function flow_in_iteration(...) | test.py:201:5:201:21 | [Name] flow_in_iteration | semmle.order | 0 |
 | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.label | 1 |
 | test.py:201:1:201:24 | [FunctionExpr] function flow_in_iteration(...) | test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | semmle.order | 1 |
-| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:201:1:201:24 | (parameters) | semmle.label | 0 |
-| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:201:1:201:24 | (parameters) | semmle.order | 0 |
-| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:202:5:202:23 | (StmtList) body | semmle.label | 5 |
-| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | test.py:202:5:202:23 | (StmtList) body | semmle.order | 5 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.label | 0 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | semmle.order | 0 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.label | 1 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:203:5:203:15 | [For]  | semmle.order | 1 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.label | 2 |
-| test.py:202:5:202:23 | (StmtList) body | test.py:205:5:205:12 | [Return] return i | semmle.order | 2 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:201:1:201:24 | [Function] function flow_in_iteration(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:5:202:5 | [Name] t | semmle.label | 1 |
 | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:5:202:5 | [Name] t | semmle.order | 1 |
 | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.label | 2 |
 | test.py:202:5:202:23 | [AssignStmt] t = ITERABLE_SOURCE | test.py:202:9:202:23 | [Name] ITERABLE_SOURCE | semmle.order | 2 |
+| test.py:203:5:203:15 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:203:5:203:15 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
 | test.py:203:5:203:15 | [For]  | test.py:203:9:203:9 | [Name] i | semmle.label | 1 |
 | test.py:203:5:203:15 | [For]  | test.py:203:9:203:9 | [Name] i | semmle.order | 1 |
 | test.py:203:5:203:15 | [For]  | test.py:203:14:203:14 | [Name] t | semmle.label | 2 |
 | test.py:203:5:203:15 | [For]  | test.py:203:14:203:14 | [Name] t | semmle.order | 2 |
-| test.py:203:5:203:15 | [For]  | test.py:204:9:204:9 | (StmtList) body | semmle.label | 5 |
-| test.py:203:5:203:15 | [For]  | test.py:204:9:204:9 | (StmtList) body | semmle.order | 5 |
-| test.py:204:9:204:9 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.label | 0 |
-| test.py:204:9:204:9 | (StmtList) body | test.py:204:9:204:9 | [ExprStmt] i | semmle.order | 0 |
 | test.py:204:9:204:9 | [ExprStmt] i | test.py:204:9:204:9 | [Name] i | semmle.label | 1 |
 | test.py:204:9:204:9 | [ExprStmt] i | test.py:204:9:204:9 | [Name] i | semmle.order | 1 |
 | test.py:205:5:205:12 | [Return] return i | test.py:205:12:205:12 | [Name] i | semmle.label | 1 |
 | test.py:205:5:205:12 | [Return] return i | test.py:205:12:205:12 | [Name] i | semmle.order | 1 |
 | test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.label | 1 |
 | test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | semmle.order | 1 |
-| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.label | 2 |
-| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.order | 2 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.label | 0 |
+| test.py:207:1:207:24 | [FunctionDef] flow_in_generator = function flow_in_generator(...) | test.py:207:5:207:21 | [Name] flow_in_generator | semmle.order | 0 |
 | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.label | 1 |
 | test.py:207:1:207:24 | [FunctionExpr] function flow_in_generator(...) | test.py:207:1:207:24 | [Function] function flow_in_generator(...) | semmle.order | 1 |
-| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:207:1:207:24 | (parameters) | semmle.label | 0 |
-| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:207:1:207:24 | (parameters) | semmle.order | 0 |
-| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:208:5:208:18 | (StmtList) body | semmle.label | 4 |
-| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | test.py:208:5:208:18 | (StmtList) body | semmle.order | 4 |
-| test.py:208:5:208:18 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.label | 0 |
-| test.py:208:5:208:18 | (StmtList) body | test.py:208:5:208:18 | [AssignStmt] seq = [...] | semmle.order | 0 |
-| test.py:208:5:208:18 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.label | 1 |
-| test.py:208:5:208:18 | (StmtList) body | test.py:209:5:209:17 | [For]  | semmle.order | 1 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 4 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 4 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:207:1:207:24 | [Function] function flow_in_generator(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:5:208:7 | [Name] seq | semmle.label | 1 |
 | test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:5:208:7 | [Name] seq | semmle.order | 1 |
 | test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:11:208:18 | [List] [...] | semmle.label | 2 |
 | test.py:208:5:208:18 | [AssignStmt] seq = [...] | test.py:208:11:208:18 | [List] [...] | semmle.order | 2 |
 | test.py:208:11:208:18 | [List] [...] | test.py:208:12:208:17 | [Name] SOURCE | semmle.label | 1 |
 | test.py:208:11:208:18 | [List] [...] | test.py:208:12:208:17 | [Name] SOURCE | semmle.order | 1 |
+| test.py:209:5:209:17 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:209:5:209:17 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
 | test.py:209:5:209:17 | [For]  | test.py:209:9:209:9 | [Name] i | semmle.label | 1 |
 | test.py:209:5:209:17 | [For]  | test.py:209:9:209:9 | [Name] i | semmle.order | 1 |
 | test.py:209:5:209:17 | [For]  | test.py:209:14:209:16 | [Name] seq | semmle.label | 2 |
 | test.py:209:5:209:17 | [For]  | test.py:209:14:209:16 | [Name] seq | semmle.order | 2 |
-| test.py:209:5:209:17 | [For]  | test.py:210:9:210:15 | (StmtList) body | semmle.label | 5 |
-| test.py:209:5:209:17 | [For]  | test.py:210:9:210:15 | (StmtList) body | semmle.order | 5 |
-| test.py:210:9:210:15 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.label | 0 |
-| test.py:210:9:210:15 | (StmtList) body | test.py:210:9:210:15 | [ExprStmt] yield i | semmle.order | 0 |
 | test.py:210:9:210:15 | [ExprStmt] yield i | test.py:210:9:210:15 | [Yield] yield i | semmle.label | 1 |
 | test.py:210:9:210:15 | [ExprStmt] yield i | test.py:210:9:210:15 | [Yield] yield i | semmle.order | 1 |
 | test.py:210:9:210:15 | [Yield] yield i | test.py:210:15:210:15 | [Name] i | semmle.label | 1 |
 | test.py:210:9:210:15 | [Yield] yield i | test.py:210:15:210:15 | [Name] i | semmle.order | 1 |
 | test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.label | 1 |
 | test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | semmle.order | 1 |
-| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.label | 2 |
-| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.order | 2 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.label | 0 |
+| test.py:212:1:212:26 | [FunctionDef] flow_from_generator = function flow_from_generator(...) | test.py:212:5:212:23 | [Name] flow_from_generator | semmle.order | 0 |
 | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.label | 1 |
 | test.py:212:1:212:26 | [FunctionExpr] function flow_from_generator(...) | test.py:212:1:212:26 | [Function] function flow_from_generator(...) | semmle.order | 1 |
-| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:212:1:212:26 | (parameters) | semmle.label | 0 |
-| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:212:1:212:26 | (parameters) | semmle.order | 0 |
-| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:213:5:213:33 | (StmtList) body | semmle.label | 3 |
-| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | test.py:213:5:213:33 | (StmtList) body | semmle.order | 3 |
-| test.py:213:5:213:33 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.label | 0 |
-| test.py:213:5:213:33 | (StmtList) body | test.py:213:5:213:33 | [For]  | semmle.order | 0 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 3 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 3 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:212:1:212:26 | [Function] function flow_from_generator(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
+| test.py:213:5:213:33 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:213:5:213:33 | [For]  | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
 | test.py:213:5:213:33 | [For]  | test.py:213:9:213:9 | [Name] x | semmle.label | 1 |
 | test.py:213:5:213:33 | [For]  | test.py:213:9:213:9 | [Name] x | semmle.order | 1 |
 | test.py:213:5:213:33 | [For]  | test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.label | 2 |
 | test.py:213:5:213:33 | [For]  | test.py:213:14:213:32 | [Call] flow_in_generator() | semmle.order | 2 |
-| test.py:213:5:213:33 | [For]  | test.py:214:9:214:15 | (StmtList) body | semmle.label | 5 |
-| test.py:213:5:213:33 | [For]  | test.py:214:9:214:15 | (StmtList) body | semmle.order | 5 |
-| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.label | 1 |
-| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.order | 1 |
-| test.py:214:9:214:15 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.label | 0 |
-| test.py:214:9:214:15 | (StmtList) body | test.py:214:9:214:15 | [ExprStmt] SINK(x) | semmle.order | 0 |
-| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.label | 1 |
-| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.order | 1 |
-| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:14:214:14 | [Name] x | semmle.label | 2 |
-| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:14:214:14 | [Name] x | semmle.order | 2 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.label | 0 |
+| test.py:213:14:213:32 | [Call] flow_in_generator() | test.py:213:14:213:30 | [Name] flow_in_generator | semmle.order | 0 |
+| test.py:214:9:214:15 | [Call] SINK(x) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:214:9:214:15 | [Call] SINK(x) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.label | 0 |
+| test.py:214:9:214:15 | [Call] SINK(x) | test.py:214:9:214:12 | [Name] SINK | semmle.order | 0 |
 | test.py:214:9:214:15 | [ExprStmt] SINK(x) | test.py:214:9:214:15 | [Call] SINK(x) | semmle.label | 1 |
 | test.py:214:9:214:15 | [ExprStmt] SINK(x) | test.py:214:9:214:15 | [Call] SINK(x) | semmle.order | 1 |
 | test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.label | 1 |
 | test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | semmle.order | 1 |
-| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.label | 2 |
-| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.order | 2 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.label | 0 |
+| test.py:216:1:216:28 | [FunctionDef] const_eq_clears_taint = function const_eq_clears_taint(...) | test.py:216:5:216:25 | [Name] const_eq_clears_taint | semmle.order | 0 |
 | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.label | 1 |
 | test.py:216:1:216:28 | [FunctionExpr] function const_eq_clears_taint(...) | test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | semmle.order | 1 |
-| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:216:1:216:28 | (parameters) | semmle.label | 0 |
-| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:216:1:216:28 | (parameters) | semmle.order | 0 |
-| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:217:5:217:20 | (StmtList) body | semmle.label | 5 |
-| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | test.py:217:5:217:20 | (StmtList) body | semmle.order | 5 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.label | 1 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:218:5:218:25 | [If] if tainted == ...: | semmle.order | 1 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
-| test.py:217:5:217:20 | (StmtList) body | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:216:1:216:28 | [Function] function const_eq_clears_taint(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:5:217:11 | [Name] tainted | semmle.label | 1 |
 | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:5:217:11 | [Name] tainted | semmle.order | 1 |
 | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:15:217:20 | [Name] SOURCE | semmle.label | 2 |
 | test.py:217:5:217:20 | [AssignStmt] tainted = SOURCE | test.py:217:15:217:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:218:5:218:25 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:218:5:218:25 | [If] if tainted == ...: | test.py:218:8:218:24 | [Compare] tainted == ... | semmle.label | 0 |
 | test.py:218:5:218:25 | [If] if tainted == ...: | test.py:218:8:218:24 | [Compare] tainted == ... | semmle.order | 0 |
-| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:219:9:219:21 | (StmtList) body | semmle.label | 2 |
-| test.py:218:5:218:25 | [If] if tainted == ...: | test.py:219:9:219:21 | (StmtList) body | semmle.order | 2 |
 | test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:8:218:14 | [Name] tainted | semmle.label | 1 |
 | test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:8:218:14 | [Name] tainted | semmle.order | 1 |
 | test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:19:218:24 | [Str] safe | semmle.label | 2 |
 | test.py:218:8:218:24 | [Compare] tainted == ... | test.py:218:19:218:24 | [Str] safe | semmle.order | 2 |
-| test.py:219:9:219:21 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
-| test.py:219:9:219:21 | (StmtList) body | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
-| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.label | 1 |
-| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.order | 1 |
-| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:14:219:20 | [Name] tainted | semmle.label | 2 |
-| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:14:219:20 | [Name] tainted | semmle.order | 2 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.label | 0 |
+| test.py:219:9:219:21 | [Call] SINK(tainted) | test.py:219:9:219:12 | [Name] SINK | semmle.order | 0 |
 | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.label | 1 |
 | test.py:219:9:219:21 | [ExprStmt] SINK(tainted) | test.py:219:9:219:21 | [Call] SINK(tainted) | semmle.order | 1 |
-| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.label | 1 |
-| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.order | 1 |
-| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:10:220:16 | [Name] tainted | semmle.label | 2 |
-| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:10:220:16 | [Name] tainted | semmle.order | 2 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.label | 0 |
+| test.py:220:5:220:17 | [Call] SINK(tainted) | test.py:220:5:220:8 | [Name] SINK | semmle.order | 0 |
 | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.label | 1 |
 | test.py:220:5:220:17 | [ExprStmt] SINK(tainted) | test.py:220:5:220:17 | [Call] SINK(tainted) | semmle.order | 1 |
 | test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.label | 1 |
 | test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | semmle.order | 1 |
-| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.label | 2 |
-| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.order | 2 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.label | 0 |
+| test.py:222:1:222:29 | [FunctionDef] const_eq_clears_taint2 = function const_eq_clears_taint2(...) | test.py:222:5:222:26 | [Name] const_eq_clears_taint2 | semmle.order | 0 |
 | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.label | 1 |
 | test.py:222:1:222:29 | [FunctionExpr] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | semmle.order | 1 |
-| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | (parameters) | semmle.label | 0 |
-| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:222:1:222:29 | (parameters) | semmle.order | 0 |
-| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:223:5:223:20 | (StmtList) body | semmle.label | 5 |
-| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | test.py:223:5:223:20 | (StmtList) body | semmle.order | 5 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.label | 1 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:224:5:224:25 | [If] if tainted != ...: | semmle.order | 1 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.label | 2 |
-| test.py:223:5:223:20 | (StmtList) body | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | semmle.order | 2 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 5 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 5 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:222:1:222:29 | [Function] function const_eq_clears_taint2(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:5:223:11 | [Name] tainted | semmle.label | 1 |
 | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:5:223:11 | [Name] tainted | semmle.order | 1 |
 | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:15:223:20 | [Name] SOURCE | semmle.label | 2 |
 | test.py:223:5:223:20 | [AssignStmt] tainted = SOURCE | test.py:223:15:223:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:224:5:224:25 | [If] if tainted != ...: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:224:5:224:25 | [If] if tainted != ...: | test.py:224:8:224:24 | [Compare] tainted != ... | semmle.label | 0 |
 | test.py:224:5:224:25 | [If] if tainted != ...: | test.py:224:8:224:24 | [Compare] tainted != ... | semmle.order | 0 |
-| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:225:9:225:14 | (StmtList) body | semmle.label | 2 |
-| test.py:224:5:224:25 | [If] if tainted != ...: | test.py:225:9:225:14 | (StmtList) body | semmle.order | 2 |
 | test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:8:224:14 | [Name] tainted | semmle.label | 1 |
 | test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:8:224:14 | [Name] tainted | semmle.order | 1 |
 | test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:19:224:24 | [Str] safe | semmle.label | 2 |
 | test.py:224:8:224:24 | [Compare] tainted != ... | test.py:224:19:224:24 | [Str] safe | semmle.order | 2 |
-| test.py:225:9:225:14 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.label | 0 |
-| test.py:225:9:225:14 | (StmtList) body | test.py:225:9:225:14 | [Return]  | semmle.order | 0 |
-| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.label | 1 |
-| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.order | 1 |
-| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:10:226:16 | [Name] tainted | semmle.label | 2 |
-| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:10:226:16 | [Name] tainted | semmle.order | 2 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.label | 0 |
+| test.py:226:5:226:17 | [Call] SINK(tainted) | test.py:226:5:226:8 | [Name] SINK | semmle.order | 0 |
 | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.label | 1 |
 | test.py:226:5:226:17 | [ExprStmt] SINK(tainted) | test.py:226:5:226:17 | [Call] SINK(tainted) | semmle.order | 1 |
-| test.py:228:1:228:36 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.label | 1 |
-| test.py:228:1:228:36 | (parameters) | test.py:228:34:228:34 | [Parameter] x | semmle.order | 1 |
 | test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.label | 1 |
 | test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | semmle.order | 1 |
-| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.label | 2 |
-| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.order | 2 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.label | 0 |
+| test.py:228:1:228:36 | [FunctionDef] non_const_eq_preserves_taint = function non_const_eq_preserves_taint(...) | test.py:228:5:228:32 | [Name] non_const_eq_preserves_taint | semmle.order | 0 |
 | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | semmle.label | 1 |
 | test.py:228:1:228:36 | [FunctionExpr] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | semmle.order | 1 |
-| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | (parameters) | semmle.label | 0 |
-| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:228:1:228:36 | (parameters) | semmle.order | 0 |
-| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:229:5:229:20 | (StmtList) body | semmle.label | 6 |
-| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | test.py:229:5:229:20 | (StmtList) body | semmle.order | 6 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.label | 0 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | semmle.order | 0 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.label | 1 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:230:5:230:26 | [If] if tainted == ...: | semmle.order | 1 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.label | 2 |
-| test.py:229:5:229:20 | (StmtList) body | test.py:232:5:232:20 | [If] if tainted == ...: | semmle.order | 2 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.label | 6 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | file://:0:0:0:0 | (StmtList) body | semmle.order | 6 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | file://:0:0:0:0 | (parameters) | semmle.label | 0 |
+| test.py:228:1:228:36 | [Function] function non_const_eq_preserves_taint(...) | file://:0:0:0:0 | (parameters) | semmle.order | 0 |
 | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:5:229:11 | [Name] tainted | semmle.label | 1 |
 | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:5:229:11 | [Name] tainted | semmle.order | 1 |
 | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:15:229:20 | [Name] SOURCE | semmle.label | 2 |
 | test.py:229:5:229:20 | [AssignStmt] tainted = SOURCE | test.py:229:15:229:20 | [Name] SOURCE | semmle.order | 2 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:230:5:230:26 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:230:5:230:26 | [If] if tainted == ...: | test.py:230:8:230:25 | [Compare] tainted == ... | semmle.label | 0 |
 | test.py:230:5:230:26 | [If] if tainted == ...: | test.py:230:8:230:25 | [Compare] tainted == ... | semmle.order | 0 |
-| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:231:9:231:21 | (StmtList) body | semmle.label | 2 |
-| test.py:230:5:230:26 | [If] if tainted == ...: | test.py:231:9:231:21 | (StmtList) body | semmle.order | 2 |
 | test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:8:230:14 | [Name] tainted | semmle.label | 1 |
 | test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:8:230:14 | [Name] tainted | semmle.order | 1 |
 | test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:19:230:25 | [Name] tainted | semmle.label | 2 |
 | test.py:230:8:230:25 | [Compare] tainted == ... | test.py:230:19:230:25 | [Name] tainted | semmle.order | 2 |
-| test.py:231:9:231:21 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
-| test.py:231:9:231:21 | (StmtList) body | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
-| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.label | 1 |
-| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.order | 1 |
-| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:14:231:20 | [Name] tainted | semmle.label | 2 |
-| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:14:231:20 | [Name] tainted | semmle.order | 2 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.label | 0 |
+| test.py:231:9:231:21 | [Call] SINK(tainted) | test.py:231:9:231:12 | [Name] SINK | semmle.order | 0 |
 | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.label | 1 |
 | test.py:231:9:231:21 | [ExprStmt] SINK(tainted) | test.py:231:9:231:21 | [Call] SINK(tainted) | semmle.order | 1 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.label | 2 |
+| test.py:232:5:232:20 | [If] if tainted == ...: | file://:0:0:0:0 | (StmtList) body | semmle.order | 2 |
 | test.py:232:5:232:20 | [If] if tainted == ...: | test.py:232:8:232:19 | [Compare] tainted == ... | semmle.label | 0 |
 | test.py:232:5:232:20 | [If] if tainted == ...: | test.py:232:8:232:19 | [Compare] tainted == ... | semmle.order | 0 |
-| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:233:9:233:21 | (StmtList) body | semmle.label | 2 |
-| test.py:232:5:232:20 | [If] if tainted == ...: | test.py:233:9:233:21 | (StmtList) body | semmle.order | 2 |
 | test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:8:232:14 | [Name] tainted | semmle.label | 1 |
 | test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:8:232:14 | [Name] tainted | semmle.order | 1 |
 | test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:19:232:19 | [Name] x | semmle.label | 2 |
 | test.py:232:8:232:19 | [Compare] tainted == ... | test.py:232:19:232:19 | [Name] x | semmle.order | 2 |
-| test.py:233:9:233:21 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.label | 0 |
-| test.py:233:9:233:21 | (StmtList) body | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | semmle.order | 0 |
-| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.label | 1 |
-| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.order | 1 |
-| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:14:233:20 | [Name] tainted | semmle.label | 2 |
-| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:14:233:20 | [Name] tainted | semmle.order | 2 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.label | 1 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | file://:0:0:0:0 | (arguments) | semmle.order | 1 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.label | 0 |
+| test.py:233:9:233:21 | [Call] SINK(tainted) | test.py:233:9:233:12 | [Name] SINK | semmle.order | 0 |
 | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.label | 1 |
 | test.py:233:9:233:21 | [ExprStmt] SINK(tainted) | test.py:233:9:233:21 | [Call] SINK(tainted) | semmle.order | 1 |
 graphProperties

--- a/python/ql/test/library-tests/taint/general/printAst.ql
+++ b/python/ql/test/library-tests/taint/general/printAst.ql
@@ -1,0 +1,1 @@
+import semmle.python.PrintAst


### PR DESCRIPTION
_(Creating a Python PR feels weird)._ 

I recommend trying out the printAst feature (see next section) before reviewing the code.

This PR adds a `printAst.ql` query that can be used for viewing the AST of Python files.

--- 

Recommended usage instructions: 
- Enable AST viewer by adding `"codeQL.experimentalAstViewer": true` to your settings in VSCode 
  (Ctrl + Shift + P: `Open Settings (JSON)`). 
- Open some Python file from some database (this step is intentionally vague). 
- Open the CodeQL view in VSCode and click the new `View AST` button in the bottom. 
- Navigate the AST a bit to see what it looks like.

--- 

The printAst.ql query produces a tree, and there are 3 basic kinds of nodes in this tree (most of the other languages have more kinds of nodes, JS has 15): 
 - **`AstElementNode`**: This node represents an `AstNode`. The children of this node can be any kind of node. 
 - **`FunctionParamsNode`**: This node represents the parameters of a function. The children are always `AstElementNode`. 
 - **`StmtListNode`**: This node represents a `StmtList`, and is e.g. used as a child of an if-statement. The children of a `StmtListNode` are always `AstElementNode`.   
The `StmtList` that this node represents must be a result from `AstElementNode::getStmtList(...)`. This is used to figure out where the `StmtList` belongs and printing a label. 

I could have made a `CallArgumentsNode` for aggregating all the arguments in a call, but I decided against this, as the result already looks pretty good as it is. (I've done that differently in JavaScript. But JavaScript have both arguments and type-arguments, so not splitting them up would look bad). 

The `AstElementNode` implements some default behavior that works for `AstNodes`, and for some it actually looks OK (it determines children based on the `AstNode::getAChildNode()` predicate).   
This default behavior is overwritten in subclasses to get more specific/prettier behavior, for example: 
- Functions, where all the parameters are aggregated into a `FunctionParamsNode`.  
- If-statements, where each `StmtList` becomes a child, instead of each `Stmt` inside the `StmtList`s. 
- Parameters, where I've "moved" the type-annotation and default value to be children of the parameter instead of the function. 
--- 

The pretty-printing is quick and dirty and far from complete.   
But it looks pretty good to me. 

Maybe the `PrettyPrinting` module should be moved somewhere else? 