### PR TITLE
C#: Simplify `toString()` for CIL entities

### DIFF
--- a/csharp/change-notes/2020-10-28-cil-to-string.md
+++ b/csharp/change-notes/2020-10-28-cil-to-string.md
@@ -1,0 +1,3 @@
+lgtm,codescanning
+* The `toString()` predicate is now less verbose for CIL entities. The old `toString()` behavior
+  can be recovered by using `toStringExtra()` and `getQualifiedName()`, respectively.

--- a/csharp/ql/src/semmle/code/cil/Attribute.qll
+++ b/csharp/ql/src/semmle/code/cil/Attribute.qll
@@ -14,7 +14,7 @@ class Attribute extends Element, @cil_attribute {
   /** Gets the type of this attribute. */
   Type getType() { result = getConstructor().getDeclaringType() }
 
-  override string toString() { result = "[" + getType().toString() + "(...)]" }
+  override string toString() { result = "[" + getType().getName() + "(...)]" }
 
   /** Gets the value of the `i`th argument of this attribute. */
   string getArgument(int i) { cil_attribute_positional_argument(this, i, result) }

--- a/csharp/ql/src/semmle/code/cil/ConsistencyChecks.qll
+++ b/csharp/ql/src/semmle/code/cil/ConsistencyChecks.qll
@@ -477,7 +477,9 @@ class InvalidOverride extends MethodViolation {
   }
 
   override string getMessage() {
-    result = "Overridden method from " + base.getDeclaringType() + " is not in a base type"
+    result =
+      "Overridden method from " + base.getDeclaringType().getQualifiedName() +
+        " is not in a base type"
   }
 }
 

