### PR TITLE
JS: add support for custom CSRF protecting middlewares in js/missing-token-validation

### DIFF
--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -43,6 +43,7 @@
 | Unsafe jQuery plugin (`js/unsafe-jquery-plugin`) | More results | This query now detects more unsafe uses of nested option properties. |
 | Client-side URL redirect (`js/client-side-unvalidated-url-redirection`) | More results | This query now recognizes some unsafe uses of `importScripts()` inside WebWorkers. |
 | Missing CSRF middleware (`js/missing-token-validation`) | More results | This query now recognizes writes to cookie and session variables as potentially vulnerable to CSRF attacks. |
+| Missing CSRF middleware (`js/missing-token-validation`) | Less results | This query now recognizes more ways of protecting against CSRF attacks. |
 
 
 ## Changes to libraries

--- a/change-notes/1.26/analysis-javascript.md
+++ b/change-notes/1.26/analysis-javascript.md
@@ -43,7 +43,7 @@
 | Unsafe jQuery plugin (`js/unsafe-jquery-plugin`) | More results | This query now detects more unsafe uses of nested option properties. |
 | Client-side URL redirect (`js/client-side-unvalidated-url-redirection`) | More results | This query now recognizes some unsafe uses of `importScripts()` inside WebWorkers. |
 | Missing CSRF middleware (`js/missing-token-validation`) | More results | This query now recognizes writes to cookie and session variables as potentially vulnerable to CSRF attacks. |
