### PR TITLE
Java: CWE-378: Temp Directory Hijacking Race Condition Vulnerability

### DIFF
--- a/java/ql/src/Security/CWE/CWE-378/TempDirHijackingVulnerability.ql
+++ b/java/ql/src/Security/CWE/CWE-378/TempDirHijackingVulnerability.ql
@@ -1,0 +1,75 @@
+/**
+ * @name Temporary Directory Hijacking Vulnerability disclosure
+ * @description Detect temporary directory hijack vulnerability
+ * @kind path-problem
+ * @problem.severity error
+ * @precision very-high
+ * @id java/temp-directory-hijacking
+ */
+
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+/**
+ * All `java.io.File::createTempFile` methods.
+ */
+private class MethodFileCreateTempFile extends Method {
+  MethodFileCreateTempFile() {
+    this.getDeclaringType() instanceof TypeFile and
+    this.hasName("createTempFile")
+  }
+}
+
+private class MethodFileMkdir extends Method {
+  MethodFileMkdir() {
+    getDeclaringType() instanceof TypeFile and
+    hasName("mkdir")
+    or
+    hasName("mkdirs")
+  }
+}
+
+private class MethodFileDelete extends Method {
+  MethodFileDelete() {
+    getDeclaringType() instanceof TypeFile and
+    hasName("delete")
+  }
+}
+
+private class DeleteFileNode extends DataFlow::Node {
+  DeleteFileNode() {
+    exists(MethodAccess ma |
+      asExpr() = ma.getQualifier() and
+      ma.getMethod() instanceof MethodFileDelete
+    )
+  }
+}
+
+private class TempDirHijackingConfig extends TaintTracking::Configuration {
+  TempDirHijackingConfig() { this = "TempDirHijackingConfig" }
+
+  override predicate isSource(DataFlow::Node source) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof MethodFileCreateTempFile and
+      DataFlow::localFlow(DataFlow::exprNode(ma), source)
+    ) and
+    source instanceof DeleteFileNode
+  }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma |
+      ma.getMethod() instanceof MethodFileMkdir and
+      ma.getQualifier() = sink.asExpr()
+    )
+  }
+}
+
+from
+  DataFlow::PathNode source, DataFlow::PathNode sink, TempDirHijackingConfig conf,
+  IfStmt ifStmnt, MethodAccess ma
+where
+  conf.hasFlowPath(source, sink) and
+  not DataFlow::localFlow(DataFlow::exprNode(ma), DataFlow::exprNode(ifStmnt.getCondition())) and
+  ma.getQualifier() = sink.getNode().asExpr()
+select source.getNode(), source, sink, "Blah %s", sink.getNode()

--- a/java/ql/test/query-tests/security/CWE-378/semmle/tests/TempDirHijackingVulnerability.qlref
+++ b/java/ql/test/query-tests/security/CWE-378/semmle/tests/TempDirHijackingVulnerability.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-378/TempDirHijackingVulnerability.ql

--- a/java/ql/test/query-tests/security/CWE-378/semmle/tests/Test.java
+++ b/java/ql/test/query-tests/security/CWE-378/semmle/tests/Test.java
@@ -1,0 +1,39 @@
+import java.io.File;
+
+public class Test {
+
+    static File vulnerable() {
+        File temp = File.createTempFile("test", "directory");
+        temp.delete();
+        temp.mkdir();
+        return temp;
+    }
+
+    static File notVulnerableToHijacking() {
+        File temp = File.createTempFile("test", "directory");
+        temp.mkdir();
+        return temp;
+    }
+
+    static File safe() {
+        File temp = File.createTempFile("test", "directory");
+        temp.delete();
+        if (temp.mkdir()) {
+            return temp;
+        } else {
+            throw new RuntimeException("Failed to create directory");
+        }
+    }
+
+    static File safe2() {
+        File temp = File.createTempFile("test", "directory");
+        temp.delete();
+        boolean didMkdirs = temp.mkdirs();
+        if (didMkdirs) {
+            return temp;
+        } else {
+            throw new RuntimeException("Failed to create directory");
+        }
+    }
+    
+}


### PR DESCRIPTION
On Unix-like systems, the temporary directory is shared with all users on the system. As such, improperly writing to the system temporary directory can allow attackers to hijack temporary directory resources.

```java
    static File vulnerable() {
		// Attacker sees file creation in temporary directory
        File temp = File.createTempFile("test", "directory");
		// Attacker observes temporary file deletion
        temp.delete();
 		// 🏁 Race condition here
		// Attacker races to create the directory with more permissive permissions
        temp.mkdir(); // mkdir response code not checked. If attacker created directory, would return `false` not fail.
        return temp; // File could be hijacked
    }
```