### PR TITLE
Python: Add script to promote experimental security queries

### DIFF
--- a/python/ql/src/experimental/Security-new-dataflow/promote.sh
+++ b/python/ql/src/experimental/Security-new-dataflow/promote.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -Eeuo pipefail # see https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+
+# Promotes new dataflow queries to be the real ones
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $SCRIPTDIR
+for file in $(find . -mindepth 2); do
+    echo "Promoting $file"
+    mkdir -p "../../Security/$(dirname $file)"
+    mv "$file" "../../Security/${file}"
+done


### PR DESCRIPTION
I initially kept this in a local branch for myself, but I think it will be useful to have in `main`, so it's easy to create a branch with the new versions of the queries for dist-compare or dist-upgrades. 