### PR TITLE
C++: Fix qldoc for getIncludeText

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Include.qll
+++ b/cpp/ql/src/semmle/code/cpp/Include.qll
@@ -21,7 +21,7 @@ class Include extends PreprocessorDirective, @ppd_include {
 
   /**
    * Gets the token which occurs after `#include`, for example `"filename"`
-   * or `&lt;filename>`.
+   * or `<filename>`.
    */
   string getIncludeText() { result = getHead() }
 


### PR DESCRIPTION
The '<' was HTML encoded for some reason.