### PR TITLE
[CodeQL docs] Update footer in Sphinx template

### DIFF
--- a/docs/language/global-sphinx-files/_static/custom.css_t
+++ b/docs/language/global-sphinx-files/_static/custom.css_t
@@ -7,19 +7,8 @@
  * For the classes provided by the primer, see https://unpkg.com/@primer/css/dist/primer.css
  */
 
-/* -- FOOTER ------------------------------------------------------------------------------- */
 
-div.footer {
-    width: 100%;
-}
-
-/* -- PRIVACY NOTICE ----------------------------------------------------------------------- */
-
-div.privacy {
-    text-align: right;
-    padding-right: 5%;
-    padding-bottom: 20px;
-}
+/* -- CODE SNIPPETS ----------------------------------------------------------------------- */
 
 code {
     font-size: 0.9em !important; /* makes code snippets in headings the correct size */
@@ -27,19 +16,28 @@ code {
 
 /* -- MAIN BODY ---------------------------------------------------------------------------- */
 
+main {
+    min-height: calc(100vh - 68px);
+}
+
 div.body {
     max-width: 100%;
     min-width: unset;
+    padding: 0;
 }
 
 div.body li {
     margin: 0 0 0.5em 0; /* Increase spacing between list items */
 }
 
+article {
+    min-height: calc(100vh - 145px); /* Makes sure GitHub footer stays at bottom of viewport */
+}
+
 /* -- SIDEBAR ------------------------------------------------------------------------------- */
 
 .SideNav {
-    height: 100vh;
+    max-height: 100vh;  /* Makes sure sidebar doesn't cover GitHub footer */
 }
 
 .SideNav li {

--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {%- block content %}
-<div class="Header">
+<header class="Header">
     <div class="Header-item--full">
         <a href="{{ pathto(master_doc) }}" class="Header-link f2 d-flex flex-items-center">
             <!-- <%= octicon "mark-github", class: "mr-2", height: 32 %> -->
@@ -93,32 +93,89 @@
 
     </div>
 
-</div>
-
-<nav
-    class="SideNav position-sticky top-0 col-lg-3 col-md-3 float-left border p-4 hide-sm hide-md overflow-y-auto">
+</header>
+<main class="bg-gray-light clearfix">
+<nav class="SideNav position-sticky top-0 col-lg-3 col-md-3 float-left p-4 hide-sm hide-md overflow-y-auto">
 
     {{ toctree(includehidden=true, maxdepth=2, collapse=true) }}
 
 </nav>
 
-<div class="body p-4 col-sm-12 col-md-9 col-lg-9 float-left">
-    <div class="hide-lg hide-xl">
+
+<div class="body col-sm-12 col-md-9 col-lg-9 float-left border-left">
+
+    <div class="hide-lg hide-xl px-4 pt-4">
         {{customrelbar()}}
     </div>
 
-    {% block body %} {% endblock %}
-</div>
+    <article class="p-4 col-lg-10 col-md-10 col-sm-12">
+        {% block body %} {% endblock %}
+    </article>
 
+    <!-- GitHub footer, with links to terms and privacy statement -->
+    <div class="px-3 px-md-6 f6 py-4 d-sm-flex flex-justify-between flex-row-reverse flex-items-center border-top">
+        <ul class="list-style-none d-flex flex-items-center mb-3 mb-sm-0 lh-condensed-ultra">
+            <li class="mr-3">
+                <a href="https://twitter.com/github" title="GitHub on Twitter" style="color: #959da5;">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.5 222.3" class="d-block" height="18">
+                        <path
+                            d="M273.5 26.3a109.77 109.77 0 0 1-32.2 8.8 56.07 56.07 0 0 0 24.7-31 113.39 113.39 0 0 1-35.7 13.6 56.1 56.1 0 0 0-97 38.4 54 54 0 0 0 1.5 12.8A159.68 159.68 0 0 1 19.1 10.3a56.12 56.12 0 0 0 17.4 74.9 56.06 56.06 0 0 1-25.4-7v.7a56.11 56.11 0 0 0 45 55 55.65 55.65 0 0 1-14.8 2 62.39 62.39 0 0 1-10.6-1 56.24 56.24 0 0 0 52.4 39 112.87 112.87 0 0 1-69.7 24 119 119 0 0 1-13.4-.8 158.83 158.83 0 0 0 86 25.2c103.2 0 159.6-85.5 159.6-159.6 0-2.4-.1-4.9-.2-7.3a114.25 114.25 0 0 0 28.1-29.1"
+                            fill="currentColor"></path>
+                    </svg>
+                </a>
+            </li>
+            <li class="mr-3">
+                <a href="https://www.facebook.com/GitHub" title="GitHub on Facebook" style="color: #959da5;">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.3 15.4" class="d-block" height="18">
+                        <path
+                            d="M14.5 0H.8a.88.88 0 0 0-.8.9v13.6a.88.88 0 0 0 .8.9h7.3v-6h-2V7.1h2V5.4a2.87 2.87 0 0 1 2.5-3.1h.5a10.87 10.87 0 0 1 1.8.1v2.1h-1.3c-1 0-1.1.5-1.1 1.1v1.5h2.3l-.3 2.3h-2v5.9h3.9a.88.88 0 0 0 .9-.8V.8a.86.86 0 0 0-.8-.8z"
+                            fill="currentColor"></path>
+                    </svg>
+                </a>
+            </li>
+            <li class="mr-3">
+                <a href="https://www.youtube.com/github" title="GitHub on YouTube" style="color: #959da5;">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19.17 13.6" class="d-block" height="16">
+                        <path
+                            d="M18.77 2.13A2.4 2.4 0 0 0 17.09.42C15.59 0 9.58 0 9.58 0a57.55 57.55 0 0 0-7.5.4A2.49 2.49 0 0 0 .39 2.13 26.27 26.27 0 0 0 0 6.8a26.15 26.15 0 0 0 .39 4.67 2.43 2.43 0 0 0 1.69 1.71c1.52.42 7.5.42 7.5.42a57.69 57.69 0 0 0 7.51-.4 2.4 2.4 0 0 0 1.68-1.71 25.63 25.63 0 0 0 .4-4.67 24 24 0 0 0-.4-4.69zM7.67 9.71V3.89l5 2.91z"
+                            fill="currentColor"></path>
+                    </svg>
+                </a>
+            </li>
+            <li class="mr-3 flex-self-start">
+                <a href="https://www.linkedin.com/company/github" title="GitHub on Linkedin" style="color: #959da5;">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 18" class="d-block" height="18">
+                        <path
+                            d="M3.94 2A2 2 0 1 1 2 0a2 2 0 0 1 1.94 2zM4 5.48H0V18h4zm6.32 0H6.34V18h3.94v-6.57c0-3.66 4.77-4 4.77 0V18H19v-7.93c0-6.17-7.06-5.94-8.72-2.91z"
+                            fill="currentColor"></path>
+                    </svg>
+                </a>
+            </li>
+            <li>
+                <a href="https://github.com/github" title="GitHub's organization" style="color: #959da5;">
+                    <svg version="1.1" width="20" height="20" viewBox="0 0 16 16" class="octicon octicon-mark-github"
+                        aria-hidden="true">
+                        <path fill-rule="evenodd"
+                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z">
+                        </path>
+                    </svg>
+                </a>
+            </li>
+        </ul>
+        <ul class="list-style-none d-flex text-gray">
+            <li class="mr-3">&copy; 2020 GitHub, Inc.</li>
+            <li class="mr-3"><a
+                    href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service"
+                    class="link-gray">Terms </a></li>
+            <li><a href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement"
+                    class="link-gray">Privacy </a></li>
+        </ul>
+    </div>
+</div>
+</main>
 {% endblock %}
 
 {% block footer %}
-<div class="privacy">
-    <a class="p5" target="_blank" href="https://help.semmle.com/privacy-policy.html"
-        alt="Privacy policy and tracking preferences" title="Privacy policy and tracking preferences">Privacy
-        policy</a>
-</div>
-
 <script type="text/javascript">
     $(document).ready(function () {
         $(".toggle > *").hide();

--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -165,9 +165,9 @@
         <ul class="list-style-none d-flex text-gray">
             <li class="mr-3">&copy; 2020 GitHub, Inc.</li>
             <li class="mr-3"><a
-                    href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-terms-of-service"
+                    href="https://docs.github.com/github/site-policy/github-terms-of-service"
                     class="link-gray">Terms </a></li>
-            <li><a href="https://docs.github.com/en/free-pro-team@latest/github/site-policy/github-privacy-statement"
+            <li><a href="https://docs.github.com/github/site-policy/github-privacy-statement"
                     class="link-gray">Privacy </a></li>
         </ul>
     </div>


### PR DESCRIPTION
Adds a slightly adapted version of the GitHub footer to the template for Sphinx-generated articles. Also includes various small changes to the HTML template and CSS to make sure the divs stay in the correct place for different page sizes.

- [Preview](http://docteam.internal.semmle.com/james/update-footer/codeql/index.html)

I haven't added the "full" version of the footer (which appears on docs.github.com and has 4 columns of links to "Product", "Platform" etc) as it took up a lot of space and crowded out the article text on certain pages. I think this version is a good compromise.