-| Missing CSRF middleware (`js/missing-token-validation`) | Less results | This query now recognizes more ways of protecting against CSRF attacks. |
+| Missing CSRF middleware (`js/missing-token-validation`) | Fewer results | This query now recognizes more ways of protecting against CSRF attacks. |
 
 
 ## Changes to libraries

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -103,10 +103,11 @@ DataFlow::CallNode csrfMiddlewareCreation() {
  */
 private DataFlow::SourceNode nodeLeadingToCsrfWrite(DataFlow::TypeBackTracker t) {
   t.start() and
-  exists(DataFlow::PropRef value |
-    value = result.getAPropertyRead(cookieProperty()).getAPropertyWrite() and
-    value.getPropertyName().regexpMatch("(?i).*(csrf|xsrf).*")
-  )
+  result
+      .getAPropertyRead(cookieProperty())
+      .getAPropertyWrite()
+      .getPropertyName()
+      .regexpMatch("(?i).*(csrf|xsrf).*")
   or
   exists(DataFlow::TypeBackTracker t2 | result = nodeLeadingToCsrfWrite(t2).backtrack(t2, t))
 }

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -126,7 +126,7 @@ private Express::RouteHandler getAHandlerSettingCsrfCookie() {
  * This is indicated either by the request parameter having a CSRF related write to a session variable.
  * Or by the response parameter setting a CSRF related cookie.
  */
-predicate isACsrfProtectionRouteHandler(Express::RouteHandler handler) {
+predicate isCsrfProtectionRouteHandler(Express::RouteHandler handler) {
   DataFlow::parameterNode(handler.getRequestParameter()) =
     nodeLeadingToCsrfWrite(DataFlow::TypeBackTracker::end())
   or
@@ -136,7 +136,7 @@ predicate isACsrfProtectionRouteHandler(Express::RouteHandler handler) {
 /** Gets a data flow node refering to a route handler that is protecting against CSRF. */
 private DataFlow::SourceNode getACsrfProtectionRouteHandler(DataFlow::TypeTracker t) {
   t.start() and
-  isACsrfProtectionRouteHandler(result)
+  isCsrfProtectionRouteHandler(result)
   or
   exists(DataFlow::TypeTracker t2, DataFlow::SourceNode pred |
     pred = getACsrfProtectionRouteHandler(t2)
@@ -150,7 +150,7 @@ private DataFlow::SourceNode getACsrfProtectionRouteHandler(DataFlow::TypeTracke
 
 /**
  * Gets an express route handler expression that is either a custom CSRF protection middleware,
- * or a CSFR protecting library.
+ * or a CSRF protecting library.
  */
 Express::RouteHandlerExpr getACsrfMiddleware() {
   csrfMiddlewareCreation().flowsToExpr(result)

--- a/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
+++ b/javascript/ql/src/Security/CWE-352/MissingCsrfMiddleware.ql
@@ -94,6 +94,8 @@ DataFlow::CallNode csrfMiddlewareCreation() {
     exists(result.getOptionArgument(0, "csrf"))
     or
     callee = DataFlow::moduleMember("lusca", "csrf")
+    or
+    callee = DataFlow::moduleMember("express", "csrf")
   )
 }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/Express.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Express.qll
@@ -718,7 +718,7 @@ module Express {
   /**
    * An invocation of the `cookie` method on an HTTP response object.
    */
-  private class SetCookie extends HTTP::CookieDefinition, MethodCallExpr {
+  class SetCookie extends HTTP::CookieDefinition, MethodCallExpr {
     RouteHandler rh;
 
     SetCookie() { calls(rh.getAResponseExpr(), "cookie") }

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
@@ -73,3 +73,20 @@ var passport = require('passport');
         let newEmail = req.cookies["newEmail"];
     })
 });
+
+(function () {
+
+    var app = express()
+
+    app.use(cookieParser())
+    app.use(passport.authorize({ session: true }))
+
+    // Assume token is being set somewhere
+    app.use(express.csrf({ value: function (request) {
+        return request.headers['x-xsrf-token'];
+    }}));
+
+    app.post('/changeEmail', function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    })
+});

--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
@@ -1,0 +1,75 @@
+var express = require('express');
+var cookieParser = require('cookie-parser');
+var passport = require('passport');
+
+(function () {
+
+    var app = express()
+
+    app.use(cookieParser())
+    app.use(passport.authorize({ session: true }))
+
+    function getCsrfToken(request) {
+        return request.headers['x-xsrf-token'];
+    }
+
+    function setCsrfToken(request, response, next) {
+        response.cookie('XSRF-TOKEN', request.csrfToken());
+        next();
+    }
+
+    const csrf = {
+        getCsrfToken: getCsrfToken,
+        setCsrfToken: setCsrfToken
+    };
+
+    app.use(express.csrf({ value: csrf.getCsrfToken }));
+    app.use(csrf.setCsrfToken);
+
+    app.post('/changeEmail', function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    })
+});
+
+
+
+(function () {
+    var app = express()
+
+    app.use(cookieParser())
+    app.use(passport.authorize({ session: true }))
+
+    var crypto = require('crypto');
+
+    var generateToken = function (len) {
+        return crypto.randomBytes(Math.ceil(len * 3 / 4))
+            .toString('base64')
+            .slice(0, len);
+    };
+    function defaultValue(req) {
+        return (req.body && req.body._csrf)
+            || (req.query && req.query._csrf)
+            || (req.headers['x-csrf-token']);
+    }
+    var checkToken = function (req, res, next) {
+        var token = req.session._csrf || (req.session._csrf = generateToken(24));
+        if ('GET' == req.method || 'HEAD' == req.method || 'OPTIONS' == req.method) return next();
+        var val = defaultValue(req);
+        if (val != token) return next(function () {
+            res.send({ auth: false });
+        });
+        next();
+    }
+    const csrf = {
+        check: checkToken
+    };
+
+    app.use(express.cookieParser());
+    app.use(express.session({ secret: 'thomasdavislovessalmon' }));
+    app.use(express.bodyParser());
+    app.use(csrf.check);
+
+    app.post('/changeEmail', function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    })
+});


### PR DESCRIPTION
Gets a TN for CVE-2020-15135

Adds detection for custom made CSFR protecting route-handlers in `js/missing-token-validation`.   
A CSFR protecting route-handler is detected by it having some write to a CSFR related cookie or session variable.

Here are some example CSRF protecting route-handlers found with GitHub grep: https://lgtm.com/query/4468160787766813050/

[An evaluation looks ok](https://git.semmle.com/erik/dist-compare-reports/tree/eriks-profile-machine_1602812407517). 