### PR TITLE
JS: avoid using getFirstToken for sorting

### DIFF
--- a/javascript/ql/src/Declarations/UnstableCyclicImport.ql
+++ b/javascript/ql/src/Declarations/UnstableCyclicImport.ql
@@ -77,7 +77,7 @@ VarAccess getFirstCandidateAccess(ImportDeclaration decl) {
   result =
     min(decl.getASpecifier().getLocal().getVariable().getAnAccess().(CandidateVarAccess) as p
       order by
-        p.getFirstToken().getIndex()
+        p.getLocation().getStartLine(), p.getLocation().getStartColumn()
     )
 }
 

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -1567,7 +1567,9 @@ private string getConcatenatedString(Expr add) {
     strictconcat(Expr leaf |
       leaf = getAnAddOperand*(add)
     |
-      getConstantString(leaf) order by leaf.getFirstToken().getIndex()
+      getConstantString(leaf)
+      order by
+        leaf.getLocation().getStartLine(), leaf.getLocation().getStartColumn()
     ) and
   result.length() < 1000 * 1000
 }

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -576,7 +576,9 @@ module StringOps {
         strictconcat(StringLiteralLike leaf |
           leaf = getALeaf().asExpr()
         |
-          leaf.getStringValue() order by leaf.getFirstToken().getIndex()
+          leaf.getStringValue()
+          order by
+            leaf.getLocation().getStartLine(), leaf.getLocation().getStartColumn()
         )
     }
   }

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -440,7 +440,11 @@ class LocalTypeName extends @local_type_name, LexicalName {
    * Gets the first declaration of this type name.
    */
   TypeDecl getFirstDeclaration() {
-    result = min(getADeclaration() as decl order by decl.getFirstToken().getIndex())
+    result =
+      min(getADeclaration() as decl
+        order by
+          decl.getLocation().getStartLine(), decl.getLocation().getStartColumn()
+      )
   }
 
   /** Gets a use of this type name in a type annotation. */
@@ -500,7 +504,11 @@ class LocalNamespaceName extends @local_namespace_name, LexicalName {
    * Gets the first declaration of this namespace name.
    */
   LocalNamespaceDecl getFirstDeclaration() {
-    result = min(getADeclaration() as decl order by decl.getFirstToken().getIndex())
+    result =
+      min(getADeclaration() as decl
+        order by
+          decl.getLocation().getStartLine(), decl.getLocation().getStartColumn()
+      )
   }
 
   /** Gets a use of this namespace name in a type annotation. */

--- a/javascript/ql/src/semmle/javascript/security/UselessUseOfCat.qll
+++ b/javascript/ql/src/semmle/javascript/security/UselessUseOfCat.qll
@@ -239,7 +239,9 @@ module PrettyPrintCatCall {
       concat(Expr leaf |
         leaf = root.getALeaf().asExpr()
       |
-        createLeafRepresentation(leaf), " + " order by leaf.getFirstToken().getIndex()
+        createLeafRepresentation(leaf), " + "
+        order by
+          leaf.getLocation().getStartLine(), leaf.getLocation().getStartColumn()
       )
     or
     // Template string


### PR DESCRIPTION
A while ago a bad join order inspired me to look into `getFirstToken` and where we use it.   
We use it in a few places to sort expression by when they appear in a file. 
But it looks like performance is better when we sort by `Location` instead of  `getFirstToken`.  
So I changed the places where we sorted based on `getFirstToken`.

[Here is an evaluation](https://docs.google.com/spreadsheets/d/1Ono3o8j-z7cJG6F9rCYPACDFUWnjLQsH8fRExPvwmkI/edit#gid=0).   
(average of three nightly runs, of which one was on my laptop, all evaluations saw a speedup).    
Looks like we get a small performance improvement in the neighborhood of 1%. 