### PR TITLE
Python: Get rid of `DataFlowCfgNode`

### DIFF
--- a/python/ql/src/experimental/dataflow/internal/Attributes.qll
+++ b/python/ql/src/experimental/dataflow/internal/Attributes.qll
@@ -62,7 +62,7 @@ abstract class AttrWrite extends AttrRef {
  * ```
  * Also gives access to the `value` being written, by extending `DefinitionNode`.
  */
-private class AttributeAssignmentNode extends DefinitionNode, AttrNode, DataFlowCfgNode {
+private class AttributeAssignmentNode extends DefinitionNode, AttrNode {
   override ControlFlowNode getValue() { result = DefinitionNode.super.getValue() }
 }
 
@@ -87,7 +87,7 @@ private class AttributeAssignmentAsAttrWrite extends AttrWrite, CfgNode {
 import semmle.python.types.Builtins
 
 /** Represents `CallNode`s that may refer to calls to built-in functions or classes. */
-private class BuiltInCallNode extends CallNode, DataFlowCfgNode {
+private class BuiltInCallNode extends CallNode {
   string name;
 
   BuiltInCallNode() {
@@ -159,7 +159,7 @@ private class SetAttrCallAsAttrWrite extends AttrWrite, CfgNode {
  * Instances of this class correspond to the `NameNode` for `attr`, and also gives access to `value` by
  * virtue of being a `DefinitionNode`.
  */
-private class ClassAttributeAssignmentNode extends DefinitionNode, NameNode, DataFlowCfgNode { }
+private class ClassAttributeAssignmentNode extends DefinitionNode, NameNode { }
 
 /**
  * An attribute assignment via a class field, e.g.
@@ -192,15 +192,9 @@ private class ClassDefinitionAsAttrWrite extends AttrWrite, CfgNode {
  */
 abstract class AttrRead extends AttrRef, Node { }
 
-/**
- * A convenience class for embedding `AttrNode` into `DataFlowCfgNode`, as the former is not
- * obviously a subtype of the latter.
- */
-private class DataFlowAttrNode extends AttrNode, DataFlowCfgNode { }
-
 /** A simple attribute read, e.g. `object.attr` */
 private class AttributeReadAsAttrRead extends AttrRead, CfgNode {
-  override DataFlowAttrNode node;
+  override AttrNode node;
 
   override Node getObject() { result.asCfgNode() = node.getObject() }
 
@@ -228,12 +222,6 @@ private class GetAttrCallAsAttrRead extends AttrRead, CfgNode {
 }
 
 /**
- * A convenience class for embedding `ImportMemberNode` into `DataFlowCfgNode`, as the former is not
- * obviously a subtype of the latter.
- */
-private class DataFlowImportMemberNode extends ImportMemberNode, DataFlowCfgNode { }
-
-/**
  * Represents a named import as an attribute read. That is,
  * ```python
  * from module import attr as attr_ref
@@ -241,7 +229,7 @@ private class DataFlowImportMemberNode extends ImportMemberNode, DataFlowCfgNode
  * is treated as if it is a read of the attribute `module.attr`, even if `module` is not imported directly.
  */
 private class ModuleAttributeImportAsAttrRead extends AttrRead, CfgNode {
-  override DataFlowImportMemberNode node;
+  override ImportMemberNode node;
 
   override Node getObject() { result.asCfgNode() = node.getModule(_) }
 

--- a/python/ql/src/experimental/dataflow/internal/DataFlowPrivate.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowPrivate.qll
@@ -11,11 +11,6 @@ private import semmle.python.essa.SsaCompute
 //--------
 predicate isExpressionNode(ControlFlowNode node) { node.getNode() instanceof Expr }
 
-/** A control flow node which is also a dataflow node */
-class DataFlowCfgNode extends ControlFlowNode {
-  DataFlowCfgNode() { isExpressionNode(this) }
-}
-
 /** A data flow node for which we should synthesise an associated pre-update node. */
 abstract class NeedsSyntheticPreUpdateNode extends Node {
   /** A label for this kind of node. This will figure in the textual representation of the synthesized pre-update node. */

--- a/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowPublic.qll
@@ -23,7 +23,7 @@ newtype TNode =
   /** A node corresponding to an SSA variable. */
   TEssaNode(EssaVariable var) or
   /** A node corresponding to a control flow node. */
-  TCfgNode(DataFlowCfgNode node) or
+  TCfgNode(ControlFlowNode node) { isExpressionNode(node) } or
   /** A synthetic node representing the value of an object before a state change */
   TSyntheticPreUpdateNode(NeedsSyntheticPreUpdateNode post) or
   /** A synthetic node representing the value of an object after a state change */
@@ -104,7 +104,7 @@ class EssaNode extends Node, TEssaNode {
 }
 
 class CfgNode extends Node, TCfgNode {
-  DataFlowCfgNode node;
+  ControlFlowNode node;
 
   CfgNode() { this = TCfgNode(node) }
 


### PR DESCRIPTION
Should make modelling data flow nodes that are also specific subclasses of `ControlFlowNode` a bit smoother.

Also, `CfgNode` and `ExprNode` are identical... Maybe we would like to get rid of one of these? (Or perhaps just make one an alias of the other?)

My thoughts:
1. From the perspective of a new user, the name `ExprNode` is probably more intuitive than `CfgNode`. I would expect most people to have an intuitive understanding of what an expression is, but not necessarily what control flow nodes are. On the other hand...
2. ... Since Python makes a clear distinction between statements and expressions, people may wonder why we don't have a corresponding `StmtNode` as well. The fact that we internally have expression nodes for many of these statements may be a bit too subtle.