### PR TITLE
Add GitHub action to automatically add EOL @ EOF

### DIFF
--- a/.github/workflows/newline.yml
+++ b/.github/workflows/newline.yml
@@ -1,0 +1,13 @@
+name: Final new line
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  build:
+    name: New line
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@master
+      - uses: Logerfo/newline-action@0.0.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to how the [posix standard defines a line](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)

> 3.206 Line
A sequence of zero or more non- <newline> characters plus a terminating <newline> character.

Thus, many of the files in this repository that don't contain a newline at the end of the file contain a file where the last line isn't, according to the spec actually a line.

![Screen Shot 2020-10-15 at 11 52 38 AM](https://user-images.githubusercontent.com/1323708/96154541-ee632100-0edc-11eb-8ab8-0ad88ce79b09.png)

This GitHub action resolves this issue by automatically adding a End of Line (EOL) @ End of File (EOF).