--- a/csharp/ql/src/semmle/code/cil/Instruction.qll
+++ b/csharp/ql/src/semmle/code/cil/Instruction.qll
@@ -4,7 +4,10 @@ private import CIL
 
 /** An instruction. */
 class Instruction extends Element, ControlFlowNode, DataFlowNode, @cil_instruction {
-  override string toString() { result = getIndex() + ": " + getOpcodeName() + getExtraStr() }
+  override string toString() { result = getOpcodeName() }
+
+  /** Gets a more verbose textual representation of this instruction. */
+  string toStringExtra() { result = getIndex() + ": " + getOpcodeName() + getExtraStr() }
 
   /** Gets the method containing this instruction. */
   override MethodImplementation getImplementation() { cil_instruction(this, _, _, result) }

--- a/csharp/ql/src/semmle/code/cil/Method.qll
+++ b/csharp/ql/src/semmle/code/cil/Method.qll
@@ -54,7 +54,11 @@ class MethodImplementation extends EntryPoint, @cil_method_implementation {
   /** Gets a string representing the disassembly of this implementation. */
   string getDisassembly() {
     result =
-      concat(Instruction i | i = this.getAnInstruction() | i.toString(), ", " order by i.getIndex())
+      concat(Instruction i |
+        i = this.getAnInstruction()
+      |
+        i.toStringExtra(), ", " order by i.getIndex()
+      )
   }
 }
 
@@ -76,7 +80,7 @@ class Method extends DotNet::Callable, Element, Member, TypeContainer, DataFlowN
 
   override string getName() { cil_method(this, result, _, _) }
 
-  override string toString() { result = this.getQualifiedName() }
+  override string toString() { result = this.getName() }
 
   override Type getDeclaringType() { cil_method(this, _, result, _) }
 

--- a/csharp/ql/src/semmle/code/cil/Type.qll
+++ b/csharp/ql/src/semmle/code/cil/Type.qll
@@ -38,7 +38,7 @@ class Type extends DotNet::Type, Declaration, TypeContainer, @cil_type {
 
   override string getName() { cil_type(this, result, _, _, _) }
 
-  override string toString() { result = getQualifiedName() }
+  override string toString() { result = this.getName() }
 
   /** Gets the containing type of this type, if any. */
   override Type getDeclaringType() { result = getParent() }

--- a/csharp/ql/src/semmle/code/cil/Variable.qll
+++ b/csharp/ql/src/semmle/code/cil/Variable.qll
@@ -39,7 +39,8 @@ class StackVariable extends Variable, @cil_stack_variable {
  */
 class LocalVariable extends StackVariable, @cil_local_variable {
   override string toString() {
-    result = "Local variable " + getIndex() + " of method " + getImplementation().getMethod()
+    result =
+      "Local variable " + getIndex() + " of method " + getImplementation().getMethod().getName()
   }
 
   /** Gets the method implementation defining this local variable. */
@@ -65,7 +66,7 @@ class Parameter extends DotNet::Parameter, StackVariable, @cil_parameter {
   /** Gets the index of this parameter. */
   int getIndex() { cil_parameter(this, _, result, _) }
 
-  override string toString() { result = "Parameter " + getIndex() + " of " + getMethod() }
+  override string toString() { result = "Parameter " + getIndex() + " of " + getMethod().getName() }
 
   override Type getType() { cil_parameter(this, _, _, result) }
 

--- a/csharp/ql/src/semmle/code/csharp/Attribute.qll
+++ b/csharp/ql/src/semmle/code/csharp/Attribute.qll
@@ -89,7 +89,7 @@ class Attribute extends TopLevelExprParent, @attribute {
   override Location getALocation() { attribute_location(this, result) }
 
   override string toString() {
-    exists(string type, string name | type = getType().toString() |
+    exists(string type, string name | type = getType().getName() |
       (if type.matches("%Attribute") then name = type.prefix(type.length() - 9) else name = type) and
       result = "[" + name + "(...)]"
     )

--- a/csharp/ql/src/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/src/semmle/code/csharp/Generics.qll
@@ -227,7 +227,7 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
   predicate hasNullableRefTypeConstraint() { general_type_parameter_constraints(this, 5) }
 
   /** Gets a textual representation of these constraints. */
-  override string toString() { result = "where " + this.getTypeParameter().toString() + ": ..." }
+  override string toString() { result = "where " + this.getTypeParameter().getName() + ": ..." }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -62,8 +62,10 @@ private class ExprNodeImpl extends ExprNode, NodeImpl {
   override string toStringImpl() {
     result = this.getControlFlowNode().toString()
     or
-    this = TCilExprNode(_) and
-    result = "CIL expression"
+    exists(CIL::Expr e |
+      this = TCilExprNode(e) and
+      result = e.toString()
+    )
   }
 }
 

--- a/csharp/ql/test/library-tests/cil/consistency/consistency.expected
+++ b/csharp/ql/test/library-tests/cil/consistency/consistency.expected
@@ -1,1 +1,1 @@
-| Finalize | Overridden method from Object is not in a base type |
+| Finalize | Overridden method from System.Object is not in a base type |

--- a/csharp/ql/test/library-tests/cil/consistency/consistency.expected
+++ b/csharp/ql/test/library-tests/cil/consistency/consistency.expected
@@ -1,1 +1,1 @@
-| System.Runtime.CompilerServices.AsyncTaskMethodBuilder.DebugFinalizableAsyncStateMachineBox.Finalize | Overridden method from System.Object is not in a base type |
+| Finalize | Overridden method from Object is not in a base type |

--- a/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.expected
+++ b/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.expected
@@ -1,41 +1,41 @@
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:6:3:6:4 | 0: nop |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 1: ldc.i4.1 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 2: stloc.0 L0 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 3: br.s 4: |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | 4: ldloc.0 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | 5: ret |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:6:3:6:4 | 0: nop |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | 1: ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | 2: stloc.0 L0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 3: ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 4: stloc.1 L1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 5: br.s 14: |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 14: ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 15: ldarg.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 16: cgt |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 17: ldc.i4.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 18: ceq |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 19: stloc.2 L2 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 20: ldloc.2 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 21: brtrue.s 6: |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 10: ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 11: ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 12: add |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 13: stloc.1 L1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 6: ldloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 7: ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 8: mul |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 9: stloc.0 L0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 22: ldloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 23: stloc.3 L3 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 24: br.s 25: |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | 25: ldloc.3 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | 26: ret |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 0: ldarg.0 |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 1: call System.Object..ctor |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 2: nop |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 3: ret |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 0: ldarg.0 |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 1: call System.Object..ctor |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 2: nop |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 3: ret |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:6:3:6:4 | nop |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | br.s |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | ldc.i4.1 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | stloc.0 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | ldloc.0 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | ret |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:6:3:6:4 | nop |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | stloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | br.s |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | stloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | brtrue.s |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ceq |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | cgt |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldarg.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldc.i4.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldloc.2 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | stloc.2 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | add |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | stloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | ldloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | mul |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | stloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | br.s |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | ldloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | stloc.3 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | ldloc.3 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | ret |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | call |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ldarg.0 |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | nop |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ret |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | call |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ldarg.0 |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | nop |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ret |

--- a/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.expected
+++ b/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.expected
@@ -1,41 +1,41 @@
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:6:3:6:4 | nop |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | br.s |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | ldc.i4.1 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | stloc.0 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | ldloc.0 |
-| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | ret |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:6:3:6:4 | nop |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | stloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | br.s |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | stloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | brtrue.s |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ceq |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | cgt |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldarg.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldc.i4.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | ldloc.2 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | stloc.2 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | add |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | ldc.i4.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | stloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | ldloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | ldloc.1 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | mul |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | stloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | br.s |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | ldloc.0 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | stloc.3 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | ldloc.3 |
-| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | ret |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | call |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ldarg.0 |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | nop |
-| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ret |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | call |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ldarg.0 |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | nop |
-| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | ret |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:6:3:6:4 | 0: nop |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 1: ldc.i4.1 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 2: stloc.0 L0 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:7:4:7:13 | 3: br.s 4: |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | 4: ldloc.0 |
+| C:/dev/projects/Sandbox/EmbeddedPdb/Class1.cs:8:3:8:4 | 5: ret |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:6:3:6:4 | 0: nop |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | 1: ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:7:4:7:20 | 2: stloc.0 L0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 3: ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 4: stloc.1 L1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:9:8:18 | 5: br.s 14: |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 14: ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 15: ldarg.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 16: cgt |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 17: ldc.i4.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 18: ceq |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 19: stloc.2 L2 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 20: ldloc.2 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:20:8:26 | 21: brtrue.s 6: |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 10: ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 11: ldc.i4.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 12: add |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:8:28:8:31 | 13: stloc.1 L1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 6: ldloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 7: ldloc.1 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 8: mul |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:9:5:9:18 | 9: stloc.0 L0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 22: ldloc.0 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 23: stloc.3 L3 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:10:4:10:19 | 24: br.s 25: |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | 25: ldloc.3 |
+| C:/dev/projects/Sandbox/PortablePdb/Class1.cs:11:3:11:4 | 26: ret |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 0: ldarg.0 |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 1: call System.Object..ctor |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 2: nop |
+| EmbeddedPdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 3: ret |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 0: ldarg.0 |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 1: call System.Object..ctor |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 2: nop |
+| PortablePdb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | 3: ret |

--- a/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.ql
+++ b/csharp/ql/test/library-tests/cil/pdbs/InstructionLocations.ql
@@ -11,4 +11,4 @@ from CIL::Instruction instruction, CIL::Location location
 where
   location = instruction.getLocation() and
   filterMethod(instruction.getImplementation().getMethod())
-select location.toString(), instruction.toString()
+select location.toString(), instruction.toStringExtra()

--- a/csharp/ql/test/library-tests/cil/regressions/ConstructedMethods.expected
+++ b/csharp/ql/test/library-tests/cil/regressions/ConstructedMethods.expected
@@ -1,2 +1,2 @@
-| Methods.dll:0:0:0:0 | Methods.Class1.F | Methods.dll:0:0:0:0 | Methods.Class1.F | Methods.dll:0:0:0:0 | Methods.Class1.G.!0 |
-| Methods.dll:0:0:0:0 | Methods.Class1.F | Methods.dll:0:0:0:0 | Methods.Class1.F | Methods.dll:0:0:0:0 | Methods.Class1.H.!0 |
+| Methods.dll:0:0:0:0 | F | Methods.dll:0:0:0:0 | F | Methods.dll:0:0:0:0 | !0 |
+| Methods.dll:0:0:0:0 | F | Methods.dll:0:0:0:0 | F | Methods.dll:0:0:0:0 | !0 |


### PR DESCRIPTION
This simplifies `toString()` for CIL entities, and makes the `toString()` predicate non-recursive.

https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/565