### PR TITLE
Java: Track taint through java.io.File::toPath & java.nio.file.Path::toFile

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/TaintTrackingUtil.qll
@@ -377,7 +377,13 @@ private predicate taintPreservingQualifierToMethod(Method m) {
   m.getDeclaringType().hasQualifiedName("java.nio", "ByteBuffer") and
   m.hasName("get")
   or
-  m.getDeclaringType().hasQualifiedName("java.io", "File") and
+  m.getDeclaringType() instanceof TypeFile and
+  m.hasName("toPath")
+  or
+  m.getDeclaringType() instanceof TypePath and
+  m.hasName("toFile")
+  or
+  m.getDeclaringType() instanceof TypeFile and
   m.hasName("toURI")
   or
   m.getDeclaringType().hasQualifiedName("java.net", "URI") and

--- a/java/ql/test/library-tests/dataflow/taint/B.java
+++ b/java/ql/test/library-tests/dataflow/taint/B.java
@@ -132,6 +132,12 @@ public class B {
     // Tainted file path and URI
     sink(new java.io.File(s).toURI().toURL());
 
+    // Tainted file to Path
+    sink(new java.io.File(s).toPath());
+
+    // Tainted File to Path to File
+    sink(new java.io.File(s).toPath().toFile());
+
     return;
   }
 

--- a/java/ql/test/library-tests/dataflow/taint/test.expected
+++ b/java/ql/test/library-tests/dataflow/taint/test.expected
@@ -34,6 +34,8 @@
 | B.java:15:21:15:27 | taint(...) | B.java:128:10:128:22 | taintedArray2 |
 | B.java:15:21:15:27 | taint(...) | B.java:130:10:130:22 | taintedArray3 |
 | B.java:15:21:15:27 | taint(...) | B.java:133:10:133:44 | toURL(...) |
+| B.java:15:21:15:27 | taint(...) | B.java:136:10:136:37 | toPath(...) |
+| B.java:15:21:15:27 | taint(...) | B.java:139:10:139:46 | toFile(...) |
 | MethodFlow.java:7:22:7:28 | taint(...) | MethodFlow.java:8:10:8:16 | tainted |
 | MethodFlow.java:9:31:9:37 | taint(...) | MethodFlow.java:10:10:10:17 | tainted2 |
 | MethodFlow.java:11:35:11:41 | taint(...) | MethodFlow.java:12:10:12:17 | tainted3 |


### PR DESCRIPTION
I'd like to utilize this for my temp directory information disclosure vulnerability. Seemed like worthy of breaking out into a seperate PR.

There does not seem to be a straightforward way to test the impact of a change like this on existing queries on various projects.