### PR TITLE
Python: Fix divergence in tuple/subscripted type `toString`

### DIFF
--- a/python/ql/src/semmle/python/objects/Classes.qll
+++ b/python/ql/src/semmle/python/objects/Classes.qll
@@ -311,7 +311,8 @@ class SubscriptedTypeInternal extends ObjectInternal, TSubscriptedType {
   override string getName() { result = this.getGeneric().getName() }
 
   override string toString() {
-    result = this.getGeneric().toString() + "[" + this.getSpecializer().toString() + "]"
+    result =
+      bounded_toString(this.getGeneric()) + "[" + bounded_toString(this.getSpecializer()) + "]"
   }
 
   override predicate introducedAt(ControlFlowNode node, PointsToContext context) {

--- a/python/ql/src/semmle/python/objects/Instances.qll
+++ b/python/ql/src/semmle/python/objects/Instances.qll
@@ -379,7 +379,8 @@ private predicate cls_descriptor(ClassObjectInternal cls, string name, ObjectInt
 /** A class representing an instance of the `super` class */
 class SuperInstance extends TSuperInstance, ObjectInternal {
   override string toString() {
-    result = "super(" + this.getStartClass().toString() + ", " + this.getSelf().toString() + ")"
+    result =
+      "super(" + this.getStartClass().toString() + ", " + bounded_toString(this.getSelf()) + ")"
   }
 
   override boolean booleanValue() { result = true }

--- a/python/ql/src/semmle/python/objects/ObjectInternal.qll
+++ b/python/ql/src/semmle/python/objects/ObjectInternal.qll
@@ -515,7 +515,7 @@ class DecoratedFunction extends ObjectInternal, TDecoratedFunction {
   override string getName() { result = this.decoratedObject().getName() }
 
   override string toString() {
-    result = "Decorated " + this.decoratedObject().toString()
+    result = "Decorated " + bounded_toString(this.decoratedObject())
     or
     not exists(this.decoratedObject()) and result = "Decorated function"
   }
@@ -591,4 +591,19 @@ boolean maybe() { result = true or result = false }
 pragma[nomagic]
 predicate receiver_type(AttrNode attr, string name, ObjectInternal value, ClassObjectInternal cls) {
   PointsToInternal::pointsTo(attr.getObject(name), _, value, _) and value.getClass() = cls
+}
+
+/**
+ * Returns a string representation of `obj`. Because some classes have (mutually) recursive
+ * `toString` implementations, this predicate acts as a stop for these classes, preventing an
+ * unbounded `toString` from being materialized.
+ */
+string bounded_toString(ObjectInternal obj) {
+  if
+    obj instanceof DecoratedFunction or
+    obj instanceof TupleObjectInternal or
+    obj instanceof SubscriptedTypeInternal or
+    obj instanceof SuperInstance
+  then result = "(...)"
+  else result = obj.toString()
 }

--- a/python/ql/src/semmle/python/objects/Sequences.qll
+++ b/python/ql/src/semmle/python/objects/Sequences.qll
@@ -54,10 +54,7 @@ abstract class TupleObjectInternal extends SequenceObjectInternal {
   }
 
   private string item(int n) {
-    exists(ObjectInternal item | item = this.getItem(n) |
-      // To avoid infinite recursion, nested tuples are replaced with the string "...".
-      if item instanceof TupleObjectInternal then result = "(...)" else result = item.toString()
-    )
+    result = bounded_toString(this.getItem(n))
     or
     n in [0 .. this.length() - 1] and
     not exists(this.getItem(n)) and


### PR DESCRIPTION
A slightly more complicated version of the situation in
https://github.com/github/codeql/pull/2507 could cause the `toString`
calculation to diverge. Although the previous PR took tuples nested
inside tuples into account (and subscripted types cannot be nested
inside each other in our modelling), it did not account for having
this nesting be interleaved, and this is what caused the divergence.

I have not done the usual "test case first to show the problem
exists", since this would also diverge and take forever to fail. The
instance observed in `scipy` was likely caused by something akin to

```python
x = ()
while True:
    x = x[(x,)]
```

Finally, to prevent this from happening with other types, I went
through and checked each instance where the string representation of
an `ObjectInternal` might potentially contain a reference to
itself (and thus explode). I encapsulated this in a
`bounded_toString` helper predicate, and used this in all the cases
where I was able to determine that the above _could_ happen.