### PR TITLE
Fix C++ Print AST handling of Conversions

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -114,9 +114,29 @@ class PrintASTNode extends TPrintASTNode {
 
   /**
    * Gets the child node at index `childIndex`. Child indices must be unique,
-   * but need not be contiguous (but see `getChildByRank`).
+   * but need not be contiguous.
    */
-  abstract PrintASTNode getChild(int childIndex);
+  abstract PrintASTNode getChildInternal(int childIndex);
+
+  /**
+   * Gets the child node at index  `childIndex`.
+   * Adds edges to fully converted expressions, that are not part of the
+   * regular parent/child relation traversal.
+   */
+  PrintASTNode getChild(int childIndex) {
+    result = getChildInternal(childIndex)
+    or
+    exists(int nonConvertedIndex, int nextIdx, Expr expr |
+      nextIdx = max(int idx | exists(this.getChildInternal(idx))) + 1 and
+      exists(getChild(nonConvertedIndex)) and
+      childIndex - nextIdx = nonConvertedIndex and
+      expr = getChild(nonConvertedIndex).(ASTNode).getAST()
+    |
+      expr.getFullyConverted() instanceof Conversion and
+      result.(ASTNode).getAST() = expr.getFullyConverted() and
+      not expr instanceof Conversion
+    )
+  }
 
   /**
    * Holds if this node should be printed in the output. By default, all nodes
@@ -154,9 +174,27 @@ class PrintASTNode extends TPrintASTNode {
    * default, this is just the index of the child, but subclasses can override
    * this.
    */
-  string getChildEdgeLabel(int childIndex) {
+  string getChildEdgeLabelInternal(int childIndex) {
     exists(getChild(childIndex)) and
     result = childIndex.toString()
+  }
+
+  /**
+   * Gets the label for the edge from this node to the specified child,
+   * including labels for edges to nodes that represent conversions.
+   */
+  string getChildEdgeLabel(int childIndex) {
+    exists(getChildInternal(childIndex)) and
+    result = getChildEdgeLabelInternal(childIndex)
+    or
+    not exists(getChildInternal(childIndex)) and
+    exists(getChild(childIndex)) and
+    exists(int nonConvertedIndex, int nextIdx |
+      nextIdx = max(int idx | exists(this.getChildInternal(idx))) + 1 and
+      childIndex - nextIdx = nonConvertedIndex
+    |
+      result = getChildEdgeLabelInternal(nonConvertedIndex) + " converted"
+    )
   }
 
   /**
@@ -205,9 +243,7 @@ class ExprNode extends ASTNode {
 
   ExprNode() { expr = ast }
 
-  override ASTNode getChild(int childIndex) {
-    result.getAST() = expr.getChild(childIndex).getFullyConverted()
-  }
+  override ASTNode getChildInternal(int childIndex) { result.getAST() = expr.getChild(childIndex) }
 
   override string getProperty(string key) {
     result = super.getProperty(key)
@@ -249,10 +285,11 @@ class ConversionNode extends ExprNode {
 
   override ASTNode getChild(int childIndex) {
     childIndex = 0 and
-    result.getAST() = conv.getExpr()
+    result.getAST() = conv.getExpr() and
+    conv.getExpr() instanceof Conversion
   }
 
-  override string getChildEdgeLabel(int childIndex) { childIndex = 0 and result = "expr" }
+  override string getChildEdgeLabelInternal(int childIndex) { childIndex = 0 and result = "expr" }
 }
 
 /**
@@ -280,7 +317,7 @@ class DeclarationEntryNode extends BaseASTNode, TDeclarationEntryNode {
 
   DeclarationEntryNode() { this = TDeclarationEntryNode(declStmt, ast) }
 
-  override PrintASTNode getChild(int childIndex) { none() }
+  override PrintASTNode getChildInternal(int childIndex) { none() }
 
   override string getProperty(string key) {
     result = BaseASTNode.super.getProperty(key)
@@ -296,12 +333,12 @@ class DeclarationEntryNode extends BaseASTNode, TDeclarationEntryNode {
 class VariableDeclarationEntryNode extends DeclarationEntryNode {
   override VariableDeclarationEntry ast;
 
-  override ASTNode getChild(int childIndex) {
+  override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
     result.getAST() = ast.getVariable().getInitializer()
   }
 
-  override string getChildEdgeLabel(int childIndex) { childIndex = 0 and result = "init" }
+  override string getChildEdgeLabelInternal(int childIndex) { childIndex = 0 and result = "init" }
 }
 
 /**
@@ -312,11 +349,11 @@ class StmtNode extends ASTNode {
 
   StmtNode() { stmt = ast }
 
-  override BaseASTNode getChild(int childIndex) {
+  override BaseASTNode getChildInternal(int childIndex) {
     exists(Locatable child |
       child = stmt.getChild(childIndex) and
       (
-        result.getAST() = child.(Expr).getFullyConverted() or
+        result.getAST() = child.(Expr) or
         result.getAST() = child.(Stmt)
       )
     )
@@ -331,7 +368,7 @@ class DeclStmtNode extends StmtNode {
 
   DeclStmtNode() { declStmt = stmt }
 
-  override DeclarationEntryNode getChild(int childIndex) {
+  override DeclarationEntryNode getChildInternal(int childIndex) {
     exists(DeclarationEntry entry |
       declStmt.getDeclarationEntry(childIndex) = entry and
       result = TDeclarationEntryNode(declStmt, entry)
@@ -347,7 +384,7 @@ class ParameterNode extends ASTNode {
 
   ParameterNode() { param = ast }
 
-  final override PrintASTNode getChild(int childIndex) { none() }
+  final override PrintASTNode getChildInternal(int childIndex) { none() }
 
   final override string getProperty(string key) {
     result = super.getProperty(key)
@@ -365,12 +402,12 @@ class InitializerNode extends ASTNode {
 
   InitializerNode() { init = ast }
 
-  override ASTNode getChild(int childIndex) {
+  override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
-    result.getAST() = init.getExpr().getFullyConverted()
+    result.getAST() = init.getExpr()
   }
 
-  override string getChildEdgeLabel(int childIndex) {
+  override string getChildEdgeLabelInternal(int childIndex) {
     childIndex = 0 and
     result = "expr"
   }
@@ -388,7 +425,9 @@ class ParametersNode extends PrintASTNode, TParametersNode {
 
   final override Location getLocation() { result = getRepresentativeLocation(func) }
 
-  override ASTNode getChild(int childIndex) { result.getAST() = func.getParameter(childIndex) }
+  override ASTNode getChildInternal(int childIndex) {
+    result.getAST() = func.getParameter(childIndex)
+  }
 
   /**
    * Gets the `Function` for which this node represents the parameters.
@@ -408,7 +447,7 @@ class ConstructorInitializersNode extends PrintASTNode, TConstructorInitializers
 
   final override Location getLocation() { result = getRepresentativeLocation(ctor) }
 
-  final override ASTNode getChild(int childIndex) {
+  final override ASTNode getChildInternal(int childIndex) {
     result.getAST() = ctor.getInitializer(childIndex)
   }
 
@@ -430,7 +469,7 @@ class DestructorDestructionsNode extends PrintASTNode, TDestructorDestructionsNo
 
   final override Location getLocation() { result = getRepresentativeLocation(dtor) }
 
-  final override ASTNode getChild(int childIndex) {
+  final override ASTNode getChildInternal(int childIndex) {
     result.getAST() = dtor.getDestruction(childIndex)
   }
 
@@ -450,7 +489,7 @@ class FunctionNode extends ASTNode {
 
   override string toString() { result = qlClass(func) + getIdentityString(func) }
 
-  override PrintASTNode getChild(int childIndex) {
+  override PrintASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
     result.(ParametersNode).getFunction() = func
     or
@@ -464,7 +503,7 @@ class FunctionNode extends ASTNode {
     result.(DestructorDestructionsNode).getDestructor() = func
   }
 
-  override string getChildEdgeLabel(int childIndex) {
+  override string getChildEdgeLabelInternal(int childIndex) {
     childIndex = 0 and result = "params"
     or
     childIndex = 1 and result = "initializations"
@@ -504,7 +543,7 @@ class ClassAggregateLiteralNode extends ExprNode {
 
   ClassAggregateLiteralNode() { list = ast }
 
-  override string getChildEdgeLabel(int childIndex) {
+  override string getChildEdgeLabelInternal(int childIndex) {
     exists(Field field |
       list.getFieldExpr(field) = list.getChild(childIndex) and
       result = "." + field.getName()
@@ -520,7 +559,7 @@ class ArrayAggregateLiteralNode extends ExprNode {
 
   ArrayAggregateLiteralNode() { list = ast }
 
-  override string getChildEdgeLabel(int childIndex) {
+  override string getChildEdgeLabelInternal(int childIndex) {
     exists(int elementIndex |
       list.getElementExpr(elementIndex) = list.getChild(childIndex) and
       result = "[" + elementIndex.toString() + "]"

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -123,7 +123,7 @@ class PrintASTNode extends TPrintASTNode {
    * Adds edges to fully converted expressions, that are not part of the
    * regular parent/child relation traversal.
    */
-  PrintASTNode getChild(int childIndex) {
+  final PrintASTNode getChild(int childIndex) {
     result = getChildInternal(childIndex)
     or
     // We first compute the first available child index that is not used by
@@ -133,7 +133,7 @@ class PrintASTNode extends TPrintASTNode {
     exists(int nonConvertedIndex, int nextAvailableIndex, Expr expr |
       nextAvailableIndex = max(int idx | exists(this.getChildInternal(idx))) + 1 and
       childIndex - nextAvailableIndex = nonConvertedIndex and
-      expr = getChild(nonConvertedIndex).(ASTNode).getAST()
+      expr = getChildInternal(nonConvertedIndex).(ASTNode).getAST()
     |
       expr.getFullyConverted() instanceof Conversion and
       result.(ASTNode).getAST() = expr.getFullyConverted() and
@@ -186,7 +186,7 @@ class PrintASTNode extends TPrintASTNode {
    * Gets the label for the edge from this node to the specified child,
    * including labels for edges to nodes that represent conversions.
    */
-  string getChildEdgeLabel(int childIndex) {
+  final string getChildEdgeLabel(int childIndex) {
     exists(getChildInternal(childIndex)) and
     result = getChildEdgeLabelInternal(childIndex)
     or
@@ -286,7 +286,7 @@ class ConversionNode extends ExprNode {
 
   ConversionNode() { conv = expr }
 
-  override ASTNode getChild(int childIndex) {
+  override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
     result.getAST() = conv.getExpr() and
     conv.getExpr() instanceof Conversion

--- a/cpp/ql/test/examples/expressions/Conversion4.c
+++ b/cpp/ql/test/examples/expressions/Conversion4.c
@@ -1,3 +1,11 @@
 void Conversion4(int x) {
   x = ((int)7);
 }
+
+char * retfn(void * v) {
+    return (char*)(void*)(int*)v;
+}
+
+void Conversion4_vardecl(int x) {
+  long y = (long) x;
+}

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -56,12 +56,12 @@ ArrayToPointer.c:
 #    9|           -1: [VariableAccess] s
 #    9|               Type = [Struct] S
 #    9|               ValueCategory = lvalue
-#    9|         1: [ArrayToPointerConversion] array to pointer conversion
+#    9|         1: [VariableAccess] c
+#    9|             Type = [ArrayType] char[6]
+#    9|             ValueCategory = lvalue
+#    9|         1 converted: [ArrayToPointerConversion] array to pointer conversion
 #    9|             Type = [CharPointerType] char *
 #    9|             ValueCategory = prvalue
-#    9|           expr: [VariableAccess] c
-#    9|               Type = [ArrayType] char[6]
-#    9|               ValueCategory = lvalue
 #   10|     3: [ReturnStmt] return ...
 Cast.c:
 #    1| [TopLevelFunction] void Cast(char*, void*)
@@ -78,13 +78,13 @@ Cast.c:
 #    2|         0: [VariableAccess] c
 #    2|             Type = [CharPointerType] char *
 #    2|             ValueCategory = lvalue
-#    2|         1: [CStyleCast] (char *)...
+#    2|         1: [VariableAccess] v
+#    2|             Type = [VoidPointerType] void *
+#    2|             ValueCategory = prvalue(load)
+#    2|         1 converted: [CStyleCast] (char *)...
 #    2|             Conversion = [PointerConversion] pointer conversion
 #    2|             Type = [CharPointerType] char *
 #    2|             ValueCategory = prvalue
-#    2|           expr: [VariableAccess] v
-#    2|               Type = [VoidPointerType] void *
-#    2|               ValueCategory = prvalue(load)
 #    3|     1: [ReturnStmt] return ...
 ConditionDecl.cpp:
 #    1| [TopLevelFunction] void ConditionDecl()
@@ -102,13 +102,13 @@ ConditionDecl.cpp:
 #    3|       0: [ConditionDeclExpr] (condition decl)
 #    3|           Type = [BoolType] bool
 #    3|           ValueCategory = prvalue
-#    3|         0: [CStyleCast] (bool)...
+#    3|         0: [VariableAccess] k
+#    3|             Type = [IntType] int
+#    3|             ValueCategory = prvalue(load)
+#    3|         0 converted: [CStyleCast] (bool)...
 #    3|             Conversion = [BoolConversion] conversion to bool
 #    3|             Type = [BoolType] bool
 #    3|             ValueCategory = prvalue
-#    3|           expr: [VariableAccess] k
-#    3|               Type = [IntType] int
-#    3|               ValueCategory = prvalue(load)
 #    3|       1: [BlockStmt] { ... }
 #    5|     2: [ReturnStmt] return ...
 ConstructorCall.cpp:
@@ -226,15 +226,15 @@ Conversion1.c:
 #    2|       0: [VariableDeclarationEntry] definition of i
 #    2|           Type = [IntType] int
 #    2|         init: [Initializer] initializer for i
-#    2|           expr: [CStyleCast] (int)...
+#    2|           expr: [Literal] 1
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 1
+#    2|               ValueCategory = prvalue
+#    2|           expr converted: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 1
-#    2|                 Type = [IntType] int
-#    2|                 Value = [Literal] 1
-#    2|                 ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
 Conversion2.c:
 #    1| [TopLevelFunction] void Conversion2(int)
@@ -253,24 +253,24 @@ Conversion2.c:
 #    2|             Type = [IntType] int
 #    2|             Value = [AddExpr] 12
 #    2|             ValueCategory = prvalue
-#    2|           0: [CStyleCast] (int)...
+#    2|           0: [Literal] 5
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 5
+#    2|               ValueCategory = prvalue
+#    2|           1: [Literal] 7
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 7
+#    2|               ValueCategory = prvalue
+#    2|           0 converted: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 5
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 5
-#    2|                 Type = [IntType] int
-#    2|                 Value = [Literal] 5
-#    2|                 ValueCategory = prvalue
-#    2|           1: [CStyleCast] (int)...
+#    2|           1 converted: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 7
-#    2|                 Type = [IntType] int
-#    2|                 Value = [Literal] 7
-#    2|                 ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
 Conversion3.cpp:
 #    1| [TopLevelFunction] void Conversion3(int)
@@ -289,38 +289,38 @@ Conversion3.cpp:
 #    2|             Type = [IntType] int
 #    2|             Value = [AddExpr] 8
 #    2|             ValueCategory = prvalue
-#    2|           0: [CStyleCast] (int)...
+#    2|           0: [Literal] 5
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 5
+#    2|               ValueCategory = prvalue
+#    2|           1: [Literal] 7
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 7
+#    2|               ValueCategory = prvalue
+#    2|           0 converted: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    2|             expr: [CStyleCast] (bool)...
+#    2|             : [CStyleCast] (bool)...
 #    2|                 Conversion = [BoolConversion] conversion to bool
 #    2|                 Type = [BoolType] bool
 #    2|                 Value = [CStyleCast] 1
 #    2|                 ValueCategory = prvalue
-#    2|               expr: [CStyleCast] (int)...
+#    2|               : [CStyleCast] (int)...
 #    2|                   Conversion = [IntegralConversion] integral conversion
 #    2|                   Type = [IntType] int
 #    2|                   Value = [CStyleCast] 1
 #    2|                   ValueCategory = prvalue
-#    2|                 expr: [Literal] 5
-#    2|                     Type = [IntType] int
-#    2|                     Value = [Literal] 5
-#    2|                     ValueCategory = prvalue
-#    2|           1: [ParenthesisExpr] (...)
+#    2|           1 converted: [ParenthesisExpr] (...)
 #    2|               Type = [IntType] int
 #    2|               Value = [ParenthesisExpr] 7
 #    2|               ValueCategory = prvalue
-#    2|             expr: [CStyleCast] (int)...
+#    2|             : [CStyleCast] (int)...
 #    2|                 Conversion = [IntegralConversion] integral conversion
 #    2|                 Type = [IntType] int
 #    2|                 Value = [CStyleCast] 7
 #    2|                 ValueCategory = prvalue
-#    2|               expr: [Literal] 7
-#    2|                   Type = [IntType] int
-#    2|                   Value = [Literal] 7
-#    2|                   ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
 Conversion4.c:
 #    1| [TopLevelFunction] void Conversion4(int)
@@ -335,19 +335,19 @@ Conversion4.c:
 #    2|         0: [VariableAccess] x
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [ParenthesisExpr] (...)
+#    2|         1: [Literal] 7
+#    2|             Type = [IntType] int
+#    2|             Value = [Literal] 7
+#    2|             ValueCategory = prvalue
+#    2|         1 converted: [ParenthesisExpr] (...)
 #    2|             Type = [IntType] int
 #    2|             Value = [ParenthesisExpr] 7
 #    2|             ValueCategory = prvalue
-#    2|           expr: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 7
-#    2|                 Type = [IntType] int
-#    2|                 Value = [Literal] 7
-#    2|                 ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
 #    5| [TopLevelFunction] char* retfn(void*)
 #    5|   params: 
@@ -355,21 +355,21 @@ Conversion4.c:
 #    5|         Type = [VoidPointerType] void *
 #    5|   body: [BlockStmt] { ... }
 #    6|     0: [ReturnStmt] return ...
-#    6|       0: [CStyleCast] (char *)...
+#    6|       0: [VariableAccess] v
+#    6|           Type = [VoidPointerType] void *
+#    6|           ValueCategory = prvalue(load)
+#    6|       0 converted: [CStyleCast] (char *)...
 #    6|           Conversion = [PointerConversion] pointer conversion
 #    6|           Type = [CharPointerType] char *
 #    6|           ValueCategory = prvalue
-#    6|         expr: [CStyleCast] (void *)...
+#    6|         : [CStyleCast] (void *)...
 #    6|             Conversion = [PointerConversion] pointer conversion
 #    6|             Type = [VoidPointerType] void *
 #    6|             ValueCategory = prvalue
-#    6|           expr: [CStyleCast] (int *)...
+#    6|           : [CStyleCast] (int *)...
 #    6|               Conversion = [PointerConversion] pointer conversion
 #    6|               Type = [IntPointerType] int *
 #    6|               ValueCategory = prvalue
-#    6|             expr: [VariableAccess] v
-#    6|                 Type = [VoidPointerType] void *
-#    6|                 ValueCategory = prvalue(load)
 #    9| [TopLevelFunction] void Conversion4_vardecl(int)
 #    9|   params: 
 #    9|     0: [Parameter] x
@@ -379,13 +379,13 @@ Conversion4.c:
 #   10|       0: [VariableDeclarationEntry] definition of y
 #   10|           Type = [LongType] long
 #   10|         init: [Initializer] initializer for y
-#   10|           expr: [CStyleCast] (long)...
+#   10|           expr: [VariableAccess] x
+#   10|               Type = [IntType] int
+#   10|               ValueCategory = prvalue(load)
+#   10|           expr converted: [CStyleCast] (long)...
 #   10|               Conversion = [IntegralConversion] integral conversion
 #   10|               Type = [LongType] long
 #   10|               ValueCategory = prvalue
-#   10|             expr: [VariableAccess] x
-#   10|                 Type = [IntType] int
-#   10|                 ValueCategory = prvalue(load)
 #   11|     1: [ReturnStmt] return ...
 DestructorCall.cpp:
 #    1| [Constructor] void C::C()
@@ -427,15 +427,15 @@ DynamicCast.cpp:
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   body: [BlockStmt] { ... }
 #-----|     0: [ReturnStmt] return ...
-#-----|       0: [ReferenceToExpr] (reference to)
+#-----|       0: [PointerDereferenceExpr] * ...
+#-----|           Type = [Class] Base
+#-----|           ValueCategory = lvalue
+#-----|         0: [ThisExpr] this
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue(load)
+#-----|       0 converted: [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
-#-----|         expr: [PointerDereferenceExpr] * ...
-#-----|             Type = [Class] Base
-#-----|             ValueCategory = lvalue
-#-----|           0: [ThisExpr] this
-#-----|               Type = [PointerType] Base *
-#-----|               ValueCategory = prvalue(load)
 #    1| [MoveAssignmentOperator] Base& Base::operator=(Base&&)
 #    1|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -460,48 +460,48 @@ DynamicCast.cpp:
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   body: [BlockStmt] { ... }
 #-----|     0: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#    4|       0: [FunctionCall] call to operator=
+#    4|           Type = [LValueReferenceType] Base &
+#    4|           ValueCategory = prvalue
+#    4|         -1: [ThisExpr] this
+#    4|             Type = [PointerType] Derived *
+#    4|             ValueCategory = prvalue(load)
+#-----|         0: [CStyleCast] (Base *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue
+#    4|         0: [PointerDereferenceExpr] * ...
+#    4|             Type = [SpecifiedType] const Base
+#    4|             ValueCategory = lvalue
+#    4|           0: [AddressOfExpr] & ...
+#    4|               Type = [PointerType] const Derived *
+#    4|               ValueCategory = prvalue
+#    4|             0: [VariableAccess] (unnamed parameter 0)
+#    4|                 Type = [LValueReferenceType] const Derived &
+#    4|                 ValueCategory = prvalue(load)
+#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|                 Type = [SpecifiedType] const Derived
+#-----|                 ValueCategory = lvalue
+#-----|           0 converted: [CStyleCast] (const Base *)...
+#-----|               Conversion = [BaseClassConversion] base class conversion
+#-----|               Type = [PointerType] const Base *
+#-----|               ValueCategory = prvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const Base &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Class] Base
 #-----|           ValueCategory = lvalue
-#    4|         expr: [FunctionCall] call to operator=
-#    4|             Type = [LValueReferenceType] Base &
-#    4|             ValueCategory = prvalue
-#-----|           -1: [CStyleCast] (Base *)...
-#-----|               Conversion = [BaseClassConversion] base class conversion
-#-----|               Type = [PointerType] Base *
-#-----|               ValueCategory = prvalue
-#    4|             expr: [ThisExpr] this
-#    4|                 Type = [PointerType] Derived *
-#    4|                 ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const Base &
-#-----|               ValueCategory = prvalue
-#    4|             expr: [PointerDereferenceExpr] * ...
-#    4|                 Type = [SpecifiedType] const Base
-#    4|                 ValueCategory = lvalue
-#-----|               0: [CStyleCast] (const Base *)...
-#-----|                   Conversion = [BaseClassConversion] base class conversion
-#-----|                   Type = [PointerType] const Base *
-#-----|                   ValueCategory = prvalue
-#    4|                 expr: [AddressOfExpr] & ...
-#    4|                     Type = [PointerType] const Derived *
-#    4|                     ValueCategory = prvalue
-#-----|                   0: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                       Type = [SpecifiedType] const Derived
-#-----|                       ValueCategory = lvalue
-#    4|                     expr: [VariableAccess] (unnamed parameter 0)
-#    4|                         Type = [LValueReferenceType] const Derived &
-#    4|                         ValueCategory = prvalue(load)
 #-----|     1: [ReturnStmt] return ...
-#-----|       0: [ReferenceToExpr] (reference to)
+#-----|       0: [PointerDereferenceExpr] * ...
+#-----|           Type = [Class] Derived
+#-----|           ValueCategory = lvalue
+#-----|         0: [ThisExpr] this
+#-----|             Type = [PointerType] Derived *
+#-----|             ValueCategory = prvalue(load)
+#-----|       0 converted: [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
-#-----|         expr: [PointerDereferenceExpr] * ...
-#-----|             Type = [Class] Derived
-#-----|             ValueCategory = lvalue
-#-----|           0: [ThisExpr] this
-#-----|               Type = [PointerType] Derived *
-#-----|               ValueCategory = prvalue(load)
 #    4| [MoveAssignmentOperator] Derived& Derived::operator=(Derived&&)
 #    4|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -534,13 +534,13 @@ DynamicCast.cpp:
 #    9|         0: [VariableAccess] d
 #    9|             Type = [PointerType] Derived *
 #    9|             ValueCategory = lvalue
-#    9|         1: [DynamicCast] dynamic_cast<Derived *>...
+#    9|         1: [VariableAccess] bp
+#    9|             Type = [PointerType] Base *
+#    9|             ValueCategory = prvalue(load)
+#    9|         1 converted: [DynamicCast] dynamic_cast<Derived *>...
 #    9|             Conversion = [DynamicCast] dynamic_cast
 #    9|             Type = [PointerType] Derived *
 #    9|             ValueCategory = prvalue
-#    9|           expr: [VariableAccess] bp
-#    9|               Type = [PointerType] Base *
-#    9|               ValueCategory = prvalue(load)
 #   10|     1: [ReturnStmt] return ...
 #   12| [TopLevelFunction] void DynamicCastRef(Base&, Derived&)
 #   12|   params: 
@@ -550,35 +550,35 @@ DynamicCast.cpp:
 #   12|         Type = [LValueReferenceType] Derived &
 #   12|   body: [BlockStmt] { ... }
 #   13|     0: [ExprStmt] ExprStmt
-#   13|       0: [ReferenceDereferenceExpr] (reference dereference)
+#   13|       0: [FunctionCall] call to operator=
+#   13|           Type = [LValueReferenceType] Derived &
+#   13|           ValueCategory = prvalue
+#   13|         -1: [VariableAccess] d
+#   13|             Type = [LValueReferenceType] Derived &
+#   13|             ValueCategory = prvalue(load)
+#   13|         0: [ReferenceDereferenceExpr] (reference dereference)
+#   13|             Type = [Class] Derived
+#   13|             ValueCategory = lvalue
+#   13|         0: [VariableAccess] bp
+#   13|             Type = [LValueReferenceType] Base &
+#   13|             ValueCategory = prvalue(load)
+#   13|         0 converted: [ReferenceToExpr] (reference to)
+#   13|             Type = [LValueReferenceType] const Derived &
+#   13|             ValueCategory = prvalue
+#   13|           : [CStyleCast] (const Derived)...
+#   13|               Conversion = [GlvalueConversion] glvalue conversion
+#   13|               Type = [SpecifiedType] const Derived
+#   13|               ValueCategory = lvalue
+#   13|             : [DynamicCast] dynamic_cast<Derived>...
+#   13|                 Conversion = [DynamicCast] dynamic_cast
+#   13|                 Type = [Class] Derived
+#   13|                 ValueCategory = lvalue
+#   13|               : [ReferenceDereferenceExpr] (reference dereference)
+#   13|                   Type = [Class] Base
+#   13|                   ValueCategory = lvalue
+#   13|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #   13|           Type = [Class] Derived
 #   13|           ValueCategory = lvalue
-#   13|         expr: [FunctionCall] call to operator=
-#   13|             Type = [LValueReferenceType] Derived &
-#   13|             ValueCategory = prvalue
-#   13|           -1: [ReferenceDereferenceExpr] (reference dereference)
-#   13|               Type = [Class] Derived
-#   13|               ValueCategory = lvalue
-#   13|             expr: [VariableAccess] d
-#   13|                 Type = [LValueReferenceType] Derived &
-#   13|                 ValueCategory = prvalue(load)
-#   13|           0: [ReferenceToExpr] (reference to)
-#   13|               Type = [LValueReferenceType] const Derived &
-#   13|               ValueCategory = prvalue
-#   13|             expr: [CStyleCast] (const Derived)...
-#   13|                 Conversion = [GlvalueConversion] glvalue conversion
-#   13|                 Type = [SpecifiedType] const Derived
-#   13|                 ValueCategory = lvalue
-#   13|               expr: [DynamicCast] dynamic_cast<Derived>...
-#   13|                   Conversion = [DynamicCast] dynamic_cast
-#   13|                   Type = [Class] Derived
-#   13|                   ValueCategory = lvalue
-#   13|                 expr: [ReferenceDereferenceExpr] (reference dereference)
-#   13|                     Type = [Class] Base
-#   13|                     ValueCategory = lvalue
-#   13|                   expr: [VariableAccess] bp
-#   13|                       Type = [LValueReferenceType] Base &
-#   13|                       ValueCategory = prvalue(load)
 #   14|     1: [ReturnStmt] return ...
 Parenthesis.c:
 #    1| [TopLevelFunction] void Parenthesis(int)
@@ -596,22 +596,22 @@ Parenthesis.c:
 #    2|         1: [MulExpr] ... * ...
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = prvalue
-#    2|           0: [ParenthesisExpr] (...)
+#    2|           0: [AddExpr] ... + ...
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
-#    2|             expr: [AddExpr] ... + ...
+#    2|             0: [VariableAccess] i
 #    2|                 Type = [IntType] int
+#    2|                 ValueCategory = prvalue(load)
+#    2|             1: [Literal] 1
+#    2|                 Type = [IntType] int
+#    2|                 Value = [Literal] 1
 #    2|                 ValueCategory = prvalue
-#    2|               0: [VariableAccess] i
-#    2|                   Type = [IntType] int
-#    2|                   ValueCategory = prvalue(load)
-#    2|               1: [Literal] 1
-#    2|                   Type = [IntType] int
-#    2|                   Value = [Literal] 1
-#    2|                   ValueCategory = prvalue
 #    2|           1: [Literal] 2
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 2
+#    2|               ValueCategory = prvalue
+#    2|           0 converted: [ParenthesisExpr] (...)
+#    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
 PointerDereference.c:
@@ -651,12 +651,12 @@ ReferenceDereference.cpp:
 #    5|         0: [VariableAccess] j
 #    5|             Type = [IntType] int
 #    5|             ValueCategory = lvalue
-#    5|         1: [ReferenceDereferenceExpr] (reference dereference)
+#    5|         1: [VariableAccess] i
+#    5|             Type = [LValueReferenceType] int &
+#    5|             ValueCategory = prvalue(load)
+#    5|         1 converted: [ReferenceDereferenceExpr] (reference dereference)
 #    5|             Type = [IntType] int
 #    5|             ValueCategory = prvalue(load)
-#    5|           expr: [VariableAccess] i
-#    5|               Type = [LValueReferenceType] int &
-#    5|               ValueCategory = prvalue(load)
 #    6|     1: [ReturnStmt] return ...
 ReferenceTo.cpp:
 #    1| [TopLevelFunction] int& ReferenceTo(int*)
@@ -665,15 +665,15 @@ ReferenceTo.cpp:
 #    1|         Type = [IntPointerType] int *
 #    1|   body: [BlockStmt] { ... }
 #    2|     0: [ReturnStmt] return ...
-#    2|       0: [ReferenceToExpr] (reference to)
+#    2|       0: [PointerDereferenceExpr] * ...
+#    2|           Type = [IntType] int
+#    2|           ValueCategory = lvalue
+#    2|         0: [VariableAccess] i
+#    2|             Type = [IntPointerType] int *
+#    2|             ValueCategory = prvalue(load)
+#    2|       0 converted: [ReferenceToExpr] (reference to)
 #    2|           Type = [LValueReferenceType] int &
 #    2|           ValueCategory = prvalue
-#    2|         expr: [PointerDereferenceExpr] * ...
-#    2|             Type = [IntType] int
-#    2|             ValueCategory = lvalue
-#    2|           0: [VariableAccess] i
-#    2|               Type = [IntPointerType] int *
-#    2|               ValueCategory = prvalue(load)
 Sizeof.c:
 #    1| [TopLevelFunction] void Sizeof(int[])
 #    1|   params: 
@@ -684,34 +684,34 @@ Sizeof.c:
 #    2|       0: [VariableDeclarationEntry] definition of i
 #    2|           Type = [IntType] int
 #    2|         init: [Initializer] initializer for i
-#    2|           expr: [CStyleCast] (int)...
+#    2|           expr: [SizeofTypeOperator] sizeof(int)
+#    2|               Type = [LongType] unsigned long
+#    2|               Value = [SizeofTypeOperator] 4
+#    2|               ValueCategory = prvalue
+#    2|           expr converted: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 4
 #    2|               ValueCategory = prvalue
-#    2|             expr: [SizeofTypeOperator] sizeof(int)
-#    2|                 Type = [LongType] unsigned long
-#    2|                 Value = [SizeofTypeOperator] 4
-#    2|                 ValueCategory = prvalue
 #    3|     1: [DeclStmt] declaration
 #    3|       0: [VariableDeclarationEntry] definition of j
 #    3|           Type = [IntType] int
 #    3|         init: [Initializer] initializer for j
-#    3|           expr: [CStyleCast] (int)...
+#    3|           expr: [SizeofExprOperator] sizeof(<expr>)
+#    3|               Type = [LongType] unsigned long
+#    3|               Value = [SizeofExprOperator] 8
+#    3|               ValueCategory = prvalue
+#    3|             0: [VariableAccess] array
+#    3|                 Type = [IntPointerType] int *
+#    3|                 ValueCategory = lvalue
+#    3|             0 converted: [ParenthesisExpr] (...)
+#    3|                 Type = [IntPointerType] int *
+#    3|                 ValueCategory = lvalue
+#    3|           expr converted: [CStyleCast] (int)...
 #    3|               Conversion = [IntegralConversion] integral conversion
 #    3|               Type = [IntType] int
 #    3|               Value = [CStyleCast] 8
 #    3|               ValueCategory = prvalue
-#    3|             expr: [SizeofExprOperator] sizeof(<expr>)
-#    3|                 Type = [LongType] unsigned long
-#    3|                 Value = [SizeofExprOperator] 8
-#    3|                 ValueCategory = prvalue
-#    3|               0: [ParenthesisExpr] (...)
-#    3|                   Type = [IntPointerType] int *
-#    3|                   ValueCategory = lvalue
-#    3|                 expr: [VariableAccess] array
-#    3|                     Type = [IntPointerType] int *
-#    3|                     ValueCategory = lvalue
 #    4|     2: [ReturnStmt] return ...
 StatementExpr.c:
 #    1| [TopLevelFunction] void StatementExpr()
@@ -751,12 +751,12 @@ StaticMemberAccess.cpp:
 #    7|         1: [VariableAccess] i
 #    7|             Type = [IntType] int
 #    7|             ValueCategory = prvalue
+#    7|           -1: [VariableAccess] xref
+#    7|               Type = [LValueReferenceType] X &
+#    7|               ValueCategory = prvalue(load)
 #    7|           -1: [ReferenceDereferenceExpr] (reference dereference)
 #    7|               Type = [Struct] X
 #    7|               ValueCategory = lvalue
-#    7|             expr: [VariableAccess] xref
-#    7|                 Type = [LValueReferenceType] X &
-#    7|                 ValueCategory = prvalue(load)
 #    9|     1: [ReturnStmt] return ...
 Subscript.c:
 #    1| [TopLevelFunction] void Subscript(int[], int)
@@ -817,13 +817,9 @@ Throw.cpp:
 #    7|     0: [TryStmt] try { ... }
 #    7|       0: [BlockStmt] { ... }
 #    8|         0: [IfStmt] if (...) ... 
-#    8|           0: [CStyleCast] (bool)...
-#    8|               Conversion = [BoolConversion] conversion to bool
-#    8|               Type = [BoolType] bool
-#    8|               ValueCategory = prvalue
-#    8|             expr: [VariableAccess] i
-#    8|                 Type = [IntType] int
-#    8|                 ValueCategory = prvalue(load)
+#    8|           0: [VariableAccess] i
+#    8|               Type = [IntType] int
+#    8|               ValueCategory = prvalue(load)
 #    9|           1: [ExprStmt] ExprStmt
 #    9|             0: [ThrowExpr] throw ...
 #    9|                 Type = [Class] E
@@ -839,6 +835,10 @@ Throw.cpp:
 #   11|               0: [ConstructorCall] call to F
 #   11|                   Type = [VoidType] void
 #   11|                   ValueCategory = prvalue
+#    8|           0 converted: [CStyleCast] (bool)...
+#    8|               Conversion = [BoolConversion] conversion to bool
+#    8|               Type = [BoolType] bool
+#    8|               ValueCategory = prvalue
 #   12|       1: [Handler] <handler>
 #   12|         0: [CatchBlock] { ... }
 #   13|           0: [ExprStmt] ExprStmt
@@ -962,25 +962,25 @@ Varargs.c:
 #   10|       0: [BuiltInVarArgsStart] __builtin_va_start
 #   10|           Type = [VoidType] void
 #   10|           ValueCategory = prvalue
-#   10|         0: [ArrayToPointerConversion] array to pointer conversion
-#   10|             Type = [PointerType] __va_list_tag *
-#   10|             ValueCategory = prvalue
-#   10|           expr: [VariableAccess] args
-#   10|               Type = [CTypedefType] va_list
-#   10|               ValueCategory = lvalue
+#   10|         0: [VariableAccess] args
+#   10|             Type = [CTypedefType] va_list
+#   10|             ValueCategory = lvalue
 #   10|         1: [VariableAccess] text
 #   10|             Type = [PointerType] const char *
 #   10|             ValueCategory = lvalue
+#   10|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   10|             Type = [PointerType] __va_list_tag *
+#   10|             ValueCategory = prvalue
 #   11|     2: [ExprStmt] ExprStmt
 #   11|       0: [BuiltInVarArgsEnd] __builtin_va_end
 #   11|           Type = [VoidType] void
 #   11|           ValueCategory = prvalue
-#   11|         0: [ArrayToPointerConversion] array to pointer conversion
+#   11|         0: [VariableAccess] args
+#   11|             Type = [CTypedefType] va_list
+#   11|             ValueCategory = lvalue
+#   11|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #   11|             Type = [PointerType] __va_list_tag *
 #   11|             ValueCategory = prvalue
-#   11|           expr: [VariableAccess] args
-#   11|               Type = [CTypedefType] va_list
-#   11|               ValueCategory = lvalue
 #   12|     3: [ReturnStmt] return ...
 macro_etc.c:
 #    3| [TopLevelFunction] int bar(int)
@@ -1070,28 +1070,28 @@ macro_etc.c:
 #   27|           0: [VariableAccess] i
 #   27|               Type = [PlainCharType] char
 #   27|               ValueCategory = lvalue
-#   27|           1: [CStyleCast] (char)...
+#   27|           1: [Literal] 0
+#   27|               Type = [IntType] int
+#   27|               Value = [Literal] 0
+#   27|               ValueCategory = prvalue
+#   27|           1 converted: [CStyleCast] (char)...
 #   27|               Conversion = [IntegralConversion] integral conversion
 #   27|               Type = [PlainCharType] char
 #   27|               Value = [CStyleCast] 0
 #   27|               ValueCategory = prvalue
-#   27|             expr: [Literal] 0
-#   27|                 Type = [IntType] int
-#   27|                 Value = [Literal] 0
-#   27|                 ValueCategory = prvalue
 #   27|       1: [LTExpr] ... < ...
 #   27|           Type = [IntType] int
 #   27|           ValueCategory = prvalue
-#   27|         0: [CStyleCast] (int)...
-#   27|             Conversion = [IntegralConversion] integral conversion
-#   27|             Type = [IntType] int
-#   27|             ValueCategory = prvalue
-#   27|           expr: [VariableAccess] i
-#   27|               Type = [PlainCharType] char
-#   27|               ValueCategory = prvalue(load)
+#   27|         0: [VariableAccess] i
+#   27|             Type = [PlainCharType] char
+#   27|             ValueCategory = prvalue(load)
 #   27|         1: [Literal] 6
 #   27|             Type = [IntType] int
 #   27|             Value = [Literal] 6
+#   27|             ValueCategory = prvalue
+#   27|         0 converted: [CStyleCast] (int)...
+#   27|             Conversion = [IntegralConversion] integral conversion
+#   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
 #   27|       2: [PrefixIncrExpr] ++ ...
 #   27|           Type = [PlainCharType] char
@@ -1107,13 +1107,13 @@ macro_etc.c:
 #   27|             0: [VariableAccess] t
 #   27|                 Type = [IntType] int
 #   27|                 ValueCategory = lvalue
-#   27|             1: [CStyleCast] (int)...
+#   27|             1: [VariableAccess] i
+#   27|                 Type = [PlainCharType] char
+#   27|                 ValueCategory = prvalue(load)
+#   27|             1 converted: [CStyleCast] (int)...
 #   27|                 Conversion = [IntegralConversion] integral conversion
 #   27|                 Type = [IntType] int
 #   27|                 ValueCategory = prvalue
-#   27|               expr: [VariableAccess] i
-#   27|                   Type = [PlainCharType] char
-#   27|                   ValueCategory = prvalue(load)
 #   28|     7: [ForStmt] for(...;...;...) ...
 #   28|       0: [ExprStmt] ExprStmt
 #   28|         0: [AssignExpr] ... = ...
@@ -1122,28 +1122,28 @@ macro_etc.c:
 #   28|           0: [VariableAccess] i
 #   28|               Type = [PlainCharType] char
 #   28|               ValueCategory = lvalue
-#   28|           1: [CStyleCast] (char)...
+#   28|           1: [Literal] 0
+#   28|               Type = [IntType] int
+#   28|               Value = [Literal] 0
+#   28|               ValueCategory = prvalue
+#   28|           1 converted: [CStyleCast] (char)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [PlainCharType] char
 #   28|               Value = [CStyleCast] 0
 #   28|               ValueCategory = prvalue
-#   28|             expr: [Literal] 0
-#   28|                 Type = [IntType] int
-#   28|                 Value = [Literal] 0
-#   28|                 ValueCategory = prvalue
 #   28|       1: [LTExpr] ... < ...
 #   28|           Type = [IntType] int
 #   28|           ValueCategory = prvalue
-#   28|         0: [CStyleCast] (int)...
-#   28|             Conversion = [IntegralConversion] integral conversion
-#   28|             Type = [IntType] int
-#   28|             ValueCategory = prvalue
-#   28|           expr: [VariableAccess] i
-#   28|               Type = [PlainCharType] char
-#   28|               ValueCategory = prvalue(load)
+#   28|         0: [VariableAccess] i
+#   28|             Type = [PlainCharType] char
+#   28|             ValueCategory = prvalue(load)
 #   28|         1: [Literal] 6
 #   28|             Type = [IntType] int
 #   28|             Value = [Literal] 6
+#   28|             ValueCategory = prvalue
+#   28|         0 converted: [CStyleCast] (int)...
+#   28|             Conversion = [IntegralConversion] integral conversion
+#   28|             Type = [IntType] int
 #   28|             ValueCategory = prvalue
 #   28|       2: [PrefixIncrExpr] ++ ...
 #   28|           Type = [PlainCharType] char
@@ -1159,13 +1159,13 @@ macro_etc.c:
 #   28|             0: [VariableAccess] t
 #   28|                 Type = [IntType] int
 #   28|                 ValueCategory = lvalue
-#   28|             1: [CStyleCast] (int)...
+#   28|             1: [VariableAccess] i
+#   28|                 Type = [PlainCharType] char
+#   28|                 ValueCategory = prvalue(load)
+#   28|             1 converted: [CStyleCast] (int)...
 #   28|                 Conversion = [IntegralConversion] integral conversion
 #   28|                 Type = [IntType] int
 #   28|                 ValueCategory = prvalue
-#   28|               expr: [VariableAccess] i
-#   28|                   Type = [PlainCharType] char
-#   28|                   ValueCategory = prvalue(load)
 #   29|     8: [ExprStmt] ExprStmt
 #   29|       0: [AssignExpr] ... = ...
 #   29|           Type = [CharPointerType] char *
@@ -1173,13 +1173,13 @@ macro_etc.c:
 #   29|         0: [VariableAccess] bt
 #   29|             Type = [CharPointerType] char *
 #   29|             ValueCategory = lvalue
-#   29|         1: [ArrayToPointerConversion] array to pointer conversion
+#   29|         1: b
+#   29|             Type = [ArrayType] char[2]
+#   29|             Value = [StringLiteral] "b"
+#   29|             ValueCategory = lvalue
+#   29|         1 converted: [ArrayToPointerConversion] array to pointer conversion
 #   29|             Type = [CharPointerType] char *
 #   29|             ValueCategory = prvalue
-#   29|           expr: b
-#   29|               Type = [ArrayType] char[2]
-#   29|               Value = [StringLiteral] "b"
-#   29|               ValueCategory = lvalue
 #   30|     9: [ExprStmt] ExprStmt
 #   30|       0: [AssignExpr] ... = ...
 #   30|           Type = [PlainCharType] char
@@ -1187,23 +1187,23 @@ macro_etc.c:
 #   30|         0: [ArrayExpr] access to array
 #   30|             Type = [PlainCharType] char
 #   30|             ValueCategory = lvalue
-#   30|           0: [ArrayToPointerConversion] array to pointer conversion
-#   30|               Type = [CharPointerType] char *
-#   30|               ValueCategory = prvalue
-#   30|             expr: [VariableAccess] arr
-#   30|                 Type = [ArrayType] char[]
-#   30|                 ValueCategory = lvalue
+#   30|           0: [VariableAccess] arr
+#   30|               Type = [ArrayType] char[]
+#   30|               ValueCategory = lvalue
 #   30|           1: [Literal] 0
 #   30|               Type = [IntType] int
 #   30|               Value = [Literal] 0
 #   30|               ValueCategory = prvalue
-#   30|         1: [CStyleCast] (char)...
+#   30|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   30|               Type = [CharPointerType] char *
+#   30|               ValueCategory = prvalue
+#   30|         1: [VariableAccess] t
+#   30|             Type = [IntType] int
+#   30|             ValueCategory = prvalue(load)
+#   30|         1 converted: [CStyleCast] (char)...
 #   30|             Conversion = [IntegralConversion] integral conversion
 #   30|             Type = [PlainCharType] char
 #   30|             ValueCategory = prvalue
-#   30|           expr: [VariableAccess] t
-#   30|               Type = [IntType] int
-#   30|               ValueCategory = prvalue(load)
 #   31|     10: [ExprStmt] ExprStmt
 #   31|       0: [AssignExpr] ... = ...
 #   31|           Type = [FunctionPointerType] ..(*)(..)
@@ -1221,23 +1221,23 @@ macro_etc.c:
 #   32|         0: [VariableAccess] t
 #   32|             Type = [IntType] int
 #   32|             ValueCategory = prvalue(load)
-#   32|         1: [CStyleCast] (int)...
+#   32|         1: [ArrayExpr] access to array
+#   32|             Type = [PlainCharType] char
+#   32|             ValueCategory = prvalue(load)
+#   32|           0: [VariableAccess] arr
+#   32|               Type = [ArrayType] char[]
+#   32|               ValueCategory = lvalue
+#   32|           1: [Literal] 1
+#   32|               Type = [IntType] int
+#   32|               Value = [Literal] 1
+#   32|               ValueCategory = prvalue
+#   32|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   32|               Type = [CharPointerType] char *
+#   32|               ValueCategory = prvalue
+#   32|         1 converted: [CStyleCast] (int)...
 #   32|             Conversion = [IntegralConversion] integral conversion
 #   32|             Type = [IntType] int
 #   32|             ValueCategory = prvalue
-#   32|           expr: [ArrayExpr] access to array
-#   32|               Type = [PlainCharType] char
-#   32|               ValueCategory = prvalue(load)
-#   32|             0: [ArrayToPointerConversion] array to pointer conversion
-#   32|                 Type = [CharPointerType] char *
-#   32|                 ValueCategory = prvalue
-#   32|               expr: [VariableAccess] arr
-#   32|                   Type = [ArrayType] char[]
-#   32|                   ValueCategory = lvalue
-#   32|             1: [Literal] 1
-#   32|                 Type = [IntType] int
-#   32|                 Value = [Literal] 1
-#   32|                 ValueCategory = prvalue
 union_etc.cpp:
 #    2| [CopyAssignmentOperator] S& S::operator=(S const&)
 #    2|   params: 
@@ -1413,27 +1413,27 @@ union_etc.cpp:
 #   27|             -1: [VariableAccess] s
 #   27|                 Type = [Struct] S
 #   27|                 ValueCategory = lvalue
-#   27|         1: [ParenthesisExpr] (...)
+#   27|         1: [AddExpr] ... + ...
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
-#   27|           expr: [AddExpr] ... + ...
+#   27|           0: [ValueFieldAccess] i
 #   27|               Type = [IntType] int
-#   27|               ValueCategory = prvalue
-#   27|             0: [ValueFieldAccess] i
-#   27|                 Type = [IntType] int
-#   27|                 ValueCategory = prvalue(load)
-#   27|               -1: [ValueFieldAccess] c
-#   27|                   Type = [NestedClass] C
-#   27|                   ValueCategory = lvalue
-#   27|                 -1: [VariableAccess] u
-#   27|                     Type = [Union] U
-#   27|                     ValueCategory = lvalue
-#   27|             1: [ValueFieldAccess] j
-#   27|                 Type = [IntType] int
-#   27|                 ValueCategory = prvalue(load)
+#   27|               ValueCategory = prvalue(load)
+#   27|             -1: [ValueFieldAccess] c
+#   27|                 Type = [NestedClass] C
+#   27|                 ValueCategory = lvalue
 #   27|               -1: [VariableAccess] u
 #   27|                   Type = [Union] U
 #   27|                   ValueCategory = lvalue
+#   27|           1: [ValueFieldAccess] j
+#   27|               Type = [IntType] int
+#   27|               ValueCategory = prvalue(load)
+#   27|             -1: [VariableAccess] u
+#   27|                 Type = [Union] U
+#   27|                 ValueCategory = lvalue
+#   27|         1 converted: [ParenthesisExpr] (...)
+#   27|             Type = [IntType] int
+#   27|             ValueCategory = prvalue
 #   28|     5: [ReturnStmt] return ...
 #   28|       0: [ValueFieldAccess] g
 #   28|           Type = [IntType] int
@@ -1485,63 +1485,63 @@ union_etc.cpp:
 #   37|       0: [VariableDeclarationEntry] definition of s
 #   37|           Type = [PointerType] const T *
 #   37|         init: [Initializer] initializer for s
-#   37|           expr: [CStyleCast] (const T *)...
+#   37|           expr: [AddressOfExpr] & ...
+#   37|               Type = [PointerType] C *
+#   37|               ValueCategory = prvalue
+#   37|             0: [VariableAccess] c
+#   37|                 Type = [Class] C
+#   37|                 ValueCategory = lvalue
+#   37|           expr converted: [CStyleCast] (const T *)...
 #   37|               Conversion = [PointerConversion] pointer conversion
 #   37|               Type = [PointerType] const T *
 #   37|               ValueCategory = prvalue
-#   37|             expr: [AddressOfExpr] & ...
-#   37|                 Type = [PointerType] C *
-#   37|                 ValueCategory = prvalue
-#   37|               0: [VariableAccess] c
-#   37|                   Type = [Class] C
-#   37|                   ValueCategory = lvalue
 #   38|     1: [DeclStmt] declaration
 #   38|       0: [VariableDeclarationEntry] definition of t
 #   38|           Type = [PointerType] const S *
 #   38|         init: [Initializer] initializer for t
-#   38|           expr: [StaticCast] static_cast<const S *>...
+#   38|           expr: [VariableAccess] s
+#   38|               Type = [PointerType] const T *
+#   38|               ValueCategory = prvalue(load)
+#   38|           expr converted: [StaticCast] static_cast<const S *>...
 #   38|               Conversion = [BaseClassConversion] base class conversion
 #   38|               Type = [PointerType] const S *
 #   38|               ValueCategory = prvalue
-#   38|             expr: [VariableAccess] s
-#   38|                 Type = [PointerType] const T *
-#   38|                 ValueCategory = prvalue(load)
 #   39|     2: [DeclStmt] declaration
 #   39|       0: [VariableDeclarationEntry] definition of x
 #   39|           Type = [PointerType] T *
 #   39|         init: [Initializer] initializer for x
-#   39|           expr: [ConstCast] const_cast<T *>...
+#   39|           expr: [VariableAccess] s
+#   39|               Type = [PointerType] const T *
+#   39|               ValueCategory = prvalue(load)
+#   39|           expr converted: [ConstCast] const_cast<T *>...
 #   39|               Conversion = [PointerConversion] pointer conversion
 #   39|               Type = [PointerType] T *
 #   39|               ValueCategory = prvalue
-#   39|             expr: [VariableAccess] s
-#   39|                 Type = [PointerType] const T *
-#   39|                 ValueCategory = prvalue(load)
 #   40|     3: [DeclStmt] declaration
 #   40|       0: [VariableDeclarationEntry] definition of v
 #   40|           Type = [PointerType] const T *
 #   40|         init: [Initializer] initializer for v
-#   40|           expr: [DynamicCast] dynamic_cast<const T *>...
+#   40|           expr: [VariableAccess] t
+#   40|               Type = [PointerType] const S *
+#   40|               ValueCategory = prvalue(load)
+#   40|           expr converted: [DynamicCast] dynamic_cast<const T *>...
 #   40|               Conversion = [DynamicCast] dynamic_cast
 #   40|               Type = [PointerType] const T *
 #   40|               ValueCategory = prvalue
-#   40|             expr: [VariableAccess] t
-#   40|                 Type = [PointerType] const S *
-#   40|                 ValueCategory = prvalue(load)
 #   41|     4: [DeclStmt] declaration
 #   41|       0: [VariableDeclarationEntry] definition of w
 #   41|           Type = [PointerType] S *
 #   41|         init: [Initializer] initializer for w
-#   41|           expr: [ReinterpretCast] reinterpret_cast<S *>...
+#   41|           expr: [AddressOfExpr] & ...
+#   41|               Type = [PointerType] C *
+#   41|               ValueCategory = prvalue
+#   41|             0: [VariableAccess] c
+#   41|                 Type = [Class] C
+#   41|                 ValueCategory = lvalue
+#   41|           expr converted: [ReinterpretCast] reinterpret_cast<S *>...
 #   41|               Conversion = [PointerConversion] pointer conversion
 #   41|               Type = [PointerType] S *
 #   41|               ValueCategory = prvalue
-#   41|             expr: [AddressOfExpr] & ...
-#   41|                 Type = [PointerType] C *
-#   41|                 ValueCategory = prvalue
-#   41|               0: [VariableAccess] c
-#   41|                   Type = [Class] C
-#   41|                   ValueCategory = lvalue
 #   42|     5: [ReturnStmt] return ...
 #   42|       0: [ValueFieldAccess] b
 #   42|           Type = [IntType] int
@@ -1549,10 +1549,10 @@ union_etc.cpp:
 #   42|         -1: [PointerFieldAccess] c
 #   42|             Type = [NestedClass] C
 #   42|             ValueCategory = lvalue
+#   42|           -1: [VariableAccess] x
+#   42|               Type = [PointerType] T *
+#   42|               ValueCategory = prvalue(load)
 #   42|           -1: [CStyleCast] (S *)...
 #   42|               Conversion = [BaseClassConversion] base class conversion
 #   42|               Type = [PointerType] S *
 #   42|               ValueCategory = prvalue
-#   42|             expr: [VariableAccess] x
-#   42|                 Type = [PointerType] T *
-#   42|                 ValueCategory = prvalue(load)

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -349,6 +349,44 @@ Conversion4.c:
 #    2|                 Value = [Literal] 7
 #    2|                 ValueCategory = prvalue
 #    3|     1: [ReturnStmt] return ...
+#    5| [TopLevelFunction] char* retfn(void*)
+#    5|   params: 
+#    5|     0: [Parameter] v
+#    5|         Type = [VoidPointerType] void *
+#    5|   body: [BlockStmt] { ... }
+#    6|     0: [ReturnStmt] return ...
+#    6|       0: [CStyleCast] (char *)...
+#    6|           Conversion = [PointerConversion] pointer conversion
+#    6|           Type = [CharPointerType] char *
+#    6|           ValueCategory = prvalue
+#    6|         expr: [CStyleCast] (void *)...
+#    6|             Conversion = [PointerConversion] pointer conversion
+#    6|             Type = [VoidPointerType] void *
+#    6|             ValueCategory = prvalue
+#    6|           expr: [CStyleCast] (int *)...
+#    6|               Conversion = [PointerConversion] pointer conversion
+#    6|               Type = [IntPointerType] int *
+#    6|               ValueCategory = prvalue
+#    6|             expr: [VariableAccess] v
+#    6|                 Type = [VoidPointerType] void *
+#    6|                 ValueCategory = prvalue(load)
+#    9| [TopLevelFunction] void Conversion4_vardecl(int)
+#    9|   params: 
+#    9|     0: [Parameter] x
+#    9|         Type = [IntType] int
+#    9|   body: [BlockStmt] { ... }
+#   10|     0: [DeclStmt] declaration
+#   10|       0: [VariableDeclarationEntry] definition of y
+#   10|           Type = [LongType] long
+#   10|         init: [Initializer] initializer for y
+#   10|           expr: [CStyleCast] (long)...
+#   10|               Conversion = [IntegralConversion] integral conversion
+#   10|               Type = [LongType] long
+#   10|               ValueCategory = prvalue
+#   10|             expr: [VariableAccess] x
+#   10|                 Type = [IntType] int
+#   10|                 ValueCategory = prvalue(load)
+#   11|     1: [ReturnStmt] return ...
 DestructorCall.cpp:
 #    1| [Constructor] void C::C()
 #    1|   params: 

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -302,12 +302,12 @@ Conversion3.cpp:
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    2|             : [CStyleCast] (bool)...
+#    2|             expr: [CStyleCast] (bool)...
 #    2|                 Conversion = [BoolConversion] conversion to bool
 #    2|                 Type = [BoolType] bool
 #    2|                 Value = [CStyleCast] 1
 #    2|                 ValueCategory = prvalue
-#    2|               : [CStyleCast] (int)...
+#    2|               expr: [CStyleCast] (int)...
 #    2|                   Conversion = [IntegralConversion] integral conversion
 #    2|                   Type = [IntType] int
 #    2|                   Value = [CStyleCast] 1
@@ -316,7 +316,7 @@ Conversion3.cpp:
 #    2|               Type = [IntType] int
 #    2|               Value = [ParenthesisExpr] 7
 #    2|               ValueCategory = prvalue
-#    2|             : [CStyleCast] (int)...
+#    2|             expr: [CStyleCast] (int)...
 #    2|                 Conversion = [IntegralConversion] integral conversion
 #    2|                 Type = [IntType] int
 #    2|                 Value = [CStyleCast] 7
@@ -343,7 +343,7 @@ Conversion4.c:
 #    2|             Type = [IntType] int
 #    2|             Value = [ParenthesisExpr] 7
 #    2|             ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           expr: [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
@@ -362,11 +362,11 @@ Conversion4.c:
 #    6|           Conversion = [PointerConversion] pointer conversion
 #    6|           Type = [CharPointerType] char *
 #    6|           ValueCategory = prvalue
-#    6|         : [CStyleCast] (void *)...
+#    6|         expr: [CStyleCast] (void *)...
 #    6|             Conversion = [PointerConversion] pointer conversion
 #    6|             Type = [VoidPointerType] void *
 #    6|             ValueCategory = prvalue
-#    6|           : [CStyleCast] (int *)...
+#    6|           expr: [CStyleCast] (int *)...
 #    6|               Conversion = [PointerConversion] pointer conversion
 #    6|               Type = [IntPointerType] int *
 #    6|               ValueCategory = prvalue
@@ -565,15 +565,15 @@ DynamicCast.cpp:
 #   13|         0 converted: [ReferenceToExpr] (reference to)
 #   13|             Type = [LValueReferenceType] const Derived &
 #   13|             ValueCategory = prvalue
-#   13|           : [CStyleCast] (const Derived)...
+#   13|           expr: [CStyleCast] (const Derived)...
 #   13|               Conversion = [GlvalueConversion] glvalue conversion
 #   13|               Type = [SpecifiedType] const Derived
 #   13|               ValueCategory = lvalue
-#   13|             : [DynamicCast] dynamic_cast<Derived>...
+#   13|             expr: [DynamicCast] dynamic_cast<Derived>...
 #   13|                 Conversion = [DynamicCast] dynamic_cast
 #   13|                 Type = [Class] Derived
 #   13|                 ValueCategory = lvalue
-#   13|               : [ReferenceDereferenceExpr] (reference dereference)
+#   13|               expr: [ReferenceDereferenceExpr] (reference dereference)
 #   13|                   Type = [Class] Base
 #   13|                   ValueCategory = lvalue
 #   13|       0 converted: [ReferenceDereferenceExpr] (reference dereference)

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -191,7 +191,7 @@ bad_asts.cpp:
 #   27|               Conversion = [GlvalueConversion] glvalue conversion
 #   27|               Type = [Struct] Point
 #   27|               ValueCategory = prvalue(load)
-#   27|             : [ReferenceDereferenceExpr] (reference dereference)
+#   27|             expr: [ReferenceDereferenceExpr] (reference dereference)
 #   27|                 Type = [SpecifiedType] const Point
 #   27|                 ValueCategory = lvalue
 #   28|     1: [ReturnStmt] return ...
@@ -3316,7 +3316,7 @@ ir.cpp:
 #  189|               Conversion = [PointerConversion] pointer conversion
 #  189|               Type = [PointerType] wchar_t *
 #  189|               ValueCategory = prvalue
-#  189|             : [ArrayToPointerConversion] array to pointer conversion
+#  189|             expr: [ArrayToPointerConversion] array to pointer conversion
 #  189|                 Type = [PointerType] const wchar_t *
 #  189|                 ValueCategory = prvalue
 #  190|     2: [DeclStmt] declaration
@@ -5485,7 +5485,7 @@ ir.cpp:
 #  623|             Conversion = [GlvalueConversion] glvalue conversion
 #  623|             Type = [SpecifiedType] const String
 #  623|             ValueCategory = lvalue
-#  623|           : [ReferenceDereferenceExpr] (reference dereference)
+#  623|           expr: [ReferenceDereferenceExpr] (reference dereference)
 #  623|               Type = [Struct] String
 #  623|               ValueCategory = lvalue
 #  624|     1: [ExprStmt] ExprStmt
@@ -5819,7 +5819,7 @@ ir.cpp:
 #  687|           expr converted: [ReferenceToExpr] (reference to)
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue
-#  687|             : [ReferenceDereferenceExpr] (reference dereference)
+#  687|             expr: [ReferenceDereferenceExpr] (reference dereference)
 #  687|                 Type = [IntType] int
 #  687|                 ValueCategory = lvalue
 #  688|     2: [DeclStmt] declaration
@@ -5832,11 +5832,11 @@ ir.cpp:
 #  688|           expr converted: [ReferenceToExpr] (reference to)
 #  688|               Type = [LValueReferenceType] const String &
 #  688|               ValueCategory = prvalue
-#  688|             : [CStyleCast] (const String)...
+#  688|             expr: [CStyleCast] (const String)...
 #  688|                 Conversion = [GlvalueConversion] glvalue conversion
 #  688|                 Type = [SpecifiedType] const String
 #  688|                 ValueCategory = lvalue
-#  688|               : [ReferenceDereferenceExpr] (reference dereference)
+#  688|               expr: [ReferenceDereferenceExpr] (reference dereference)
 #  688|                   Type = [Struct] String
 #  688|                   ValueCategory = lvalue
 #  689|     3: [ReturnStmt] return ...
@@ -5873,7 +5873,7 @@ ir.cpp:
 #  694|             0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  694|                 Type = [IntPointerType] int *
 #  694|                 ValueCategory = prvalue
-#  694|               : [ReferenceDereferenceExpr] (reference dereference)
+#  694|               expr: [ReferenceDereferenceExpr] (reference dereference)
 #  694|                   Type = [ArrayType] int[10]
 #  694|                   ValueCategory = lvalue
 #  695|     3: [ReturnStmt] return ...
@@ -5945,7 +5945,7 @@ ir.cpp:
 #  705|             Conversion = [BoolConversion] conversion to bool
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
-#  705|           : [ParenthesisExpr] (...)
+#  705|           expr: [ParenthesisExpr] (...)
 #  705|               Type = [UnknownType] unknown
 #  705|               ValueCategory = prvalue
 #  704| [FunctionTemplateInstantiation,TopLevelFunction] int min<int>(int, int)
@@ -6660,7 +6660,7 @@ ir.cpp:
 #  808|         0 converted: [ReferenceToExpr] (reference to)
 #  808|             Type = [LValueReferenceType] const Base &
 #  808|             ValueCategory = prvalue
-#  808|           : [CStyleCast] (const Base)...
+#  808|           expr: [CStyleCast] (const Base)...
 #  808|               Conversion = [BaseClassConversion] base class conversion
 #  808|               Type = [SpecifiedType] const Base
 #  808|               ValueCategory = lvalue
@@ -6683,14 +6683,14 @@ ir.cpp:
 #  809|           0 converted: [ReferenceToExpr] (reference to)
 #  809|               Type = [LValueReferenceType] const Base &
 #  809|               ValueCategory = prvalue
-#  809|             : [CStyleCast] (const Base)...
+#  809|             expr: [CStyleCast] (const Base)...
 #  809|                 Conversion = [BaseClassConversion] base class conversion
 #  809|                 Type = [SpecifiedType] const Base
 #  809|                 ValueCategory = lvalue
 #  809|         0 converted: [ReferenceToExpr] (reference to)
 #  809|             Type = [LValueReferenceType] const Base &
 #  809|             ValueCategory = prvalue
-#  809|           : [CStyleCast] (const Base)...
+#  809|           expr: [CStyleCast] (const Base)...
 #  809|               Conversion = [GlvalueConversion] glvalue conversion
 #  809|               Type = [SpecifiedType] const Base
 #  809|               ValueCategory = lvalue
@@ -6713,14 +6713,14 @@ ir.cpp:
 #  810|           0 converted: [ReferenceToExpr] (reference to)
 #  810|               Type = [LValueReferenceType] const Base &
 #  810|               ValueCategory = prvalue
-#  810|             : [CStyleCast] (const Base)...
+#  810|             expr: [CStyleCast] (const Base)...
 #  810|                 Conversion = [BaseClassConversion] base class conversion
 #  810|                 Type = [SpecifiedType] const Base
 #  810|                 ValueCategory = lvalue
 #  810|         0 converted: [ReferenceToExpr] (reference to)
 #  810|             Type = [LValueReferenceType] const Base &
 #  810|             ValueCategory = prvalue
-#  810|           : [CStyleCast] (const Base)...
+#  810|           expr: [CStyleCast] (const Base)...
 #  810|               Conversion = [GlvalueConversion] glvalue conversion
 #  810|               Type = [SpecifiedType] const Base
 #  810|               ValueCategory = lvalue
@@ -6796,11 +6796,11 @@ ir.cpp:
 #  816|         0 converted: [ReferenceToExpr] (reference to)
 #  816|             Type = [LValueReferenceType] const Middle &
 #  816|             ValueCategory = prvalue
-#  816|           : [CStyleCast] (const Middle)...
+#  816|           expr: [CStyleCast] (const Middle)...
 #  816|               Conversion = [GlvalueConversion] glvalue conversion
 #  816|               Type = [SpecifiedType] const Middle
 #  816|               ValueCategory = lvalue
-#  816|             : [CStyleCast] (Middle)...
+#  816|             expr: [CStyleCast] (Middle)...
 #  816|                 Conversion = [DerivedClassConversion] derived class conversion
 #  816|                 Type = [Struct] Middle
 #  816|                 ValueCategory = lvalue
@@ -6820,11 +6820,11 @@ ir.cpp:
 #  817|         0 converted: [ReferenceToExpr] (reference to)
 #  817|             Type = [LValueReferenceType] const Middle &
 #  817|             ValueCategory = prvalue
-#  817|           : [CStyleCast] (const Middle)...
+#  817|           expr: [CStyleCast] (const Middle)...
 #  817|               Conversion = [GlvalueConversion] glvalue conversion
 #  817|               Type = [SpecifiedType] const Middle
 #  817|               ValueCategory = lvalue
-#  817|             : [StaticCast] static_cast<Middle>...
+#  817|             expr: [StaticCast] static_cast<Middle>...
 #  817|                 Conversion = [DerivedClassConversion] derived class conversion
 #  817|                 Type = [Struct] Middle
 #  817|                 ValueCategory = lvalue
@@ -6886,11 +6886,11 @@ ir.cpp:
 #  822|         0 converted: [ReferenceToExpr] (reference to)
 #  822|             Type = [LValueReferenceType] const Base &
 #  822|             ValueCategory = prvalue
-#  822|           : [CStyleCast] (const Base)...
+#  822|           expr: [CStyleCast] (const Base)...
 #  822|               Conversion = [BaseClassConversion] base class conversion
 #  822|               Type = [SpecifiedType] const Base
 #  822|               ValueCategory = lvalue
-#  822|             : [CStyleCast] (const Middle)...
+#  822|             expr: [CStyleCast] (const Middle)...
 #  822|                 Conversion = [BaseClassConversion] base class conversion
 #  822|                 Type = [SpecifiedType] const Middle
 #  822|                 ValueCategory = lvalue
@@ -6913,18 +6913,18 @@ ir.cpp:
 #  823|           0 converted: [ReferenceToExpr] (reference to)
 #  823|               Type = [LValueReferenceType] const Base &
 #  823|               ValueCategory = prvalue
-#  823|             : [CStyleCast] (const Base)...
+#  823|             expr: [CStyleCast] (const Base)...
 #  823|                 Conversion = [BaseClassConversion] base class conversion
 #  823|                 Type = [SpecifiedType] const Base
 #  823|                 ValueCategory = lvalue
-#  823|               : [CStyleCast] (const Middle)...
+#  823|               expr: [CStyleCast] (const Middle)...
 #  823|                   Conversion = [BaseClassConversion] base class conversion
 #  823|                   Type = [SpecifiedType] const Middle
 #  823|                   ValueCategory = lvalue
 #  823|         0 converted: [ReferenceToExpr] (reference to)
 #  823|             Type = [LValueReferenceType] const Base &
 #  823|             ValueCategory = prvalue
-#  823|           : [CStyleCast] (const Base)...
+#  823|           expr: [CStyleCast] (const Base)...
 #  823|               Conversion = [GlvalueConversion] glvalue conversion
 #  823|               Type = [SpecifiedType] const Base
 #  823|               ValueCategory = lvalue
@@ -6947,18 +6947,18 @@ ir.cpp:
 #  824|           0 converted: [ReferenceToExpr] (reference to)
 #  824|               Type = [LValueReferenceType] const Base &
 #  824|               ValueCategory = prvalue
-#  824|             : [CStyleCast] (const Base)...
+#  824|             expr: [CStyleCast] (const Base)...
 #  824|                 Conversion = [BaseClassConversion] base class conversion
 #  824|                 Type = [SpecifiedType] const Base
 #  824|                 ValueCategory = lvalue
-#  824|               : [CStyleCast] (const Middle)...
+#  824|               expr: [CStyleCast] (const Middle)...
 #  824|                   Conversion = [BaseClassConversion] base class conversion
 #  824|                   Type = [SpecifiedType] const Middle
 #  824|                   ValueCategory = lvalue
 #  824|         0 converted: [ReferenceToExpr] (reference to)
 #  824|             Type = [LValueReferenceType] const Base &
 #  824|             ValueCategory = prvalue
-#  824|           : [CStyleCast] (const Base)...
+#  824|           expr: [CStyleCast] (const Base)...
 #  824|               Conversion = [GlvalueConversion] glvalue conversion
 #  824|               Type = [SpecifiedType] const Base
 #  824|               ValueCategory = lvalue
@@ -6979,7 +6979,7 @@ ir.cpp:
 #  825|             Conversion = [BaseClassConversion] base class conversion
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = prvalue
-#  825|           : [CStyleCast] (Middle *)...
+#  825|           expr: [CStyleCast] (Middle *)...
 #  825|               Conversion = [BaseClassConversion] base class conversion
 #  825|               Type = [PointerType] Middle *
 #  825|               ValueCategory = prvalue
@@ -6997,7 +6997,7 @@ ir.cpp:
 #  826|             Conversion = [BaseClassConversion] base class conversion
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = prvalue
-#  826|           : [CStyleCast] (Middle *)...
+#  826|           expr: [CStyleCast] (Middle *)...
 #  826|               Conversion = [BaseClassConversion] base class conversion
 #  826|               Type = [PointerType] Middle *
 #  826|               ValueCategory = prvalue
@@ -7015,7 +7015,7 @@ ir.cpp:
 #  827|             Conversion = [BaseClassConversion] base class conversion
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = prvalue
-#  827|           : [CStyleCast] (Middle *)...
+#  827|           expr: [CStyleCast] (Middle *)...
 #  827|               Conversion = [BaseClassConversion] base class conversion
 #  827|               Type = [PointerType] Middle *
 #  827|               ValueCategory = prvalue
@@ -7046,15 +7046,15 @@ ir.cpp:
 #  830|         0 converted: [ReferenceToExpr] (reference to)
 #  830|             Type = [LValueReferenceType] const Derived &
 #  830|             ValueCategory = prvalue
-#  830|           : [CStyleCast] (const Derived)...
+#  830|           expr: [CStyleCast] (const Derived)...
 #  830|               Conversion = [GlvalueConversion] glvalue conversion
 #  830|               Type = [SpecifiedType] const Derived
 #  830|               ValueCategory = lvalue
-#  830|             : [CStyleCast] (Derived)...
+#  830|             expr: [CStyleCast] (Derived)...
 #  830|                 Conversion = [DerivedClassConversion] derived class conversion
 #  830|                 Type = [Struct] Derived
 #  830|                 ValueCategory = lvalue
-#  830|               : [CStyleCast] (Middle)...
+#  830|               expr: [CStyleCast] (Middle)...
 #  830|                   Conversion = [DerivedClassConversion] derived class conversion
 #  830|                   Type = [Struct] Middle
 #  830|                   ValueCategory = lvalue
@@ -7074,15 +7074,15 @@ ir.cpp:
 #  831|         0 converted: [ReferenceToExpr] (reference to)
 #  831|             Type = [LValueReferenceType] const Derived &
 #  831|             ValueCategory = prvalue
-#  831|           : [CStyleCast] (const Derived)...
+#  831|           expr: [CStyleCast] (const Derived)...
 #  831|               Conversion = [GlvalueConversion] glvalue conversion
 #  831|               Type = [SpecifiedType] const Derived
 #  831|               ValueCategory = lvalue
-#  831|             : [StaticCast] static_cast<Derived>...
+#  831|             expr: [StaticCast] static_cast<Derived>...
 #  831|                 Conversion = [DerivedClassConversion] derived class conversion
 #  831|                 Type = [Struct] Derived
 #  831|                 ValueCategory = lvalue
-#  831|               : [CStyleCast] (Middle)...
+#  831|               expr: [CStyleCast] (Middle)...
 #  831|                   Conversion = [DerivedClassConversion] derived class conversion
 #  831|                   Type = [Struct] Middle
 #  831|                   ValueCategory = lvalue
@@ -7103,7 +7103,7 @@ ir.cpp:
 #  832|             Conversion = [DerivedClassConversion] derived class conversion
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = prvalue
-#  832|           : [CStyleCast] (Middle *)...
+#  832|           expr: [CStyleCast] (Middle *)...
 #  832|               Conversion = [DerivedClassConversion] derived class conversion
 #  832|               Type = [PointerType] Middle *
 #  832|               ValueCategory = prvalue
@@ -7121,7 +7121,7 @@ ir.cpp:
 #  833|             Conversion = [DerivedClassConversion] derived class conversion
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = prvalue
-#  833|           : [CStyleCast] (Middle *)...
+#  833|           expr: [CStyleCast] (Middle *)...
 #  833|               Conversion = [DerivedClassConversion] derived class conversion
 #  833|               Type = [PointerType] Middle *
 #  833|               ValueCategory = prvalue
@@ -7302,7 +7302,7 @@ ir.cpp:
 #  858|           expr converted: [ReferenceToExpr] (reference to)
 #  858|               Type = [LValueReferenceType] PolymorphicBase &
 #  858|               ValueCategory = prvalue
-#  858|             : [DynamicCast] dynamic_cast<PolymorphicBase>...
+#  858|             expr: [DynamicCast] dynamic_cast<PolymorphicBase>...
 #  858|                 Conversion = [DynamicCast] dynamic_cast
 #  858|                 Type = [Struct] PolymorphicBase
 #  858|                 ValueCategory = lvalue
@@ -7330,7 +7330,7 @@ ir.cpp:
 #  861|           expr converted: [ReferenceToExpr] (reference to)
 #  861|               Type = [LValueReferenceType] PolymorphicDerived &
 #  861|               ValueCategory = prvalue
-#  861|             : [DynamicCast] dynamic_cast<PolymorphicDerived>...
+#  861|             expr: [DynamicCast] dynamic_cast<PolymorphicDerived>...
 #  861|                 Conversion = [DynamicCast] dynamic_cast
 #  861|                 Type = [Struct] PolymorphicDerived
 #  861|                 ValueCategory = lvalue
@@ -7389,7 +7389,7 @@ ir.cpp:
 #  873|               Conversion = [PointerConversion] pointer conversion
 #  873|               Type = [PointerType] const char *
 #  873|               ValueCategory = prvalue
-#  873|             : [ArrayToPointerConversion] array to pointer conversion
+#  873|             expr: [ArrayToPointerConversion] array to pointer conversion
 #  873|                 Type = [CharPointerType] char *
 #  873|                 ValueCategory = prvalue
 #  874|     2: [ExprStmt] ExprStmt
@@ -8536,7 +8536,7 @@ ir.cpp:
 # 1043|               .s converted: [ReferenceToExpr] (reference to)
 # 1043|                   Type = [LValueReferenceType] const String &
 # 1043|                   ValueCategory = prvalue
-# 1043|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1043|                 expr: [ReferenceDereferenceExpr] (reference dereference)
 # 1043|                     Type = [SpecifiedType] const String
 # 1043|                     ValueCategory = lvalue
 #-----|               .x converted: [ReferenceToExpr] (reference to)
@@ -8614,7 +8614,7 @@ ir.cpp:
 # 1047|               .s converted: [ReferenceToExpr] (reference to)
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue
-# 1047|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1047|                 expr: [ReferenceDereferenceExpr] (reference dereference)
 # 1047|                     Type = [SpecifiedType] const String
 # 1047|                     ValueCategory = lvalue
 # 1048|     7: [ExprStmt] ExprStmt
@@ -8689,7 +8689,7 @@ ir.cpp:
 # 1051|               .s converted: [ReferenceToExpr] (reference to)
 # 1051|                   Type = [LValueReferenceType] const String &
 # 1051|                   ValueCategory = prvalue
-# 1051|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1051|                 expr: [ReferenceDereferenceExpr] (reference dereference)
 # 1051|                     Type = [SpecifiedType] const String
 # 1051|                     ValueCategory = lvalue
 # 1052|     11: [ExprStmt] ExprStmt
@@ -8758,7 +8758,7 @@ ir.cpp:
 # 1054|               .s converted: [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] const String &
 # 1054|                   ValueCategory = prvalue
-# 1054|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1054|                 expr: [ReferenceDereferenceExpr] (reference dereference)
 # 1054|                     Type = [SpecifiedType] const String
 # 1054|                     ValueCategory = lvalue
 # 1054|               .j converted: [ReferenceToExpr] (reference to)

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -184,16 +184,16 @@ bad_asts.cpp:
 #   27|       0: [VariableDeclarationEntry] definition of b
 #   27|           Type = [Struct] Point
 #   27|         init: [Initializer] initializer for b
-#   27|           expr: [CStyleCast] (Point)...
+#   27|           expr: [VariableAccess] a
+#   27|               Type = [LValueReferenceType] const Point &
+#   27|               ValueCategory = prvalue(load)
+#   27|           expr converted: [CStyleCast] (Point)...
 #   27|               Conversion = [GlvalueConversion] glvalue conversion
 #   27|               Type = [Struct] Point
 #   27|               ValueCategory = prvalue(load)
-#   27|             expr: [ReferenceDereferenceExpr] (reference dereference)
+#   27|             : [ReferenceDereferenceExpr] (reference dereference)
 #   27|                 Type = [SpecifiedType] const Point
 #   27|                 ValueCategory = lvalue
-#   27|               expr: [VariableAccess] a
-#   27|                   Type = [LValueReferenceType] const Point &
-#   27|                   ValueCategory = prvalue(load)
 #   28|     1: [ReturnStmt] return ...
 #   30| [TopLevelFunction] void Bad::errorExpr()
 #   30|   params: 
@@ -242,14 +242,14 @@ complex.c:
 #    2|       0: [VariableDeclarationEntry] definition of cf
 #    2|           Type = [ArithmeticType] _Complex float
 #    2|         init: [Initializer] initializer for cf
-#    2|           expr: [CStyleCast] (_Complex float)...
+#    2|           expr: [Literal] 2.0
+#    2|               Type = [DoubleType] double
+#    2|               Value = [Literal] 2.0
+#    2|               ValueCategory = prvalue
+#    2|           expr converted: [CStyleCast] (_Complex float)...
 #    2|               Conversion = [FloatingPointConversion] floating point conversion
 #    2|               Type = [ArithmeticType] _Complex float
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 2.0
-#    2|                 Type = [DoubleType] double
-#    2|                 Value = [Literal] 2.0
-#    2|                 ValueCategory = prvalue
 #    3|     1: [ExprStmt] ExprStmt
 #    3|       0: [AssignExpr] ... = ...
 #    3|           Type = [ArithmeticType] _Complex float
@@ -257,26 +257,26 @@ complex.c:
 #    3|         0: [VariableAccess] cf
 #    3|             Type = [ArithmeticType] _Complex float
 #    3|             ValueCategory = lvalue
-#    3|         1: [CStyleCast] (_Complex float)...
+#    3|         1: [Literal] 1.0i
+#    3|             Type = [ArithmeticType] _Imaginary float
+#    3|             Value = [Literal] 1.0i
+#    3|             ValueCategory = prvalue
+#    3|         1 converted: [CStyleCast] (_Complex float)...
 #    3|             Conversion = [FloatingPointConversion] floating point conversion
 #    3|             Type = [ArithmeticType] _Complex float
 #    3|             ValueCategory = prvalue
-#    3|           expr: [Literal] 1.0i
-#    3|               Type = [ArithmeticType] _Imaginary float
-#    3|               Value = [Literal] 1.0i
-#    3|               ValueCategory = prvalue
 #    4|     2: [DeclStmt] declaration
 #    4|       0: [VariableDeclarationEntry] definition of cd
 #    4|           Type = [ArithmeticType] _Complex double
 #    4|         init: [Initializer] initializer for cd
-#    4|           expr: [CStyleCast] (_Complex double)...
+#    4|           expr: [Literal] 3.0
+#    4|               Type = [DoubleType] double
+#    4|               Value = [Literal] 3.0
+#    4|               ValueCategory = prvalue
+#    4|           expr converted: [CStyleCast] (_Complex double)...
 #    4|               Conversion = [FloatingPointConversion] floating point conversion
 #    4|               Type = [ArithmeticType] _Complex double
 #    4|               ValueCategory = prvalue
-#    4|             expr: [Literal] 3.0
-#    4|                 Type = [DoubleType] double
-#    4|                 Value = [Literal] 3.0
-#    4|                 ValueCategory = prvalue
 #    5|     3: [ExprStmt] ExprStmt
 #    5|       0: [AssignExpr] ... = ...
 #    5|           Type = [ArithmeticType] _Complex double
@@ -284,26 +284,26 @@ complex.c:
 #    5|         0: [VariableAccess] cd
 #    5|             Type = [ArithmeticType] _Complex double
 #    5|             ValueCategory = lvalue
-#    5|         1: [CStyleCast] (_Complex double)...
+#    5|         1: [Literal] 1.0i
+#    5|             Type = [ArithmeticType] _Imaginary float
+#    5|             Value = [Literal] 1.0i
+#    5|             ValueCategory = prvalue
+#    5|         1 converted: [CStyleCast] (_Complex double)...
 #    5|             Conversion = [FloatingPointConversion] floating point conversion
 #    5|             Type = [ArithmeticType] _Complex double
 #    5|             ValueCategory = prvalue
-#    5|           expr: [Literal] 1.0i
-#    5|               Type = [ArithmeticType] _Imaginary float
-#    5|               Value = [Literal] 1.0i
-#    5|               ValueCategory = prvalue
 #    6|     4: [DeclStmt] declaration
 #    6|       0: [VariableDeclarationEntry] definition of cld
 #    6|           Type = [ArithmeticType] _Complex long double
 #    6|         init: [Initializer] initializer for cld
-#    6|           expr: [CStyleCast] (_Complex long double)...
+#    6|           expr: [Literal] 5.0
+#    6|               Type = [DoubleType] double
+#    6|               Value = [Literal] 5.0
+#    6|               ValueCategory = prvalue
+#    6|           expr converted: [CStyleCast] (_Complex long double)...
 #    6|               Conversion = [FloatingPointConversion] floating point conversion
 #    6|               Type = [ArithmeticType] _Complex long double
 #    6|               ValueCategory = prvalue
-#    6|             expr: [Literal] 5.0
-#    6|                 Type = [DoubleType] double
-#    6|                 Value = [Literal] 5.0
-#    6|                 ValueCategory = prvalue
 #    7|     5: [ExprStmt] ExprStmt
 #    7|       0: [AssignExpr] ... = ...
 #    7|           Type = [ArithmeticType] _Complex long double
@@ -311,14 +311,14 @@ complex.c:
 #    7|         0: [VariableAccess] cld
 #    7|             Type = [ArithmeticType] _Complex long double
 #    7|             ValueCategory = lvalue
-#    7|         1: [CStyleCast] (_Complex long double)...
+#    7|         1: [Literal] 1.0i
+#    7|             Type = [ArithmeticType] _Imaginary float
+#    7|             Value = [Literal] 1.0i
+#    7|             ValueCategory = prvalue
+#    7|         1 converted: [CStyleCast] (_Complex long double)...
 #    7|             Conversion = [FloatingPointConversion] floating point conversion
 #    7|             Type = [ArithmeticType] _Complex long double
 #    7|             ValueCategory = prvalue
-#    7|           expr: [Literal] 1.0i
-#    7|               Type = [ArithmeticType] _Imaginary float
-#    7|               Value = [Literal] 1.0i
-#    7|               ValueCategory = prvalue
 #    9|     6: [DeclStmt] declaration
 #    9|       0: [VariableDeclarationEntry] definition of jf
 #    9|           Type = [ArithmeticType] _Imaginary float
@@ -331,26 +331,26 @@ complex.c:
 #   10|       0: [VariableDeclarationEntry] definition of jd
 #   10|           Type = [ArithmeticType] _Imaginary double
 #   10|         init: [Initializer] initializer for jd
-#   10|           expr: [CStyleCast] (_Imaginary double)...
+#   10|           expr: [Literal] 1.0i
+#   10|               Type = [ArithmeticType] _Imaginary float
+#   10|               Value = [Literal] 1.0i
+#   10|               ValueCategory = prvalue
+#   10|           expr converted: [CStyleCast] (_Imaginary double)...
 #   10|               Conversion = [FloatingPointConversion] floating point conversion
 #   10|               Type = [ArithmeticType] _Imaginary double
 #   10|               ValueCategory = prvalue
-#   10|             expr: [Literal] 1.0i
-#   10|                 Type = [ArithmeticType] _Imaginary float
-#   10|                 Value = [Literal] 1.0i
-#   10|                 ValueCategory = prvalue
 #   11|     8: [DeclStmt] declaration
 #   11|       0: [VariableDeclarationEntry] definition of jld
 #   11|           Type = [ArithmeticType] _Imaginary long double
 #   11|         init: [Initializer] initializer for jld
-#   11|           expr: [CStyleCast] (_Imaginary long double)...
+#   11|           expr: [Literal] 1.0i
+#   11|               Type = [ArithmeticType] _Imaginary float
+#   11|               Value = [Literal] 1.0i
+#   11|               ValueCategory = prvalue
+#   11|           expr converted: [CStyleCast] (_Imaginary long double)...
 #   11|               Conversion = [FloatingPointConversion] floating point conversion
 #   11|               Type = [ArithmeticType] _Imaginary long double
 #   11|               ValueCategory = prvalue
-#   11|             expr: [Literal] 1.0i
-#   11|                 Type = [ArithmeticType] _Imaginary float
-#   11|                 Value = [Literal] 1.0i
-#   11|                 ValueCategory = prvalue
 #   12|     9: [ReturnStmt] return ...
 #   14| [TopLevelFunction] void complex_arithmetic()
 #   14|   params: 
@@ -359,28 +359,28 @@ complex.c:
 #   15|       0: [VariableDeclarationEntry] definition of f1
 #   15|           Type = [FloatType] float
 #   15|         init: [Initializer] initializer for f1
-#   15|           expr: [CStyleCast] (float)...
+#   15|           expr: [Literal] 5.0
+#   15|               Type = [DoubleType] double
+#   15|               Value = [Literal] 5.0
+#   15|               ValueCategory = prvalue
+#   15|           expr converted: [CStyleCast] (float)...
 #   15|               Conversion = [FloatingPointConversion] floating point conversion
 #   15|               Type = [FloatType] float
 #   15|               Value = [CStyleCast] 5.0
 #   15|               ValueCategory = prvalue
-#   15|             expr: [Literal] 5.0
-#   15|                 Type = [DoubleType] double
-#   15|                 Value = [Literal] 5.0
-#   15|                 ValueCategory = prvalue
 #   16|     1: [DeclStmt] declaration
 #   16|       0: [VariableDeclarationEntry] definition of f2
 #   16|           Type = [FloatType] float
 #   16|         init: [Initializer] initializer for f2
-#   16|           expr: [CStyleCast] (float)...
+#   16|           expr: [Literal] 7.0
+#   16|               Type = [DoubleType] double
+#   16|               Value = [Literal] 7.0
+#   16|               ValueCategory = prvalue
+#   16|           expr converted: [CStyleCast] (float)...
 #   16|               Conversion = [FloatingPointConversion] floating point conversion
 #   16|               Type = [FloatType] float
 #   16|               Value = [CStyleCast] 7.0
 #   16|               ValueCategory = prvalue
-#   16|             expr: [Literal] 7.0
-#   16|                 Type = [DoubleType] double
-#   16|                 Value = [Literal] 7.0
-#   16|                 ValueCategory = prvalue
 #   17|     2: [DeclStmt] declaration
 #   17|       0: [VariableDeclarationEntry] definition of f3
 #   17|           Type = [FloatType] float
@@ -388,26 +388,26 @@ complex.c:
 #   18|       0: [VariableDeclarationEntry] definition of cf1
 #   18|           Type = [ArithmeticType] _Complex float
 #   18|         init: [Initializer] initializer for cf1
-#   18|           expr: [CStyleCast] (_Complex float)...
+#   18|           expr: [Literal] 2.0
+#   18|               Type = [DoubleType] double
+#   18|               Value = [Literal] 2.0
+#   18|               ValueCategory = prvalue
+#   18|           expr converted: [CStyleCast] (_Complex float)...
 #   18|               Conversion = [FloatingPointConversion] floating point conversion
 #   18|               Type = [ArithmeticType] _Complex float
 #   18|               ValueCategory = prvalue
-#   18|             expr: [Literal] 2.0
-#   18|                 Type = [DoubleType] double
-#   18|                 Value = [Literal] 2.0
-#   18|                 ValueCategory = prvalue
 #   19|     4: [DeclStmt] declaration
 #   19|       0: [VariableDeclarationEntry] definition of cf2
 #   19|           Type = [ArithmeticType] _Complex float
 #   19|         init: [Initializer] initializer for cf2
-#   19|           expr: [CStyleCast] (_Complex float)...
+#   19|           expr: [Literal] 1.0i
+#   19|               Type = [ArithmeticType] _Imaginary float
+#   19|               Value = [Literal] 1.0i
+#   19|               ValueCategory = prvalue
+#   19|           expr converted: [CStyleCast] (_Complex float)...
 #   19|               Conversion = [FloatingPointConversion] floating point conversion
 #   19|               Type = [ArithmeticType] _Complex float
 #   19|               ValueCategory = prvalue
-#   19|             expr: [Literal] 1.0i
-#   19|                 Type = [ArithmeticType] _Imaginary float
-#   19|                 Value = [Literal] 1.0i
-#   19|                 ValueCategory = prvalue
 #   20|     5: [DeclStmt] declaration
 #   20|       0: [VariableDeclarationEntry] definition of cf3
 #   20|           Type = [ArithmeticType] _Complex float
@@ -746,15 +746,15 @@ complex.c:
 #   59|       0: [VariableDeclarationEntry] definition of f
 #   59|           Type = [FloatType] float
 #   59|         init: [Initializer] initializer for f
-#   59|           expr: [CStyleCast] (float)...
+#   59|           expr: [Literal] 2.0
+#   59|               Type = [DoubleType] double
+#   59|               Value = [Literal] 2.0
+#   59|               ValueCategory = prvalue
+#   59|           expr converted: [CStyleCast] (float)...
 #   59|               Conversion = [FloatingPointConversion] floating point conversion
 #   59|               Type = [FloatType] float
 #   59|               Value = [CStyleCast] 2.0
 #   59|               ValueCategory = prvalue
-#   59|             expr: [Literal] 2.0
-#   59|                 Type = [DoubleType] double
-#   59|                 Value = [Literal] 2.0
-#   59|                 ValueCategory = prvalue
 #   60|     1: [DeclStmt] declaration
 #   60|       0: [VariableDeclarationEntry] definition of d
 #   60|           Type = [DoubleType] double
@@ -767,51 +767,51 @@ complex.c:
 #   61|       0: [VariableDeclarationEntry] definition of ld
 #   61|           Type = [LongDoubleType] long double
 #   61|         init: [Initializer] initializer for ld
-#   61|           expr: [CStyleCast] (long double)...
+#   61|           expr: [Literal] 5.0
+#   61|               Type = [DoubleType] double
+#   61|               Value = [Literal] 5.0
+#   61|               ValueCategory = prvalue
+#   61|           expr converted: [CStyleCast] (long double)...
 #   61|               Conversion = [FloatingPointConversion] floating point conversion
 #   61|               Type = [LongDoubleType] long double
 #   61|               Value = [CStyleCast] 5.0
 #   61|               ValueCategory = prvalue
-#   61|             expr: [Literal] 5.0
-#   61|                 Type = [DoubleType] double
-#   61|                 Value = [Literal] 5.0
-#   61|                 ValueCategory = prvalue
 #   62|     3: [DeclStmt] declaration
 #   62|       0: [VariableDeclarationEntry] definition of cf
 #   62|           Type = [ArithmeticType] _Complex float
 #   62|         init: [Initializer] initializer for cf
-#   62|           expr: [CStyleCast] (_Complex float)...
+#   62|           expr: [Literal] 7.0
+#   62|               Type = [DoubleType] double
+#   62|               Value = [Literal] 7.0
+#   62|               ValueCategory = prvalue
+#   62|           expr converted: [CStyleCast] (_Complex float)...
 #   62|               Conversion = [FloatingPointConversion] floating point conversion
 #   62|               Type = [ArithmeticType] _Complex float
 #   62|               ValueCategory = prvalue
-#   62|             expr: [Literal] 7.0
-#   62|                 Type = [DoubleType] double
-#   62|                 Value = [Literal] 7.0
-#   62|                 ValueCategory = prvalue
 #   63|     4: [DeclStmt] declaration
 #   63|       0: [VariableDeclarationEntry] definition of cd
 #   63|           Type = [ArithmeticType] _Complex double
 #   63|         init: [Initializer] initializer for cd
-#   63|           expr: [CStyleCast] (_Complex double)...
+#   63|           expr: [Literal] 11.0
+#   63|               Type = [DoubleType] double
+#   63|               Value = [Literal] 11.0
+#   63|               ValueCategory = prvalue
+#   63|           expr converted: [CStyleCast] (_Complex double)...
 #   63|               Conversion = [FloatingPointConversion] floating point conversion
 #   63|               Type = [ArithmeticType] _Complex double
 #   63|               ValueCategory = prvalue
-#   63|             expr: [Literal] 11.0
-#   63|                 Type = [DoubleType] double
-#   63|                 Value = [Literal] 11.0
-#   63|                 ValueCategory = prvalue
 #   64|     5: [DeclStmt] declaration
 #   64|       0: [VariableDeclarationEntry] definition of cld
 #   64|           Type = [ArithmeticType] _Complex long double
 #   64|         init: [Initializer] initializer for cld
-#   64|           expr: [CStyleCast] (_Complex long double)...
+#   64|           expr: [Literal] 13.0
+#   64|               Type = [DoubleType] double
+#   64|               Value = [Literal] 13.0
+#   64|               ValueCategory = prvalue
+#   64|           expr converted: [CStyleCast] (_Complex long double)...
 #   64|               Conversion = [FloatingPointConversion] floating point conversion
 #   64|               Type = [ArithmeticType] _Complex long double
 #   64|               ValueCategory = prvalue
-#   64|             expr: [Literal] 13.0
-#   64|                 Type = [DoubleType] double
-#   64|                 Value = [Literal] 13.0
-#   64|                 ValueCategory = prvalue
 #   65|     6: [DeclStmt] declaration
 #   65|       0: [VariableDeclarationEntry] definition of jf
 #   65|           Type = [ArithmeticType] _Imaginary float
@@ -824,26 +824,26 @@ complex.c:
 #   66|       0: [VariableDeclarationEntry] definition of jd
 #   66|           Type = [ArithmeticType] _Imaginary double
 #   66|         init: [Initializer] initializer for jd
-#   66|           expr: [CStyleCast] (_Imaginary double)...
+#   66|           expr: [Literal] 1.0i
+#   66|               Type = [ArithmeticType] _Imaginary float
+#   66|               Value = [Literal] 1.0i
+#   66|               ValueCategory = prvalue
+#   66|           expr converted: [CStyleCast] (_Imaginary double)...
 #   66|               Conversion = [FloatingPointConversion] floating point conversion
 #   66|               Type = [ArithmeticType] _Imaginary double
 #   66|               ValueCategory = prvalue
-#   66|             expr: [Literal] 1.0i
-#   66|                 Type = [ArithmeticType] _Imaginary float
-#   66|                 Value = [Literal] 1.0i
-#   66|                 ValueCategory = prvalue
 #   67|     8: [DeclStmt] declaration
 #   67|       0: [VariableDeclarationEntry] definition of jld
 #   67|           Type = [ArithmeticType] _Imaginary long double
 #   67|         init: [Initializer] initializer for jld
-#   67|           expr: [CStyleCast] (_Imaginary long double)...
+#   67|           expr: [Literal] 1.0i
+#   67|               Type = [ArithmeticType] _Imaginary float
+#   67|               Value = [Literal] 1.0i
+#   67|               ValueCategory = prvalue
+#   67|           expr converted: [CStyleCast] (_Imaginary long double)...
 #   67|               Conversion = [FloatingPointConversion] floating point conversion
 #   67|               Type = [ArithmeticType] _Imaginary long double
 #   67|               ValueCategory = prvalue
-#   67|             expr: [Literal] 1.0i
-#   67|                 Type = [ArithmeticType] _Imaginary float
-#   67|                 Value = [Literal] 1.0i
-#   67|                 ValueCategory = prvalue
 #   70|     9: [ExprStmt] ExprStmt
 #   70|       0: [AssignExpr] ... = ...
 #   70|           Type = [ArithmeticType] _Complex float
@@ -861,13 +861,13 @@ complex.c:
 #   71|         0: [VariableAccess] cf
 #   71|             Type = [ArithmeticType] _Complex float
 #   71|             ValueCategory = lvalue
-#   71|         1: [CStyleCast] (_Complex float)...
+#   71|         1: [VariableAccess] cd
+#   71|             Type = [ArithmeticType] _Complex double
+#   71|             ValueCategory = prvalue(load)
+#   71|         1 converted: [CStyleCast] (_Complex float)...
 #   71|             Conversion = [FloatingPointConversion] floating point conversion
 #   71|             Type = [ArithmeticType] _Complex float
 #   71|             ValueCategory = prvalue
-#   71|           expr: [VariableAccess] cd
-#   71|               Type = [ArithmeticType] _Complex double
-#   71|               ValueCategory = prvalue(load)
 #   72|     11: [ExprStmt] ExprStmt
 #   72|       0: [AssignExpr] ... = ...
 #   72|           Type = [ArithmeticType] _Complex float
@@ -875,13 +875,13 @@ complex.c:
 #   72|         0: [VariableAccess] cf
 #   72|             Type = [ArithmeticType] _Complex float
 #   72|             ValueCategory = lvalue
-#   72|         1: [CStyleCast] (_Complex float)...
+#   72|         1: [VariableAccess] cld
+#   72|             Type = [ArithmeticType] _Complex long double
+#   72|             ValueCategory = prvalue(load)
+#   72|         1 converted: [CStyleCast] (_Complex float)...
 #   72|             Conversion = [FloatingPointConversion] floating point conversion
 #   72|             Type = [ArithmeticType] _Complex float
 #   72|             ValueCategory = prvalue
-#   72|           expr: [VariableAccess] cld
-#   72|               Type = [ArithmeticType] _Complex long double
-#   72|               ValueCategory = prvalue(load)
 #   73|     12: [ExprStmt] ExprStmt
 #   73|       0: [AssignExpr] ... = ...
 #   73|           Type = [ArithmeticType] _Complex double
@@ -889,13 +889,13 @@ complex.c:
 #   73|         0: [VariableAccess] cd
 #   73|             Type = [ArithmeticType] _Complex double
 #   73|             ValueCategory = lvalue
-#   73|         1: [CStyleCast] (_Complex double)...
+#   73|         1: [VariableAccess] cf
+#   73|             Type = [ArithmeticType] _Complex float
+#   73|             ValueCategory = prvalue(load)
+#   73|         1 converted: [CStyleCast] (_Complex double)...
 #   73|             Conversion = [FloatingPointConversion] floating point conversion
 #   73|             Type = [ArithmeticType] _Complex double
 #   73|             ValueCategory = prvalue
-#   73|           expr: [VariableAccess] cf
-#   73|               Type = [ArithmeticType] _Complex float
-#   73|               ValueCategory = prvalue(load)
 #   74|     13: [ExprStmt] ExprStmt
 #   74|       0: [AssignExpr] ... = ...
 #   74|           Type = [ArithmeticType] _Complex double
@@ -913,13 +913,13 @@ complex.c:
 #   75|         0: [VariableAccess] cd
 #   75|             Type = [ArithmeticType] _Complex double
 #   75|             ValueCategory = lvalue
-#   75|         1: [CStyleCast] (_Complex double)...
+#   75|         1: [VariableAccess] cld
+#   75|             Type = [ArithmeticType] _Complex long double
+#   75|             ValueCategory = prvalue(load)
+#   75|         1 converted: [CStyleCast] (_Complex double)...
 #   75|             Conversion = [FloatingPointConversion] floating point conversion
 #   75|             Type = [ArithmeticType] _Complex double
 #   75|             ValueCategory = prvalue
-#   75|           expr: [VariableAccess] cld
-#   75|               Type = [ArithmeticType] _Complex long double
-#   75|               ValueCategory = prvalue(load)
 #   76|     15: [ExprStmt] ExprStmt
 #   76|       0: [AssignExpr] ... = ...
 #   76|           Type = [ArithmeticType] _Complex long double
@@ -927,13 +927,13 @@ complex.c:
 #   76|         0: [VariableAccess] cld
 #   76|             Type = [ArithmeticType] _Complex long double
 #   76|             ValueCategory = lvalue
-#   76|         1: [CStyleCast] (_Complex long double)...
+#   76|         1: [VariableAccess] cf
+#   76|             Type = [ArithmeticType] _Complex float
+#   76|             ValueCategory = prvalue(load)
+#   76|         1 converted: [CStyleCast] (_Complex long double)...
 #   76|             Conversion = [FloatingPointConversion] floating point conversion
 #   76|             Type = [ArithmeticType] _Complex long double
 #   76|             ValueCategory = prvalue
-#   76|           expr: [VariableAccess] cf
-#   76|               Type = [ArithmeticType] _Complex float
-#   76|               ValueCategory = prvalue(load)
 #   77|     16: [ExprStmt] ExprStmt
 #   77|       0: [AssignExpr] ... = ...
 #   77|           Type = [ArithmeticType] _Complex long double
@@ -941,13 +941,13 @@ complex.c:
 #   77|         0: [VariableAccess] cld
 #   77|             Type = [ArithmeticType] _Complex long double
 #   77|             ValueCategory = lvalue
-#   77|         1: [CStyleCast] (_Complex long double)...
+#   77|         1: [VariableAccess] cd
+#   77|             Type = [ArithmeticType] _Complex double
+#   77|             ValueCategory = prvalue(load)
+#   77|         1 converted: [CStyleCast] (_Complex long double)...
 #   77|             Conversion = [FloatingPointConversion] floating point conversion
 #   77|             Type = [ArithmeticType] _Complex long double
 #   77|             ValueCategory = prvalue
-#   77|           expr: [VariableAccess] cd
-#   77|               Type = [ArithmeticType] _Complex double
-#   77|               ValueCategory = prvalue(load)
 #   78|     17: [ExprStmt] ExprStmt
 #   78|       0: [AssignExpr] ... = ...
 #   78|           Type = [ArithmeticType] _Complex long double
@@ -965,13 +965,13 @@ complex.c:
 #   81|         0: [VariableAccess] cf
 #   81|             Type = [ArithmeticType] _Complex float
 #   81|             ValueCategory = lvalue
-#   81|         1: [CStyleCast] (_Complex float)...
+#   81|         1: [VariableAccess] f
+#   81|             Type = [FloatType] float
+#   81|             ValueCategory = prvalue(load)
+#   81|         1 converted: [CStyleCast] (_Complex float)...
 #   81|             Conversion = [FloatingPointConversion] floating point conversion
 #   81|             Type = [ArithmeticType] _Complex float
 #   81|             ValueCategory = prvalue
-#   81|           expr: [VariableAccess] f
-#   81|               Type = [FloatType] float
-#   81|               ValueCategory = prvalue(load)
 #   82|     19: [ExprStmt] ExprStmt
 #   82|       0: [AssignExpr] ... = ...
 #   82|           Type = [ArithmeticType] _Complex float
@@ -979,13 +979,13 @@ complex.c:
 #   82|         0: [VariableAccess] cf
 #   82|             Type = [ArithmeticType] _Complex float
 #   82|             ValueCategory = lvalue
-#   82|         1: [CStyleCast] (_Complex float)...
+#   82|         1: [VariableAccess] d
+#   82|             Type = [DoubleType] double
+#   82|             ValueCategory = prvalue(load)
+#   82|         1 converted: [CStyleCast] (_Complex float)...
 #   82|             Conversion = [FloatingPointConversion] floating point conversion
 #   82|             Type = [ArithmeticType] _Complex float
 #   82|             ValueCategory = prvalue
-#   82|           expr: [VariableAccess] d
-#   82|               Type = [DoubleType] double
-#   82|               ValueCategory = prvalue(load)
 #   83|     20: [ExprStmt] ExprStmt
 #   83|       0: [AssignExpr] ... = ...
 #   83|           Type = [ArithmeticType] _Complex float
@@ -993,13 +993,13 @@ complex.c:
 #   83|         0: [VariableAccess] cf
 #   83|             Type = [ArithmeticType] _Complex float
 #   83|             ValueCategory = lvalue
-#   83|         1: [CStyleCast] (_Complex float)...
+#   83|         1: [VariableAccess] ld
+#   83|             Type = [LongDoubleType] long double
+#   83|             ValueCategory = prvalue(load)
+#   83|         1 converted: [CStyleCast] (_Complex float)...
 #   83|             Conversion = [FloatingPointConversion] floating point conversion
 #   83|             Type = [ArithmeticType] _Complex float
 #   83|             ValueCategory = prvalue
-#   83|           expr: [VariableAccess] ld
-#   83|               Type = [LongDoubleType] long double
-#   83|               ValueCategory = prvalue(load)
 #   84|     21: [ExprStmt] ExprStmt
 #   84|       0: [AssignExpr] ... = ...
 #   84|           Type = [ArithmeticType] _Complex double
@@ -1007,13 +1007,13 @@ complex.c:
 #   84|         0: [VariableAccess] cd
 #   84|             Type = [ArithmeticType] _Complex double
 #   84|             ValueCategory = lvalue
-#   84|         1: [CStyleCast] (_Complex double)...
+#   84|         1: [VariableAccess] f
+#   84|             Type = [FloatType] float
+#   84|             ValueCategory = prvalue(load)
+#   84|         1 converted: [CStyleCast] (_Complex double)...
 #   84|             Conversion = [FloatingPointConversion] floating point conversion
 #   84|             Type = [ArithmeticType] _Complex double
 #   84|             ValueCategory = prvalue
-#   84|           expr: [VariableAccess] f
-#   84|               Type = [FloatType] float
-#   84|               ValueCategory = prvalue(load)
 #   85|     22: [ExprStmt] ExprStmt
 #   85|       0: [AssignExpr] ... = ...
 #   85|           Type = [ArithmeticType] _Complex double
@@ -1021,13 +1021,13 @@ complex.c:
 #   85|         0: [VariableAccess] cd
 #   85|             Type = [ArithmeticType] _Complex double
 #   85|             ValueCategory = lvalue
-#   85|         1: [CStyleCast] (_Complex double)...
+#   85|         1: [VariableAccess] d
+#   85|             Type = [DoubleType] double
+#   85|             ValueCategory = prvalue(load)
+#   85|         1 converted: [CStyleCast] (_Complex double)...
 #   85|             Conversion = [FloatingPointConversion] floating point conversion
 #   85|             Type = [ArithmeticType] _Complex double
 #   85|             ValueCategory = prvalue
-#   85|           expr: [VariableAccess] d
-#   85|               Type = [DoubleType] double
-#   85|               ValueCategory = prvalue(load)
 #   86|     23: [ExprStmt] ExprStmt
 #   86|       0: [AssignExpr] ... = ...
 #   86|           Type = [ArithmeticType] _Complex double
@@ -1035,13 +1035,13 @@ complex.c:
 #   86|         0: [VariableAccess] cd
 #   86|             Type = [ArithmeticType] _Complex double
 #   86|             ValueCategory = lvalue
-#   86|         1: [CStyleCast] (_Complex double)...
+#   86|         1: [VariableAccess] ld
+#   86|             Type = [LongDoubleType] long double
+#   86|             ValueCategory = prvalue(load)
+#   86|         1 converted: [CStyleCast] (_Complex double)...
 #   86|             Conversion = [FloatingPointConversion] floating point conversion
 #   86|             Type = [ArithmeticType] _Complex double
 #   86|             ValueCategory = prvalue
-#   86|           expr: [VariableAccess] ld
-#   86|               Type = [LongDoubleType] long double
-#   86|               ValueCategory = prvalue(load)
 #   87|     24: [ExprStmt] ExprStmt
 #   87|       0: [AssignExpr] ... = ...
 #   87|           Type = [ArithmeticType] _Complex long double
@@ -1049,13 +1049,13 @@ complex.c:
 #   87|         0: [VariableAccess] cld
 #   87|             Type = [ArithmeticType] _Complex long double
 #   87|             ValueCategory = lvalue
-#   87|         1: [CStyleCast] (_Complex long double)...
+#   87|         1: [VariableAccess] f
+#   87|             Type = [FloatType] float
+#   87|             ValueCategory = prvalue(load)
+#   87|         1 converted: [CStyleCast] (_Complex long double)...
 #   87|             Conversion = [FloatingPointConversion] floating point conversion
 #   87|             Type = [ArithmeticType] _Complex long double
 #   87|             ValueCategory = prvalue
-#   87|           expr: [VariableAccess] f
-#   87|               Type = [FloatType] float
-#   87|               ValueCategory = prvalue(load)
 #   88|     25: [ExprStmt] ExprStmt
 #   88|       0: [AssignExpr] ... = ...
 #   88|           Type = [ArithmeticType] _Complex long double
@@ -1063,13 +1063,13 @@ complex.c:
 #   88|         0: [VariableAccess] cld
 #   88|             Type = [ArithmeticType] _Complex long double
 #   88|             ValueCategory = lvalue
-#   88|         1: [CStyleCast] (_Complex long double)...
+#   88|         1: [VariableAccess] d
+#   88|             Type = [DoubleType] double
+#   88|             ValueCategory = prvalue(load)
+#   88|         1 converted: [CStyleCast] (_Complex long double)...
 #   88|             Conversion = [FloatingPointConversion] floating point conversion
 #   88|             Type = [ArithmeticType] _Complex long double
 #   88|             ValueCategory = prvalue
-#   88|           expr: [VariableAccess] d
-#   88|               Type = [DoubleType] double
-#   88|               ValueCategory = prvalue(load)
 #   89|     26: [ExprStmt] ExprStmt
 #   89|       0: [AssignExpr] ... = ...
 #   89|           Type = [ArithmeticType] _Complex long double
@@ -1077,13 +1077,13 @@ complex.c:
 #   89|         0: [VariableAccess] cld
 #   89|             Type = [ArithmeticType] _Complex long double
 #   89|             ValueCategory = lvalue
-#   89|         1: [CStyleCast] (_Complex long double)...
+#   89|         1: [VariableAccess] ld
+#   89|             Type = [LongDoubleType] long double
+#   89|             ValueCategory = prvalue(load)
+#   89|         1 converted: [CStyleCast] (_Complex long double)...
 #   89|             Conversion = [FloatingPointConversion] floating point conversion
 #   89|             Type = [ArithmeticType] _Complex long double
 #   89|             ValueCategory = prvalue
-#   89|           expr: [VariableAccess] ld
-#   89|               Type = [LongDoubleType] long double
-#   89|               ValueCategory = prvalue(load)
 #   92|     27: [ExprStmt] ExprStmt
 #   92|       0: [AssignExpr] ... = ...
 #   92|           Type = [FloatType] float
@@ -1091,13 +1091,13 @@ complex.c:
 #   92|         0: [VariableAccess] f
 #   92|             Type = [FloatType] float
 #   92|             ValueCategory = lvalue
-#   92|         1: [CStyleCast] (float)...
+#   92|         1: [VariableAccess] cf
+#   92|             Type = [ArithmeticType] _Complex float
+#   92|             ValueCategory = prvalue(load)
+#   92|         1 converted: [CStyleCast] (float)...
 #   92|             Conversion = [FloatingPointConversion] floating point conversion
 #   92|             Type = [FloatType] float
 #   92|             ValueCategory = prvalue
-#   92|           expr: [VariableAccess] cf
-#   92|               Type = [ArithmeticType] _Complex float
-#   92|               ValueCategory = prvalue(load)
 #   93|     28: [ExprStmt] ExprStmt
 #   93|       0: [AssignExpr] ... = ...
 #   93|           Type = [FloatType] float
@@ -1105,13 +1105,13 @@ complex.c:
 #   93|         0: [VariableAccess] f
 #   93|             Type = [FloatType] float
 #   93|             ValueCategory = lvalue
-#   93|         1: [CStyleCast] (float)...
+#   93|         1: [VariableAccess] cd
+#   93|             Type = [ArithmeticType] _Complex double
+#   93|             ValueCategory = prvalue(load)
+#   93|         1 converted: [CStyleCast] (float)...
 #   93|             Conversion = [FloatingPointConversion] floating point conversion
 #   93|             Type = [FloatType] float
 #   93|             ValueCategory = prvalue
-#   93|           expr: [VariableAccess] cd
-#   93|               Type = [ArithmeticType] _Complex double
-#   93|               ValueCategory = prvalue(load)
 #   94|     29: [ExprStmt] ExprStmt
 #   94|       0: [AssignExpr] ... = ...
 #   94|           Type = [FloatType] float
@@ -1119,13 +1119,13 @@ complex.c:
 #   94|         0: [VariableAccess] f
 #   94|             Type = [FloatType] float
 #   94|             ValueCategory = lvalue
-#   94|         1: [CStyleCast] (float)...
+#   94|         1: [VariableAccess] cld
+#   94|             Type = [ArithmeticType] _Complex long double
+#   94|             ValueCategory = prvalue(load)
+#   94|         1 converted: [CStyleCast] (float)...
 #   94|             Conversion = [FloatingPointConversion] floating point conversion
 #   94|             Type = [FloatType] float
 #   94|             ValueCategory = prvalue
-#   94|           expr: [VariableAccess] cld
-#   94|               Type = [ArithmeticType] _Complex long double
-#   94|               ValueCategory = prvalue(load)
 #   95|     30: [ExprStmt] ExprStmt
 #   95|       0: [AssignExpr] ... = ...
 #   95|           Type = [DoubleType] double
@@ -1133,13 +1133,13 @@ complex.c:
 #   95|         0: [VariableAccess] d
 #   95|             Type = [DoubleType] double
 #   95|             ValueCategory = lvalue
-#   95|         1: [CStyleCast] (double)...
+#   95|         1: [VariableAccess] cf
+#   95|             Type = [ArithmeticType] _Complex float
+#   95|             ValueCategory = prvalue(load)
+#   95|         1 converted: [CStyleCast] (double)...
 #   95|             Conversion = [FloatingPointConversion] floating point conversion
 #   95|             Type = [DoubleType] double
 #   95|             ValueCategory = prvalue
-#   95|           expr: [VariableAccess] cf
-#   95|               Type = [ArithmeticType] _Complex float
-#   95|               ValueCategory = prvalue(load)
 #   96|     31: [ExprStmt] ExprStmt
 #   96|       0: [AssignExpr] ... = ...
 #   96|           Type = [DoubleType] double
@@ -1147,13 +1147,13 @@ complex.c:
 #   96|         0: [VariableAccess] d
 #   96|             Type = [DoubleType] double
 #   96|             ValueCategory = lvalue
-#   96|         1: [CStyleCast] (double)...
+#   96|         1: [VariableAccess] cd
+#   96|             Type = [ArithmeticType] _Complex double
+#   96|             ValueCategory = prvalue(load)
+#   96|         1 converted: [CStyleCast] (double)...
 #   96|             Conversion = [FloatingPointConversion] floating point conversion
 #   96|             Type = [DoubleType] double
 #   96|             ValueCategory = prvalue
-#   96|           expr: [VariableAccess] cd
-#   96|               Type = [ArithmeticType] _Complex double
-#   96|               ValueCategory = prvalue(load)
 #   97|     32: [ExprStmt] ExprStmt
 #   97|       0: [AssignExpr] ... = ...
 #   97|           Type = [DoubleType] double
@@ -1161,13 +1161,13 @@ complex.c:
 #   97|         0: [VariableAccess] d
 #   97|             Type = [DoubleType] double
 #   97|             ValueCategory = lvalue
-#   97|         1: [CStyleCast] (double)...
+#   97|         1: [VariableAccess] cld
+#   97|             Type = [ArithmeticType] _Complex long double
+#   97|             ValueCategory = prvalue(load)
+#   97|         1 converted: [CStyleCast] (double)...
 #   97|             Conversion = [FloatingPointConversion] floating point conversion
 #   97|             Type = [DoubleType] double
 #   97|             ValueCategory = prvalue
-#   97|           expr: [VariableAccess] cld
-#   97|               Type = [ArithmeticType] _Complex long double
-#   97|               ValueCategory = prvalue(load)
 #   98|     33: [ExprStmt] ExprStmt
 #   98|       0: [AssignExpr] ... = ...
 #   98|           Type = [LongDoubleType] long double
@@ -1175,13 +1175,13 @@ complex.c:
 #   98|         0: [VariableAccess] ld
 #   98|             Type = [LongDoubleType] long double
 #   98|             ValueCategory = lvalue
-#   98|         1: [CStyleCast] (long double)...
+#   98|         1: [VariableAccess] cf
+#   98|             Type = [ArithmeticType] _Complex float
+#   98|             ValueCategory = prvalue(load)
+#   98|         1 converted: [CStyleCast] (long double)...
 #   98|             Conversion = [FloatingPointConversion] floating point conversion
 #   98|             Type = [LongDoubleType] long double
 #   98|             ValueCategory = prvalue
-#   98|           expr: [VariableAccess] cf
-#   98|               Type = [ArithmeticType] _Complex float
-#   98|               ValueCategory = prvalue(load)
 #   99|     34: [ExprStmt] ExprStmt
 #   99|       0: [AssignExpr] ... = ...
 #   99|           Type = [LongDoubleType] long double
@@ -1189,13 +1189,13 @@ complex.c:
 #   99|         0: [VariableAccess] ld
 #   99|             Type = [LongDoubleType] long double
 #   99|             ValueCategory = lvalue
-#   99|         1: [CStyleCast] (long double)...
+#   99|         1: [VariableAccess] cd
+#   99|             Type = [ArithmeticType] _Complex double
+#   99|             ValueCategory = prvalue(load)
+#   99|         1 converted: [CStyleCast] (long double)...
 #   99|             Conversion = [FloatingPointConversion] floating point conversion
 #   99|             Type = [LongDoubleType] long double
 #   99|             ValueCategory = prvalue
-#   99|           expr: [VariableAccess] cd
-#   99|               Type = [ArithmeticType] _Complex double
-#   99|               ValueCategory = prvalue(load)
 #  100|     35: [ExprStmt] ExprStmt
 #  100|       0: [AssignExpr] ... = ...
 #  100|           Type = [LongDoubleType] long double
@@ -1203,13 +1203,13 @@ complex.c:
 #  100|         0: [VariableAccess] ld
 #  100|             Type = [LongDoubleType] long double
 #  100|             ValueCategory = lvalue
-#  100|         1: [CStyleCast] (long double)...
+#  100|         1: [VariableAccess] cld
+#  100|             Type = [ArithmeticType] _Complex long double
+#  100|             ValueCategory = prvalue(load)
+#  100|         1 converted: [CStyleCast] (long double)...
 #  100|             Conversion = [FloatingPointConversion] floating point conversion
 #  100|             Type = [LongDoubleType] long double
 #  100|             ValueCategory = prvalue
-#  100|           expr: [VariableAccess] cld
-#  100|               Type = [ArithmeticType] _Complex long double
-#  100|               ValueCategory = prvalue(load)
 #  103|     36: [ExprStmt] ExprStmt
 #  103|       0: [AssignExpr] ... = ...
 #  103|           Type = [ArithmeticType] _Complex float
@@ -1217,13 +1217,13 @@ complex.c:
 #  103|         0: [VariableAccess] cf
 #  103|             Type = [ArithmeticType] _Complex float
 #  103|             ValueCategory = lvalue
-#  103|         1: [CStyleCast] (_Complex float)...
+#  103|         1: [VariableAccess] jf
+#  103|             Type = [ArithmeticType] _Imaginary float
+#  103|             ValueCategory = prvalue(load)
+#  103|         1 converted: [CStyleCast] (_Complex float)...
 #  103|             Conversion = [FloatingPointConversion] floating point conversion
 #  103|             Type = [ArithmeticType] _Complex float
 #  103|             ValueCategory = prvalue
-#  103|           expr: [VariableAccess] jf
-#  103|               Type = [ArithmeticType] _Imaginary float
-#  103|               ValueCategory = prvalue(load)
 #  104|     37: [ExprStmt] ExprStmt
 #  104|       0: [AssignExpr] ... = ...
 #  104|           Type = [ArithmeticType] _Complex float
@@ -1231,13 +1231,13 @@ complex.c:
 #  104|         0: [VariableAccess] cf
 #  104|             Type = [ArithmeticType] _Complex float
 #  104|             ValueCategory = lvalue
-#  104|         1: [CStyleCast] (_Complex float)...
+#  104|         1: [VariableAccess] jd
+#  104|             Type = [ArithmeticType] _Imaginary double
+#  104|             ValueCategory = prvalue(load)
+#  104|         1 converted: [CStyleCast] (_Complex float)...
 #  104|             Conversion = [FloatingPointConversion] floating point conversion
 #  104|             Type = [ArithmeticType] _Complex float
 #  104|             ValueCategory = prvalue
-#  104|           expr: [VariableAccess] jd
-#  104|               Type = [ArithmeticType] _Imaginary double
-#  104|               ValueCategory = prvalue(load)
 #  105|     38: [ExprStmt] ExprStmt
 #  105|       0: [AssignExpr] ... = ...
 #  105|           Type = [ArithmeticType] _Complex float
@@ -1245,13 +1245,13 @@ complex.c:
 #  105|         0: [VariableAccess] cf
 #  105|             Type = [ArithmeticType] _Complex float
 #  105|             ValueCategory = lvalue
-#  105|         1: [CStyleCast] (_Complex float)...
+#  105|         1: [VariableAccess] jld
+#  105|             Type = [ArithmeticType] _Imaginary long double
+#  105|             ValueCategory = prvalue(load)
+#  105|         1 converted: [CStyleCast] (_Complex float)...
 #  105|             Conversion = [FloatingPointConversion] floating point conversion
 #  105|             Type = [ArithmeticType] _Complex float
 #  105|             ValueCategory = prvalue
-#  105|           expr: [VariableAccess] jld
-#  105|               Type = [ArithmeticType] _Imaginary long double
-#  105|               ValueCategory = prvalue(load)
 #  106|     39: [ExprStmt] ExprStmt
 #  106|       0: [AssignExpr] ... = ...
 #  106|           Type = [ArithmeticType] _Complex double
@@ -1259,13 +1259,13 @@ complex.c:
 #  106|         0: [VariableAccess] cd
 #  106|             Type = [ArithmeticType] _Complex double
 #  106|             ValueCategory = lvalue
-#  106|         1: [CStyleCast] (_Complex double)...
+#  106|         1: [VariableAccess] jf
+#  106|             Type = [ArithmeticType] _Imaginary float
+#  106|             ValueCategory = prvalue(load)
+#  106|         1 converted: [CStyleCast] (_Complex double)...
 #  106|             Conversion = [FloatingPointConversion] floating point conversion
 #  106|             Type = [ArithmeticType] _Complex double
 #  106|             ValueCategory = prvalue
-#  106|           expr: [VariableAccess] jf
-#  106|               Type = [ArithmeticType] _Imaginary float
-#  106|               ValueCategory = prvalue(load)
 #  107|     40: [ExprStmt] ExprStmt
 #  107|       0: [AssignExpr] ... = ...
 #  107|           Type = [ArithmeticType] _Complex double
@@ -1273,13 +1273,13 @@ complex.c:
 #  107|         0: [VariableAccess] cd
 #  107|             Type = [ArithmeticType] _Complex double
 #  107|             ValueCategory = lvalue
-#  107|         1: [CStyleCast] (_Complex double)...
+#  107|         1: [VariableAccess] jd
+#  107|             Type = [ArithmeticType] _Imaginary double
+#  107|             ValueCategory = prvalue(load)
+#  107|         1 converted: [CStyleCast] (_Complex double)...
 #  107|             Conversion = [FloatingPointConversion] floating point conversion
 #  107|             Type = [ArithmeticType] _Complex double
 #  107|             ValueCategory = prvalue
-#  107|           expr: [VariableAccess] jd
-#  107|               Type = [ArithmeticType] _Imaginary double
-#  107|               ValueCategory = prvalue(load)
 #  108|     41: [ExprStmt] ExprStmt
 #  108|       0: [AssignExpr] ... = ...
 #  108|           Type = [ArithmeticType] _Complex double
@@ -1287,13 +1287,13 @@ complex.c:
 #  108|         0: [VariableAccess] cd
 #  108|             Type = [ArithmeticType] _Complex double
 #  108|             ValueCategory = lvalue
-#  108|         1: [CStyleCast] (_Complex double)...
+#  108|         1: [VariableAccess] jld
+#  108|             Type = [ArithmeticType] _Imaginary long double
+#  108|             ValueCategory = prvalue(load)
+#  108|         1 converted: [CStyleCast] (_Complex double)...
 #  108|             Conversion = [FloatingPointConversion] floating point conversion
 #  108|             Type = [ArithmeticType] _Complex double
 #  108|             ValueCategory = prvalue
-#  108|           expr: [VariableAccess] jld
-#  108|               Type = [ArithmeticType] _Imaginary long double
-#  108|               ValueCategory = prvalue(load)
 #  109|     42: [ExprStmt] ExprStmt
 #  109|       0: [AssignExpr] ... = ...
 #  109|           Type = [ArithmeticType] _Complex long double
@@ -1301,13 +1301,13 @@ complex.c:
 #  109|         0: [VariableAccess] cld
 #  109|             Type = [ArithmeticType] _Complex long double
 #  109|             ValueCategory = lvalue
-#  109|         1: [CStyleCast] (_Complex long double)...
+#  109|         1: [VariableAccess] jf
+#  109|             Type = [ArithmeticType] _Imaginary float
+#  109|             ValueCategory = prvalue(load)
+#  109|         1 converted: [CStyleCast] (_Complex long double)...
 #  109|             Conversion = [FloatingPointConversion] floating point conversion
 #  109|             Type = [ArithmeticType] _Complex long double
 #  109|             ValueCategory = prvalue
-#  109|           expr: [VariableAccess] jf
-#  109|               Type = [ArithmeticType] _Imaginary float
-#  109|               ValueCategory = prvalue(load)
 #  110|     43: [ExprStmt] ExprStmt
 #  110|       0: [AssignExpr] ... = ...
 #  110|           Type = [ArithmeticType] _Complex long double
@@ -1315,13 +1315,13 @@ complex.c:
 #  110|         0: [VariableAccess] cld
 #  110|             Type = [ArithmeticType] _Complex long double
 #  110|             ValueCategory = lvalue
-#  110|         1: [CStyleCast] (_Complex long double)...
+#  110|         1: [VariableAccess] jd
+#  110|             Type = [ArithmeticType] _Imaginary double
+#  110|             ValueCategory = prvalue(load)
+#  110|         1 converted: [CStyleCast] (_Complex long double)...
 #  110|             Conversion = [FloatingPointConversion] floating point conversion
 #  110|             Type = [ArithmeticType] _Complex long double
 #  110|             ValueCategory = prvalue
-#  110|           expr: [VariableAccess] jd
-#  110|               Type = [ArithmeticType] _Imaginary double
-#  110|               ValueCategory = prvalue(load)
 #  111|     44: [ExprStmt] ExprStmt
 #  111|       0: [AssignExpr] ... = ...
 #  111|           Type = [ArithmeticType] _Complex long double
@@ -1329,13 +1329,13 @@ complex.c:
 #  111|         0: [VariableAccess] cld
 #  111|             Type = [ArithmeticType] _Complex long double
 #  111|             ValueCategory = lvalue
-#  111|         1: [CStyleCast] (_Complex long double)...
+#  111|         1: [VariableAccess] jld
+#  111|             Type = [ArithmeticType] _Imaginary long double
+#  111|             ValueCategory = prvalue(load)
+#  111|         1 converted: [CStyleCast] (_Complex long double)...
 #  111|             Conversion = [FloatingPointConversion] floating point conversion
 #  111|             Type = [ArithmeticType] _Complex long double
 #  111|             ValueCategory = prvalue
-#  111|           expr: [VariableAccess] jld
-#  111|               Type = [ArithmeticType] _Imaginary long double
-#  111|               ValueCategory = prvalue(load)
 #  114|     45: [ExprStmt] ExprStmt
 #  114|       0: [AssignExpr] ... = ...
 #  114|           Type = [ArithmeticType] _Imaginary float
@@ -1343,13 +1343,13 @@ complex.c:
 #  114|         0: [VariableAccess] jf
 #  114|             Type = [ArithmeticType] _Imaginary float
 #  114|             ValueCategory = lvalue
-#  114|         1: [CStyleCast] (_Imaginary float)...
+#  114|         1: [VariableAccess] cf
+#  114|             Type = [ArithmeticType] _Complex float
+#  114|             ValueCategory = prvalue(load)
+#  114|         1 converted: [CStyleCast] (_Imaginary float)...
 #  114|             Conversion = [FloatingPointConversion] floating point conversion
 #  114|             Type = [ArithmeticType] _Imaginary float
 #  114|             ValueCategory = prvalue
-#  114|           expr: [VariableAccess] cf
-#  114|               Type = [ArithmeticType] _Complex float
-#  114|               ValueCategory = prvalue(load)
 #  115|     46: [ExprStmt] ExprStmt
 #  115|       0: [AssignExpr] ... = ...
 #  115|           Type = [ArithmeticType] _Imaginary float
@@ -1357,13 +1357,13 @@ complex.c:
 #  115|         0: [VariableAccess] jf
 #  115|             Type = [ArithmeticType] _Imaginary float
 #  115|             ValueCategory = lvalue
-#  115|         1: [CStyleCast] (_Imaginary float)...
+#  115|         1: [VariableAccess] cd
+#  115|             Type = [ArithmeticType] _Complex double
+#  115|             ValueCategory = prvalue(load)
+#  115|         1 converted: [CStyleCast] (_Imaginary float)...
 #  115|             Conversion = [FloatingPointConversion] floating point conversion
 #  115|             Type = [ArithmeticType] _Imaginary float
 #  115|             ValueCategory = prvalue
-#  115|           expr: [VariableAccess] cd
-#  115|               Type = [ArithmeticType] _Complex double
-#  115|               ValueCategory = prvalue(load)
 #  116|     47: [ExprStmt] ExprStmt
 #  116|       0: [AssignExpr] ... = ...
 #  116|           Type = [ArithmeticType] _Imaginary float
@@ -1371,13 +1371,13 @@ complex.c:
 #  116|         0: [VariableAccess] jf
 #  116|             Type = [ArithmeticType] _Imaginary float
 #  116|             ValueCategory = lvalue
-#  116|         1: [CStyleCast] (_Imaginary float)...
+#  116|         1: [VariableAccess] cld
+#  116|             Type = [ArithmeticType] _Complex long double
+#  116|             ValueCategory = prvalue(load)
+#  116|         1 converted: [CStyleCast] (_Imaginary float)...
 #  116|             Conversion = [FloatingPointConversion] floating point conversion
 #  116|             Type = [ArithmeticType] _Imaginary float
 #  116|             ValueCategory = prvalue
-#  116|           expr: [VariableAccess] cld
-#  116|               Type = [ArithmeticType] _Complex long double
-#  116|               ValueCategory = prvalue(load)
 #  117|     48: [ExprStmt] ExprStmt
 #  117|       0: [AssignExpr] ... = ...
 #  117|           Type = [ArithmeticType] _Imaginary double
@@ -1385,13 +1385,13 @@ complex.c:
 #  117|         0: [VariableAccess] jd
 #  117|             Type = [ArithmeticType] _Imaginary double
 #  117|             ValueCategory = lvalue
-#  117|         1: [CStyleCast] (_Imaginary double)...
+#  117|         1: [VariableAccess] cf
+#  117|             Type = [ArithmeticType] _Complex float
+#  117|             ValueCategory = prvalue(load)
+#  117|         1 converted: [CStyleCast] (_Imaginary double)...
 #  117|             Conversion = [FloatingPointConversion] floating point conversion
 #  117|             Type = [ArithmeticType] _Imaginary double
 #  117|             ValueCategory = prvalue
-#  117|           expr: [VariableAccess] cf
-#  117|               Type = [ArithmeticType] _Complex float
-#  117|               ValueCategory = prvalue(load)
 #  118|     49: [ExprStmt] ExprStmt
 #  118|       0: [AssignExpr] ... = ...
 #  118|           Type = [ArithmeticType] _Imaginary double
@@ -1399,13 +1399,13 @@ complex.c:
 #  118|         0: [VariableAccess] jd
 #  118|             Type = [ArithmeticType] _Imaginary double
 #  118|             ValueCategory = lvalue
-#  118|         1: [CStyleCast] (_Imaginary double)...
+#  118|         1: [VariableAccess] cd
+#  118|             Type = [ArithmeticType] _Complex double
+#  118|             ValueCategory = prvalue(load)
+#  118|         1 converted: [CStyleCast] (_Imaginary double)...
 #  118|             Conversion = [FloatingPointConversion] floating point conversion
 #  118|             Type = [ArithmeticType] _Imaginary double
 #  118|             ValueCategory = prvalue
-#  118|           expr: [VariableAccess] cd
-#  118|               Type = [ArithmeticType] _Complex double
-#  118|               ValueCategory = prvalue(load)
 #  119|     50: [ExprStmt] ExprStmt
 #  119|       0: [AssignExpr] ... = ...
 #  119|           Type = [ArithmeticType] _Imaginary double
@@ -1413,13 +1413,13 @@ complex.c:
 #  119|         0: [VariableAccess] jd
 #  119|             Type = [ArithmeticType] _Imaginary double
 #  119|             ValueCategory = lvalue
-#  119|         1: [CStyleCast] (_Imaginary double)...
+#  119|         1: [VariableAccess] cld
+#  119|             Type = [ArithmeticType] _Complex long double
+#  119|             ValueCategory = prvalue(load)
+#  119|         1 converted: [CStyleCast] (_Imaginary double)...
 #  119|             Conversion = [FloatingPointConversion] floating point conversion
 #  119|             Type = [ArithmeticType] _Imaginary double
 #  119|             ValueCategory = prvalue
-#  119|           expr: [VariableAccess] cld
-#  119|               Type = [ArithmeticType] _Complex long double
-#  119|               ValueCategory = prvalue(load)
 #  120|     51: [ExprStmt] ExprStmt
 #  120|       0: [AssignExpr] ... = ...
 #  120|           Type = [ArithmeticType] _Imaginary long double
@@ -1427,13 +1427,13 @@ complex.c:
 #  120|         0: [VariableAccess] jld
 #  120|             Type = [ArithmeticType] _Imaginary long double
 #  120|             ValueCategory = lvalue
-#  120|         1: [CStyleCast] (_Imaginary long double)...
+#  120|         1: [VariableAccess] cf
+#  120|             Type = [ArithmeticType] _Complex float
+#  120|             ValueCategory = prvalue(load)
+#  120|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  120|             Conversion = [FloatingPointConversion] floating point conversion
 #  120|             Type = [ArithmeticType] _Imaginary long double
 #  120|             ValueCategory = prvalue
-#  120|           expr: [VariableAccess] cf
-#  120|               Type = [ArithmeticType] _Complex float
-#  120|               ValueCategory = prvalue(load)
 #  121|     52: [ExprStmt] ExprStmt
 #  121|       0: [AssignExpr] ... = ...
 #  121|           Type = [ArithmeticType] _Imaginary long double
@@ -1441,13 +1441,13 @@ complex.c:
 #  121|         0: [VariableAccess] jld
 #  121|             Type = [ArithmeticType] _Imaginary long double
 #  121|             ValueCategory = lvalue
-#  121|         1: [CStyleCast] (_Imaginary long double)...
+#  121|         1: [VariableAccess] cd
+#  121|             Type = [ArithmeticType] _Complex double
+#  121|             ValueCategory = prvalue(load)
+#  121|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  121|             Conversion = [FloatingPointConversion] floating point conversion
 #  121|             Type = [ArithmeticType] _Imaginary long double
 #  121|             ValueCategory = prvalue
-#  121|           expr: [VariableAccess] cd
-#  121|               Type = [ArithmeticType] _Complex double
-#  121|               ValueCategory = prvalue(load)
 #  122|     53: [ExprStmt] ExprStmt
 #  122|       0: [AssignExpr] ... = ...
 #  122|           Type = [ArithmeticType] _Imaginary long double
@@ -1455,13 +1455,13 @@ complex.c:
 #  122|         0: [VariableAccess] jld
 #  122|             Type = [ArithmeticType] _Imaginary long double
 #  122|             ValueCategory = lvalue
-#  122|         1: [CStyleCast] (_Imaginary long double)...
+#  122|         1: [VariableAccess] cld
+#  122|             Type = [ArithmeticType] _Complex long double
+#  122|             ValueCategory = prvalue(load)
+#  122|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  122|             Conversion = [FloatingPointConversion] floating point conversion
 #  122|             Type = [ArithmeticType] _Imaginary long double
 #  122|             ValueCategory = prvalue
-#  122|           expr: [VariableAccess] cld
-#  122|               Type = [ArithmeticType] _Complex long double
-#  122|               ValueCategory = prvalue(load)
 #  125|     54: [ExprStmt] ExprStmt
 #  125|       0: [AssignExpr] ... = ...
 #  125|           Type = [ArithmeticType] _Imaginary float
@@ -1469,13 +1469,13 @@ complex.c:
 #  125|         0: [VariableAccess] jf
 #  125|             Type = [ArithmeticType] _Imaginary float
 #  125|             ValueCategory = lvalue
-#  125|         1: [CStyleCast] (_Imaginary float)...
+#  125|         1: [VariableAccess] f
+#  125|             Type = [FloatType] float
+#  125|             ValueCategory = prvalue(load)
+#  125|         1 converted: [CStyleCast] (_Imaginary float)...
 #  125|             Conversion = [FloatingPointConversion] floating point conversion
 #  125|             Type = [ArithmeticType] _Imaginary float
 #  125|             ValueCategory = prvalue
-#  125|           expr: [VariableAccess] f
-#  125|               Type = [FloatType] float
-#  125|               ValueCategory = prvalue(load)
 #  126|     55: [ExprStmt] ExprStmt
 #  126|       0: [AssignExpr] ... = ...
 #  126|           Type = [ArithmeticType] _Imaginary float
@@ -1483,13 +1483,13 @@ complex.c:
 #  126|         0: [VariableAccess] jf
 #  126|             Type = [ArithmeticType] _Imaginary float
 #  126|             ValueCategory = lvalue
-#  126|         1: [CStyleCast] (_Imaginary float)...
+#  126|         1: [VariableAccess] d
+#  126|             Type = [DoubleType] double
+#  126|             ValueCategory = prvalue(load)
+#  126|         1 converted: [CStyleCast] (_Imaginary float)...
 #  126|             Conversion = [FloatingPointConversion] floating point conversion
 #  126|             Type = [ArithmeticType] _Imaginary float
 #  126|             ValueCategory = prvalue
-#  126|           expr: [VariableAccess] d
-#  126|               Type = [DoubleType] double
-#  126|               ValueCategory = prvalue(load)
 #  127|     56: [ExprStmt] ExprStmt
 #  127|       0: [AssignExpr] ... = ...
 #  127|           Type = [ArithmeticType] _Imaginary float
@@ -1497,13 +1497,13 @@ complex.c:
 #  127|         0: [VariableAccess] jf
 #  127|             Type = [ArithmeticType] _Imaginary float
 #  127|             ValueCategory = lvalue
-#  127|         1: [CStyleCast] (_Imaginary float)...
+#  127|         1: [VariableAccess] ld
+#  127|             Type = [LongDoubleType] long double
+#  127|             ValueCategory = prvalue(load)
+#  127|         1 converted: [CStyleCast] (_Imaginary float)...
 #  127|             Conversion = [FloatingPointConversion] floating point conversion
 #  127|             Type = [ArithmeticType] _Imaginary float
 #  127|             ValueCategory = prvalue
-#  127|           expr: [VariableAccess] ld
-#  127|               Type = [LongDoubleType] long double
-#  127|               ValueCategory = prvalue(load)
 #  128|     57: [ExprStmt] ExprStmt
 #  128|       0: [AssignExpr] ... = ...
 #  128|           Type = [ArithmeticType] _Imaginary double
@@ -1511,13 +1511,13 @@ complex.c:
 #  128|         0: [VariableAccess] jd
 #  128|             Type = [ArithmeticType] _Imaginary double
 #  128|             ValueCategory = lvalue
-#  128|         1: [CStyleCast] (_Imaginary double)...
+#  128|         1: [VariableAccess] f
+#  128|             Type = [FloatType] float
+#  128|             ValueCategory = prvalue(load)
+#  128|         1 converted: [CStyleCast] (_Imaginary double)...
 #  128|             Conversion = [FloatingPointConversion] floating point conversion
 #  128|             Type = [ArithmeticType] _Imaginary double
 #  128|             ValueCategory = prvalue
-#  128|           expr: [VariableAccess] f
-#  128|               Type = [FloatType] float
-#  128|               ValueCategory = prvalue(load)
 #  129|     58: [ExprStmt] ExprStmt
 #  129|       0: [AssignExpr] ... = ...
 #  129|           Type = [ArithmeticType] _Imaginary double
@@ -1525,13 +1525,13 @@ complex.c:
 #  129|         0: [VariableAccess] jd
 #  129|             Type = [ArithmeticType] _Imaginary double
 #  129|             ValueCategory = lvalue
-#  129|         1: [CStyleCast] (_Imaginary double)...
+#  129|         1: [VariableAccess] d
+#  129|             Type = [DoubleType] double
+#  129|             ValueCategory = prvalue(load)
+#  129|         1 converted: [CStyleCast] (_Imaginary double)...
 #  129|             Conversion = [FloatingPointConversion] floating point conversion
 #  129|             Type = [ArithmeticType] _Imaginary double
 #  129|             ValueCategory = prvalue
-#  129|           expr: [VariableAccess] d
-#  129|               Type = [DoubleType] double
-#  129|               ValueCategory = prvalue(load)
 #  130|     59: [ExprStmt] ExprStmt
 #  130|       0: [AssignExpr] ... = ...
 #  130|           Type = [ArithmeticType] _Imaginary double
@@ -1539,13 +1539,13 @@ complex.c:
 #  130|         0: [VariableAccess] jd
 #  130|             Type = [ArithmeticType] _Imaginary double
 #  130|             ValueCategory = lvalue
-#  130|         1: [CStyleCast] (_Imaginary double)...
+#  130|         1: [VariableAccess] ld
+#  130|             Type = [LongDoubleType] long double
+#  130|             ValueCategory = prvalue(load)
+#  130|         1 converted: [CStyleCast] (_Imaginary double)...
 #  130|             Conversion = [FloatingPointConversion] floating point conversion
 #  130|             Type = [ArithmeticType] _Imaginary double
 #  130|             ValueCategory = prvalue
-#  130|           expr: [VariableAccess] ld
-#  130|               Type = [LongDoubleType] long double
-#  130|               ValueCategory = prvalue(load)
 #  131|     60: [ExprStmt] ExprStmt
 #  131|       0: [AssignExpr] ... = ...
 #  131|           Type = [ArithmeticType] _Imaginary long double
@@ -1553,13 +1553,13 @@ complex.c:
 #  131|         0: [VariableAccess] jld
 #  131|             Type = [ArithmeticType] _Imaginary long double
 #  131|             ValueCategory = lvalue
-#  131|         1: [CStyleCast] (_Imaginary long double)...
+#  131|         1: [VariableAccess] f
+#  131|             Type = [FloatType] float
+#  131|             ValueCategory = prvalue(load)
+#  131|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  131|             Conversion = [FloatingPointConversion] floating point conversion
 #  131|             Type = [ArithmeticType] _Imaginary long double
 #  131|             ValueCategory = prvalue
-#  131|           expr: [VariableAccess] f
-#  131|               Type = [FloatType] float
-#  131|               ValueCategory = prvalue(load)
 #  132|     61: [ExprStmt] ExprStmt
 #  132|       0: [AssignExpr] ... = ...
 #  132|           Type = [ArithmeticType] _Imaginary long double
@@ -1567,13 +1567,13 @@ complex.c:
 #  132|         0: [VariableAccess] jld
 #  132|             Type = [ArithmeticType] _Imaginary long double
 #  132|             ValueCategory = lvalue
-#  132|         1: [CStyleCast] (_Imaginary long double)...
+#  132|         1: [VariableAccess] d
+#  132|             Type = [DoubleType] double
+#  132|             ValueCategory = prvalue(load)
+#  132|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  132|             Conversion = [FloatingPointConversion] floating point conversion
 #  132|             Type = [ArithmeticType] _Imaginary long double
 #  132|             ValueCategory = prvalue
-#  132|           expr: [VariableAccess] d
-#  132|               Type = [DoubleType] double
-#  132|               ValueCategory = prvalue(load)
 #  133|     62: [ExprStmt] ExprStmt
 #  133|       0: [AssignExpr] ... = ...
 #  133|           Type = [ArithmeticType] _Imaginary long double
@@ -1581,13 +1581,13 @@ complex.c:
 #  133|         0: [VariableAccess] jld
 #  133|             Type = [ArithmeticType] _Imaginary long double
 #  133|             ValueCategory = lvalue
-#  133|         1: [CStyleCast] (_Imaginary long double)...
+#  133|         1: [VariableAccess] ld
+#  133|             Type = [LongDoubleType] long double
+#  133|             ValueCategory = prvalue(load)
+#  133|         1 converted: [CStyleCast] (_Imaginary long double)...
 #  133|             Conversion = [FloatingPointConversion] floating point conversion
 #  133|             Type = [ArithmeticType] _Imaginary long double
 #  133|             ValueCategory = prvalue
-#  133|           expr: [VariableAccess] ld
-#  133|               Type = [LongDoubleType] long double
-#  133|               ValueCategory = prvalue(load)
 #  136|     63: [ExprStmt] ExprStmt
 #  136|       0: [AssignExpr] ... = ...
 #  136|           Type = [FloatType] float
@@ -1595,13 +1595,13 @@ complex.c:
 #  136|         0: [VariableAccess] f
 #  136|             Type = [FloatType] float
 #  136|             ValueCategory = lvalue
-#  136|         1: [CStyleCast] (float)...
+#  136|         1: [VariableAccess] jf
+#  136|             Type = [ArithmeticType] _Imaginary float
+#  136|             ValueCategory = prvalue(load)
+#  136|         1 converted: [CStyleCast] (float)...
 #  136|             Conversion = [FloatingPointConversion] floating point conversion
 #  136|             Type = [FloatType] float
 #  136|             ValueCategory = prvalue
-#  136|           expr: [VariableAccess] jf
-#  136|               Type = [ArithmeticType] _Imaginary float
-#  136|               ValueCategory = prvalue(load)
 #  137|     64: [ExprStmt] ExprStmt
 #  137|       0: [AssignExpr] ... = ...
 #  137|           Type = [FloatType] float
@@ -1609,13 +1609,13 @@ complex.c:
 #  137|         0: [VariableAccess] f
 #  137|             Type = [FloatType] float
 #  137|             ValueCategory = lvalue
-#  137|         1: [CStyleCast] (float)...
+#  137|         1: [VariableAccess] jd
+#  137|             Type = [ArithmeticType] _Imaginary double
+#  137|             ValueCategory = prvalue(load)
+#  137|         1 converted: [CStyleCast] (float)...
 #  137|             Conversion = [FloatingPointConversion] floating point conversion
 #  137|             Type = [FloatType] float
 #  137|             ValueCategory = prvalue
-#  137|           expr: [VariableAccess] jd
-#  137|               Type = [ArithmeticType] _Imaginary double
-#  137|               ValueCategory = prvalue(load)
 #  138|     65: [ExprStmt] ExprStmt
 #  138|       0: [AssignExpr] ... = ...
 #  138|           Type = [FloatType] float
@@ -1623,13 +1623,13 @@ complex.c:
 #  138|         0: [VariableAccess] f
 #  138|             Type = [FloatType] float
 #  138|             ValueCategory = lvalue
-#  138|         1: [CStyleCast] (float)...
+#  138|         1: [VariableAccess] jld
+#  138|             Type = [ArithmeticType] _Imaginary long double
+#  138|             ValueCategory = prvalue(load)
+#  138|         1 converted: [CStyleCast] (float)...
 #  138|             Conversion = [FloatingPointConversion] floating point conversion
 #  138|             Type = [FloatType] float
 #  138|             ValueCategory = prvalue
-#  138|           expr: [VariableAccess] jld
-#  138|               Type = [ArithmeticType] _Imaginary long double
-#  138|               ValueCategory = prvalue(load)
 #  139|     66: [ExprStmt] ExprStmt
 #  139|       0: [AssignExpr] ... = ...
 #  139|           Type = [DoubleType] double
@@ -1637,13 +1637,13 @@ complex.c:
 #  139|         0: [VariableAccess] d
 #  139|             Type = [DoubleType] double
 #  139|             ValueCategory = lvalue
-#  139|         1: [CStyleCast] (double)...
+#  139|         1: [VariableAccess] jf
+#  139|             Type = [ArithmeticType] _Imaginary float
+#  139|             ValueCategory = prvalue(load)
+#  139|         1 converted: [CStyleCast] (double)...
 #  139|             Conversion = [FloatingPointConversion] floating point conversion
 #  139|             Type = [DoubleType] double
 #  139|             ValueCategory = prvalue
-#  139|           expr: [VariableAccess] jf
-#  139|               Type = [ArithmeticType] _Imaginary float
-#  139|               ValueCategory = prvalue(load)
 #  140|     67: [ExprStmt] ExprStmt
 #  140|       0: [AssignExpr] ... = ...
 #  140|           Type = [DoubleType] double
@@ -1651,13 +1651,13 @@ complex.c:
 #  140|         0: [VariableAccess] d
 #  140|             Type = [DoubleType] double
 #  140|             ValueCategory = lvalue
-#  140|         1: [CStyleCast] (double)...
+#  140|         1: [VariableAccess] jd
+#  140|             Type = [ArithmeticType] _Imaginary double
+#  140|             ValueCategory = prvalue(load)
+#  140|         1 converted: [CStyleCast] (double)...
 #  140|             Conversion = [FloatingPointConversion] floating point conversion
 #  140|             Type = [DoubleType] double
 #  140|             ValueCategory = prvalue
-#  140|           expr: [VariableAccess] jd
-#  140|               Type = [ArithmeticType] _Imaginary double
-#  140|               ValueCategory = prvalue(load)
 #  141|     68: [ExprStmt] ExprStmt
 #  141|       0: [AssignExpr] ... = ...
 #  141|           Type = [DoubleType] double
@@ -1665,13 +1665,13 @@ complex.c:
 #  141|         0: [VariableAccess] d
 #  141|             Type = [DoubleType] double
 #  141|             ValueCategory = lvalue
-#  141|         1: [CStyleCast] (double)...
+#  141|         1: [VariableAccess] jld
+#  141|             Type = [ArithmeticType] _Imaginary long double
+#  141|             ValueCategory = prvalue(load)
+#  141|         1 converted: [CStyleCast] (double)...
 #  141|             Conversion = [FloatingPointConversion] floating point conversion
 #  141|             Type = [DoubleType] double
 #  141|             ValueCategory = prvalue
-#  141|           expr: [VariableAccess] jld
-#  141|               Type = [ArithmeticType] _Imaginary long double
-#  141|               ValueCategory = prvalue(load)
 #  142|     69: [ExprStmt] ExprStmt
 #  142|       0: [AssignExpr] ... = ...
 #  142|           Type = [LongDoubleType] long double
@@ -1679,13 +1679,13 @@ complex.c:
 #  142|         0: [VariableAccess] ld
 #  142|             Type = [LongDoubleType] long double
 #  142|             ValueCategory = lvalue
-#  142|         1: [CStyleCast] (long double)...
+#  142|         1: [VariableAccess] jf
+#  142|             Type = [ArithmeticType] _Imaginary float
+#  142|             ValueCategory = prvalue(load)
+#  142|         1 converted: [CStyleCast] (long double)...
 #  142|             Conversion = [FloatingPointConversion] floating point conversion
 #  142|             Type = [LongDoubleType] long double
 #  142|             ValueCategory = prvalue
-#  142|           expr: [VariableAccess] jf
-#  142|               Type = [ArithmeticType] _Imaginary float
-#  142|               ValueCategory = prvalue(load)
 #  143|     70: [ExprStmt] ExprStmt
 #  143|       0: [AssignExpr] ... = ...
 #  143|           Type = [LongDoubleType] long double
@@ -1693,13 +1693,13 @@ complex.c:
 #  143|         0: [VariableAccess] ld
 #  143|             Type = [LongDoubleType] long double
 #  143|             ValueCategory = lvalue
-#  143|         1: [CStyleCast] (long double)...
+#  143|         1: [VariableAccess] jd
+#  143|             Type = [ArithmeticType] _Imaginary double
+#  143|             ValueCategory = prvalue(load)
+#  143|         1 converted: [CStyleCast] (long double)...
 #  143|             Conversion = [FloatingPointConversion] floating point conversion
 #  143|             Type = [LongDoubleType] long double
 #  143|             ValueCategory = prvalue
-#  143|           expr: [VariableAccess] jd
-#  143|               Type = [ArithmeticType] _Imaginary double
-#  143|               ValueCategory = prvalue(load)
 #  144|     71: [ExprStmt] ExprStmt
 #  144|       0: [AssignExpr] ... = ...
 #  144|           Type = [LongDoubleType] long double
@@ -1707,13 +1707,13 @@ complex.c:
 #  144|         0: [VariableAccess] ld
 #  144|             Type = [LongDoubleType] long double
 #  144|             ValueCategory = lvalue
-#  144|         1: [CStyleCast] (long double)...
+#  144|         1: [VariableAccess] jld
+#  144|             Type = [ArithmeticType] _Imaginary long double
+#  144|             ValueCategory = prvalue(load)
+#  144|         1 converted: [CStyleCast] (long double)...
 #  144|             Conversion = [FloatingPointConversion] floating point conversion
 #  144|             Type = [LongDoubleType] long double
 #  144|             ValueCategory = prvalue
-#  144|           expr: [VariableAccess] jld
-#  144|               Type = [ArithmeticType] _Imaginary long double
-#  144|               ValueCategory = prvalue(load)
 #  145|     72: [ReturnStmt] return ...
 ir.cpp:
 #    1| [TopLevelFunction] void Constants()
@@ -1723,15 +1723,15 @@ ir.cpp:
 #    2|       0: [VariableDeclarationEntry] definition of c_i
 #    2|           Type = [PlainCharType] char
 #    2|         init: [Initializer] initializer for c_i
-#    2|           expr: [CStyleCast] (char)...
+#    2|           expr: [Literal] 1
+#    2|               Type = [IntType] int
+#    2|               Value = [Literal] 1
+#    2|               ValueCategory = prvalue
+#    2|           expr converted: [CStyleCast] (char)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [PlainCharType] char
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    2|             expr: [Literal] 1
-#    2|                 Type = [IntType] int
-#    2|                 Value = [Literal] 1
-#    2|                 ValueCategory = prvalue
 #    3|     1: [DeclStmt] declaration
 #    3|       0: [VariableDeclarationEntry] definition of c_c
 #    3|           Type = [PlainCharType] char
@@ -1744,84 +1744,84 @@ ir.cpp:
 #    5|       0: [VariableDeclarationEntry] definition of sc_i
 #    5|           Type = [SignedCharType] signed char
 #    5|         init: [Initializer] initializer for sc_i
-#    5|           expr: [CStyleCast] (signed char)...
+#    5|           expr: [UnaryMinusExpr] - ...
+#    5|               Type = [IntType] int
+#    5|               Value = [UnaryMinusExpr] -1
+#    5|               ValueCategory = prvalue
+#    5|             0: [Literal] 1
+#    5|                 Type = [IntType] int
+#    5|                 Value = [Literal] 1
+#    5|                 ValueCategory = prvalue
+#    5|           expr converted: [CStyleCast] (signed char)...
 #    5|               Conversion = [IntegralConversion] integral conversion
 #    5|               Type = [SignedCharType] signed char
 #    5|               Value = [CStyleCast] -1
 #    5|               ValueCategory = prvalue
-#    5|             expr: [UnaryMinusExpr] - ...
-#    5|                 Type = [IntType] int
-#    5|                 Value = [UnaryMinusExpr] -1
-#    5|                 ValueCategory = prvalue
-#    5|               0: [Literal] 1
-#    5|                   Type = [IntType] int
-#    5|                   Value = [Literal] 1
-#    5|                   ValueCategory = prvalue
 #    6|     3: [DeclStmt] declaration
 #    6|       0: [VariableDeclarationEntry] definition of sc_c
 #    6|           Type = [SignedCharType] signed char
 #    6|         init: [Initializer] initializer for sc_c
-#    6|           expr: [CStyleCast] (signed char)...
+#    6|           expr: [CharLiteral] 65
+#    6|               Type = [PlainCharType] char
+#    6|               Value = [CharLiteral] 65
+#    6|               ValueCategory = prvalue
+#    6|           expr converted: [CStyleCast] (signed char)...
 #    6|               Conversion = [IntegralConversion] integral conversion
 #    6|               Type = [SignedCharType] signed char
 #    6|               Value = [CStyleCast] 65
 #    6|               ValueCategory = prvalue
-#    6|             expr: [CharLiteral] 65
-#    6|                 Type = [PlainCharType] char
-#    6|                 Value = [CharLiteral] 65
-#    6|                 ValueCategory = prvalue
 #    8|     4: [DeclStmt] declaration
 #    8|       0: [VariableDeclarationEntry] definition of uc_i
 #    8|           Type = [UnsignedCharType] unsigned char
 #    8|         init: [Initializer] initializer for uc_i
-#    8|           expr: [CStyleCast] (unsigned char)...
+#    8|           expr: [Literal] 5
+#    8|               Type = [IntType] int
+#    8|               Value = [Literal] 5
+#    8|               ValueCategory = prvalue
+#    8|           expr converted: [CStyleCast] (unsigned char)...
 #    8|               Conversion = [IntegralConversion] integral conversion
 #    8|               Type = [UnsignedCharType] unsigned char
 #    8|               Value = [CStyleCast] 5
 #    8|               ValueCategory = prvalue
-#    8|             expr: [Literal] 5
-#    8|                 Type = [IntType] int
-#    8|                 Value = [Literal] 5
-#    8|                 ValueCategory = prvalue
 #    9|     5: [DeclStmt] declaration
 #    9|       0: [VariableDeclarationEntry] definition of uc_c
 #    9|           Type = [UnsignedCharType] unsigned char
 #    9|         init: [Initializer] initializer for uc_c
-#    9|           expr: [CStyleCast] (unsigned char)...
+#    9|           expr: [CharLiteral] 65
+#    9|               Type = [PlainCharType] char
+#    9|               Value = [CharLiteral] 65
+#    9|               ValueCategory = prvalue
+#    9|           expr converted: [CStyleCast] (unsigned char)...
 #    9|               Conversion = [IntegralConversion] integral conversion
 #    9|               Type = [UnsignedCharType] unsigned char
 #    9|               Value = [CStyleCast] 65
 #    9|               ValueCategory = prvalue
-#    9|             expr: [CharLiteral] 65
-#    9|                 Type = [PlainCharType] char
-#    9|                 Value = [CharLiteral] 65
-#    9|                 ValueCategory = prvalue
 #   11|     6: [DeclStmt] declaration
 #   11|       0: [VariableDeclarationEntry] definition of s
 #   11|           Type = [ShortType] short
 #   11|         init: [Initializer] initializer for s
-#   11|           expr: [CStyleCast] (short)...
+#   11|           expr: [Literal] 5
+#   11|               Type = [IntType] int
+#   11|               Value = [Literal] 5
+#   11|               ValueCategory = prvalue
+#   11|           expr converted: [CStyleCast] (short)...
 #   11|               Conversion = [IntegralConversion] integral conversion
 #   11|               Type = [ShortType] short
 #   11|               Value = [CStyleCast] 5
 #   11|               ValueCategory = prvalue
-#   11|             expr: [Literal] 5
-#   11|                 Type = [IntType] int
-#   11|                 Value = [Literal] 5
-#   11|                 ValueCategory = prvalue
 #   12|     7: [DeclStmt] declaration
 #   12|       0: [VariableDeclarationEntry] definition of us
 #   12|           Type = [ShortType] unsigned short
 #   12|         init: [Initializer] initializer for us
-#   12|           expr: [CStyleCast] (unsigned short)...
+#   12|           expr: [Literal] 5
+#   12|               Type = [IntType] int
+#   12|               Value = [Literal] 5
+#   12|               ValueCategory = prvalue
+#   12|           expr converted: [CStyleCast] (unsigned short)...
 #   12|               Conversion = [IntegralConversion] integral conversion
 #   12|               Type = [ShortType] unsigned short
 #   12|               Value = [CStyleCast] 5
 #   12|               ValueCategory = prvalue
-#   12|             expr: [Literal] 5
-#   12|                 Type = [IntType] int
-#   12|                 Value = [Literal] 5
-#   12|                 ValueCategory = prvalue
 #   14|     8: [DeclStmt] declaration
 #   14|       0: [VariableDeclarationEntry] definition of i
 #   14|           Type = [IntType] int
@@ -1834,54 +1834,54 @@ ir.cpp:
 #   15|       0: [VariableDeclarationEntry] definition of ui
 #   15|           Type = [IntType] unsigned int
 #   15|         init: [Initializer] initializer for ui
-#   15|           expr: [CStyleCast] (unsigned int)...
+#   15|           expr: [Literal] 5
+#   15|               Type = [IntType] int
+#   15|               Value = [Literal] 5
+#   15|               ValueCategory = prvalue
+#   15|           expr converted: [CStyleCast] (unsigned int)...
 #   15|               Conversion = [IntegralConversion] integral conversion
 #   15|               Type = [IntType] unsigned int
 #   15|               Value = [CStyleCast] 5
 #   15|               ValueCategory = prvalue
-#   15|             expr: [Literal] 5
-#   15|                 Type = [IntType] int
-#   15|                 Value = [Literal] 5
-#   15|                 ValueCategory = prvalue
 #   17|     10: [DeclStmt] declaration
 #   17|       0: [VariableDeclarationEntry] definition of l
 #   17|           Type = [LongType] long
 #   17|         init: [Initializer] initializer for l
-#   17|           expr: [CStyleCast] (long)...
+#   17|           expr: [Literal] 5
+#   17|               Type = [IntType] int
+#   17|               Value = [Literal] 5
+#   17|               ValueCategory = prvalue
+#   17|           expr converted: [CStyleCast] (long)...
 #   17|               Conversion = [IntegralConversion] integral conversion
 #   17|               Type = [LongType] long
 #   17|               Value = [CStyleCast] 5
 #   17|               ValueCategory = prvalue
-#   17|             expr: [Literal] 5
-#   17|                 Type = [IntType] int
-#   17|                 Value = [Literal] 5
-#   17|                 ValueCategory = prvalue
 #   18|     11: [DeclStmt] declaration
 #   18|       0: [VariableDeclarationEntry] definition of ul
 #   18|           Type = [LongType] unsigned long
 #   18|         init: [Initializer] initializer for ul
-#   18|           expr: [CStyleCast] (unsigned long)...
+#   18|           expr: [Literal] 5
+#   18|               Type = [IntType] int
+#   18|               Value = [Literal] 5
+#   18|               ValueCategory = prvalue
+#   18|           expr converted: [CStyleCast] (unsigned long)...
 #   18|               Conversion = [IntegralConversion] integral conversion
 #   18|               Type = [LongType] unsigned long
 #   18|               Value = [CStyleCast] 5
 #   18|               ValueCategory = prvalue
-#   18|             expr: [Literal] 5
-#   18|                 Type = [IntType] int
-#   18|                 Value = [Literal] 5
-#   18|                 ValueCategory = prvalue
 #   20|     12: [DeclStmt] declaration
 #   20|       0: [VariableDeclarationEntry] definition of ll_i
 #   20|           Type = [LongLongType] long long
 #   20|         init: [Initializer] initializer for ll_i
-#   20|           expr: [CStyleCast] (long long)...
+#   20|           expr: [Literal] 5
+#   20|               Type = [IntType] int
+#   20|               Value = [Literal] 5
+#   20|               ValueCategory = prvalue
+#   20|           expr converted: [CStyleCast] (long long)...
 #   20|               Conversion = [IntegralConversion] integral conversion
 #   20|               Type = [LongLongType] long long
 #   20|               Value = [CStyleCast] 5
 #   20|               ValueCategory = prvalue
-#   20|             expr: [Literal] 5
-#   20|                 Type = [IntType] int
-#   20|                 Value = [Literal] 5
-#   20|                 ValueCategory = prvalue
 #   21|     13: [DeclStmt] declaration
 #   21|       0: [VariableDeclarationEntry] definition of ll_ll
 #   21|           Type = [LongLongType] long long
@@ -1894,15 +1894,15 @@ ir.cpp:
 #   22|       0: [VariableDeclarationEntry] definition of ull_i
 #   22|           Type = [LongLongType] unsigned long long
 #   22|         init: [Initializer] initializer for ull_i
-#   22|           expr: [CStyleCast] (unsigned long long)...
+#   22|           expr: [Literal] 5
+#   22|               Type = [IntType] int
+#   22|               Value = [Literal] 5
+#   22|               ValueCategory = prvalue
+#   22|           expr converted: [CStyleCast] (unsigned long long)...
 #   22|               Conversion = [IntegralConversion] integral conversion
 #   22|               Type = [LongLongType] unsigned long long
 #   22|               Value = [CStyleCast] 5
 #   22|               ValueCategory = prvalue
-#   22|             expr: [Literal] 5
-#   22|                 Type = [IntType] int
-#   22|                 Value = [Literal] 5
-#   22|                 ValueCategory = prvalue
 #   23|     15: [DeclStmt] declaration
 #   23|       0: [VariableDeclarationEntry] definition of ull_ull
 #   23|           Type = [LongLongType] unsigned long long
@@ -1931,15 +1931,15 @@ ir.cpp:
 #   28|       0: [VariableDeclarationEntry] definition of wc_i
 #   28|           Type = [Wchar_t,WideCharType] wchar_t
 #   28|         init: [Initializer] initializer for wc_i
-#   28|           expr: [CStyleCast] (wchar_t)...
+#   28|           expr: [Literal] 5
+#   28|               Type = [IntType] int
+#   28|               Value = [Literal] 5
+#   28|               ValueCategory = prvalue
+#   28|           expr converted: [CStyleCast] (wchar_t)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [Wchar_t,WideCharType] wchar_t
 #   28|               Value = [CStyleCast] 5
 #   28|               ValueCategory = prvalue
-#   28|             expr: [Literal] 5
-#   28|                 Type = [IntType] int
-#   28|                 Value = [Literal] 5
-#   28|                 ValueCategory = prvalue
 #   29|     19: [DeclStmt] declaration
 #   29|       0: [VariableDeclarationEntry] definition of wc_c
 #   29|           Type = [Wchar_t,WideCharType] wchar_t
@@ -1968,15 +1968,15 @@ ir.cpp:
 #   34|       0: [VariableDeclarationEntry] definition of f_i
 #   34|           Type = [FloatType] float
 #   34|         init: [Initializer] initializer for f_i
-#   34|           expr: [CStyleCast] (float)...
+#   34|           expr: [Literal] 1
+#   34|               Type = [IntType] int
+#   34|               Value = [Literal] 1
+#   34|               ValueCategory = prvalue
+#   34|           expr converted: [CStyleCast] (float)...
 #   34|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   34|               Type = [FloatType] float
 #   34|               Value = [CStyleCast] 1.0
 #   34|               ValueCategory = prvalue
-#   34|             expr: [Literal] 1
-#   34|                 Type = [IntType] int
-#   34|                 Value = [Literal] 1
-#   34|                 ValueCategory = prvalue
 #   35|     23: [DeclStmt] declaration
 #   35|       0: [VariableDeclarationEntry] definition of f_f
 #   35|           Type = [FloatType] float
@@ -1989,41 +1989,41 @@ ir.cpp:
 #   36|       0: [VariableDeclarationEntry] definition of f_d
 #   36|           Type = [FloatType] float
 #   36|         init: [Initializer] initializer for f_d
-#   36|           expr: [CStyleCast] (float)...
+#   36|           expr: [Literal] 1.0
+#   36|               Type = [DoubleType] double
+#   36|               Value = [Literal] 1.0
+#   36|               ValueCategory = prvalue
+#   36|           expr converted: [CStyleCast] (float)...
 #   36|               Conversion = [FloatingPointConversion] floating point conversion
 #   36|               Type = [FloatType] float
 #   36|               Value = [CStyleCast] 1.0
 #   36|               ValueCategory = prvalue
-#   36|             expr: [Literal] 1.0
-#   36|                 Type = [DoubleType] double
-#   36|                 Value = [Literal] 1.0
-#   36|                 ValueCategory = prvalue
 #   38|     25: [DeclStmt] declaration
 #   38|       0: [VariableDeclarationEntry] definition of d_i
 #   38|           Type = [DoubleType] double
 #   38|         init: [Initializer] initializer for d_i
-#   38|           expr: [CStyleCast] (double)...
+#   38|           expr: [Literal] 1
+#   38|               Type = [IntType] int
+#   38|               Value = [Literal] 1
+#   38|               ValueCategory = prvalue
+#   38|           expr converted: [CStyleCast] (double)...
 #   38|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   38|               Type = [DoubleType] double
 #   38|               Value = [CStyleCast] 1.0
 #   38|               ValueCategory = prvalue
-#   38|             expr: [Literal] 1
-#   38|                 Type = [IntType] int
-#   38|                 Value = [Literal] 1
-#   38|                 ValueCategory = prvalue
 #   39|     26: [DeclStmt] declaration
 #   39|       0: [VariableDeclarationEntry] definition of d_f
 #   39|           Type = [DoubleType] double
 #   39|         init: [Initializer] initializer for d_f
-#   39|           expr: [CStyleCast] (double)...
+#   39|           expr: [Literal] 1.0
+#   39|               Type = [FloatType] float
+#   39|               Value = [Literal] 1.0
+#   39|               ValueCategory = prvalue
+#   39|           expr converted: [CStyleCast] (double)...
 #   39|               Conversion = [FloatingPointConversion] floating point conversion
 #   39|               Type = [DoubleType] double
 #   39|               Value = [CStyleCast] 1.0
 #   39|               ValueCategory = prvalue
-#   39|             expr: [Literal] 1.0
-#   39|                 Type = [FloatType] float
-#   39|                 Value = [Literal] 1.0
-#   39|                 ValueCategory = prvalue
 #   40|     27: [DeclStmt] declaration
 #   40|       0: [VariableDeclarationEntry] definition of d_d
 #   40|           Type = [DoubleType] double
@@ -2056,15 +2056,15 @@ ir.cpp:
 #   45|       0: [VariableDeclarationEntry] definition of y
 #   45|           Type = [ShortType] short
 #   45|         init: [Initializer] initializer for y
-#   45|           expr: [CStyleCast] (short)...
+#   45|           expr: [Literal] 7
+#   45|               Type = [IntType] int
+#   45|               Value = [Literal] 7
+#   45|               ValueCategory = prvalue
+#   45|           expr converted: [CStyleCast] (short)...
 #   45|               Conversion = [IntegralConversion] integral conversion
 #   45|               Type = [ShortType] short
 #   45|               Value = [CStyleCast] 7
 #   45|               ValueCategory = prvalue
-#   45|             expr: [Literal] 7
-#   45|                 Type = [IntType] int
-#   45|                 Value = [Literal] 7
-#   45|                 ValueCategory = prvalue
 #   46|     2: [ExprStmt] ExprStmt
 #   46|       0: [AssignExpr] ... = ...
 #   46|           Type = [ShortType] short
@@ -2072,23 +2072,23 @@ ir.cpp:
 #   46|         0: [VariableAccess] y
 #   46|             Type = [ShortType] short
 #   46|             ValueCategory = lvalue
-#   46|         1: [CStyleCast] (short)...
+#   46|         1: [AddExpr] ... + ...
+#   46|             Type = [IntType] int
+#   46|             ValueCategory = prvalue
+#   46|           0: [VariableAccess] x
+#   46|               Type = [IntType] int
+#   46|               ValueCategory = prvalue(load)
+#   46|           1: [VariableAccess] y
+#   46|               Type = [ShortType] short
+#   46|               ValueCategory = prvalue(load)
+#   46|           1 converted: [CStyleCast] (int)...
+#   46|               Conversion = [IntegralConversion] integral conversion
+#   46|               Type = [IntType] int
+#   46|               ValueCategory = prvalue
+#   46|         1 converted: [CStyleCast] (short)...
 #   46|             Conversion = [IntegralConversion] integral conversion
 #   46|             Type = [ShortType] short
 #   46|             ValueCategory = prvalue
-#   46|           expr: [AddExpr] ... + ...
-#   46|               Type = [IntType] int
-#   46|               ValueCategory = prvalue
-#   46|             0: [VariableAccess] x
-#   46|                 Type = [IntType] int
-#   46|                 ValueCategory = prvalue(load)
-#   46|             1: [CStyleCast] (int)...
-#   46|                 Conversion = [IntegralConversion] integral conversion
-#   46|                 Type = [IntType] int
-#   46|                 ValueCategory = prvalue
-#   46|               expr: [VariableAccess] y
-#   46|                   Type = [ShortType] short
-#   46|                   ValueCategory = prvalue(load)
 #   47|     3: [ExprStmt] ExprStmt
 #   47|       0: [AssignExpr] ... = ...
 #   47|           Type = [IntType] int
@@ -2102,13 +2102,13 @@ ir.cpp:
 #   47|           0: [VariableAccess] x
 #   47|               Type = [IntType] int
 #   47|               ValueCategory = prvalue(load)
-#   47|           1: [CStyleCast] (int)...
+#   47|           1: [VariableAccess] y
+#   47|               Type = [ShortType] short
+#   47|               ValueCategory = prvalue(load)
+#   47|           1 converted: [CStyleCast] (int)...
 #   47|               Conversion = [IntegralConversion] integral conversion
 #   47|               Type = [IntType] int
 #   47|               ValueCategory = prvalue
-#   47|             expr: [VariableAccess] y
-#   47|                 Type = [ShortType] short
-#   47|                 ValueCategory = prvalue(load)
 #   48|     4: [ReturnStmt] return ...
 #   50| [TopLevelFunction] void IntegerOps(int, int)
 #   50|   params: 
@@ -2436,20 +2436,20 @@ ir.cpp:
 #   84|         0: [VariableAccess] z
 #   84|             Type = [IntType] int
 #   84|             ValueCategory = lvalue
-#   84|         1: [CStyleCast] (int)...
+#   84|         1: [NotExpr] ! ...
+#   84|             Type = [BoolType] bool
+#   84|             ValueCategory = prvalue
+#   84|           0: [VariableAccess] x
+#   84|               Type = [IntType] int
+#   84|               ValueCategory = prvalue(load)
+#   84|           0 converted: [CStyleCast] (bool)...
+#   84|               Conversion = [BoolConversion] conversion to bool
+#   84|               Type = [BoolType] bool
+#   84|               ValueCategory = prvalue
+#   84|         1 converted: [CStyleCast] (int)...
 #   84|             Conversion = [IntegralConversion] integral conversion
 #   84|             Type = [IntType] int
 #   84|             ValueCategory = prvalue
-#   84|           expr: [NotExpr] ! ...
-#   84|               Type = [BoolType] bool
-#   84|               ValueCategory = prvalue
-#   84|             0: [CStyleCast] (bool)...
-#   84|                 Conversion = [BoolConversion] conversion to bool
-#   84|                 Type = [BoolType] bool
-#   84|                 ValueCategory = prvalue
-#   84|               expr: [VariableAccess] x
-#   84|                   Type = [IntType] int
-#   84|                   ValueCategory = prvalue(load)
 #   85|     26: [ReturnStmt] return ...
 #   87| [TopLevelFunction] void IntegerCompare(int, int)
 #   87|   params: 
@@ -2637,15 +2637,15 @@ ir.cpp:
 #  110|         1: [AddressOfExpr] & ...
 #  110|             Type = [IntPointerType] int *
 #  110|             ValueCategory = prvalue
-#  110|           0: [ParenthesisExpr] (...)
+#  110|           0: [PrefixIncrExpr] ++ ...
 #  110|               Type = [IntType] int
 #  110|               ValueCategory = lvalue
-#  110|             expr: [PrefixIncrExpr] ++ ...
+#  110|             0: [VariableAccess] x
 #  110|                 Type = [IntType] int
 #  110|                 ValueCategory = lvalue
-#  110|               0: [VariableAccess] x
-#  110|                   Type = [IntType] int
-#  110|                   ValueCategory = lvalue
+#  110|           0 converted: [ParenthesisExpr] (...)
+#  110|               Type = [IntType] int
+#  110|               ValueCategory = lvalue
 #  111|     2: [ExprStmt] ExprStmt
 #  111|       0: [AssignExpr] ... = ...
 #  111|           Type = [IntPointerType] int *
@@ -2656,15 +2656,15 @@ ir.cpp:
 #  111|         1: [AddressOfExpr] & ...
 #  111|             Type = [IntPointerType] int *
 #  111|             ValueCategory = prvalue
-#  111|           0: [ParenthesisExpr] (...)
+#  111|           0: [PrefixDecrExpr] -- ...
 #  111|               Type = [IntType] int
 #  111|               ValueCategory = lvalue
-#  111|             expr: [PrefixDecrExpr] -- ...
+#  111|             0: [VariableAccess] x
 #  111|                 Type = [IntType] int
 #  111|                 ValueCategory = lvalue
-#  111|               0: [VariableAccess] x
-#  111|                   Type = [IntType] int
-#  111|                   ValueCategory = lvalue
+#  111|           0 converted: [ParenthesisExpr] (...)
+#  111|               Type = [IntType] int
+#  111|               ValueCategory = lvalue
 #  112|     3: [ReturnStmt] return ...
 #  114| [TopLevelFunction] void FloatOps(double, double)
 #  114|   params: 
@@ -3053,19 +3053,19 @@ ir.cpp:
 #  160|         0: [VariableAccess] i
 #  160|             Type = [IntType] int
 #  160|             ValueCategory = lvalue
-#  160|         1: [CStyleCast] (int)...
+#  160|         1: [PointerDiffExpr] ... - ...
+#  160|             Type = [LongType] long
+#  160|             ValueCategory = prvalue
+#  160|           0: [VariableAccess] p
+#  160|               Type = [IntPointerType] int *
+#  160|               ValueCategory = prvalue(load)
+#  160|           1: [VariableAccess] q
+#  160|               Type = [IntPointerType] int *
+#  160|               ValueCategory = prvalue(load)
+#  160|         1 converted: [CStyleCast] (int)...
 #  160|             Conversion = [IntegralConversion] integral conversion
 #  160|             Type = [IntType] int
 #  160|             ValueCategory = prvalue
-#  160|           expr: [PointerDiffExpr] ... - ...
-#  160|               Type = [LongType] long
-#  160|               ValueCategory = prvalue
-#  160|             0: [VariableAccess] p
-#  160|                 Type = [IntPointerType] int *
-#  160|                 ValueCategory = prvalue(load)
-#  160|             1: [VariableAccess] q
-#  160|                 Type = [IntPointerType] int *
-#  160|                 ValueCategory = prvalue(load)
 #  162|     6: [ExprStmt] ExprStmt
 #  162|       0: [AssignExpr] ... = ...
 #  162|           Type = [IntPointerType] int *
@@ -3103,13 +3103,13 @@ ir.cpp:
 #  167|         0: [VariableAccess] b
 #  167|             Type = [BoolType] bool
 #  167|             ValueCategory = lvalue
-#  167|         1: [CStyleCast] (bool)...
+#  167|         1: [VariableAccess] p
+#  167|             Type = [IntPointerType] int *
+#  167|             ValueCategory = prvalue(load)
+#  167|         1 converted: [CStyleCast] (bool)...
 #  167|             Conversion = [BoolConversion] conversion to bool
 #  167|             Type = [BoolType] bool
 #  167|             ValueCategory = prvalue
-#  167|           expr: [VariableAccess] p
-#  167|               Type = [IntPointerType] int *
-#  167|               ValueCategory = prvalue(load)
 #  168|     10: [ExprStmt] ExprStmt
 #  168|       0: [AssignExpr] ... = ...
 #  168|           Type = [BoolType] bool
@@ -3120,13 +3120,13 @@ ir.cpp:
 #  168|         1: [NotExpr] ! ...
 #  168|             Type = [BoolType] bool
 #  168|             ValueCategory = prvalue
-#  168|           0: [CStyleCast] (bool)...
+#  168|           0: [VariableAccess] p
+#  168|               Type = [IntPointerType] int *
+#  168|               ValueCategory = prvalue(load)
+#  168|           0 converted: [CStyleCast] (bool)...
 #  168|               Conversion = [BoolConversion] conversion to bool
 #  168|               Type = [BoolType] bool
 #  168|               ValueCategory = prvalue
-#  168|             expr: [VariableAccess] p
-#  168|                 Type = [IntPointerType] int *
-#  168|                 ValueCategory = prvalue(load)
 #  169|     11: [ReturnStmt] return ...
 #  171| [TopLevelFunction] void ArrayAccess(int*, int)
 #  171|   params: 
@@ -3215,15 +3215,15 @@ ir.cpp:
 #  181|         1: [ArrayExpr] access to array
 #  181|             Type = [IntType] int
 #  181|             ValueCategory = prvalue(load)
-#  181|           0: [ArrayToPointerConversion] array to pointer conversion
-#  181|               Type = [IntPointerType] int *
-#  181|               ValueCategory = prvalue
-#  181|             expr: [VariableAccess] a
-#  181|                 Type = [ArrayType] int[10]
-#  181|                 ValueCategory = lvalue
+#  181|           0: [VariableAccess] a
+#  181|               Type = [ArrayType] int[10]
+#  181|               ValueCategory = lvalue
 #  181|           1: [VariableAccess] i
 #  181|               Type = [IntType] int
 #  181|               ValueCategory = prvalue(load)
+#  181|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  181|               Type = [IntPointerType] int *
+#  181|               ValueCategory = prvalue
 #  182|     7: [ExprStmt] ExprStmt
 #  182|       0: [AssignExpr] ... = ...
 #  182|           Type = [IntType] int
@@ -3234,15 +3234,15 @@ ir.cpp:
 #  182|         1: [ArrayExpr] access to array
 #  182|             Type = [IntType] int
 #  182|             ValueCategory = prvalue(load)
-#  182|           0: [ArrayToPointerConversion] array to pointer conversion
-#  182|               Type = [IntPointerType] int *
-#  182|               ValueCategory = prvalue
-#  182|             expr: [VariableAccess] a
-#  182|                 Type = [ArrayType] int[10]
-#  182|                 ValueCategory = lvalue
+#  182|           0: [VariableAccess] a
+#  182|               Type = [ArrayType] int[10]
+#  182|               ValueCategory = lvalue
 #  182|           1: [VariableAccess] i
 #  182|               Type = [IntType] int
 #  182|               ValueCategory = prvalue(load)
+#  182|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  182|               Type = [IntPointerType] int *
+#  182|               ValueCategory = prvalue
 #  183|     8: [ExprStmt] ExprStmt
 #  183|       0: [AssignExpr] ... = ...
 #  183|           Type = [IntType] int
@@ -3250,15 +3250,15 @@ ir.cpp:
 #  183|         0: [ArrayExpr] access to array
 #  183|             Type = [IntType] int
 #  183|             ValueCategory = lvalue
-#  183|           0: [ArrayToPointerConversion] array to pointer conversion
-#  183|               Type = [IntPointerType] int *
-#  183|               ValueCategory = prvalue
-#  183|             expr: [VariableAccess] a
-#  183|                 Type = [ArrayType] int[10]
-#  183|                 ValueCategory = lvalue
+#  183|           0: [VariableAccess] a
+#  183|               Type = [ArrayType] int[10]
+#  183|               ValueCategory = lvalue
 #  183|           1: [VariableAccess] i
 #  183|               Type = [IntType] int
 #  183|               ValueCategory = prvalue(load)
+#  183|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  183|               Type = [IntPointerType] int *
+#  183|               ValueCategory = prvalue
 #  183|         1: [VariableAccess] x
 #  183|             Type = [IntType] int
 #  183|             ValueCategory = prvalue(load)
@@ -3269,15 +3269,15 @@ ir.cpp:
 #  184|         0: [ArrayExpr] access to array
 #  184|             Type = [IntType] int
 #  184|             ValueCategory = lvalue
-#  184|           0: [ArrayToPointerConversion] array to pointer conversion
-#  184|               Type = [IntPointerType] int *
-#  184|               ValueCategory = prvalue
-#  184|             expr: [VariableAccess] a
-#  184|                 Type = [ArrayType] int[10]
-#  184|                 ValueCategory = lvalue
+#  184|           0: [VariableAccess] a
+#  184|               Type = [ArrayType] int[10]
+#  184|               ValueCategory = lvalue
 #  184|           1: [VariableAccess] i
 #  184|               Type = [IntType] int
 #  184|               ValueCategory = prvalue(load)
+#  184|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  184|               Type = [IntPointerType] int *
+#  184|               ValueCategory = prvalue
 #  184|         1: [VariableAccess] x
 #  184|             Type = [IntType] int
 #  184|             ValueCategory = prvalue(load)
@@ -3294,31 +3294,31 @@ ir.cpp:
 #  188|           expr: [ArrayExpr] access to array
 #  188|               Type = [PlainCharType] char
 #  188|               ValueCategory = prvalue(load)
-#  188|             0: [ArrayToPointerConversion] array to pointer conversion
-#  188|                 Type = [PointerType] const char *
-#  188|                 ValueCategory = prvalue
-#  188|               expr: Foo
-#  188|                   Type = [ArrayType] const char[4]
-#  188|                   Value = [StringLiteral] "Foo"
-#  188|                   ValueCategory = lvalue
+#  188|             0: Foo
+#  188|                 Type = [ArrayType] const char[4]
+#  188|                 Value = [StringLiteral] "Foo"
+#  188|                 ValueCategory = lvalue
 #  188|             1: [VariableAccess] i
 #  188|                 Type = [IntType] int
 #  188|                 ValueCategory = prvalue(load)
+#  188|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  188|                 Type = [PointerType] const char *
+#  188|                 ValueCategory = prvalue
 #  189|     1: [DeclStmt] declaration
 #  189|       0: [VariableDeclarationEntry] definition of pwc
 #  189|           Type = [PointerType] wchar_t *
 #  189|         init: [Initializer] initializer for pwc
-#  189|           expr: [CStyleCast] (wchar_t *)...
+#  189|           expr: Bar
+#  189|               Type = [ArrayType] const wchar_t[4]
+#  189|               Value = [StringLiteral] "Bar"
+#  189|               ValueCategory = lvalue
+#  189|           expr converted: [CStyleCast] (wchar_t *)...
 #  189|               Conversion = [PointerConversion] pointer conversion
 #  189|               Type = [PointerType] wchar_t *
 #  189|               ValueCategory = prvalue
-#  189|             expr: [ArrayToPointerConversion] array to pointer conversion
+#  189|             : [ArrayToPointerConversion] array to pointer conversion
 #  189|                 Type = [PointerType] const wchar_t *
 #  189|                 ValueCategory = prvalue
-#  189|               expr: Bar
-#  189|                   Type = [ArrayType] const wchar_t[4]
-#  189|                   Value = [StringLiteral] "Bar"
-#  189|                   ValueCategory = lvalue
 #  190|     2: [DeclStmt] declaration
 #  190|       0: [VariableDeclarationEntry] definition of wc
 #  190|           Type = [Wchar_t,WideCharType] wchar_t
@@ -3527,15 +3527,15 @@ ir.cpp:
 #  219|       0: [VariableDeclarationEntry] definition of y
 #  219|           Type = [ShortType] short
 #  219|         init: [Initializer] initializer for y
-#  219|           expr: [CStyleCast] (short)...
+#  219|           expr: [Literal] 5
+#  219|               Type = [IntType] int
+#  219|               Value = [Literal] 5
+#  219|               ValueCategory = prvalue
+#  219|           expr converted: [CStyleCast] (short)...
 #  219|               Conversion = [IntegralConversion] integral conversion
 #  219|               Type = [ShortType] short
 #  219|               Value = [CStyleCast] 5
 #  219|               ValueCategory = prvalue
-#  219|             expr: [Literal] 5
-#  219|                 Type = [IntType] int
-#  219|                 Value = [Literal] 5
-#  219|                 ValueCategory = prvalue
 #  220|     3: [ExprStmt] ExprStmt
 #  220|       0: [AssignAddExpr] ... += ...
 #  220|           Type = [ShortType] short
@@ -3561,15 +3561,15 @@ ir.cpp:
 #  226|       0: [VariableDeclarationEntry] definition of z
 #  226|           Type = [LongType] long
 #  226|         init: [Initializer] initializer for z
-#  226|           expr: [CStyleCast] (long)...
+#  226|           expr: [Literal] 7
+#  226|               Type = [IntType] int
+#  226|               Value = [Literal] 7
+#  226|               ValueCategory = prvalue
+#  226|           expr converted: [CStyleCast] (long)...
 #  226|               Conversion = [IntegralConversion] integral conversion
 #  226|               Type = [LongType] long
 #  226|               Value = [CStyleCast] 7
 #  226|               ValueCategory = prvalue
-#  226|             expr: [Literal] 7
-#  226|                 Type = [IntType] int
-#  226|                 Value = [Literal] 7
-#  226|                 ValueCategory = prvalue
 #  227|     6: [ExprStmt] ExprStmt
 #  227|       0: [AssignAddExpr] ... += ...
 #  227|           Type = [LongType] long
@@ -4608,18 +4608,18 @@ ir.cpp:
 #  467|       0: [NotExpr] ! ...
 #  467|           Type = [BoolType] bool
 #  467|           ValueCategory = prvalue
-#  467|         0: [ParenthesisExpr] (...)
+#  467|         0: [LogicalAndExpr] ... && ...
 #  467|             Type = [BoolType] bool
 #  467|             ValueCategory = prvalue
-#  467|           expr: [LogicalAndExpr] ... && ...
+#  467|           0: [VariableAccess] a
 #  467|               Type = [BoolType] bool
-#  467|               ValueCategory = prvalue
-#  467|             0: [VariableAccess] a
-#  467|                 Type = [BoolType] bool
-#  467|                 ValueCategory = prvalue(load)
-#  467|             1: [VariableAccess] b
-#  467|                 Type = [BoolType] bool
-#  467|                 ValueCategory = prvalue(load)
+#  467|               ValueCategory = prvalue(load)
+#  467|           1: [VariableAccess] b
+#  467|               Type = [BoolType] bool
+#  467|               ValueCategory = prvalue(load)
+#  467|         0 converted: [ParenthesisExpr] (...)
+#  467|             Type = [BoolType] bool
+#  467|             ValueCategory = prvalue
 #  467|       1: [BlockStmt] { ... }
 #  468|         0: [ExprStmt] ExprStmt
 #  468|           0: [AssignExpr] ... = ...
@@ -4697,18 +4697,18 @@ ir.cpp:
 #  479|         1: [NotExpr] ! ...
 #  479|             Type = [BoolType] bool
 #  479|             ValueCategory = prvalue
-#  479|           0: [ParenthesisExpr] (...)
+#  479|           0: [LogicalOrExpr] ... || ...
 #  479|               Type = [BoolType] bool
 #  479|               ValueCategory = prvalue
-#  479|             expr: [LogicalOrExpr] ... || ...
+#  479|             0: [VariableAccess] a
 #  479|                 Type = [BoolType] bool
-#  479|                 ValueCategory = prvalue
-#  479|               0: [VariableAccess] a
-#  479|                   Type = [BoolType] bool
-#  479|                   ValueCategory = prvalue(load)
-#  479|               1: [VariableAccess] b
-#  479|                   Type = [BoolType] bool
-#  479|                   ValueCategory = prvalue(load)
+#  479|                 ValueCategory = prvalue(load)
+#  479|             1: [VariableAccess] b
+#  479|                 Type = [BoolType] bool
+#  479|                 ValueCategory = prvalue(load)
+#  479|           0 converted: [ParenthesisExpr] (...)
+#  479|               Type = [BoolType] bool
+#  479|               ValueCategory = prvalue
 #  480|     4: [ReturnStmt] return ...
 #  482| [TopLevelFunction] void Conditional(bool, int, int)
 #  482|   params: 
@@ -4751,25 +4751,25 @@ ir.cpp:
 #  489|       0: [AssignExpr] ... = ...
 #  489|           Type = [IntType] int
 #  489|           ValueCategory = lvalue
-#  489|         0: [ParenthesisExpr] (...)
+#  489|         0: [ConditionalExpr] ... ? ... : ...
 #  489|             Type = [IntType] int
 #  489|             ValueCategory = lvalue
-#  489|           expr: [ConditionalExpr] ... ? ... : ...
+#  489|           0: [VariableAccess] a
+#  489|               Type = [BoolType] bool
+#  489|               ValueCategory = prvalue(load)
+#  489|           1: [VariableAccess] x
 #  489|               Type = [IntType] int
 #  489|               ValueCategory = lvalue
-#  489|             0: [VariableAccess] a
-#  489|                 Type = [BoolType] bool
-#  489|                 ValueCategory = prvalue(load)
-#  489|             1: [VariableAccess] x
-#  489|                 Type = [IntType] int
-#  489|                 ValueCategory = lvalue
-#  489|             2: [VariableAccess] y
-#  489|                 Type = [IntType] int
-#  489|                 ValueCategory = lvalue
+#  489|           2: [VariableAccess] y
+#  489|               Type = [IntType] int
+#  489|               ValueCategory = lvalue
 #  489|         1: [Literal] 5
 #  489|             Type = [IntType] int
 #  489|             Value = [Literal] 5
 #  489|             ValueCategory = prvalue
+#  489|         0 converted: [ParenthesisExpr] (...)
+#  489|             Type = [IntType] int
+#  489|             ValueCategory = lvalue
 #  490|     3: [ReturnStmt] return ...
 #  492| [TopLevelFunction] void Conditional_Void(bool)
 #  492|   params: 
@@ -4797,28 +4797,28 @@ ir.cpp:
 #  497|       0: [VariableDeclarationEntry] definition of p
 #  497|           Type = [IntPointerType] int *
 #  497|         init: [Initializer] initializer for p
-#  497|           expr: [CStyleCast] (int *)...
+#  497|           expr: [Literal] 0
+#  497|               Type = [NullPointerType] decltype(nullptr)
+#  497|               Value = [Literal] 0
+#  497|               ValueCategory = prvalue
+#  497|           expr converted: [CStyleCast] (int *)...
 #  497|               Conversion = [PointerConversion] pointer conversion
 #  497|               Type = [IntPointerType] int *
 #  497|               Value = [CStyleCast] 0
 #  497|               ValueCategory = prvalue
-#  497|             expr: [Literal] 0
-#  497|                 Type = [NullPointerType] decltype(nullptr)
-#  497|                 Value = [Literal] 0
-#  497|                 ValueCategory = prvalue
 #  498|     1: [DeclStmt] declaration
 #  498|       0: [VariableDeclarationEntry] definition of q
 #  498|           Type = [IntPointerType] int *
 #  498|         init: [Initializer] initializer for q
-#  498|           expr: [CStyleCast] (int *)...
+#  498|           expr: [Literal] 0
+#  498|               Type = [IntType] int
+#  498|               Value = [Literal] 0
+#  498|               ValueCategory = prvalue
+#  498|           expr converted: [CStyleCast] (int *)...
 #  498|               Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  498|               Type = [IntPointerType] int *
 #  498|               Value = [CStyleCast] 0
 #  498|               ValueCategory = prvalue
-#  498|             expr: [Literal] 0
-#  498|                 Type = [IntType] int
-#  498|                 Value = [Literal] 0
-#  498|                 ValueCategory = prvalue
 #  499|     2: [ExprStmt] ExprStmt
 #  499|       0: [AssignExpr] ... = ...
 #  499|           Type = [IntPointerType] int *
@@ -4826,15 +4826,15 @@ ir.cpp:
 #  499|         0: [VariableAccess] p
 #  499|             Type = [IntPointerType] int *
 #  499|             ValueCategory = lvalue
-#  499|         1: [CStyleCast] (int *)...
+#  499|         1: [Literal] 0
+#  499|             Type = [NullPointerType] decltype(nullptr)
+#  499|             Value = [Literal] 0
+#  499|             ValueCategory = prvalue
+#  499|         1 converted: [CStyleCast] (int *)...
 #  499|             Conversion = [PointerConversion] pointer conversion
 #  499|             Type = [IntPointerType] int *
 #  499|             Value = [CStyleCast] 0
 #  499|             ValueCategory = prvalue
-#  499|           expr: [Literal] 0
-#  499|               Type = [NullPointerType] decltype(nullptr)
-#  499|               Value = [Literal] 0
-#  499|               ValueCategory = prvalue
 #  500|     3: [ExprStmt] ExprStmt
 #  500|       0: [AssignExpr] ... = ...
 #  500|           Type = [IntPointerType] int *
@@ -4842,15 +4842,15 @@ ir.cpp:
 #  500|         0: [VariableAccess] q
 #  500|             Type = [IntPointerType] int *
 #  500|             ValueCategory = lvalue
-#  500|         1: [CStyleCast] (int *)...
+#  500|         1: [Literal] 0
+#  500|             Type = [IntType] int
+#  500|             Value = [Literal] 0
+#  500|             ValueCategory = prvalue
+#  500|         1 converted: [CStyleCast] (int *)...
 #  500|             Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  500|             Type = [IntPointerType] int *
 #  500|             Value = [CStyleCast] 0
 #  500|             ValueCategory = prvalue
-#  500|           expr: [Literal] 0
-#  500|               Type = [IntType] int
-#  500|               Value = [Literal] 0
-#  500|               ValueCategory = prvalue
 #  501|     4: [ReturnStmt] return ...
 #  503| [TopLevelFunction] void InitList(int, float)
 #  503|   params: 
@@ -4869,13 +4869,13 @@ ir.cpp:
 #  504|             .x: [VariableAccess] x
 #  504|                 Type = [IntType] int
 #  504|                 ValueCategory = prvalue(load)
-#  504|             .y: [CStyleCast] (int)...
+#  504|             .y: [VariableAccess] f
+#  504|                 Type = [FloatType] float
+#  504|                 ValueCategory = prvalue(load)
+#  504|             .y converted: [CStyleCast] (int)...
 #  504|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  504|                 Type = [IntType] int
 #  504|                 ValueCategory = prvalue
-#  504|               expr: [VariableAccess] f
-#  504|                   Type = [FloatType] float
-#  504|                   ValueCategory = prvalue(load)
 #  505|     1: [DeclStmt] declaration
 #  505|       0: [VariableDeclarationEntry] definition of pt2
 #  505|           Type = [Struct] Point
@@ -4937,13 +4937,13 @@ ir.cpp:
 #  514|               .x: [VariableAccess] x
 #  514|                   Type = [IntType] int
 #  514|                   ValueCategory = prvalue(load)
-#  514|               .y: [CStyleCast] (int)...
+#  514|               .y: [VariableAccess] f
+#  514|                   Type = [FloatType] float
+#  514|                   ValueCategory = prvalue(load)
+#  514|               .y converted: [CStyleCast] (int)...
 #  514|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  514|                   Type = [IntType] int
 #  514|                   ValueCategory = prvalue
-#  514|                 expr: [VariableAccess] f
-#  514|                     Type = [FloatType] float
-#  514|                     ValueCategory = prvalue(load)
 #  515|     2: [DeclStmt] declaration
 #  515|       0: [VariableDeclarationEntry] definition of r3
 #  515|           Type = [Struct] Rect
@@ -4957,26 +4957,26 @@ ir.cpp:
 #  515|               .x: [VariableAccess] x
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y: [CStyleCast] (int)...
+#  515|               .y: [VariableAccess] f
+#  515|                   Type = [FloatType] float
+#  515|                   ValueCategory = prvalue(load)
+#  515|               .y converted: [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
-#  515|                 expr: [VariableAccess] f
-#  515|                     Type = [FloatType] float
-#  515|                     ValueCategory = prvalue(load)
 #  515|             .bottomRight: [ClassAggregateLiteral] {...}
 #  515|                 Type = [Struct] Point
 #  515|                 ValueCategory = prvalue
 #  515|               .x: [VariableAccess] x
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y: [CStyleCast] (int)...
+#  515|               .y: [VariableAccess] f
+#  515|                   Type = [FloatType] float
+#  515|                   ValueCategory = prvalue(load)
+#  515|               .y converted: [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
-#  515|                 expr: [VariableAccess] f
-#  515|                     Type = [FloatType] float
-#  515|                     ValueCategory = prvalue(load)
 #  516|     3: [DeclStmt] declaration
 #  516|       0: [VariableDeclarationEntry] definition of r4
 #  516|           Type = [Struct] Rect
@@ -5021,16 +5021,16 @@ ir.cpp:
 #  521|             [0]: [VariableAccess] x
 #  521|                 Type = [IntType] int
 #  521|                 ValueCategory = prvalue(load)
-#  521|             [1]: [CStyleCast] (int)...
-#  521|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
-#  521|                 Type = [IntType] int
-#  521|                 ValueCategory = prvalue
-#  521|               expr: [VariableAccess] f
-#  521|                   Type = [FloatType] float
-#  521|                   ValueCategory = prvalue(load)
+#  521|             [1]: [VariableAccess] f
+#  521|                 Type = [FloatType] float
+#  521|                 ValueCategory = prvalue(load)
 #  521|             [2]: [Literal] 0
 #  521|                 Type = [IntType] int
 #  521|                 Value = [Literal] 0
+#  521|                 ValueCategory = prvalue
+#  521|             [1] converted: [CStyleCast] (int)...
+#  521|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
+#  521|                 Type = [IntType] int
 #  521|                 ValueCategory = prvalue
 #  522|     2: [DeclStmt] declaration
 #  522|       0: [VariableDeclarationEntry] definition of a3
@@ -5065,13 +5065,13 @@ ir.cpp:
 #  531|           expr: [ClassAggregateLiteral] {...}
 #  531|               Type = [Union] U
 #  531|               ValueCategory = prvalue
-#  531|             .d: [CStyleCast] (double)...
+#  531|             .d: [VariableAccess] f
+#  531|                 Type = [FloatType] float
+#  531|                 ValueCategory = prvalue(load)
+#  531|             .d converted: [CStyleCast] (double)...
 #  531|                 Conversion = [FloatingPointConversion] floating point conversion
 #  531|                 Type = [DoubleType] double
 #  531|                 ValueCategory = prvalue
-#  531|               expr: [VariableAccess] f
-#  531|                   Type = [FloatType] float
-#  531|                   ValueCategory = prvalue(load)
 #  533|     1: [ReturnStmt] return ...
 #  535| [TopLevelFunction] void EarlyReturn(int, int)
 #  535|   params: 
@@ -5157,39 +5157,35 @@ ir.cpp:
 #  560|         Type = [CTypedefType] E
 #  560|   body: [BlockStmt] { ... }
 #  561|     0: [SwitchStmt] switch (...) ... 
-#  561|       0: [CStyleCast] (int)...
-#  561|           Conversion = [IntegralConversion] integral conversion
-#  561|           Type = [IntType] int
-#  561|           ValueCategory = prvalue
-#  561|         expr: [VariableAccess] e
-#  561|             Type = [CTypedefType] E
-#  561|             ValueCategory = prvalue(load)
+#  561|       0: [VariableAccess] e
+#  561|           Type = [CTypedefType] E
+#  561|           ValueCategory = prvalue(load)
 #  561|       1: [BlockStmt] { ... }
 #  562|         0: [SwitchCase] case ...:
-#  562|           0: [CStyleCast] (int)...
+#  562|           0: [EnumConstantAccess] E_0
+#  562|               Type = [Enum] E
+#  562|               Value = [EnumConstantAccess] 0
+#  562|               ValueCategory = prvalue
+#  562|           0 converted: [CStyleCast] (int)...
 #  562|               Conversion = [IntegralConversion] integral conversion
 #  562|               Type = [IntType] int
 #  562|               Value = [CStyleCast] 0
 #  562|               ValueCategory = prvalue
-#  562|             expr: [EnumConstantAccess] E_0
-#  562|                 Type = [Enum] E
-#  562|                 Value = [EnumConstantAccess] 0
-#  562|                 ValueCategory = prvalue
 #  563|         1: [ReturnStmt] return ...
 #  563|           0: [Literal] 0
 #  563|               Type = [IntType] int
 #  563|               Value = [Literal] 0
 #  563|               ValueCategory = prvalue
 #  564|         2: [SwitchCase] case ...:
-#  564|           0: [CStyleCast] (int)...
+#  564|           0: [EnumConstantAccess] E_1
+#  564|               Type = [Enum] E
+#  564|               Value = [EnumConstantAccess] 1
+#  564|               ValueCategory = prvalue
+#  564|           0 converted: [CStyleCast] (int)...
 #  564|               Conversion = [IntegralConversion] integral conversion
 #  564|               Type = [IntType] int
 #  564|               Value = [CStyleCast] 1
 #  564|               ValueCategory = prvalue
-#  564|             expr: [EnumConstantAccess] E_1
-#  564|                 Type = [Enum] E
-#  564|                 Value = [EnumConstantAccess] 1
-#  564|                 ValueCategory = prvalue
 #  565|         3: [ReturnStmt] return ...
 #  565|           0: [Literal] 1
 #  565|               Type = [IntType] int
@@ -5205,6 +5201,10 @@ ir.cpp:
 #  567|                 Type = [IntType] int
 #  567|                 Value = [Literal] 1
 #  567|                 ValueCategory = prvalue
+#  561|       0 converted: [CStyleCast] (int)...
+#  561|           Conversion = [IntegralConversion] integral conversion
+#  561|           Type = [IntType] int
+#  561|           ValueCategory = prvalue
 #  571| [TopLevelFunction] void InitArray()
 #  571|   params: 
 #  571|   body: [BlockStmt] { ... }
@@ -5249,15 +5249,15 @@ ir.cpp:
 #  577|           expr: [ArrayAggregateLiteral] {...}
 #  577|               Type = [ArrayType] char[2]
 #  577|               ValueCategory = prvalue
-#  577|             [0]: [CStyleCast] (char)...
+#  577|             [0]: [Literal] 0
+#  577|                 Type = [IntType] int
+#  577|                 Value = [Literal] 0
+#  577|                 ValueCategory = prvalue
+#  577|             [0] converted: [CStyleCast] (char)...
 #  577|                 Conversion = [IntegralConversion] integral conversion
 #  577|                 Type = [PlainCharType] char
 #  577|                 Value = [CStyleCast] 0
 #  577|                 ValueCategory = prvalue
-#  577|               expr: [Literal] 0
-#  577|                   Type = [IntType] int
-#  577|                   Value = [Literal] 0
-#  577|                   ValueCategory = prvalue
 #  578|     6: [DeclStmt] declaration
 #  578|       0: [VariableDeclarationEntry] definition of e
 #  578|           Type = [ArrayType] char[2]
@@ -5265,24 +5265,24 @@ ir.cpp:
 #  578|           expr: [ArrayAggregateLiteral] {...}
 #  578|               Type = [ArrayType] char[2]
 #  578|               ValueCategory = prvalue
-#  578|             [0]: [CStyleCast] (char)...
+#  578|             [0]: [Literal] 0
+#  578|                 Type = [IntType] int
+#  578|                 Value = [Literal] 0
+#  578|                 ValueCategory = prvalue
+#  578|             [1]: [Literal] 1
+#  578|                 Type = [IntType] int
+#  578|                 Value = [Literal] 1
+#  578|                 ValueCategory = prvalue
+#  578|             [0] converted: [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 0
 #  578|                 ValueCategory = prvalue
-#  578|               expr: [Literal] 0
-#  578|                   Type = [IntType] int
-#  578|                   Value = [Literal] 0
-#  578|                   ValueCategory = prvalue
-#  578|             [1]: [CStyleCast] (char)...
+#  578|             [1] converted: [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 1
 #  578|                 ValueCategory = prvalue
-#  578|               expr: [Literal] 1
-#  578|                   Type = [IntType] int
-#  578|                   Value = [Literal] 1
-#  578|                   ValueCategory = prvalue
 #  579|     7: [DeclStmt] declaration
 #  579|       0: [VariableDeclarationEntry] definition of f
 #  579|           Type = [ArrayType] char[3]
@@ -5290,15 +5290,15 @@ ir.cpp:
 #  579|           expr: [ArrayAggregateLiteral] {...}
 #  579|               Type = [ArrayType] char[3]
 #  579|               ValueCategory = prvalue
-#  579|             [0]: [CStyleCast] (char)...
+#  579|             [0]: [Literal] 0
+#  579|                 Type = [IntType] int
+#  579|                 Value = [Literal] 0
+#  579|                 ValueCategory = prvalue
+#  579|             [0] converted: [CStyleCast] (char)...
 #  579|                 Conversion = [IntegralConversion] integral conversion
 #  579|                 Type = [PlainCharType] char
 #  579|                 Value = [CStyleCast] 0
 #  579|                 ValueCategory = prvalue
-#  579|               expr: [Literal] 0
-#  579|                   Type = [IntType] int
-#  579|                   Value = [Literal] 0
-#  579|                   ValueCategory = prvalue
 #  580|     8: [ReturnStmt] return ...
 #  582| [TopLevelFunction] void VarArgFunction(char const*)
 #  582|   params: 
@@ -5311,24 +5311,24 @@ ir.cpp:
 #  585|       0: [FunctionCall] call to VarArgFunction
 #  585|           Type = [VoidType] void
 #  585|           ValueCategory = prvalue
-#  585|         0: [ArrayToPointerConversion] array to pointer conversion
-#  585|             Type = [PointerType] const char *
-#  585|             ValueCategory = prvalue
-#  585|           expr: %d %s
-#  585|               Type = [ArrayType] const char[6]
-#  585|               Value = [StringLiteral] "%d %s"
-#  585|               ValueCategory = lvalue
+#  585|         0: %d %s
+#  585|             Type = [ArrayType] const char[6]
+#  585|             Value = [StringLiteral] "%d %s"
+#  585|             ValueCategory = lvalue
 #  585|         1: [Literal] 1
 #  585|             Type = [IntType] int
 #  585|             Value = [Literal] 1
 #  585|             ValueCategory = prvalue
-#  585|         2: [ArrayToPointerConversion] array to pointer conversion
+#  585|         2: string
+#  585|             Type = [ArrayType] const char[7]
+#  585|             Value = [StringLiteral] "string"
+#  585|             ValueCategory = lvalue
+#  585|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  585|             Type = [PointerType] const char *
 #  585|             ValueCategory = prvalue
-#  585|           expr: string
-#  585|               Type = [ArrayType] const char[7]
-#  585|               Value = [StringLiteral] "string"
-#  585|               ValueCategory = lvalue
+#  585|         2 converted: [ArrayToPointerConversion] array to pointer conversion
+#  585|             Type = [PointerType] const char *
+#  585|             ValueCategory = prvalue
 #  586|     1: [ReturnStmt] return ...
 #  588| [TopLevelFunction] int FuncPtrTarget(int)
 #  588|   params: 
@@ -5436,13 +5436,13 @@ ir.cpp:
 #  617|           expr: [ConstructorCall] call to String
 #  617|               Type = [VoidType] void
 #  617|               ValueCategory = prvalue
-#  617|             0: [ArrayToPointerConversion] array to pointer conversion
+#  617|             0: hello
+#  617|                 Type = [ArrayType] const char[6]
+#  617|                 Value = [StringLiteral] "hello"
+#  617|                 ValueCategory = lvalue
+#  617|             0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  617|                 Type = [PointerType] const char *
 #  617|                 ValueCategory = prvalue
-#  617|               expr: hello
-#  617|                   Type = [ArrayType] const char[6]
-#  617|                   Value = [StringLiteral] "hello"
-#  617|                   ValueCategory = lvalue
 #  618|     2: [DeclStmt] declaration
 #  618|       0: [VariableDeclarationEntry] definition of s3
 #  618|           Type = [Struct] String
@@ -5457,13 +5457,13 @@ ir.cpp:
 #  619|           expr: [ConstructorCall] call to String
 #  619|               Type = [VoidType] void
 #  619|               ValueCategory = prvalue
-#  619|             0: [ArrayToPointerConversion] array to pointer conversion
+#  619|             0: test
+#  619|                 Type = [ArrayType] const char[5]
+#  619|                 Value = [StringLiteral] "test"
+#  619|                 ValueCategory = lvalue
+#  619|             0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  619|                 Type = [PointerType] const char *
 #  619|                 ValueCategory = prvalue
-#  619|               expr: test
-#  619|                   Type = [ArrayType] const char[5]
-#  619|                   Value = [StringLiteral] "test"
-#  619|                   ValueCategory = lvalue
 #  620|     4: [ReturnStmt] return ...
 #  622| [TopLevelFunction] void CallMethods(String&, String*, String)
 #  622|   params: 
@@ -5478,38 +5478,38 @@ ir.cpp:
 #  623|       0: [FunctionCall] call to c_str
 #  623|           Type = [PointerType] const char *
 #  623|           ValueCategory = prvalue
+#  623|         -1: [VariableAccess] r
+#  623|             Type = [LValueReferenceType] String &
+#  623|             ValueCategory = prvalue(load)
 #  623|         -1: [CStyleCast] (const String)...
 #  623|             Conversion = [GlvalueConversion] glvalue conversion
 #  623|             Type = [SpecifiedType] const String
 #  623|             ValueCategory = lvalue
-#  623|           expr: [ReferenceDereferenceExpr] (reference dereference)
+#  623|           : [ReferenceDereferenceExpr] (reference dereference)
 #  623|               Type = [Struct] String
 #  623|               ValueCategory = lvalue
-#  623|             expr: [VariableAccess] r
-#  623|                 Type = [LValueReferenceType] String &
-#  623|                 ValueCategory = prvalue(load)
 #  624|     1: [ExprStmt] ExprStmt
 #  624|       0: [FunctionCall] call to c_str
 #  624|           Type = [PointerType] const char *
 #  624|           ValueCategory = prvalue
+#  624|         -1: [VariableAccess] p
+#  624|             Type = [PointerType] String *
+#  624|             ValueCategory = prvalue(load)
 #  624|         -1: [CStyleCast] (const String *)...
 #  624|             Conversion = [PointerConversion] pointer conversion
 #  624|             Type = [PointerType] const String *
 #  624|             ValueCategory = prvalue
-#  624|           expr: [VariableAccess] p
-#  624|               Type = [PointerType] String *
-#  624|               ValueCategory = prvalue(load)
 #  625|     2: [ExprStmt] ExprStmt
 #  625|       0: [FunctionCall] call to c_str
 #  625|           Type = [PointerType] const char *
 #  625|           ValueCategory = prvalue
+#  625|         -1: [VariableAccess] s
+#  625|             Type = [Struct] String
+#  625|             ValueCategory = lvalue
 #  625|         -1: [CStyleCast] (const String)...
 #  625|             Conversion = [GlvalueConversion] glvalue conversion
 #  625|             Type = [SpecifiedType] const String
 #  625|             ValueCategory = lvalue
-#  625|           expr: [VariableAccess] s
-#  625|               Type = [Struct] String
-#  625|               ValueCategory = lvalue
 #  626|     3: [ReturnStmt] return ...
 #  628| [CopyAssignmentOperator] C& C::operator=(C const&)
 #  628|   params: 
@@ -5601,15 +5601,15 @@ ir.cpp:
 #  644|         0: [ValueFieldAccess] m_a
 #  644|             Type = [IntType] int
 #  644|             ValueCategory = lvalue
+#  644|           -1: [PointerDereferenceExpr] * ...
+#  644|               Type = [Class] C
+#  644|               ValueCategory = lvalue
+#  644|             0: [ThisExpr] this
+#  644|                 Type = [PointerType] C *
+#  644|                 ValueCategory = prvalue(load)
 #  644|           -1: [ParenthesisExpr] (...)
 #  644|               Type = [Class] C
 #  644|               ValueCategory = lvalue
-#  644|             expr: [PointerDereferenceExpr] * ...
-#  644|                 Type = [Class] C
-#  644|                 ValueCategory = lvalue
-#  644|               0: [ThisExpr] this
-#  644|                   Type = [PointerType] C *
-#  644|                   ValueCategory = prvalue(load)
 #  644|         1: [Literal] 1
 #  644|             Type = [IntType] int
 #  644|             Value = [Literal] 1
@@ -5654,15 +5654,15 @@ ir.cpp:
 #  648|         1: [ValueFieldAccess] m_a
 #  648|             Type = [IntType] int
 #  648|             ValueCategory = prvalue(load)
+#  648|           -1: [PointerDereferenceExpr] * ...
+#  648|               Type = [Class] C
+#  648|               ValueCategory = lvalue
+#  648|             0: [ThisExpr] this
+#  648|                 Type = [PointerType] C *
+#  648|                 ValueCategory = prvalue(load)
 #  648|           -1: [ParenthesisExpr] (...)
 #  648|               Type = [Class] C
 #  648|               ValueCategory = lvalue
-#  648|             expr: [PointerDereferenceExpr] * ...
-#  648|                 Type = [Class] C
-#  648|                 ValueCategory = lvalue
-#  648|               0: [ThisExpr] this
-#  648|                   Type = [PointerType] C *
-#  648|                   ValueCategory = prvalue(load)
 #  649|     6: [ExprStmt] ExprStmt
 #  649|       0: [AssignExpr] ... = ...
 #  649|           Type = [IntType] int
@@ -5695,15 +5695,15 @@ ir.cpp:
 #  654|       0: [FunctionCall] call to InstanceMemberFunction
 #  654|           Type = [IntType] int
 #  654|           ValueCategory = prvalue
-#  654|         -1: [ParenthesisExpr] (...)
+#  654|         -1: [PointerDereferenceExpr] * ...
 #  654|             Type = [Class] C
 #  654|             ValueCategory = lvalue
-#  654|           expr: [PointerDereferenceExpr] * ...
-#  654|               Type = [Class] C
-#  654|               ValueCategory = lvalue
-#  654|             0: [ThisExpr] this
-#  654|                 Type = [PointerType] C *
-#  654|                 ValueCategory = prvalue(load)
+#  654|           0: [ThisExpr] this
+#  654|               Type = [PointerType] C *
+#  654|               ValueCategory = prvalue(load)
+#  654|         0: [ParenthesisExpr] (...)
+#  654|             Type = [Class] C
+#  654|             ValueCategory = lvalue
 #  654|         0: [Literal] 1
 #  654|             Type = [IntType] int
 #  654|             Value = [Literal] 1
@@ -5739,15 +5739,15 @@ ir.cpp:
 #  660|     2: [ConstructorFieldInit] constructor init of field m_c
 #  660|         Type = [PlainCharType] char
 #  660|         ValueCategory = prvalue
-#  660|       0: [CStyleCast] (char)...
+#  660|       0: [Literal] 3
+#  660|           Type = [IntType] int
+#  660|           Value = [Literal] 3
+#  660|           ValueCategory = prvalue
+#  660|       0 converted: [CStyleCast] (char)...
 #  660|           Conversion = [IntegralConversion] integral conversion
 #  660|           Type = [PlainCharType] char
 #  660|           Value = [CStyleCast] 3
 #  660|           ValueCategory = prvalue
-#  660|         expr: [Literal] 3
-#  660|             Type = [IntType] int
-#  660|             Value = [Literal] 3
-#  660|             ValueCategory = prvalue
 #  661|     3: [ConstructorFieldInit] constructor init of field m_e
 #  661|         Type = [VoidPointerType] void *
 #  661|         ValueCategory = prvalue
@@ -5761,13 +5761,13 @@ ir.cpp:
 #  662|       0: [ConstructorCall] call to String
 #  662|           Type = [VoidType] void
 #  662|           ValueCategory = prvalue
-#  662|         0: [ArrayToPointerConversion] array to pointer conversion
+#  662|         0: test
+#  662|             Type = [ArrayType] const char[5]
+#  662|             Value = [StringLiteral] "test"
+#  662|             ValueCategory = lvalue
+#  662|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  662|             Type = [PointerType] const char *
 #  662|             ValueCategory = prvalue
-#  662|           expr: test
-#  662|               Type = [ArrayType] const char[5]
-#  662|               Value = [StringLiteral] "test"
-#  662|               ValueCategory = lvalue
 #  663|   body: [BlockStmt] { ... }
 #  664|     0: [ReturnStmt] return ...
 #  675| [TopLevelFunction] int DerefReference(int&)
@@ -5776,22 +5776,22 @@ ir.cpp:
 #  675|         Type = [LValueReferenceType] int &
 #  675|   body: [BlockStmt] { ... }
 #  676|     0: [ReturnStmt] return ...
-#  676|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  676|       0: [VariableAccess] r
+#  676|           Type = [LValueReferenceType] int &
+#  676|           ValueCategory = prvalue(load)
+#  676|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  676|           Type = [IntType] int
 #  676|           ValueCategory = prvalue(load)
-#  676|         expr: [VariableAccess] r
-#  676|             Type = [LValueReferenceType] int &
-#  676|             ValueCategory = prvalue(load)
 #  679| [TopLevelFunction] int& TakeReference()
 #  679|   params: 
 #  679|   body: [BlockStmt] { ... }
 #  680|     0: [ReturnStmt] return ...
-#  680|       0: [ReferenceToExpr] (reference to)
+#  680|       0: [VariableAccess] g
+#  680|           Type = [IntType] int
+#  680|           ValueCategory = lvalue
+#  680|       0 converted: [ReferenceToExpr] (reference to)
 #  680|           Type = [LValueReferenceType] int &
 #  680|           ValueCategory = prvalue
-#  680|         expr: [VariableAccess] g
-#  680|             Type = [IntType] int
-#  680|             ValueCategory = lvalue
 #  683| [TopLevelFunction] String& ReturnReference()
 #  683|   params: 
 #  685| [TopLevelFunction] void InitReference(int)
@@ -5803,42 +5803,42 @@ ir.cpp:
 #  686|       0: [VariableDeclarationEntry] definition of r
 #  686|           Type = [LValueReferenceType] int &
 #  686|         init: [Initializer] initializer for r
-#  686|           expr: [ReferenceToExpr] (reference to)
+#  686|           expr: [VariableAccess] x
+#  686|               Type = [IntType] int
+#  686|               ValueCategory = lvalue
+#  686|           expr converted: [ReferenceToExpr] (reference to)
 #  686|               Type = [LValueReferenceType] int &
 #  686|               ValueCategory = prvalue
-#  686|             expr: [VariableAccess] x
-#  686|                 Type = [IntType] int
-#  686|                 ValueCategory = lvalue
 #  687|     1: [DeclStmt] declaration
 #  687|       0: [VariableDeclarationEntry] definition of r2
 #  687|           Type = [LValueReferenceType] int &
 #  687|         init: [Initializer] initializer for r2
-#  687|           expr: [ReferenceToExpr] (reference to)
+#  687|           expr: [VariableAccess] r
+#  687|               Type = [LValueReferenceType] int &
+#  687|               ValueCategory = prvalue(load)
+#  687|           expr converted: [ReferenceToExpr] (reference to)
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue
-#  687|             expr: [ReferenceDereferenceExpr] (reference dereference)
+#  687|             : [ReferenceDereferenceExpr] (reference dereference)
 #  687|                 Type = [IntType] int
 #  687|                 ValueCategory = lvalue
-#  687|               expr: [VariableAccess] r
-#  687|                   Type = [LValueReferenceType] int &
-#  687|                   ValueCategory = prvalue(load)
 #  688|     2: [DeclStmt] declaration
 #  688|       0: [VariableDeclarationEntry] definition of r3
 #  688|           Type = [LValueReferenceType] const String &
 #  688|         init: [Initializer] initializer for r3
-#  688|           expr: [ReferenceToExpr] (reference to)
+#  688|           expr: [FunctionCall] call to ReturnReference
+#  688|               Type = [LValueReferenceType] String &
+#  688|               ValueCategory = prvalue
+#  688|           expr converted: [ReferenceToExpr] (reference to)
 #  688|               Type = [LValueReferenceType] const String &
 #  688|               ValueCategory = prvalue
-#  688|             expr: [CStyleCast] (const String)...
+#  688|             : [CStyleCast] (const String)...
 #  688|                 Conversion = [GlvalueConversion] glvalue conversion
 #  688|                 Type = [SpecifiedType] const String
 #  688|                 ValueCategory = lvalue
-#  688|               expr: [ReferenceDereferenceExpr] (reference dereference)
+#  688|               : [ReferenceDereferenceExpr] (reference dereference)
 #  688|                   Type = [Struct] String
 #  688|                   ValueCategory = lvalue
-#  688|                 expr: [FunctionCall] call to ReturnReference
-#  688|                     Type = [LValueReferenceType] String &
-#  688|                     ValueCategory = prvalue
 #  689|     3: [ReturnStmt] return ...
 #  691| [TopLevelFunction] void ArrayReferences()
 #  691|   params: 
@@ -5850,12 +5850,12 @@ ir.cpp:
 #  693|       0: [VariableDeclarationEntry] definition of ra
 #  693|           Type = [LValueReferenceType] int(&)[10]
 #  693|         init: [Initializer] initializer for ra
-#  693|           expr: [ReferenceToExpr] (reference to)
+#  693|           expr: [VariableAccess] a
+#  693|               Type = [ArrayType] int[10]
+#  693|               ValueCategory = lvalue
+#  693|           expr converted: [ReferenceToExpr] (reference to)
 #  693|               Type = [LValueReferenceType] int(&)[10]
 #  693|               ValueCategory = prvalue
-#  693|             expr: [VariableAccess] a
-#  693|                 Type = [ArrayType] int[10]
-#  693|                 ValueCategory = lvalue
 #  694|     2: [DeclStmt] declaration
 #  694|       0: [VariableDeclarationEntry] definition of x
 #  694|           Type = [IntType] int
@@ -5863,19 +5863,19 @@ ir.cpp:
 #  694|           expr: [ArrayExpr] access to array
 #  694|               Type = [IntType] int
 #  694|               ValueCategory = prvalue(load)
-#  694|             0: [ArrayToPointerConversion] array to pointer conversion
-#  694|                 Type = [IntPointerType] int *
-#  694|                 ValueCategory = prvalue
-#  694|               expr: [ReferenceDereferenceExpr] (reference dereference)
-#  694|                   Type = [ArrayType] int[10]
-#  694|                   ValueCategory = lvalue
-#  694|                 expr: [VariableAccess] ra
-#  694|                     Type = [LValueReferenceType] int(&)[10]
-#  694|                     ValueCategory = prvalue(load)
+#  694|             0: [VariableAccess] ra
+#  694|                 Type = [LValueReferenceType] int(&)[10]
+#  694|                 ValueCategory = prvalue(load)
 #  694|             1: [Literal] 5
 #  694|                 Type = [IntType] int
 #  694|                 Value = [Literal] 5
 #  694|                 ValueCategory = prvalue
+#  694|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  694|                 Type = [IntPointerType] int *
+#  694|                 ValueCategory = prvalue
+#  694|               : [ReferenceDereferenceExpr] (reference dereference)
+#  694|                   Type = [ArrayType] int[10]
+#  694|                   ValueCategory = lvalue
 #  695|     3: [ReturnStmt] return ...
 #  697| [TopLevelFunction] void FunctionReferences()
 #  697|   params: 
@@ -5884,36 +5884,36 @@ ir.cpp:
 #  698|       0: [VariableDeclarationEntry] definition of rfn
 #  698|           Type = [FunctionReferenceType] ..(&)(..)
 #  698|         init: [Initializer] initializer for rfn
-#  698|           expr: [ReferenceToExpr] (reference to)
+#  698|           expr: [FunctionAccess] FuncPtrTarget
+#  698|               Type = [RoutineType] ..()(..)
+#  698|               ValueCategory = lvalue
+#  698|           expr converted: [ReferenceToExpr] (reference to)
 #  698|               Type = [FunctionReferenceType] ..(&)(..)
 #  698|               ValueCategory = prvalue
-#  698|             expr: [FunctionAccess] FuncPtrTarget
-#  698|                 Type = [RoutineType] ..()(..)
-#  698|                 ValueCategory = lvalue
 #  699|     1: [DeclStmt] declaration
 #  699|       0: [VariableDeclarationEntry] definition of pfn
 #  699|           Type = [FunctionPointerType] ..(*)(..)
 #  699|         init: [Initializer] initializer for pfn
-#  699|           expr: [ReferenceDereferenceExpr] (reference dereference)
+#  699|           expr: [VariableAccess] rfn
+#  699|               Type = [FunctionReferenceType] ..(&)(..)
+#  699|               ValueCategory = prvalue(load)
+#  699|           expr converted: [ReferenceDereferenceExpr] (reference dereference)
 #  699|               Type = [FunctionPointerType] ..(*)(..)
 #  699|               ValueCategory = prvalue(load)
-#  699|             expr: [VariableAccess] rfn
-#  699|                 Type = [FunctionReferenceType] ..(&)(..)
-#  699|                 ValueCategory = prvalue(load)
 #  700|     2: [ExprStmt] ExprStmt
 #  700|       0: [VariableCall] call to expression
 #  700|           Type = [IntType] int
 #  700|           ValueCategory = prvalue
-#  700|         0: [ReferenceDereferenceExpr] (reference dereference)
-#  700|             Type = [FunctionPointerType] ..(*)(..)
+#  700|         0: [VariableAccess] rfn
+#  700|             Type = [FunctionReferenceType] ..(&)(..)
 #  700|             ValueCategory = prvalue(load)
-#  700|           expr: [VariableAccess] rfn
-#  700|               Type = [FunctionReferenceType] ..(&)(..)
-#  700|               ValueCategory = prvalue(load)
 #  700|         1: [Literal] 5
 #  700|             Type = [IntType] int
 #  700|             Value = [Literal] 5
 #  700|             ValueCategory = prvalue
+#  700|         0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  700|             Type = [FunctionPointerType] ..(*)(..)
+#  700|             ValueCategory = prvalue(load)
 #  701|     3: [ReturnStmt] return ...
 #  704| [TemplateFunction,TopLevelFunction] T min<T>(T, T)
 #  704|   params: 
@@ -5926,28 +5926,28 @@ ir.cpp:
 #  705|       0: [ConditionalExpr] ... ? ... : ...
 #  705|           Type = [UnknownType] unknown
 #  705|           ValueCategory = prvalue
-#  705|         0: [CStyleCast] (bool)...
-#  705|             Conversion = [BoolConversion] conversion to bool
-#  705|             Type = [BoolType] bool
+#  705|         0: [LTExpr] ... < ...
+#  705|             Type = [UnknownType] unknown
 #  705|             ValueCategory = prvalue
-#  705|           expr: [ParenthesisExpr] (...)
-#  705|               Type = [UnknownType] unknown
-#  705|               ValueCategory = prvalue
-#  705|             expr: [LTExpr] ... < ...
-#  705|                 Type = [UnknownType] unknown
-#  705|                 ValueCategory = prvalue
-#  705|               0: [VariableAccess] x
-#  705|                   Type = [TemplateParameter] T
-#  705|                   ValueCategory = lvalue
-#  705|               1: [VariableAccess] y
-#  705|                   Type = [TemplateParameter] T
-#  705|                   ValueCategory = lvalue
+#  705|           0: [VariableAccess] x
+#  705|               Type = [TemplateParameter] T
+#  705|               ValueCategory = lvalue
+#  705|           1: [VariableAccess] y
+#  705|               Type = [TemplateParameter] T
+#  705|               ValueCategory = lvalue
 #  705|         1: [VariableAccess] x
 #  705|             Type = [TemplateParameter] T
 #  705|             ValueCategory = lvalue
 #  705|         2: [VariableAccess] y
 #  705|             Type = [TemplateParameter] T
 #  705|             ValueCategory = lvalue
+#  705|         0 converted: [CStyleCast] (bool)...
+#  705|             Conversion = [BoolConversion] conversion to bool
+#  705|             Type = [BoolType] bool
+#  705|             ValueCategory = prvalue
+#  705|           : [ParenthesisExpr] (...)
+#  705|               Type = [UnknownType] unknown
+#  705|               ValueCategory = prvalue
 #  704| [FunctionTemplateInstantiation,TopLevelFunction] int min<int>(int, int)
 #  704|   params: 
 #  704|     0: [Parameter] x
@@ -5959,24 +5959,24 @@ ir.cpp:
 #  705|       0: [ConditionalExpr] ... ? ... : ...
 #  705|           Type = [IntType] int
 #  705|           ValueCategory = prvalue
-#  705|         0: [ParenthesisExpr] (...)
+#  705|         0: [LTExpr] ... < ...
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
-#  705|           expr: [LTExpr] ... < ...
-#  705|               Type = [BoolType] bool
-#  705|               ValueCategory = prvalue
-#  705|             0: [VariableAccess] x
-#  705|                 Type = [IntType] int
-#  705|                 ValueCategory = prvalue(load)
-#  705|             1: [VariableAccess] y
-#  705|                 Type = [IntType] int
-#  705|                 ValueCategory = prvalue(load)
+#  705|           0: [VariableAccess] x
+#  705|               Type = [IntType] int
+#  705|               ValueCategory = prvalue(load)
+#  705|           1: [VariableAccess] y
+#  705|               Type = [IntType] int
+#  705|               ValueCategory = prvalue(load)
 #  705|         1: [VariableAccess] x
 #  705|             Type = [IntType] int
 #  705|             ValueCategory = prvalue(load)
 #  705|         2: [VariableAccess] y
 #  705|             Type = [IntType] int
 #  705|             ValueCategory = prvalue(load)
+#  705|         0 converted: [ParenthesisExpr] (...)
+#  705|             Type = [BoolType] bool
+#  705|             ValueCategory = prvalue
 #  708| [TopLevelFunction] int CallMin(int, int)
 #  708|   params: 
 #  708|     0: [Parameter] x
@@ -6036,26 +6036,26 @@ ir.cpp:
 #  720|   params: 
 #  720|   body: [BlockStmt] { ... }
 #  721|     0: [ReturnStmt] return ...
-#  721|       0: [CStyleCast] (double)...
+#  721|       0: [FunctionCall] call to Func
+#  721|           Type = [LongType] long
+#  721|           ValueCategory = prvalue
+#  721|         0: [Literal] 0
+#  721|             Type = [NullPointerType] decltype(nullptr)
+#  721|             Value = [Literal] 0
+#  721|             ValueCategory = prvalue
+#  721|         1: [CharLiteral] 111
+#  721|             Type = [PlainCharType] char
+#  721|             Value = [CharLiteral] 111
+#  721|             ValueCategory = prvalue
+#  721|         0 converted: [CStyleCast] (void *)...
+#  721|             Conversion = [PointerConversion] pointer conversion
+#  721|             Type = [VoidPointerType] void *
+#  721|             Value = [CStyleCast] 0
+#  721|             ValueCategory = prvalue
+#  721|       0 converted: [CStyleCast] (double)...
 #  721|           Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  721|           Type = [DoubleType] double
 #  721|           ValueCategory = prvalue
-#  721|         expr: [FunctionCall] call to Func
-#  721|             Type = [LongType] long
-#  721|             ValueCategory = prvalue
-#  721|           0: [CStyleCast] (void *)...
-#  721|               Conversion = [PointerConversion] pointer conversion
-#  721|               Type = [VoidPointerType] void *
-#  721|               Value = [CStyleCast] 0
-#  721|               ValueCategory = prvalue
-#  721|             expr: [Literal] 0
-#  721|                 Type = [NullPointerType] decltype(nullptr)
-#  721|                 Value = [Literal] 0
-#  721|                 ValueCategory = prvalue
-#  721|           1: [CharLiteral] 111
-#  721|               Type = [PlainCharType] char
-#  721|               Value = [CharLiteral] 111
-#  721|               ValueCategory = prvalue
 #  724| [TopLevelFunction] void TryCatch(bool)
 #  724|   params: 
 #  724|     0: [Parameter] b
@@ -6080,13 +6080,13 @@ ir.cpp:
 #  728|               0: [ThrowExpr] throw ...
 #  728|                   Type = [PointerType] const char *
 #  728|                   ValueCategory = prvalue
-#  728|                 0: [ArrayToPointerConversion] array to pointer conversion
+#  728|                 0: string literal
+#  728|                     Type = [ArrayType] const char[15]
+#  728|                     Value = [StringLiteral] "string literal"
+#  728|                     ValueCategory = lvalue
+#  728|                 0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  728|                     Type = [PointerType] const char *
 #  728|                     ValueCategory = prvalue
-#  728|                   expr: string literal
-#  728|                       Type = [ArrayType] const char[15]
-#  728|                       Value = [StringLiteral] "string literal"
-#  728|                       ValueCategory = lvalue
 #  730|           2: [IfStmt] if (...) ... 
 #  730|             0: [LTExpr] ... < ...
 #  730|                 Type = [BoolType] bool
@@ -6122,13 +6122,13 @@ ir.cpp:
 #  731|                       0: [ConstructorCall] call to String
 #  731|                           Type = [VoidType] void
 #  731|                           ValueCategory = prvalue
-#  731|                         0: [ArrayToPointerConversion] array to pointer conversion
+#  731|                         0: String object
+#  731|                             Type = [ArrayType] const char[14]
+#  731|                             Value = [StringLiteral] "String object"
+#  731|                             ValueCategory = lvalue
+#  731|                         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  731|                             Type = [PointerType] const char *
 #  731|                             ValueCategory = prvalue
-#  731|                           expr: String object
-#  731|                               Type = [ArrayType] const char[14]
-#  731|                               Value = [StringLiteral] "String object"
-#  731|                               ValueCategory = lvalue
 #  733|         2: [ExprStmt] ExprStmt
 #  733|           0: [AssignExpr] ... = ...
 #  733|               Type = [IntType] int
@@ -6167,43 +6167,43 @@ ir.cpp:
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   body: [BlockStmt] { ... }
 #-----|     0: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  745|       0: [FunctionCall] call to operator=
+#  745|           Type = [LValueReferenceType] String &
+#  745|           ValueCategory = prvalue
+#  745|         -1: [AddressOfExpr] & ...
+#  745|             Type = [PointerType] String *
+#  745|             ValueCategory = prvalue
+#  745|           0: [PointerFieldAccess] base_s
+#  745|               Type = [Struct] String
+#  745|               ValueCategory = lvalue
+#  745|             -1: [ThisExpr] this
+#  745|                 Type = [PointerType] Base *
+#  745|                 ValueCategory = prvalue(load)
+#  745|         0: [ReferenceFieldAccess] base_s
+#  745|             Type = [Struct] String
+#  745|             ValueCategory = lvalue
+#  745|           -1: [VariableAccess] (unnamed parameter 0)
+#  745|               Type = [LValueReferenceType] const Base &
+#  745|               ValueCategory = prvalue(load)
+#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|               Type = [SpecifiedType] const Base
+#-----|               ValueCategory = lvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const String &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#  745|         expr: [FunctionCall] call to operator=
-#  745|             Type = [LValueReferenceType] String &
-#  745|             ValueCategory = prvalue
-#  745|           -1: [AddressOfExpr] & ...
-#  745|               Type = [PointerType] String *
-#  745|               ValueCategory = prvalue
-#  745|             0: [PointerFieldAccess] base_s
-#  745|                 Type = [Struct] String
-#  745|                 ValueCategory = lvalue
-#  745|               -1: [ThisExpr] this
-#  745|                   Type = [PointerType] Base *
-#  745|                   ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const String &
-#-----|               ValueCategory = prvalue
-#  745|             expr: [ReferenceFieldAccess] base_s
-#  745|                 Type = [Struct] String
-#  745|                 ValueCategory = lvalue
-#-----|               -1: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                   Type = [SpecifiedType] const Base
-#-----|                   ValueCategory = lvalue
-#  745|                 expr: [VariableAccess] (unnamed parameter 0)
-#  745|                     Type = [LValueReferenceType] const Base &
-#  745|                     ValueCategory = prvalue(load)
 #-----|     1: [ReturnStmt] return ...
-#-----|       0: [ReferenceToExpr] (reference to)
+#-----|       0: [PointerDereferenceExpr] * ...
+#-----|           Type = [Struct,VirtualBaseClass] Base
+#-----|           ValueCategory = lvalue
+#-----|         0: [ThisExpr] this
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue(load)
+#-----|       0 converted: [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
-#-----|         expr: [PointerDereferenceExpr] * ...
-#-----|             Type = [Struct,VirtualBaseClass] Base
-#-----|             ValueCategory = lvalue
-#-----|           0: [ThisExpr] this
-#-----|               Type = [PointerType] Base *
-#-----|               ValueCategory = prvalue(load)
 #  745| [CopyConstructor] void Base::Base(Base const&)
 #  745|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -6248,76 +6248,76 @@ ir.cpp:
 #-----|         Type = [LValueReferenceType] const Middle &
 #-----|   body: [BlockStmt] { ... }
 #-----|     0: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  754|       0: [FunctionCall] call to operator=
+#  754|           Type = [LValueReferenceType] Base &
+#  754|           ValueCategory = prvalue
+#  754|         -1: [ThisExpr] this
+#  754|             Type = [PointerType] Middle *
+#  754|             ValueCategory = prvalue(load)
+#-----|         0: [CStyleCast] (Base *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue
+#  754|         0: [PointerDereferenceExpr] * ...
+#  754|             Type = [SpecifiedType] const Base
+#  754|             ValueCategory = lvalue
+#  754|           0: [AddressOfExpr] & ...
+#  754|               Type = [PointerType] const Middle *
+#  754|               ValueCategory = prvalue
+#  754|             0: [VariableAccess] (unnamed parameter 0)
+#  754|                 Type = [LValueReferenceType] const Middle &
+#  754|                 ValueCategory = prvalue(load)
+#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|                 Type = [SpecifiedType] const Middle
+#-----|                 ValueCategory = lvalue
+#-----|           0 converted: [CStyleCast] (const Base *)...
+#-----|               Conversion = [BaseClassConversion] base class conversion
+#-----|               Type = [PointerType] const Base *
+#-----|               ValueCategory = prvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const Base &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct,VirtualBaseClass] Base
 #-----|           ValueCategory = lvalue
-#  754|         expr: [FunctionCall] call to operator=
-#  754|             Type = [LValueReferenceType] Base &
+#-----|     1: [ExprStmt] ExprStmt
+#  754|       0: [FunctionCall] call to operator=
+#  754|           Type = [LValueReferenceType] String &
+#  754|           ValueCategory = prvalue
+#  754|         -1: [AddressOfExpr] & ...
+#  754|             Type = [PointerType] String *
 #  754|             ValueCategory = prvalue
-#-----|           -1: [CStyleCast] (Base *)...
-#-----|               Conversion = [BaseClassConversion] base class conversion
-#-----|               Type = [PointerType] Base *
-#-----|               ValueCategory = prvalue
-#  754|             expr: [ThisExpr] this
+#  754|           0: [PointerFieldAccess] middle_s
+#  754|               Type = [Struct] String
+#  754|               ValueCategory = lvalue
+#  754|             -1: [ThisExpr] this
 #  754|                 Type = [PointerType] Middle *
 #  754|                 ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const Base &
-#-----|               ValueCategory = prvalue
-#  754|             expr: [PointerDereferenceExpr] * ...
-#  754|                 Type = [SpecifiedType] const Base
-#  754|                 ValueCategory = lvalue
-#-----|               0: [CStyleCast] (const Base *)...
-#-----|                   Conversion = [BaseClassConversion] base class conversion
-#-----|                   Type = [PointerType] const Base *
-#-----|                   ValueCategory = prvalue
-#  754|                 expr: [AddressOfExpr] & ...
-#  754|                     Type = [PointerType] const Middle *
-#  754|                     ValueCategory = prvalue
-#-----|                   0: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                       Type = [SpecifiedType] const Middle
-#-----|                       ValueCategory = lvalue
-#  754|                     expr: [VariableAccess] (unnamed parameter 0)
-#  754|                         Type = [LValueReferenceType] const Middle &
-#  754|                         ValueCategory = prvalue(load)
-#-----|     1: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  754|         0: [ReferenceFieldAccess] middle_s
+#  754|             Type = [Struct] String
+#  754|             ValueCategory = lvalue
+#  754|           -1: [VariableAccess] (unnamed parameter 0)
+#  754|               Type = [LValueReferenceType] const Middle &
+#  754|               ValueCategory = prvalue(load)
+#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|               Type = [SpecifiedType] const Middle
+#-----|               ValueCategory = lvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const String &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#  754|         expr: [FunctionCall] call to operator=
-#  754|             Type = [LValueReferenceType] String &
-#  754|             ValueCategory = prvalue
-#  754|           -1: [AddressOfExpr] & ...
-#  754|               Type = [PointerType] String *
-#  754|               ValueCategory = prvalue
-#  754|             0: [PointerFieldAccess] middle_s
-#  754|                 Type = [Struct] String
-#  754|                 ValueCategory = lvalue
-#  754|               -1: [ThisExpr] this
-#  754|                   Type = [PointerType] Middle *
-#  754|                   ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const String &
-#-----|               ValueCategory = prvalue
-#  754|             expr: [ReferenceFieldAccess] middle_s
-#  754|                 Type = [Struct] String
-#  754|                 ValueCategory = lvalue
-#-----|               -1: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                   Type = [SpecifiedType] const Middle
-#-----|                   ValueCategory = lvalue
-#  754|                 expr: [VariableAccess] (unnamed parameter 0)
-#  754|                     Type = [LValueReferenceType] const Middle &
-#  754|                     ValueCategory = prvalue(load)
 #-----|     2: [ReturnStmt] return ...
-#-----|       0: [ReferenceToExpr] (reference to)
+#-----|       0: [PointerDereferenceExpr] * ...
+#-----|           Type = [Struct] Middle
+#-----|           ValueCategory = lvalue
+#-----|         0: [ThisExpr] this
+#-----|             Type = [PointerType] Middle *
+#-----|             ValueCategory = prvalue(load)
+#-----|       0 converted: [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Middle &
 #-----|           ValueCategory = prvalue
-#-----|         expr: [PointerDereferenceExpr] * ...
-#-----|             Type = [Struct] Middle
-#-----|             ValueCategory = lvalue
-#-----|           0: [ThisExpr] this
-#-----|               Type = [PointerType] Middle *
-#-----|               ValueCategory = prvalue(load)
 #  754| [CopyConstructor] void Middle::Middle(Middle const&)
 #  754|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -6359,76 +6359,76 @@ ir.cpp:
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   body: [BlockStmt] { ... }
 #-----|     0: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  763|       0: [FunctionCall] call to operator=
+#  763|           Type = [LValueReferenceType] Middle &
+#  763|           ValueCategory = prvalue
+#  763|         -1: [ThisExpr] this
+#  763|             Type = [PointerType] Derived *
+#  763|             ValueCategory = prvalue(load)
+#-----|         0: [CStyleCast] (Middle *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Middle *
+#-----|             ValueCategory = prvalue
+#  763|         0: [PointerDereferenceExpr] * ...
+#  763|             Type = [SpecifiedType] const Middle
+#  763|             ValueCategory = lvalue
+#  763|           0: [AddressOfExpr] & ...
+#  763|               Type = [PointerType] const Derived *
+#  763|               ValueCategory = prvalue
+#  763|             0: [VariableAccess] (unnamed parameter 0)
+#  763|                 Type = [LValueReferenceType] const Derived &
+#  763|                 ValueCategory = prvalue(load)
+#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|                 Type = [SpecifiedType] const Derived
+#-----|                 ValueCategory = lvalue
+#-----|           0 converted: [CStyleCast] (const Middle *)...
+#-----|               Conversion = [BaseClassConversion] base class conversion
+#-----|               Type = [PointerType] const Middle *
+#-----|               ValueCategory = prvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const Middle &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] Middle
 #-----|           ValueCategory = lvalue
-#  763|         expr: [FunctionCall] call to operator=
-#  763|             Type = [LValueReferenceType] Middle &
+#-----|     1: [ExprStmt] ExprStmt
+#  763|       0: [FunctionCall] call to operator=
+#  763|           Type = [LValueReferenceType] String &
+#  763|           ValueCategory = prvalue
+#  763|         -1: [AddressOfExpr] & ...
+#  763|             Type = [PointerType] String *
 #  763|             ValueCategory = prvalue
-#-----|           -1: [CStyleCast] (Middle *)...
-#-----|               Conversion = [BaseClassConversion] base class conversion
-#-----|               Type = [PointerType] Middle *
-#-----|               ValueCategory = prvalue
-#  763|             expr: [ThisExpr] this
+#  763|           0: [PointerFieldAccess] derived_s
+#  763|               Type = [Struct] String
+#  763|               ValueCategory = lvalue
+#  763|             -1: [ThisExpr] this
 #  763|                 Type = [PointerType] Derived *
 #  763|                 ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const Middle &
-#-----|               ValueCategory = prvalue
-#  763|             expr: [PointerDereferenceExpr] * ...
-#  763|                 Type = [SpecifiedType] const Middle
-#  763|                 ValueCategory = lvalue
-#-----|               0: [CStyleCast] (const Middle *)...
-#-----|                   Conversion = [BaseClassConversion] base class conversion
-#-----|                   Type = [PointerType] const Middle *
-#-----|                   ValueCategory = prvalue
-#  763|                 expr: [AddressOfExpr] & ...
-#  763|                     Type = [PointerType] const Derived *
-#  763|                     ValueCategory = prvalue
-#-----|                   0: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                       Type = [SpecifiedType] const Derived
-#-----|                       ValueCategory = lvalue
-#  763|                     expr: [VariableAccess] (unnamed parameter 0)
-#  763|                         Type = [LValueReferenceType] const Derived &
-#  763|                         ValueCategory = prvalue(load)
-#-----|     1: [ExprStmt] ExprStmt
-#-----|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  763|         0: [ReferenceFieldAccess] derived_s
+#  763|             Type = [Struct] String
+#  763|             ValueCategory = lvalue
+#  763|           -1: [VariableAccess] (unnamed parameter 0)
+#  763|               Type = [LValueReferenceType] const Derived &
+#  763|               ValueCategory = prvalue(load)
+#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|               Type = [SpecifiedType] const Derived
+#-----|               ValueCategory = lvalue
+#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|             Type = [LValueReferenceType] const String &
+#-----|             ValueCategory = prvalue
+#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#  763|         expr: [FunctionCall] call to operator=
-#  763|             Type = [LValueReferenceType] String &
-#  763|             ValueCategory = prvalue
-#  763|           -1: [AddressOfExpr] & ...
-#  763|               Type = [PointerType] String *
-#  763|               ValueCategory = prvalue
-#  763|             0: [PointerFieldAccess] derived_s
-#  763|                 Type = [Struct] String
-#  763|                 ValueCategory = lvalue
-#  763|               -1: [ThisExpr] this
-#  763|                   Type = [PointerType] Derived *
-#  763|                   ValueCategory = prvalue(load)
-#-----|           0: [ReferenceToExpr] (reference to)
-#-----|               Type = [LValueReferenceType] const String &
-#-----|               ValueCategory = prvalue
-#  763|             expr: [ReferenceFieldAccess] derived_s
-#  763|                 Type = [Struct] String
-#  763|                 ValueCategory = lvalue
-#-----|               -1: [ReferenceDereferenceExpr] (reference dereference)
-#-----|                   Type = [SpecifiedType] const Derived
-#-----|                   ValueCategory = lvalue
-#  763|                 expr: [VariableAccess] (unnamed parameter 0)
-#  763|                     Type = [LValueReferenceType] const Derived &
-#  763|                     ValueCategory = prvalue(load)
 #-----|     2: [ReturnStmt] return ...
-#-----|       0: [ReferenceToExpr] (reference to)
+#-----|       0: [PointerDereferenceExpr] * ...
+#-----|           Type = [Struct] Derived
+#-----|           ValueCategory = lvalue
+#-----|         0: [ThisExpr] this
+#-----|             Type = [PointerType] Derived *
+#-----|             ValueCategory = prvalue(load)
+#-----|       0 converted: [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
-#-----|         expr: [PointerDereferenceExpr] * ...
-#-----|             Type = [Struct] Derived
-#-----|             ValueCategory = lvalue
-#-----|           0: [ThisExpr] this
-#-----|               Type = [PointerType] Derived *
-#-----|               ValueCategory = prvalue(load)
 #  763| [CopyConstructor] void Derived::Derived(Derived const&)
 #  763|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -6648,85 +6648,85 @@ ir.cpp:
 #  806|                 Type = [Struct] Derived
 #  806|                 ValueCategory = lvalue
 #  808|     6: [ExprStmt] ExprStmt
-#  808|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  808|       0: [FunctionCall] call to operator=
+#  808|           Type = [LValueReferenceType] Base &
+#  808|           ValueCategory = prvalue
+#  808|         -1: [VariableAccess] b
+#  808|             Type = [Struct,VirtualBaseClass] Base
+#  808|             ValueCategory = lvalue
+#  808|         0: [VariableAccess] m
+#  808|             Type = [Struct] Middle
+#  808|             ValueCategory = lvalue
+#  808|         0 converted: [ReferenceToExpr] (reference to)
+#  808|             Type = [LValueReferenceType] const Base &
+#  808|             ValueCategory = prvalue
+#  808|           : [CStyleCast] (const Base)...
+#  808|               Conversion = [BaseClassConversion] base class conversion
+#  808|               Type = [SpecifiedType] const Base
+#  808|               ValueCategory = lvalue
+#  808|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  808|           Type = [Struct,VirtualBaseClass] Base
 #  808|           ValueCategory = lvalue
-#  808|         expr: [FunctionCall] call to operator=
-#  808|             Type = [LValueReferenceType] Base &
-#  808|             ValueCategory = prvalue
-#  808|           -1: [VariableAccess] b
-#  808|               Type = [Struct,VirtualBaseClass] Base
-#  808|               ValueCategory = lvalue
-#  808|           0: [ReferenceToExpr] (reference to)
-#  808|               Type = [LValueReferenceType] const Base &
-#  808|               ValueCategory = prvalue
-#  808|             expr: [CStyleCast] (const Base)...
-#  808|                 Conversion = [BaseClassConversion] base class conversion
-#  808|                 Type = [SpecifiedType] const Base
-#  808|                 ValueCategory = lvalue
-#  808|               expr: [VariableAccess] m
-#  808|                   Type = [Struct] Middle
-#  808|                   ValueCategory = lvalue
 #  809|     7: [ExprStmt] ExprStmt
-#  809|       0: [ReferenceDereferenceExpr] (reference dereference)
-#  809|           Type = [Struct,VirtualBaseClass] Base
-#  809|           ValueCategory = lvalue
-#  809|         expr: [FunctionCall] call to operator=
-#  809|             Type = [LValueReferenceType] Base &
+#  809|       0: [FunctionCall] call to operator=
+#  809|           Type = [LValueReferenceType] Base &
+#  809|           ValueCategory = prvalue
+#  809|         -1: [VariableAccess] b
+#  809|             Type = [Struct,VirtualBaseClass] Base
+#  809|             ValueCategory = lvalue
+#  809|         0: [ConstructorCall] call to Base
+#  809|             Type = [VoidType] void
 #  809|             ValueCategory = prvalue
-#  809|           -1: [VariableAccess] b
-#  809|               Type = [Struct,VirtualBaseClass] Base
+#  809|           0: [VariableAccess] m
+#  809|               Type = [Struct] Middle
 #  809|               ValueCategory = lvalue
-#  809|           0: [ReferenceToExpr] (reference to)
+#  809|           0 converted: [ReferenceToExpr] (reference to)
 #  809|               Type = [LValueReferenceType] const Base &
 #  809|               ValueCategory = prvalue
-#  809|             expr: [CStyleCast] (const Base)...
-#  809|                 Conversion = [GlvalueConversion] glvalue conversion
+#  809|             : [CStyleCast] (const Base)...
+#  809|                 Conversion = [BaseClassConversion] base class conversion
 #  809|                 Type = [SpecifiedType] const Base
 #  809|                 ValueCategory = lvalue
-#  809|               expr: [ConstructorCall] call to Base
-#  809|                   Type = [VoidType] void
-#  809|                   ValueCategory = prvalue
-#  809|                 0: [ReferenceToExpr] (reference to)
-#  809|                     Type = [LValueReferenceType] const Base &
-#  809|                     ValueCategory = prvalue
-#  809|                   expr: [CStyleCast] (const Base)...
-#  809|                       Conversion = [BaseClassConversion] base class conversion
-#  809|                       Type = [SpecifiedType] const Base
-#  809|                       ValueCategory = lvalue
-#  809|                     expr: [VariableAccess] m
-#  809|                         Type = [Struct] Middle
-#  809|                         ValueCategory = lvalue
+#  809|         0 converted: [ReferenceToExpr] (reference to)
+#  809|             Type = [LValueReferenceType] const Base &
+#  809|             ValueCategory = prvalue
+#  809|           : [CStyleCast] (const Base)...
+#  809|               Conversion = [GlvalueConversion] glvalue conversion
+#  809|               Type = [SpecifiedType] const Base
+#  809|               ValueCategory = lvalue
+#  809|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  809|           Type = [Struct,VirtualBaseClass] Base
+#  809|           ValueCategory = lvalue
 #  810|     8: [ExprStmt] ExprStmt
-#  810|       0: [ReferenceDereferenceExpr] (reference dereference)
-#  810|           Type = [Struct,VirtualBaseClass] Base
-#  810|           ValueCategory = lvalue
-#  810|         expr: [FunctionCall] call to operator=
-#  810|             Type = [LValueReferenceType] Base &
+#  810|       0: [FunctionCall] call to operator=
+#  810|           Type = [LValueReferenceType] Base &
+#  810|           ValueCategory = prvalue
+#  810|         -1: [VariableAccess] b
+#  810|             Type = [Struct,VirtualBaseClass] Base
+#  810|             ValueCategory = lvalue
+#  810|         0: [ConstructorCall] call to Base
+#  810|             Type = [VoidType] void
 #  810|             ValueCategory = prvalue
-#  810|           -1: [VariableAccess] b
-#  810|               Type = [Struct,VirtualBaseClass] Base
+#  810|           0: [VariableAccess] m
+#  810|               Type = [Struct] Middle
 #  810|               ValueCategory = lvalue
-#  810|           0: [ReferenceToExpr] (reference to)
+#  810|           0 converted: [ReferenceToExpr] (reference to)
 #  810|               Type = [LValueReferenceType] const Base &
 #  810|               ValueCategory = prvalue
-#  810|             expr: [CStyleCast] (const Base)...
-#  810|                 Conversion = [GlvalueConversion] glvalue conversion
+#  810|             : [CStyleCast] (const Base)...
+#  810|                 Conversion = [BaseClassConversion] base class conversion
 #  810|                 Type = [SpecifiedType] const Base
 #  810|                 ValueCategory = lvalue
-#  810|               expr: [ConstructorCall] call to Base
-#  810|                   Type = [VoidType] void
-#  810|                   ValueCategory = prvalue
-#  810|                 0: [ReferenceToExpr] (reference to)
-#  810|                     Type = [LValueReferenceType] const Base &
-#  810|                     ValueCategory = prvalue
-#  810|                   expr: [CStyleCast] (const Base)...
-#  810|                       Conversion = [BaseClassConversion] base class conversion
-#  810|                       Type = [SpecifiedType] const Base
-#  810|                       ValueCategory = lvalue
-#  810|                     expr: [VariableAccess] m
-#  810|                         Type = [Struct] Middle
-#  810|                         ValueCategory = lvalue
+#  810|         0 converted: [ReferenceToExpr] (reference to)
+#  810|             Type = [LValueReferenceType] const Base &
+#  810|             ValueCategory = prvalue
+#  810|           : [CStyleCast] (const Base)...
+#  810|               Conversion = [GlvalueConversion] glvalue conversion
+#  810|               Type = [SpecifiedType] const Base
+#  810|               ValueCategory = lvalue
+#  810|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  810|           Type = [Struct,VirtualBaseClass] Base
+#  810|           ValueCategory = lvalue
 #  811|     9: [ExprStmt] ExprStmt
 #  811|       0: [AssignExpr] ... = ...
 #  811|           Type = [PointerType] Base *
@@ -6734,13 +6734,13 @@ ir.cpp:
 #  811|         0: [VariableAccess] pb
 #  811|             Type = [PointerType] Base *
 #  811|             ValueCategory = lvalue
-#  811|         1: [CStyleCast] (Base *)...
+#  811|         1: [VariableAccess] pm
+#  811|             Type = [PointerType] Middle *
+#  811|             ValueCategory = prvalue(load)
+#  811|         1 converted: [CStyleCast] (Base *)...
 #  811|             Conversion = [BaseClassConversion] base class conversion
 #  811|             Type = [PointerType] Base *
 #  811|             ValueCategory = prvalue
-#  811|           expr: [VariableAccess] pm
-#  811|               Type = [PointerType] Middle *
-#  811|               ValueCategory = prvalue(load)
 #  812|     10: [ExprStmt] ExprStmt
 #  812|       0: [AssignExpr] ... = ...
 #  812|           Type = [PointerType] Base *
@@ -6748,13 +6748,13 @@ ir.cpp:
 #  812|         0: [VariableAccess] pb
 #  812|             Type = [PointerType] Base *
 #  812|             ValueCategory = lvalue
-#  812|         1: [CStyleCast] (Base *)...
+#  812|         1: [VariableAccess] pm
+#  812|             Type = [PointerType] Middle *
+#  812|             ValueCategory = prvalue(load)
+#  812|         1 converted: [CStyleCast] (Base *)...
 #  812|             Conversion = [BaseClassConversion] base class conversion
 #  812|             Type = [PointerType] Base *
 #  812|             ValueCategory = prvalue
-#  812|           expr: [VariableAccess] pm
-#  812|               Type = [PointerType] Middle *
-#  812|               ValueCategory = prvalue(load)
 #  813|     11: [ExprStmt] ExprStmt
 #  813|       0: [AssignExpr] ... = ...
 #  813|           Type = [PointerType] Base *
@@ -6762,13 +6762,13 @@ ir.cpp:
 #  813|         0: [VariableAccess] pb
 #  813|             Type = [PointerType] Base *
 #  813|             ValueCategory = lvalue
-#  813|         1: [StaticCast] static_cast<Base *>...
+#  813|         1: [VariableAccess] pm
+#  813|             Type = [PointerType] Middle *
+#  813|             ValueCategory = prvalue(load)
+#  813|         1 converted: [StaticCast] static_cast<Base *>...
 #  813|             Conversion = [BaseClassConversion] base class conversion
 #  813|             Type = [PointerType] Base *
 #  813|             ValueCategory = prvalue
-#  813|           expr: [VariableAccess] pm
-#  813|               Type = [PointerType] Middle *
-#  813|               ValueCategory = prvalue(load)
 #  814|     12: [ExprStmt] ExprStmt
 #  814|       0: [AssignExpr] ... = ...
 #  814|           Type = [PointerType] Base *
@@ -6776,61 +6776,61 @@ ir.cpp:
 #  814|         0: [VariableAccess] pb
 #  814|             Type = [PointerType] Base *
 #  814|             ValueCategory = lvalue
-#  814|         1: [ReinterpretCast] reinterpret_cast<Base *>...
+#  814|         1: [VariableAccess] pm
+#  814|             Type = [PointerType] Middle *
+#  814|             ValueCategory = prvalue(load)
+#  814|         1 converted: [ReinterpretCast] reinterpret_cast<Base *>...
 #  814|             Conversion = [PointerConversion] pointer conversion
 #  814|             Type = [PointerType] Base *
 #  814|             ValueCategory = prvalue
-#  814|           expr: [VariableAccess] pm
-#  814|               Type = [PointerType] Middle *
-#  814|               ValueCategory = prvalue(load)
 #  816|     13: [ExprStmt] ExprStmt
-#  816|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  816|       0: [FunctionCall] call to operator=
+#  816|           Type = [LValueReferenceType] Middle &
+#  816|           ValueCategory = prvalue
+#  816|         -1: [VariableAccess] m
+#  816|             Type = [Struct] Middle
+#  816|             ValueCategory = lvalue
+#  816|         0: [VariableAccess] b
+#  816|             Type = [Struct,VirtualBaseClass] Base
+#  816|             ValueCategory = lvalue
+#  816|         0 converted: [ReferenceToExpr] (reference to)
+#  816|             Type = [LValueReferenceType] const Middle &
+#  816|             ValueCategory = prvalue
+#  816|           : [CStyleCast] (const Middle)...
+#  816|               Conversion = [GlvalueConversion] glvalue conversion
+#  816|               Type = [SpecifiedType] const Middle
+#  816|               ValueCategory = lvalue
+#  816|             : [CStyleCast] (Middle)...
+#  816|                 Conversion = [DerivedClassConversion] derived class conversion
+#  816|                 Type = [Struct] Middle
+#  816|                 ValueCategory = lvalue
+#  816|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  816|           Type = [Struct] Middle
 #  816|           ValueCategory = lvalue
-#  816|         expr: [FunctionCall] call to operator=
-#  816|             Type = [LValueReferenceType] Middle &
-#  816|             ValueCategory = prvalue
-#  816|           -1: [VariableAccess] m
-#  816|               Type = [Struct] Middle
-#  816|               ValueCategory = lvalue
-#  816|           0: [ReferenceToExpr] (reference to)
-#  816|               Type = [LValueReferenceType] const Middle &
-#  816|               ValueCategory = prvalue
-#  816|             expr: [CStyleCast] (const Middle)...
-#  816|                 Conversion = [GlvalueConversion] glvalue conversion
-#  816|                 Type = [SpecifiedType] const Middle
-#  816|                 ValueCategory = lvalue
-#  816|               expr: [CStyleCast] (Middle)...
-#  816|                   Conversion = [DerivedClassConversion] derived class conversion
-#  816|                   Type = [Struct] Middle
-#  816|                   ValueCategory = lvalue
-#  816|                 expr: [VariableAccess] b
-#  816|                     Type = [Struct,VirtualBaseClass] Base
-#  816|                     ValueCategory = lvalue
 #  817|     14: [ExprStmt] ExprStmt
-#  817|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  817|       0: [FunctionCall] call to operator=
+#  817|           Type = [LValueReferenceType] Middle &
+#  817|           ValueCategory = prvalue
+#  817|         -1: [VariableAccess] m
+#  817|             Type = [Struct] Middle
+#  817|             ValueCategory = lvalue
+#  817|         0: [VariableAccess] b
+#  817|             Type = [Struct,VirtualBaseClass] Base
+#  817|             ValueCategory = lvalue
+#  817|         0 converted: [ReferenceToExpr] (reference to)
+#  817|             Type = [LValueReferenceType] const Middle &
+#  817|             ValueCategory = prvalue
+#  817|           : [CStyleCast] (const Middle)...
+#  817|               Conversion = [GlvalueConversion] glvalue conversion
+#  817|               Type = [SpecifiedType] const Middle
+#  817|               ValueCategory = lvalue
+#  817|             : [StaticCast] static_cast<Middle>...
+#  817|                 Conversion = [DerivedClassConversion] derived class conversion
+#  817|                 Type = [Struct] Middle
+#  817|                 ValueCategory = lvalue
+#  817|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  817|           Type = [Struct] Middle
 #  817|           ValueCategory = lvalue
-#  817|         expr: [FunctionCall] call to operator=
-#  817|             Type = [LValueReferenceType] Middle &
-#  817|             ValueCategory = prvalue
-#  817|           -1: [VariableAccess] m
-#  817|               Type = [Struct] Middle
-#  817|               ValueCategory = lvalue
-#  817|           0: [ReferenceToExpr] (reference to)
-#  817|               Type = [LValueReferenceType] const Middle &
-#  817|               ValueCategory = prvalue
-#  817|             expr: [CStyleCast] (const Middle)...
-#  817|                 Conversion = [GlvalueConversion] glvalue conversion
-#  817|                 Type = [SpecifiedType] const Middle
-#  817|                 ValueCategory = lvalue
-#  817|               expr: [StaticCast] static_cast<Middle>...
-#  817|                   Conversion = [DerivedClassConversion] derived class conversion
-#  817|                   Type = [Struct] Middle
-#  817|                   ValueCategory = lvalue
-#  817|                 expr: [VariableAccess] b
-#  817|                     Type = [Struct,VirtualBaseClass] Base
-#  817|                     ValueCategory = lvalue
 #  818|     15: [ExprStmt] ExprStmt
 #  818|       0: [AssignExpr] ... = ...
 #  818|           Type = [PointerType] Middle *
@@ -6838,13 +6838,13 @@ ir.cpp:
 #  818|         0: [VariableAccess] pm
 #  818|             Type = [PointerType] Middle *
 #  818|             ValueCategory = lvalue
-#  818|         1: [CStyleCast] (Middle *)...
+#  818|         1: [VariableAccess] pb
+#  818|             Type = [PointerType] Base *
+#  818|             ValueCategory = prvalue(load)
+#  818|         1 converted: [CStyleCast] (Middle *)...
 #  818|             Conversion = [DerivedClassConversion] derived class conversion
 #  818|             Type = [PointerType] Middle *
 #  818|             ValueCategory = prvalue
-#  818|           expr: [VariableAccess] pb
-#  818|               Type = [PointerType] Base *
-#  818|               ValueCategory = prvalue(load)
 #  819|     16: [ExprStmt] ExprStmt
 #  819|       0: [AssignExpr] ... = ...
 #  819|           Type = [PointerType] Middle *
@@ -6852,13 +6852,13 @@ ir.cpp:
 #  819|         0: [VariableAccess] pm
 #  819|             Type = [PointerType] Middle *
 #  819|             ValueCategory = lvalue
-#  819|         1: [StaticCast] static_cast<Middle *>...
+#  819|         1: [VariableAccess] pb
+#  819|             Type = [PointerType] Base *
+#  819|             ValueCategory = prvalue(load)
+#  819|         1 converted: [StaticCast] static_cast<Middle *>...
 #  819|             Conversion = [DerivedClassConversion] derived class conversion
 #  819|             Type = [PointerType] Middle *
 #  819|             ValueCategory = prvalue
-#  819|           expr: [VariableAccess] pb
-#  819|               Type = [PointerType] Base *
-#  819|               ValueCategory = prvalue(load)
 #  820|     17: [ExprStmt] ExprStmt
 #  820|       0: [AssignExpr] ... = ...
 #  820|           Type = [PointerType] Middle *
@@ -6866,105 +6866,105 @@ ir.cpp:
 #  820|         0: [VariableAccess] pm
 #  820|             Type = [PointerType] Middle *
 #  820|             ValueCategory = lvalue
-#  820|         1: [ReinterpretCast] reinterpret_cast<Middle *>...
+#  820|         1: [VariableAccess] pb
+#  820|             Type = [PointerType] Base *
+#  820|             ValueCategory = prvalue(load)
+#  820|         1 converted: [ReinterpretCast] reinterpret_cast<Middle *>...
 #  820|             Conversion = [PointerConversion] pointer conversion
 #  820|             Type = [PointerType] Middle *
 #  820|             ValueCategory = prvalue
-#  820|           expr: [VariableAccess] pb
-#  820|               Type = [PointerType] Base *
-#  820|               ValueCategory = prvalue(load)
 #  822|     18: [ExprStmt] ExprStmt
-#  822|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  822|       0: [FunctionCall] call to operator=
+#  822|           Type = [LValueReferenceType] Base &
+#  822|           ValueCategory = prvalue
+#  822|         -1: [VariableAccess] b
+#  822|             Type = [Struct,VirtualBaseClass] Base
+#  822|             ValueCategory = lvalue
+#  822|         0: [VariableAccess] d
+#  822|             Type = [Struct] Derived
+#  822|             ValueCategory = lvalue
+#  822|         0 converted: [ReferenceToExpr] (reference to)
+#  822|             Type = [LValueReferenceType] const Base &
+#  822|             ValueCategory = prvalue
+#  822|           : [CStyleCast] (const Base)...
+#  822|               Conversion = [BaseClassConversion] base class conversion
+#  822|               Type = [SpecifiedType] const Base
+#  822|               ValueCategory = lvalue
+#  822|             : [CStyleCast] (const Middle)...
+#  822|                 Conversion = [BaseClassConversion] base class conversion
+#  822|                 Type = [SpecifiedType] const Middle
+#  822|                 ValueCategory = lvalue
+#  822|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  822|           Type = [Struct,VirtualBaseClass] Base
 #  822|           ValueCategory = lvalue
-#  822|         expr: [FunctionCall] call to operator=
-#  822|             Type = [LValueReferenceType] Base &
-#  822|             ValueCategory = prvalue
-#  822|           -1: [VariableAccess] b
-#  822|               Type = [Struct,VirtualBaseClass] Base
-#  822|               ValueCategory = lvalue
-#  822|           0: [ReferenceToExpr] (reference to)
-#  822|               Type = [LValueReferenceType] const Base &
-#  822|               ValueCategory = prvalue
-#  822|             expr: [CStyleCast] (const Base)...
-#  822|                 Conversion = [BaseClassConversion] base class conversion
-#  822|                 Type = [SpecifiedType] const Base
-#  822|                 ValueCategory = lvalue
-#  822|               expr: [CStyleCast] (const Middle)...
-#  822|                   Conversion = [BaseClassConversion] base class conversion
-#  822|                   Type = [SpecifiedType] const Middle
-#  822|                   ValueCategory = lvalue
-#  822|                 expr: [VariableAccess] d
-#  822|                     Type = [Struct] Derived
-#  822|                     ValueCategory = lvalue
 #  823|     19: [ExprStmt] ExprStmt
-#  823|       0: [ReferenceDereferenceExpr] (reference dereference)
-#  823|           Type = [Struct,VirtualBaseClass] Base
-#  823|           ValueCategory = lvalue
-#  823|         expr: [FunctionCall] call to operator=
-#  823|             Type = [LValueReferenceType] Base &
+#  823|       0: [FunctionCall] call to operator=
+#  823|           Type = [LValueReferenceType] Base &
+#  823|           ValueCategory = prvalue
+#  823|         -1: [VariableAccess] b
+#  823|             Type = [Struct,VirtualBaseClass] Base
+#  823|             ValueCategory = lvalue
+#  823|         0: [ConstructorCall] call to Base
+#  823|             Type = [VoidType] void
 #  823|             ValueCategory = prvalue
-#  823|           -1: [VariableAccess] b
-#  823|               Type = [Struct,VirtualBaseClass] Base
+#  823|           0: [VariableAccess] d
+#  823|               Type = [Struct] Derived
 #  823|               ValueCategory = lvalue
-#  823|           0: [ReferenceToExpr] (reference to)
+#  823|           0 converted: [ReferenceToExpr] (reference to)
 #  823|               Type = [LValueReferenceType] const Base &
 #  823|               ValueCategory = prvalue
-#  823|             expr: [CStyleCast] (const Base)...
-#  823|                 Conversion = [GlvalueConversion] glvalue conversion
+#  823|             : [CStyleCast] (const Base)...
+#  823|                 Conversion = [BaseClassConversion] base class conversion
 #  823|                 Type = [SpecifiedType] const Base
 #  823|                 ValueCategory = lvalue
-#  823|               expr: [ConstructorCall] call to Base
-#  823|                   Type = [VoidType] void
-#  823|                   ValueCategory = prvalue
-#  823|                 0: [ReferenceToExpr] (reference to)
-#  823|                     Type = [LValueReferenceType] const Base &
-#  823|                     ValueCategory = prvalue
-#  823|                   expr: [CStyleCast] (const Base)...
-#  823|                       Conversion = [BaseClassConversion] base class conversion
-#  823|                       Type = [SpecifiedType] const Base
-#  823|                       ValueCategory = lvalue
-#  823|                     expr: [CStyleCast] (const Middle)...
-#  823|                         Conversion = [BaseClassConversion] base class conversion
-#  823|                         Type = [SpecifiedType] const Middle
-#  823|                         ValueCategory = lvalue
-#  823|                       expr: [VariableAccess] d
-#  823|                           Type = [Struct] Derived
-#  823|                           ValueCategory = lvalue
+#  823|               : [CStyleCast] (const Middle)...
+#  823|                   Conversion = [BaseClassConversion] base class conversion
+#  823|                   Type = [SpecifiedType] const Middle
+#  823|                   ValueCategory = lvalue
+#  823|         0 converted: [ReferenceToExpr] (reference to)
+#  823|             Type = [LValueReferenceType] const Base &
+#  823|             ValueCategory = prvalue
+#  823|           : [CStyleCast] (const Base)...
+#  823|               Conversion = [GlvalueConversion] glvalue conversion
+#  823|               Type = [SpecifiedType] const Base
+#  823|               ValueCategory = lvalue
+#  823|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  823|           Type = [Struct,VirtualBaseClass] Base
+#  823|           ValueCategory = lvalue
 #  824|     20: [ExprStmt] ExprStmt
-#  824|       0: [ReferenceDereferenceExpr] (reference dereference)
-#  824|           Type = [Struct,VirtualBaseClass] Base
-#  824|           ValueCategory = lvalue
-#  824|         expr: [FunctionCall] call to operator=
-#  824|             Type = [LValueReferenceType] Base &
+#  824|       0: [FunctionCall] call to operator=
+#  824|           Type = [LValueReferenceType] Base &
+#  824|           ValueCategory = prvalue
+#  824|         -1: [VariableAccess] b
+#  824|             Type = [Struct,VirtualBaseClass] Base
+#  824|             ValueCategory = lvalue
+#  824|         0: [ConstructorCall] call to Base
+#  824|             Type = [VoidType] void
 #  824|             ValueCategory = prvalue
-#  824|           -1: [VariableAccess] b
-#  824|               Type = [Struct,VirtualBaseClass] Base
+#  824|           0: [VariableAccess] d
+#  824|               Type = [Struct] Derived
 #  824|               ValueCategory = lvalue
-#  824|           0: [ReferenceToExpr] (reference to)
+#  824|           0 converted: [ReferenceToExpr] (reference to)
 #  824|               Type = [LValueReferenceType] const Base &
 #  824|               ValueCategory = prvalue
-#  824|             expr: [CStyleCast] (const Base)...
-#  824|                 Conversion = [GlvalueConversion] glvalue conversion
+#  824|             : [CStyleCast] (const Base)...
+#  824|                 Conversion = [BaseClassConversion] base class conversion
 #  824|                 Type = [SpecifiedType] const Base
 #  824|                 ValueCategory = lvalue
-#  824|               expr: [ConstructorCall] call to Base
-#  824|                   Type = [VoidType] void
-#  824|                   ValueCategory = prvalue
-#  824|                 0: [ReferenceToExpr] (reference to)
-#  824|                     Type = [LValueReferenceType] const Base &
-#  824|                     ValueCategory = prvalue
-#  824|                   expr: [CStyleCast] (const Base)...
-#  824|                       Conversion = [BaseClassConversion] base class conversion
-#  824|                       Type = [SpecifiedType] const Base
-#  824|                       ValueCategory = lvalue
-#  824|                     expr: [CStyleCast] (const Middle)...
-#  824|                         Conversion = [BaseClassConversion] base class conversion
-#  824|                         Type = [SpecifiedType] const Middle
-#  824|                         ValueCategory = lvalue
-#  824|                       expr: [VariableAccess] d
-#  824|                           Type = [Struct] Derived
-#  824|                           ValueCategory = lvalue
+#  824|               : [CStyleCast] (const Middle)...
+#  824|                   Conversion = [BaseClassConversion] base class conversion
+#  824|                   Type = [SpecifiedType] const Middle
+#  824|                   ValueCategory = lvalue
+#  824|         0 converted: [ReferenceToExpr] (reference to)
+#  824|             Type = [LValueReferenceType] const Base &
+#  824|             ValueCategory = prvalue
+#  824|           : [CStyleCast] (const Base)...
+#  824|               Conversion = [GlvalueConversion] glvalue conversion
+#  824|               Type = [SpecifiedType] const Base
+#  824|               ValueCategory = lvalue
+#  824|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  824|           Type = [Struct,VirtualBaseClass] Base
+#  824|           ValueCategory = lvalue
 #  825|     21: [ExprStmt] ExprStmt
 #  825|       0: [AssignExpr] ... = ...
 #  825|           Type = [PointerType] Base *
@@ -6972,17 +6972,17 @@ ir.cpp:
 #  825|         0: [VariableAccess] pb
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = lvalue
-#  825|         1: [CStyleCast] (Base *)...
+#  825|         1: [VariableAccess] pd
+#  825|             Type = [PointerType] Derived *
+#  825|             ValueCategory = prvalue(load)
+#  825|         1 converted: [CStyleCast] (Base *)...
 #  825|             Conversion = [BaseClassConversion] base class conversion
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = prvalue
-#  825|           expr: [CStyleCast] (Middle *)...
+#  825|           : [CStyleCast] (Middle *)...
 #  825|               Conversion = [BaseClassConversion] base class conversion
 #  825|               Type = [PointerType] Middle *
 #  825|               ValueCategory = prvalue
-#  825|             expr: [VariableAccess] pd
-#  825|                 Type = [PointerType] Derived *
-#  825|                 ValueCategory = prvalue(load)
 #  826|     22: [ExprStmt] ExprStmt
 #  826|       0: [AssignExpr] ... = ...
 #  826|           Type = [PointerType] Base *
@@ -6990,17 +6990,17 @@ ir.cpp:
 #  826|         0: [VariableAccess] pb
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = lvalue
-#  826|         1: [CStyleCast] (Base *)...
+#  826|         1: [VariableAccess] pd
+#  826|             Type = [PointerType] Derived *
+#  826|             ValueCategory = prvalue(load)
+#  826|         1 converted: [CStyleCast] (Base *)...
 #  826|             Conversion = [BaseClassConversion] base class conversion
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = prvalue
-#  826|           expr: [CStyleCast] (Middle *)...
+#  826|           : [CStyleCast] (Middle *)...
 #  826|               Conversion = [BaseClassConversion] base class conversion
 #  826|               Type = [PointerType] Middle *
 #  826|               ValueCategory = prvalue
-#  826|             expr: [VariableAccess] pd
-#  826|                 Type = [PointerType] Derived *
-#  826|                 ValueCategory = prvalue(load)
 #  827|     23: [ExprStmt] ExprStmt
 #  827|       0: [AssignExpr] ... = ...
 #  827|           Type = [PointerType] Base *
@@ -7008,17 +7008,17 @@ ir.cpp:
 #  827|         0: [VariableAccess] pb
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = lvalue
-#  827|         1: [StaticCast] static_cast<Base *>...
+#  827|         1: [VariableAccess] pd
+#  827|             Type = [PointerType] Derived *
+#  827|             ValueCategory = prvalue(load)
+#  827|         1 converted: [StaticCast] static_cast<Base *>...
 #  827|             Conversion = [BaseClassConversion] base class conversion
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = prvalue
-#  827|           expr: [CStyleCast] (Middle *)...
+#  827|           : [CStyleCast] (Middle *)...
 #  827|               Conversion = [BaseClassConversion] base class conversion
 #  827|               Type = [PointerType] Middle *
 #  827|               ValueCategory = prvalue
-#  827|             expr: [VariableAccess] pd
-#  827|                 Type = [PointerType] Derived *
-#  827|                 ValueCategory = prvalue(load)
 #  828|     24: [ExprStmt] ExprStmt
 #  828|       0: [AssignExpr] ... = ...
 #  828|           Type = [PointerType] Base *
@@ -7026,69 +7026,69 @@ ir.cpp:
 #  828|         0: [VariableAccess] pb
 #  828|             Type = [PointerType] Base *
 #  828|             ValueCategory = lvalue
-#  828|         1: [ReinterpretCast] reinterpret_cast<Base *>...
+#  828|         1: [VariableAccess] pd
+#  828|             Type = [PointerType] Derived *
+#  828|             ValueCategory = prvalue(load)
+#  828|         1 converted: [ReinterpretCast] reinterpret_cast<Base *>...
 #  828|             Conversion = [PointerConversion] pointer conversion
 #  828|             Type = [PointerType] Base *
 #  828|             ValueCategory = prvalue
-#  828|           expr: [VariableAccess] pd
-#  828|               Type = [PointerType] Derived *
-#  828|               ValueCategory = prvalue(load)
 #  830|     25: [ExprStmt] ExprStmt
-#  830|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  830|       0: [FunctionCall] call to operator=
+#  830|           Type = [LValueReferenceType] Derived &
+#  830|           ValueCategory = prvalue
+#  830|         -1: [VariableAccess] d
+#  830|             Type = [Struct] Derived
+#  830|             ValueCategory = lvalue
+#  830|         0: [VariableAccess] b
+#  830|             Type = [Struct,VirtualBaseClass] Base
+#  830|             ValueCategory = lvalue
+#  830|         0 converted: [ReferenceToExpr] (reference to)
+#  830|             Type = [LValueReferenceType] const Derived &
+#  830|             ValueCategory = prvalue
+#  830|           : [CStyleCast] (const Derived)...
+#  830|               Conversion = [GlvalueConversion] glvalue conversion
+#  830|               Type = [SpecifiedType] const Derived
+#  830|               ValueCategory = lvalue
+#  830|             : [CStyleCast] (Derived)...
+#  830|                 Conversion = [DerivedClassConversion] derived class conversion
+#  830|                 Type = [Struct] Derived
+#  830|                 ValueCategory = lvalue
+#  830|               : [CStyleCast] (Middle)...
+#  830|                   Conversion = [DerivedClassConversion] derived class conversion
+#  830|                   Type = [Struct] Middle
+#  830|                   ValueCategory = lvalue
+#  830|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  830|           Type = [Struct] Derived
 #  830|           ValueCategory = lvalue
-#  830|         expr: [FunctionCall] call to operator=
-#  830|             Type = [LValueReferenceType] Derived &
-#  830|             ValueCategory = prvalue
-#  830|           -1: [VariableAccess] d
-#  830|               Type = [Struct] Derived
-#  830|               ValueCategory = lvalue
-#  830|           0: [ReferenceToExpr] (reference to)
-#  830|               Type = [LValueReferenceType] const Derived &
-#  830|               ValueCategory = prvalue
-#  830|             expr: [CStyleCast] (const Derived)...
-#  830|                 Conversion = [GlvalueConversion] glvalue conversion
-#  830|                 Type = [SpecifiedType] const Derived
-#  830|                 ValueCategory = lvalue
-#  830|               expr: [CStyleCast] (Derived)...
-#  830|                   Conversion = [DerivedClassConversion] derived class conversion
-#  830|                   Type = [Struct] Derived
-#  830|                   ValueCategory = lvalue
-#  830|                 expr: [CStyleCast] (Middle)...
-#  830|                     Conversion = [DerivedClassConversion] derived class conversion
-#  830|                     Type = [Struct] Middle
-#  830|                     ValueCategory = lvalue
-#  830|                   expr: [VariableAccess] b
-#  830|                       Type = [Struct,VirtualBaseClass] Base
-#  830|                       ValueCategory = lvalue
 #  831|     26: [ExprStmt] ExprStmt
-#  831|       0: [ReferenceDereferenceExpr] (reference dereference)
+#  831|       0: [FunctionCall] call to operator=
+#  831|           Type = [LValueReferenceType] Derived &
+#  831|           ValueCategory = prvalue
+#  831|         -1: [VariableAccess] d
+#  831|             Type = [Struct] Derived
+#  831|             ValueCategory = lvalue
+#  831|         0: [VariableAccess] b
+#  831|             Type = [Struct,VirtualBaseClass] Base
+#  831|             ValueCategory = lvalue
+#  831|         0 converted: [ReferenceToExpr] (reference to)
+#  831|             Type = [LValueReferenceType] const Derived &
+#  831|             ValueCategory = prvalue
+#  831|           : [CStyleCast] (const Derived)...
+#  831|               Conversion = [GlvalueConversion] glvalue conversion
+#  831|               Type = [SpecifiedType] const Derived
+#  831|               ValueCategory = lvalue
+#  831|             : [StaticCast] static_cast<Derived>...
+#  831|                 Conversion = [DerivedClassConversion] derived class conversion
+#  831|                 Type = [Struct] Derived
+#  831|                 ValueCategory = lvalue
+#  831|               : [CStyleCast] (Middle)...
+#  831|                   Conversion = [DerivedClassConversion] derived class conversion
+#  831|                   Type = [Struct] Middle
+#  831|                   ValueCategory = lvalue
+#  831|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
 #  831|           Type = [Struct] Derived
 #  831|           ValueCategory = lvalue
-#  831|         expr: [FunctionCall] call to operator=
-#  831|             Type = [LValueReferenceType] Derived &
-#  831|             ValueCategory = prvalue
-#  831|           -1: [VariableAccess] d
-#  831|               Type = [Struct] Derived
-#  831|               ValueCategory = lvalue
-#  831|           0: [ReferenceToExpr] (reference to)
-#  831|               Type = [LValueReferenceType] const Derived &
-#  831|               ValueCategory = prvalue
-#  831|             expr: [CStyleCast] (const Derived)...
-#  831|                 Conversion = [GlvalueConversion] glvalue conversion
-#  831|                 Type = [SpecifiedType] const Derived
-#  831|                 ValueCategory = lvalue
-#  831|               expr: [StaticCast] static_cast<Derived>...
-#  831|                   Conversion = [DerivedClassConversion] derived class conversion
-#  831|                   Type = [Struct] Derived
-#  831|                   ValueCategory = lvalue
-#  831|                 expr: [CStyleCast] (Middle)...
-#  831|                     Conversion = [DerivedClassConversion] derived class conversion
-#  831|                     Type = [Struct] Middle
-#  831|                     ValueCategory = lvalue
-#  831|                   expr: [VariableAccess] b
-#  831|                       Type = [Struct,VirtualBaseClass] Base
-#  831|                       ValueCategory = lvalue
 #  832|     27: [ExprStmt] ExprStmt
 #  832|       0: [AssignExpr] ... = ...
 #  832|           Type = [PointerType] Derived *
@@ -7096,17 +7096,17 @@ ir.cpp:
 #  832|         0: [VariableAccess] pd
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = lvalue
-#  832|         1: [CStyleCast] (Derived *)...
+#  832|         1: [VariableAccess] pb
+#  832|             Type = [PointerType] Base *
+#  832|             ValueCategory = prvalue(load)
+#  832|         1 converted: [CStyleCast] (Derived *)...
 #  832|             Conversion = [DerivedClassConversion] derived class conversion
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = prvalue
-#  832|           expr: [CStyleCast] (Middle *)...
+#  832|           : [CStyleCast] (Middle *)...
 #  832|               Conversion = [DerivedClassConversion] derived class conversion
 #  832|               Type = [PointerType] Middle *
 #  832|               ValueCategory = prvalue
-#  832|             expr: [VariableAccess] pb
-#  832|                 Type = [PointerType] Base *
-#  832|                 ValueCategory = prvalue(load)
 #  833|     28: [ExprStmt] ExprStmt
 #  833|       0: [AssignExpr] ... = ...
 #  833|           Type = [PointerType] Derived *
@@ -7114,17 +7114,17 @@ ir.cpp:
 #  833|         0: [VariableAccess] pd
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = lvalue
-#  833|         1: [StaticCast] static_cast<Derived *>...
+#  833|         1: [VariableAccess] pb
+#  833|             Type = [PointerType] Base *
+#  833|             ValueCategory = prvalue(load)
+#  833|         1 converted: [StaticCast] static_cast<Derived *>...
 #  833|             Conversion = [DerivedClassConversion] derived class conversion
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = prvalue
-#  833|           expr: [CStyleCast] (Middle *)...
+#  833|           : [CStyleCast] (Middle *)...
 #  833|               Conversion = [DerivedClassConversion] derived class conversion
 #  833|               Type = [PointerType] Middle *
 #  833|               ValueCategory = prvalue
-#  833|             expr: [VariableAccess] pb
-#  833|                 Type = [PointerType] Base *
-#  833|                 ValueCategory = prvalue(load)
 #  834|     29: [ExprStmt] ExprStmt
 #  834|       0: [AssignExpr] ... = ...
 #  834|           Type = [PointerType] Derived *
@@ -7132,39 +7132,39 @@ ir.cpp:
 #  834|         0: [VariableAccess] pd
 #  834|             Type = [PointerType] Derived *
 #  834|             ValueCategory = lvalue
-#  834|         1: [ReinterpretCast] reinterpret_cast<Derived *>...
+#  834|         1: [VariableAccess] pb
+#  834|             Type = [PointerType] Base *
+#  834|             ValueCategory = prvalue(load)
+#  834|         1 converted: [ReinterpretCast] reinterpret_cast<Derived *>...
 #  834|             Conversion = [PointerConversion] pointer conversion
 #  834|             Type = [PointerType] Derived *
 #  834|             ValueCategory = prvalue
-#  834|           expr: [VariableAccess] pb
-#  834|               Type = [PointerType] Base *
-#  834|               ValueCategory = prvalue(load)
 #  836|     30: [DeclStmt] declaration
 #  836|       0: [VariableDeclarationEntry] definition of pmv
 #  836|           Type = [PointerType] MiddleVB1 *
 #  836|         init: [Initializer] initializer for pmv
-#  836|           expr: [CStyleCast] (MiddleVB1 *)...
+#  836|           expr: [Literal] 0
+#  836|               Type = [NullPointerType] decltype(nullptr)
+#  836|               Value = [Literal] 0
+#  836|               ValueCategory = prvalue
+#  836|           expr converted: [CStyleCast] (MiddleVB1 *)...
 #  836|               Conversion = [PointerConversion] pointer conversion
 #  836|               Type = [PointerType] MiddleVB1 *
 #  836|               Value = [CStyleCast] 0
 #  836|               ValueCategory = prvalue
-#  836|             expr: [Literal] 0
-#  836|                 Type = [NullPointerType] decltype(nullptr)
-#  836|                 Value = [Literal] 0
-#  836|                 ValueCategory = prvalue
 #  837|     31: [DeclStmt] declaration
 #  837|       0: [VariableDeclarationEntry] definition of pdv
 #  837|           Type = [PointerType] DerivedVB *
 #  837|         init: [Initializer] initializer for pdv
-#  837|           expr: [CStyleCast] (DerivedVB *)...
+#  837|           expr: [Literal] 0
+#  837|               Type = [NullPointerType] decltype(nullptr)
+#  837|               Value = [Literal] 0
+#  837|               ValueCategory = prvalue
+#  837|           expr converted: [CStyleCast] (DerivedVB *)...
 #  837|               Conversion = [PointerConversion] pointer conversion
 #  837|               Type = [PointerType] DerivedVB *
 #  837|               Value = [CStyleCast] 0
 #  837|               ValueCategory = prvalue
-#  837|             expr: [Literal] 0
-#  837|                 Type = [NullPointerType] decltype(nullptr)
-#  837|                 Value = [Literal] 0
-#  837|                 ValueCategory = prvalue
 #  838|     32: [ExprStmt] ExprStmt
 #  838|       0: [AssignExpr] ... = ...
 #  838|           Type = [PointerType] Base *
@@ -7172,13 +7172,13 @@ ir.cpp:
 #  838|         0: [VariableAccess] pb
 #  838|             Type = [PointerType] Base *
 #  838|             ValueCategory = lvalue
-#  838|         1: [CStyleCast] (Base *)...
+#  838|         1: [VariableAccess] pmv
+#  838|             Type = [PointerType] MiddleVB1 *
+#  838|             ValueCategory = prvalue(load)
+#  838|         1 converted: [CStyleCast] (Base *)...
 #  838|             Conversion = [BaseClassConversion] base class conversion
 #  838|             Type = [PointerType] Base *
 #  838|             ValueCategory = prvalue
-#  838|           expr: [VariableAccess] pmv
-#  838|               Type = [PointerType] MiddleVB1 *
-#  838|               ValueCategory = prvalue(load)
 #  839|     33: [ExprStmt] ExprStmt
 #  839|       0: [AssignExpr] ... = ...
 #  839|           Type = [PointerType] Base *
@@ -7186,13 +7186,13 @@ ir.cpp:
 #  839|         0: [VariableAccess] pb
 #  839|             Type = [PointerType] Base *
 #  839|             ValueCategory = lvalue
-#  839|         1: [CStyleCast] (Base *)...
+#  839|         1: [VariableAccess] pdv
+#  839|             Type = [PointerType] DerivedVB *
+#  839|             ValueCategory = prvalue(load)
+#  839|         1 converted: [CStyleCast] (Base *)...
 #  839|             Conversion = [BaseClassConversion] base class conversion
 #  839|             Type = [PointerType] Base *
 #  839|             ValueCategory = prvalue
-#  839|           expr: [VariableAccess] pdv
-#  839|               Type = [PointerType] DerivedVB *
-#  839|               ValueCategory = prvalue(load)
 #  840|     34: [ReturnStmt] return ...
 #  842| [CopyAssignmentOperator] PolymorphicBase& PolymorphicBase::operator=(PolymorphicBase const&)
 #  842|   params: 
@@ -7285,27 +7285,27 @@ ir.cpp:
 #  857|         0: [VariableAccess] pb
 #  857|             Type = [PointerType] PolymorphicBase *
 #  857|             ValueCategory = lvalue
-#  857|         1: [DynamicCast] dynamic_cast<PolymorphicBase *>...
+#  857|         1: [VariableAccess] pd
+#  857|             Type = [PointerType] PolymorphicDerived *
+#  857|             ValueCategory = prvalue(load)
+#  857|         1 converted: [DynamicCast] dynamic_cast<PolymorphicBase *>...
 #  857|             Conversion = [DynamicCast] dynamic_cast
 #  857|             Type = [PointerType] PolymorphicBase *
 #  857|             ValueCategory = prvalue
-#  857|           expr: [VariableAccess] pd
-#  857|               Type = [PointerType] PolymorphicDerived *
-#  857|               ValueCategory = prvalue(load)
 #  858|     5: [DeclStmt] declaration
 #  858|       0: [VariableDeclarationEntry] definition of rb
 #  858|           Type = [LValueReferenceType] PolymorphicBase &
 #  858|         init: [Initializer] initializer for rb
-#  858|           expr: [ReferenceToExpr] (reference to)
+#  858|           expr: [VariableAccess] d
+#  858|               Type = [Struct] PolymorphicDerived
+#  858|               ValueCategory = lvalue
+#  858|           expr converted: [ReferenceToExpr] (reference to)
 #  858|               Type = [LValueReferenceType] PolymorphicBase &
 #  858|               ValueCategory = prvalue
-#  858|             expr: [DynamicCast] dynamic_cast<PolymorphicBase>...
+#  858|             : [DynamicCast] dynamic_cast<PolymorphicBase>...
 #  858|                 Conversion = [DynamicCast] dynamic_cast
 #  858|                 Type = [Struct] PolymorphicBase
 #  858|                 ValueCategory = lvalue
-#  858|               expr: [VariableAccess] d
-#  858|                   Type = [Struct] PolymorphicDerived
-#  858|                   ValueCategory = lvalue
 #  860|     6: [ExprStmt] ExprStmt
 #  860|       0: [AssignExpr] ... = ...
 #  860|           Type = [PointerType] PolymorphicDerived *
@@ -7313,49 +7313,49 @@ ir.cpp:
 #  860|         0: [VariableAccess] pd
 #  860|             Type = [PointerType] PolymorphicDerived *
 #  860|             ValueCategory = lvalue
-#  860|         1: [DynamicCast] dynamic_cast<PolymorphicDerived *>...
+#  860|         1: [VariableAccess] pb
+#  860|             Type = [PointerType] PolymorphicBase *
+#  860|             ValueCategory = prvalue(load)
+#  860|         1 converted: [DynamicCast] dynamic_cast<PolymorphicDerived *>...
 #  860|             Conversion = [DynamicCast] dynamic_cast
 #  860|             Type = [PointerType] PolymorphicDerived *
 #  860|             ValueCategory = prvalue
-#  860|           expr: [VariableAccess] pb
-#  860|               Type = [PointerType] PolymorphicBase *
-#  860|               ValueCategory = prvalue(load)
 #  861|     7: [DeclStmt] declaration
 #  861|       0: [VariableDeclarationEntry] definition of rd
 #  861|           Type = [LValueReferenceType] PolymorphicDerived &
 #  861|         init: [Initializer] initializer for rd
-#  861|           expr: [ReferenceToExpr] (reference to)
+#  861|           expr: [VariableAccess] b
+#  861|               Type = [Struct] PolymorphicBase
+#  861|               ValueCategory = lvalue
+#  861|           expr converted: [ReferenceToExpr] (reference to)
 #  861|               Type = [LValueReferenceType] PolymorphicDerived &
 #  861|               ValueCategory = prvalue
-#  861|             expr: [DynamicCast] dynamic_cast<PolymorphicDerived>...
+#  861|             : [DynamicCast] dynamic_cast<PolymorphicDerived>...
 #  861|                 Conversion = [DynamicCast] dynamic_cast
 #  861|                 Type = [Struct] PolymorphicDerived
 #  861|                 ValueCategory = lvalue
-#  861|               expr: [VariableAccess] b
-#  861|                   Type = [Struct] PolymorphicBase
-#  861|                   ValueCategory = lvalue
 #  863|     8: [DeclStmt] declaration
 #  863|       0: [VariableDeclarationEntry] definition of pv
 #  863|           Type = [VoidPointerType] void *
 #  863|         init: [Initializer] initializer for pv
-#  863|           expr: [DynamicCast] dynamic_cast<void *>...
+#  863|           expr: [VariableAccess] pb
+#  863|               Type = [PointerType] PolymorphicBase *
+#  863|               ValueCategory = prvalue(load)
+#  863|           expr converted: [DynamicCast] dynamic_cast<void *>...
 #  863|               Conversion = [DynamicCast] dynamic_cast
 #  863|               Type = [VoidPointerType] void *
 #  863|               ValueCategory = prvalue
-#  863|             expr: [VariableAccess] pb
-#  863|                 Type = [PointerType] PolymorphicBase *
-#  863|                 ValueCategory = prvalue(load)
 #  864|     9: [DeclStmt] declaration
 #  864|       0: [VariableDeclarationEntry] definition of pcv
 #  864|           Type = [PointerType] const void *
 #  864|         init: [Initializer] initializer for pcv
-#  864|           expr: [DynamicCast] dynamic_cast<const void *>...
+#  864|           expr: [VariableAccess] pd
+#  864|               Type = [PointerType] PolymorphicDerived *
+#  864|               ValueCategory = prvalue(load)
+#  864|           expr converted: [DynamicCast] dynamic_cast<const void *>...
 #  864|               Conversion = [DynamicCast] dynamic_cast
 #  864|               Type = [PointerType] const void *
 #  864|               ValueCategory = prvalue
-#  864|             expr: [VariableAccess] pd
-#  864|                 Type = [PointerType] PolymorphicDerived *
-#  864|                 ValueCategory = prvalue(load)
 #  865|     10: [ReturnStmt] return ...
 #  867| [Constructor] void String::String()
 #  867|   params: 
@@ -7363,13 +7363,13 @@ ir.cpp:
 #  868|     0: [ConstructorDelegationInit] call to String
 #  868|         Type = [VoidType] void
 #  868|         ValueCategory = prvalue
-#  868|       0: [ArrayToPointerConversion] array to pointer conversion
+#  868|       0: 
+#  868|           Type = [ArrayType] const char[1]
+#  868|           Value = [StringLiteral] ""
+#  868|           ValueCategory = lvalue
+#  868|       0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  868|           Type = [PointerType] const char *
 #  868|           ValueCategory = prvalue
-#  868|         expr: 
-#  868|             Type = [ArrayType] const char[1]
-#  868|             Value = [StringLiteral] ""
-#  868|             ValueCategory = lvalue
 #  868|   body: [BlockStmt] { ... }
 #  869|     0: [ReturnStmt] return ...
 #  871| [TopLevelFunction] void ArrayConversions()
@@ -7382,16 +7382,16 @@ ir.cpp:
 #  873|       0: [VariableDeclarationEntry] definition of p
 #  873|           Type = [PointerType] const char *
 #  873|         init: [Initializer] initializer for p
-#  873|           expr: [CStyleCast] (const char *)...
+#  873|           expr: [VariableAccess] a
+#  873|               Type = [ArrayType] char[5]
+#  873|               ValueCategory = lvalue
+#  873|           expr converted: [CStyleCast] (const char *)...
 #  873|               Conversion = [PointerConversion] pointer conversion
 #  873|               Type = [PointerType] const char *
 #  873|               ValueCategory = prvalue
-#  873|             expr: [ArrayToPointerConversion] array to pointer conversion
+#  873|             : [ArrayToPointerConversion] array to pointer conversion
 #  873|                 Type = [CharPointerType] char *
 #  873|                 ValueCategory = prvalue
-#  873|               expr: [VariableAccess] a
-#  873|                   Type = [ArrayType] char[5]
-#  873|                   ValueCategory = lvalue
 #  874|     2: [ExprStmt] ExprStmt
 #  874|       0: [AssignExpr] ... = ...
 #  874|           Type = [PointerType] const char *
@@ -7399,13 +7399,13 @@ ir.cpp:
 #  874|         0: [VariableAccess] p
 #  874|             Type = [PointerType] const char *
 #  874|             ValueCategory = lvalue
-#  874|         1: [ArrayToPointerConversion] array to pointer conversion
+#  874|         1: test
+#  874|             Type = [ArrayType] const char[5]
+#  874|             Value = [StringLiteral] "test"
+#  874|             ValueCategory = lvalue
+#  874|         1 converted: [ArrayToPointerConversion] array to pointer conversion
 #  874|             Type = [PointerType] const char *
 #  874|             ValueCategory = prvalue
-#  874|           expr: test
-#  874|               Type = [ArrayType] const char[5]
-#  874|               Value = [StringLiteral] "test"
-#  874|               ValueCategory = lvalue
 #  875|     3: [ExprStmt] ExprStmt
 #  875|       0: [AssignExpr] ... = ...
 #  875|           Type = [PointerType] const char *
@@ -7413,26 +7413,26 @@ ir.cpp:
 #  875|         0: [VariableAccess] p
 #  875|             Type = [PointerType] const char *
 #  875|             ValueCategory = lvalue
-#  875|         1: [CStyleCast] (const char *)...
+#  875|         1: [AddressOfExpr] & ...
+#  875|             Type = [CharPointerType] char *
+#  875|             ValueCategory = prvalue
+#  875|           0: [ArrayExpr] access to array
+#  875|               Type = [PlainCharType] char
+#  875|               ValueCategory = lvalue
+#  875|             0: [VariableAccess] a
+#  875|                 Type = [ArrayType] char[5]
+#  875|                 ValueCategory = lvalue
+#  875|             1: [Literal] 0
+#  875|                 Type = [IntType] int
+#  875|                 Value = [Literal] 0
+#  875|                 ValueCategory = prvalue
+#  875|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  875|                 Type = [CharPointerType] char *
+#  875|                 ValueCategory = prvalue
+#  875|         1 converted: [CStyleCast] (const char *)...
 #  875|             Conversion = [PointerConversion] pointer conversion
 #  875|             Type = [PointerType] const char *
 #  875|             ValueCategory = prvalue
-#  875|           expr: [AddressOfExpr] & ...
-#  875|               Type = [CharPointerType] char *
-#  875|               ValueCategory = prvalue
-#  875|             0: [ArrayExpr] access to array
-#  875|                 Type = [PlainCharType] char
-#  875|                 ValueCategory = lvalue
-#  875|               0: [ArrayToPointerConversion] array to pointer conversion
-#  875|                   Type = [CharPointerType] char *
-#  875|                   ValueCategory = prvalue
-#  875|                 expr: [VariableAccess] a
-#  875|                     Type = [ArrayType] char[5]
-#  875|                     ValueCategory = lvalue
-#  875|               1: [Literal] 0
-#  875|                   Type = [IntType] int
-#  875|                   Value = [Literal] 0
-#  875|                   ValueCategory = prvalue
 #  876|     4: [ExprStmt] ExprStmt
 #  876|       0: [AssignExpr] ... = ...
 #  876|           Type = [PointerType] const char *
@@ -7446,52 +7446,52 @@ ir.cpp:
 #  876|           0: [ArrayExpr] access to array
 #  876|               Type = [SpecifiedType] const char
 #  876|               ValueCategory = lvalue
-#  876|             0: [ArrayToPointerConversion] array to pointer conversion
-#  876|                 Type = [PointerType] const char *
-#  876|                 ValueCategory = prvalue
-#  876|               expr: test
-#  876|                   Type = [ArrayType] const char[5]
-#  876|                   Value = [StringLiteral] "test"
-#  876|                   ValueCategory = lvalue
+#  876|             0: test
+#  876|                 Type = [ArrayType] const char[5]
+#  876|                 Value = [StringLiteral] "test"
+#  876|                 ValueCategory = lvalue
 #  876|             1: [Literal] 0
 #  876|                 Type = [IntType] int
 #  876|                 Value = [Literal] 0
+#  876|                 ValueCategory = prvalue
+#  876|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  876|                 Type = [PointerType] const char *
 #  876|                 ValueCategory = prvalue
 #  877|     5: [DeclStmt] declaration
 #  877|       0: [VariableDeclarationEntry] definition of ra
 #  877|           Type = [LValueReferenceType] char(&)[5]
 #  877|         init: [Initializer] initializer for ra
-#  877|           expr: [ReferenceToExpr] (reference to)
+#  877|           expr: [VariableAccess] a
+#  877|               Type = [ArrayType] char[5]
+#  877|               ValueCategory = lvalue
+#  877|           expr converted: [ReferenceToExpr] (reference to)
 #  877|               Type = [LValueReferenceType] char(&)[5]
 #  877|               ValueCategory = prvalue
-#  877|             expr: [VariableAccess] a
-#  877|                 Type = [ArrayType] char[5]
-#  877|                 ValueCategory = lvalue
 #  878|     6: [DeclStmt] declaration
 #  878|       0: [VariableDeclarationEntry] definition of rs
 #  878|           Type = [LValueReferenceType] const char(&)[5]
 #  878|         init: [Initializer] initializer for rs
-#  878|           expr: [ReferenceToExpr] (reference to)
+#  878|           expr: test
+#  878|               Type = [ArrayType] const char[5]
+#  878|               Value = [StringLiteral] "test"
+#  878|               ValueCategory = lvalue
+#  878|           expr converted: [ReferenceToExpr] (reference to)
 #  878|               Type = [LValueReferenceType] const char(&)[5]
 #  878|               ValueCategory = prvalue
-#  878|             expr: test
-#  878|                 Type = [ArrayType] const char[5]
-#  878|                 Value = [StringLiteral] "test"
-#  878|                 ValueCategory = lvalue
 #  879|     7: [DeclStmt] declaration
 #  879|       0: [VariableDeclarationEntry] definition of pa
 #  879|           Type = [PointerType] const char(*)[5]
 #  879|         init: [Initializer] initializer for pa
-#  879|           expr: [CStyleCast] (const char(*)[5])...
+#  879|           expr: [AddressOfExpr] & ...
+#  879|               Type = [PointerType] char(*)[5]
+#  879|               ValueCategory = prvalue
+#  879|             0: [VariableAccess] a
+#  879|                 Type = [ArrayType] char[5]
+#  879|                 ValueCategory = lvalue
+#  879|           expr converted: [CStyleCast] (const char(*)[5])...
 #  879|               Conversion = [PointerConversion] pointer conversion
 #  879|               Type = [PointerType] const char(*)[5]
 #  879|               ValueCategory = prvalue
-#  879|             expr: [AddressOfExpr] & ...
-#  879|                 Type = [PointerType] char(*)[5]
-#  879|                 ValueCategory = prvalue
-#  879|               0: [VariableAccess] a
-#  879|                   Type = [ArrayType] char[5]
-#  879|                   ValueCategory = lvalue
 #  880|     8: [ExprStmt] ExprStmt
 #  880|       0: [AssignExpr] ... = ...
 #  880|           Type = [PointerType] const char(*)[5]
@@ -7521,13 +7521,13 @@ ir.cpp:
 #  884|         0: [VariableAccess] p
 #  884|             Type = [VoidPointerType] void *
 #  884|             ValueCategory = lvalue
-#  884|         1: [CStyleCast] (void *)...
+#  884|         1: [VariableAccess] pfn
+#  884|             Type = [FunctionPointerType] ..(*)(..)
+#  884|             ValueCategory = prvalue(load)
+#  884|         1 converted: [CStyleCast] (void *)...
 #  884|             Conversion = [PointerConversion] pointer conversion
 #  884|             Type = [VoidPointerType] void *
 #  884|             ValueCategory = prvalue
-#  884|           expr: [VariableAccess] pfn
-#  884|               Type = [FunctionPointerType] ..(*)(..)
-#  884|               ValueCategory = prvalue(load)
 #  885|     1: [ExprStmt] ExprStmt
 #  885|       0: [AssignExpr] ... = ...
 #  885|           Type = [FunctionPointerType] ..(*)(..)
@@ -7535,13 +7535,13 @@ ir.cpp:
 #  885|         0: [VariableAccess] pfn
 #  885|             Type = [FunctionPointerType] ..(*)(..)
 #  885|             ValueCategory = lvalue
-#  885|         1: [CStyleCast] (..(*)(..))...
+#  885|         1: [VariableAccess] p
+#  885|             Type = [VoidPointerType] void *
+#  885|             ValueCategory = prvalue(load)
+#  885|         1 converted: [CStyleCast] (..(*)(..))...
 #  885|             Conversion = [PointerConversion] pointer conversion
 #  885|             Type = [FunctionPointerType] ..(*)(..)
 #  885|             ValueCategory = prvalue
-#  885|           expr: [VariableAccess] p
-#  885|               Type = [VoidPointerType] void *
-#  885|               ValueCategory = prvalue(load)
 #  886|     2: [ReturnStmt] return ...
 #  888| [TopLevelFunction] void VAListUsage(int, __va_list_tag[1])
 #  888|   params: 
@@ -7557,15 +7557,15 @@ ir.cpp:
 #  890|       0: [BuiltInVarArgCopy] __builtin_va_copy
 #  890|           Type = [VoidType] void
 #  890|           ValueCategory = prvalue
-#  890|         0: [ArrayToPointerConversion] array to pointer conversion
-#  890|             Type = [PointerType] __va_list_tag *
-#  890|             ValueCategory = prvalue
-#  890|           expr: [VariableAccess] args2
-#  890|               Type = [ArrayType] __va_list_tag[1]
-#  890|               ValueCategory = lvalue
+#  890|         0: [VariableAccess] args2
+#  890|             Type = [ArrayType] __va_list_tag[1]
+#  890|             ValueCategory = lvalue
 #  890|         1: [VariableAccess] args
 #  890|             Type = [PointerType] __va_list_tag *
 #  890|             ValueCategory = prvalue(load)
+#  890|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  890|             Type = [PointerType] __va_list_tag *
+#  890|             ValueCategory = prvalue
 #  891|     2: [DeclStmt] declaration
 #  891|       0: [VariableDeclarationEntry] definition of d
 #  891|           Type = [DoubleType] double
@@ -7580,26 +7580,26 @@ ir.cpp:
 #  892|       0: [VariableDeclarationEntry] definition of f
 #  892|           Type = [FloatType] float
 #  892|         init: [Initializer] initializer for f
-#  892|           expr: [CStyleCast] (float)...
+#  892|           expr: [BuiltInVarArg] __builtin_va_arg
+#  892|               Type = [IntType] int
+#  892|               ValueCategory = prvalue(load)
+#  892|             0: [VariableAccess] args
+#  892|                 Type = [PointerType] __va_list_tag *
+#  892|                 ValueCategory = prvalue(load)
+#  892|           expr converted: [CStyleCast] (float)...
 #  892|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  892|               Type = [FloatType] float
 #  892|               ValueCategory = prvalue
-#  892|             expr: [BuiltInVarArg] __builtin_va_arg
-#  892|                 Type = [IntType] int
-#  892|                 ValueCategory = prvalue(load)
-#  892|               0: [VariableAccess] args
-#  892|                   Type = [PointerType] __va_list_tag *
-#  892|                   ValueCategory = prvalue(load)
 #  893|     4: [ExprStmt] ExprStmt
 #  893|       0: [BuiltInVarArgsEnd] __builtin_va_end
 #  893|           Type = [VoidType] void
 #  893|           ValueCategory = prvalue
-#  893|         0: [ArrayToPointerConversion] array to pointer conversion
+#  893|         0: [VariableAccess] args2
+#  893|             Type = [ArrayType] __va_list_tag[1]
+#  893|             ValueCategory = lvalue
+#  893|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  893|             Type = [PointerType] __va_list_tag *
 #  893|             ValueCategory = prvalue
-#  893|           expr: [VariableAccess] args2
-#  893|               Type = [ArrayType] __va_list_tag[1]
-#  893|               ValueCategory = lvalue
 #  894|     5: [ReturnStmt] return ...
 #  896| [TopLevelFunction] void VarArgUsage(int)
 #  896|   params: 
@@ -7613,15 +7613,15 @@ ir.cpp:
 #  899|       0: [BuiltInVarArgsStart] __builtin_va_start
 #  899|           Type = [VoidType] void
 #  899|           ValueCategory = prvalue
-#  899|         0: [ArrayToPointerConversion] array to pointer conversion
-#  899|             Type = [PointerType] __va_list_tag *
-#  899|             ValueCategory = prvalue
-#  899|           expr: [VariableAccess] args
-#  899|               Type = [ArrayType] __va_list_tag[1]
-#  899|               ValueCategory = lvalue
+#  899|         0: [VariableAccess] args
+#  899|             Type = [ArrayType] __va_list_tag[1]
+#  899|             ValueCategory = lvalue
 #  899|         1: [VariableAccess] x
 #  899|             Type = [IntType] int
 #  899|             ValueCategory = lvalue
+#  899|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  899|             Type = [PointerType] __va_list_tag *
+#  899|             ValueCategory = prvalue
 #  900|     2: [DeclStmt] declaration
 #  900|       0: [VariableDeclarationEntry] definition of args2
 #  900|           Type = [ArrayType] __va_list_tag[1]
@@ -7629,18 +7629,18 @@ ir.cpp:
 #  901|       0: [BuiltInVarArgCopy] __builtin_va_copy
 #  901|           Type = [VoidType] void
 #  901|           ValueCategory = prvalue
-#  901|         0: [ArrayToPointerConversion] array to pointer conversion
+#  901|         0: [VariableAccess] args2
+#  901|             Type = [ArrayType] __va_list_tag[1]
+#  901|             ValueCategory = lvalue
+#  901|         1: [VariableAccess] args
+#  901|             Type = [ArrayType] __va_list_tag[1]
+#  901|             ValueCategory = lvalue
+#  901|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
-#  901|           expr: [VariableAccess] args2
-#  901|               Type = [ArrayType] __va_list_tag[1]
-#  901|               ValueCategory = lvalue
-#  901|         1: [ArrayToPointerConversion] array to pointer conversion
+#  901|         1 converted: [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
-#  901|           expr: [VariableAccess] args
-#  901|               Type = [ArrayType] __va_list_tag[1]
-#  901|               ValueCategory = lvalue
 #  902|     4: [DeclStmt] declaration
 #  902|       0: [VariableDeclarationEntry] definition of d
 #  902|           Type = [DoubleType] double
@@ -7648,39 +7648,39 @@ ir.cpp:
 #  902|           expr: [BuiltInVarArg] __builtin_va_arg
 #  902|               Type = [DoubleType] double
 #  902|               ValueCategory = prvalue(load)
-#  902|             0: [ArrayToPointerConversion] array to pointer conversion
+#  902|             0: [VariableAccess] args
+#  902|                 Type = [ArrayType] __va_list_tag[1]
+#  902|                 ValueCategory = lvalue
+#  902|             0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  902|                 Type = [PointerType] __va_list_tag *
 #  902|                 ValueCategory = prvalue
-#  902|               expr: [VariableAccess] args
-#  902|                   Type = [ArrayType] __va_list_tag[1]
-#  902|                   ValueCategory = lvalue
 #  903|     5: [DeclStmt] declaration
 #  903|       0: [VariableDeclarationEntry] definition of f
 #  903|           Type = [FloatType] float
 #  903|         init: [Initializer] initializer for f
-#  903|           expr: [CStyleCast] (float)...
+#  903|           expr: [BuiltInVarArg] __builtin_va_arg
+#  903|               Type = [IntType] int
+#  903|               ValueCategory = prvalue(load)
+#  903|             0: [VariableAccess] args
+#  903|                 Type = [ArrayType] __va_list_tag[1]
+#  903|                 ValueCategory = lvalue
+#  903|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  903|                 Type = [PointerType] __va_list_tag *
+#  903|                 ValueCategory = prvalue
+#  903|           expr converted: [CStyleCast] (float)...
 #  903|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  903|               Type = [FloatType] float
 #  903|               ValueCategory = prvalue
-#  903|             expr: [BuiltInVarArg] __builtin_va_arg
-#  903|                 Type = [IntType] int
-#  903|                 ValueCategory = prvalue(load)
-#  903|               0: [ArrayToPointerConversion] array to pointer conversion
-#  903|                   Type = [PointerType] __va_list_tag *
-#  903|                   ValueCategory = prvalue
-#  903|                 expr: [VariableAccess] args
-#  903|                     Type = [ArrayType] __va_list_tag[1]
-#  903|                     ValueCategory = lvalue
 #  904|     6: [ExprStmt] ExprStmt
 #  904|       0: [BuiltInVarArgsEnd] __builtin_va_end
 #  904|           Type = [VoidType] void
 #  904|           ValueCategory = prvalue
-#  904|         0: [ArrayToPointerConversion] array to pointer conversion
+#  904|         0: [VariableAccess] args
+#  904|             Type = [ArrayType] __va_list_tag[1]
+#  904|             ValueCategory = lvalue
+#  904|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  904|             Type = [PointerType] __va_list_tag *
 #  904|             ValueCategory = prvalue
-#  904|           expr: [VariableAccess] args
-#  904|               Type = [ArrayType] __va_list_tag[1]
-#  904|               ValueCategory = lvalue
 #  905|     7: [ExprStmt] ExprStmt
 #  905|       0: [FunctionCall] call to VAListUsage
 #  905|           Type = [VoidType] void
@@ -7688,22 +7688,22 @@ ir.cpp:
 #  905|         0: [VariableAccess] x
 #  905|             Type = [IntType] int
 #  905|             ValueCategory = prvalue(load)
-#  905|         1: [ArrayToPointerConversion] array to pointer conversion
+#  905|         1: [VariableAccess] args2
+#  905|             Type = [ArrayType] __va_list_tag[1]
+#  905|             ValueCategory = lvalue
+#  905|         1 converted: [ArrayToPointerConversion] array to pointer conversion
 #  905|             Type = [PointerType] __va_list_tag *
 #  905|             ValueCategory = prvalue
-#  905|           expr: [VariableAccess] args2
-#  905|               Type = [ArrayType] __va_list_tag[1]
-#  905|               ValueCategory = lvalue
 #  906|     8: [ExprStmt] ExprStmt
 #  906|       0: [BuiltInVarArgsEnd] __builtin_va_end
 #  906|           Type = [VoidType] void
 #  906|           ValueCategory = prvalue
-#  906|         0: [ArrayToPointerConversion] array to pointer conversion
+#  906|         0: [VariableAccess] args2
+#  906|             Type = [ArrayType] __va_list_tag[1]
+#  906|             ValueCategory = lvalue
+#  906|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  906|             Type = [PointerType] __va_list_tag *
 #  906|             ValueCategory = prvalue
-#  906|           expr: [VariableAccess] args2
-#  906|               Type = [ArrayType] __va_list_tag[1]
-#  906|               ValueCategory = lvalue
 #  907|     9: [ReturnStmt] return ...
 #  909| [TopLevelFunction] void CastToVoid(int)
 #  909|   params: 
@@ -7711,13 +7711,13 @@ ir.cpp:
 #  909|         Type = [IntType] int
 #  909|   body: [BlockStmt] { ... }
 #  910|     0: [ExprStmt] ExprStmt
-#  910|       0: [CStyleCast] (void)...
+#  910|       0: [VariableAccess] x
+#  910|           Type = [IntType] int
+#  910|           ValueCategory = lvalue
+#  910|       0 converted: [CStyleCast] (void)...
 #  910|           Conversion = [VoidConversion] conversion to void
 #  910|           Type = [VoidType] void
 #  910|           ValueCategory = prvalue
-#  910|         expr: [VariableAccess] x
-#  910|             Type = [IntType] int
-#  910|             ValueCategory = lvalue
 #  911|     1: [ReturnStmt] return ...
 #  913| [TopLevelFunction] void ConstantConditions(int)
 #  913|   params: 
@@ -7747,20 +7747,20 @@ ir.cpp:
 #  915|           expr: [ConditionalExpr] ... ? ... : ...
 #  915|               Type = [IntType] int
 #  915|               ValueCategory = prvalue
-#  915|             0: [ParenthesisExpr] (...)
+#  915|             0: [Literal] 1
 #  915|                 Type = [BoolType] bool
-#  915|                 Value = [ParenthesisExpr] 1
+#  915|                 Value = [Literal] 1
 #  915|                 ValueCategory = prvalue
-#  915|               expr: [Literal] 1
-#  915|                   Type = [BoolType] bool
-#  915|                   Value = [Literal] 1
-#  915|                   ValueCategory = prvalue
 #  915|             1: [VariableAccess] x
 #  915|                 Type = [IntType] int
 #  915|                 ValueCategory = prvalue(load)
 #  915|             2: [VariableAccess] x
 #  915|                 Type = [IntType] int
 #  915|                 ValueCategory = prvalue(load)
+#  915|             0 converted: [ParenthesisExpr] (...)
+#  915|                 Type = [BoolType] bool
+#  915|                 Value = [ParenthesisExpr] 1
+#  915|                 ValueCategory = prvalue
 #  916|     2: [ReturnStmt] return ...
 #  924| [Operator,TopLevelFunction] void* operator new(size_t, float)
 #  924|   params: 
@@ -7927,13 +7927,13 @@ ir.cpp:
 #  954|         1: [ConstructorCall] call to String
 #  954|             Type = [VoidType] void
 #  954|             ValueCategory = prvalue
-#  954|           0: [ArrayToPointerConversion] array to pointer conversion
+#  954|           0: hello
+#  954|               Type = [ArrayType] const char[6]
+#  954|               Value = [StringLiteral] "hello"
+#  954|               ValueCategory = lvalue
+#  954|           0 converted: [ArrayToPointerConversion] array to pointer conversion
 #  954|               Type = [PointerType] const char *
 #  954|               ValueCategory = prvalue
-#  954|             expr: hello
-#  954|                 Type = [ArrayType] const char[6]
-#  954|                 Value = [StringLiteral] "hello"
-#  954|                 ValueCategory = lvalue
 #  955|     5: [ExprStmt] ExprStmt
 #  955|       0: [NewExpr] new
 #  955|           Type = [PointerType] Overaligned *
@@ -8098,15 +8098,15 @@ ir.cpp:
 #  972|       0: [ArrayExpr] access to array
 #  972|           Type = [IntType] int
 #  972|           ValueCategory = prvalue(load)
-#  972|         0: [ArrayToPointerConversion] array to pointer conversion
-#  972|             Type = [IntPointerType] int *
-#  972|             ValueCategory = prvalue
-#  972|           expr: [VariableAccess] a1
-#  972|               Type = [ArrayType] int[1000]
-#  972|               ValueCategory = lvalue
+#  972|         0: [VariableAccess] a1
+#  972|             Type = [ArrayType] int[1000]
+#  972|             ValueCategory = lvalue
 #  972|         1: [Literal] 900
 #  972|             Type = [IntType] int
 #  972|             Value = [Literal] 900
+#  972|             ValueCategory = prvalue
+#  972|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  972|             Type = [IntPointerType] int *
 #  972|             ValueCategory = prvalue
 #  975| [TopLevelFunction] void IfStmtWithDeclaration(int, int)
 #  975|   params: 
@@ -8138,13 +8138,13 @@ ir.cpp:
 #  979|         0: [ConditionDeclExpr] (condition decl)
 #  979|             Type = [BoolType] bool
 #  979|             ValueCategory = prvalue
-#  979|           0: [CStyleCast] (bool)...
+#  979|           0: [VariableAccess] z
+#  979|               Type = [IntType] int
+#  979|               ValueCategory = prvalue(load)
+#  979|           0 converted: [CStyleCast] (bool)...
 #  979|               Conversion = [BoolConversion] conversion to bool
 #  979|               Type = [BoolType] bool
 #  979|               ValueCategory = prvalue
-#  979|             expr: [VariableAccess] z
-#  979|                 Type = [IntType] int
-#  979|                 ValueCategory = prvalue(load)
 #  979|         1: [BlockStmt] { ... }
 #  980|           0: [ExprStmt] ExprStmt
 #  980|             0: [AssignExpr] ... = ...
@@ -8161,13 +8161,13 @@ ir.cpp:
 #  982|           0: [ConditionDeclExpr] (condition decl)
 #  982|               Type = [BoolType] bool
 #  982|               ValueCategory = prvalue
-#  982|             0: [CStyleCast] (bool)...
+#  982|             0: [VariableAccess] p
+#  982|                 Type = [IntPointerType] int *
+#  982|                 ValueCategory = prvalue(load)
+#  982|             0 converted: [CStyleCast] (bool)...
 #  982|                 Conversion = [BoolConversion] conversion to bool
 #  982|                 Type = [BoolType] bool
 #  982|                 ValueCategory = prvalue
-#  982|               expr: [VariableAccess] p
-#  982|                   Type = [IntPointerType] int *
-#  982|                   ValueCategory = prvalue(load)
 #  982|           1: [BlockStmt] { ... }
 #  983|             0: [ExprStmt] ExprStmt
 #  983|               0: [AssignExpr] ... = ...
@@ -8203,25 +8203,25 @@ ir.cpp:
 #  990|       0: [ConditionDeclExpr] (condition decl)
 #  990|           Type = [BoolType] bool
 #  990|           ValueCategory = prvalue
-#  990|         0: [CStyleCast] (bool)...
+#  990|         0: [VariableAccess] z
+#  990|             Type = [IntType] int
+#  990|             ValueCategory = prvalue(load)
+#  990|         0 converted: [CStyleCast] (bool)...
 #  990|             Conversion = [BoolConversion] conversion to bool
 #  990|             Type = [BoolType] bool
 #  990|             ValueCategory = prvalue
-#  990|           expr: [VariableAccess] z
-#  990|               Type = [IntType] int
-#  990|               ValueCategory = prvalue(load)
 #  990|       1: [BlockStmt] { ... }
 #  992|     2: [WhileStmt] while (...) ...
 #  992|       0: [ConditionDeclExpr] (condition decl)
 #  992|           Type = [BoolType] bool
 #  992|           ValueCategory = prvalue
-#  992|         0: [CStyleCast] (bool)...
+#  992|         0: [VariableAccess] p
+#  992|             Type = [IntPointerType] int *
+#  992|             ValueCategory = prvalue(load)
+#  992|         0 converted: [CStyleCast] (bool)...
 #  992|             Conversion = [BoolConversion] conversion to bool
 #  992|             Type = [BoolType] bool
 #  992|             ValueCategory = prvalue
-#  992|           expr: [VariableAccess] p
-#  992|               Type = [IntPointerType] int *
-#  992|               ValueCategory = prvalue(load)
 #  992|       1: [BlockStmt] { ... }
 #  994|     3: [ReturnStmt] return ...
 #  996| [TopLevelFunction] int PointerDecay(int[], int(float))
@@ -8251,15 +8251,15 @@ ir.cpp:
 #  997|           0: [VariableAccess] fn
 #  997|               Type = [FunctionPointerType] ..(*)(..)
 #  997|               ValueCategory = prvalue(load)
-#  997|           1: [CStyleCast] (float)...
+#  997|           1: [Literal] 1.0
+#  997|               Type = [DoubleType] double
+#  997|               Value = [Literal] 1.0
+#  997|               ValueCategory = prvalue
+#  997|           1 converted: [CStyleCast] (float)...
 #  997|               Conversion = [FloatingPointConversion] floating point conversion
 #  997|               Type = [FloatType] float
 #  997|               Value = [CStyleCast] 1.0
 #  997|               ValueCategory = prvalue
-#  997|             expr: [Literal] 1.0
-#  997|                 Type = [DoubleType] double
-#  997|                 Value = [Literal] 1.0
-#  997|                 ValueCategory = prvalue
 # 1000| [TopLevelFunction] int ExprStmt(int, int, int)
 # 1000|   params: 
 # 1000|     0: [Parameter] b
@@ -8287,15 +8287,15 @@ ir.cpp:
 # 1016|       0: [DeleteExpr] delete
 # 1016|           Type = [VoidType] void
 # 1016|           ValueCategory = prvalue
-# 1016|         3: [StaticCast] static_cast<int *>...
+# 1016|         3: [Literal] 0
+# 1016|             Type = [NullPointerType] decltype(nullptr)
+# 1016|             Value = [Literal] 0
+# 1016|             ValueCategory = prvalue
+# 1016|         3 converted: [StaticCast] static_cast<int *>...
 # 1016|             Conversion = [PointerConversion] pointer conversion
 # 1016|             Type = [IntPointerType] int *
 # 1016|             Value = [StaticCast] 0
 # 1016|             ValueCategory = prvalue
-# 1016|           expr: [Literal] 0
-# 1016|               Type = [NullPointerType] decltype(nullptr)
-# 1016|               Value = [Literal] 0
-# 1016|               ValueCategory = prvalue
 # 1017|     1: [ExprStmt] ExprStmt
 # 1017|       0: [DeleteExpr] delete
 # 1017|           Type = [VoidType] void
@@ -8303,15 +8303,15 @@ ir.cpp:
 # 1017|         1: [DestructorCall] call to ~String
 # 1017|             Type = [VoidType] void
 # 1017|             ValueCategory = prvalue
+# 1017|           -1: [Literal] 0
+# 1017|               Type = [NullPointerType] decltype(nullptr)
+# 1017|               Value = [Literal] 0
+# 1017|               ValueCategory = prvalue
 # 1017|           -1: [StaticCast] static_cast<String *>...
 # 1017|               Conversion = [PointerConversion] pointer conversion
 # 1017|               Type = [PointerType] String *
 # 1017|               Value = [StaticCast] 0
 # 1017|               ValueCategory = prvalue
-# 1017|             expr: [Literal] 0
-# 1017|                 Type = [NullPointerType] decltype(nullptr)
-# 1017|                 Value = [Literal] 0
-# 1017|                 ValueCategory = prvalue
 # 1018|     2: [ExprStmt] ExprStmt
 # 1018|       0: [DeleteExpr] delete
 # 1018|           Type = [VoidType] void
@@ -8319,28 +8319,28 @@ ir.cpp:
 # 1018|         0: [FunctionCall] call to operator delete
 # 1018|             Type = [VoidType] void
 # 1018|             ValueCategory = prvalue
-# 1018|         3: [StaticCast] static_cast<SizedDealloc *>...
+# 1018|         3: [Literal] 0
+# 1018|             Type = [NullPointerType] decltype(nullptr)
+# 1018|             Value = [Literal] 0
+# 1018|             ValueCategory = prvalue
+# 1018|         3 converted: [StaticCast] static_cast<SizedDealloc *>...
 # 1018|             Conversion = [PointerConversion] pointer conversion
 # 1018|             Type = [PointerType] SizedDealloc *
 # 1018|             Value = [StaticCast] 0
 # 1018|             ValueCategory = prvalue
-# 1018|           expr: [Literal] 0
-# 1018|               Type = [NullPointerType] decltype(nullptr)
-# 1018|               Value = [Literal] 0
-# 1018|               ValueCategory = prvalue
 # 1019|     3: [ExprStmt] ExprStmt
 # 1019|       0: [DeleteExpr] delete
 # 1019|           Type = [VoidType] void
 # 1019|           ValueCategory = prvalue
-# 1019|         3: [StaticCast] static_cast<Overaligned *>...
+# 1019|         3: [Literal] 0
+# 1019|             Type = [NullPointerType] decltype(nullptr)
+# 1019|             Value = [Literal] 0
+# 1019|             ValueCategory = prvalue
+# 1019|         3 converted: [StaticCast] static_cast<Overaligned *>...
 # 1019|             Conversion = [PointerConversion] pointer conversion
 # 1019|             Type = [PointerType] Overaligned *
 # 1019|             Value = [StaticCast] 0
 # 1019|             ValueCategory = prvalue
-# 1019|           expr: [Literal] 0
-# 1019|               Type = [NullPointerType] decltype(nullptr)
-# 1019|               Value = [Literal] 0
-# 1019|               ValueCategory = prvalue
 # 1020|     4: [ExprStmt] ExprStmt
 # 1020|       0: [DeleteExpr] delete
 # 1020|           Type = [VoidType] void
@@ -8348,15 +8348,15 @@ ir.cpp:
 # 1020|         1: [DestructorCall] call to ~PolymorphicBase
 # 1020|             Type = [VoidType] void
 # 1020|             ValueCategory = prvalue
+# 1020|           -1: [Literal] 0
+# 1020|               Type = [NullPointerType] decltype(nullptr)
+# 1020|               Value = [Literal] 0
+# 1020|               ValueCategory = prvalue
 # 1020|           -1: [StaticCast] static_cast<PolymorphicBase *>...
 # 1020|               Conversion = [PointerConversion] pointer conversion
 # 1020|               Type = [PointerType] PolymorphicBase *
 # 1020|               Value = [StaticCast] 0
 # 1020|               ValueCategory = prvalue
-# 1020|             expr: [Literal] 0
-# 1020|                 Type = [NullPointerType] decltype(nullptr)
-# 1020|                 Value = [Literal] 0
-# 1020|                 ValueCategory = prvalue
 # 1021|     5: [ReturnStmt] return ...
 # 1024| [TopLevelFunction] void OperatorDeleteArray()
 # 1024|   params: 
@@ -8365,15 +8365,15 @@ ir.cpp:
 # 1025|       0: [DeleteArrayExpr] delete[]
 # 1025|           Type = [VoidType] void
 # 1025|           ValueCategory = prvalue
-# 1025|         3: [StaticCast] static_cast<int *>...
+# 1025|         3: [Literal] 0
+# 1025|             Type = [NullPointerType] decltype(nullptr)
+# 1025|             Value = [Literal] 0
+# 1025|             ValueCategory = prvalue
+# 1025|         3 converted: [StaticCast] static_cast<int *>...
 # 1025|             Conversion = [PointerConversion] pointer conversion
 # 1025|             Type = [IntPointerType] int *
 # 1025|             Value = [StaticCast] 0
 # 1025|             ValueCategory = prvalue
-# 1025|           expr: [Literal] 0
-# 1025|               Type = [NullPointerType] decltype(nullptr)
-# 1025|               Value = [Literal] 0
-# 1025|               ValueCategory = prvalue
 # 1026|     1: [ExprStmt] ExprStmt
 # 1026|       0: [DeleteArrayExpr] delete[]
 # 1026|           Type = [VoidType] void
@@ -8381,15 +8381,15 @@ ir.cpp:
 # 1026|         1: [DestructorCall] call to ~String
 # 1026|             Type = [VoidType] void
 # 1026|             ValueCategory = prvalue
+# 1026|           -1: [Literal] 0
+# 1026|               Type = [NullPointerType] decltype(nullptr)
+# 1026|               Value = [Literal] 0
+# 1026|               ValueCategory = prvalue
 # 1026|           -1: [StaticCast] static_cast<String *>...
 # 1026|               Conversion = [PointerConversion] pointer conversion
 # 1026|               Type = [PointerType] String *
 # 1026|               Value = [StaticCast] 0
 # 1026|               ValueCategory = prvalue
-# 1026|             expr: [Literal] 0
-# 1026|                 Type = [NullPointerType] decltype(nullptr)
-# 1026|                 Value = [Literal] 0
-# 1026|                 ValueCategory = prvalue
 # 1027|     2: [ExprStmt] ExprStmt
 # 1027|       0: [DeleteArrayExpr] delete[]
 # 1027|           Type = [VoidType] void
@@ -8397,28 +8397,28 @@ ir.cpp:
 # 1027|         0: [FunctionCall] call to operator delete[]
 # 1027|             Type = [VoidType] void
 # 1027|             ValueCategory = prvalue
-# 1027|         3: [StaticCast] static_cast<SizedDealloc *>...
+# 1027|         3: [Literal] 0
+# 1027|             Type = [NullPointerType] decltype(nullptr)
+# 1027|             Value = [Literal] 0
+# 1027|             ValueCategory = prvalue
+# 1027|         3 converted: [StaticCast] static_cast<SizedDealloc *>...
 # 1027|             Conversion = [PointerConversion] pointer conversion
 # 1027|             Type = [PointerType] SizedDealloc *
 # 1027|             Value = [StaticCast] 0
 # 1027|             ValueCategory = prvalue
-# 1027|           expr: [Literal] 0
-# 1027|               Type = [NullPointerType] decltype(nullptr)
-# 1027|               Value = [Literal] 0
-# 1027|               ValueCategory = prvalue
 # 1028|     3: [ExprStmt] ExprStmt
 # 1028|       0: [DeleteArrayExpr] delete[]
 # 1028|           Type = [VoidType] void
 # 1028|           ValueCategory = prvalue
-# 1028|         3: [StaticCast] static_cast<Overaligned *>...
+# 1028|         3: [Literal] 0
+# 1028|             Type = [NullPointerType] decltype(nullptr)
+# 1028|             Value = [Literal] 0
+# 1028|             ValueCategory = prvalue
+# 1028|         3 converted: [StaticCast] static_cast<Overaligned *>...
 # 1028|             Conversion = [PointerConversion] pointer conversion
 # 1028|             Type = [PointerType] Overaligned *
 # 1028|             Value = [StaticCast] 0
 # 1028|             ValueCategory = prvalue
-# 1028|           expr: [Literal] 0
-# 1028|               Type = [NullPointerType] decltype(nullptr)
-# 1028|               Value = [Literal] 0
-# 1028|               ValueCategory = prvalue
 # 1029|     4: [ExprStmt] ExprStmt
 # 1029|       0: [DeleteArrayExpr] delete[]
 # 1029|           Type = [VoidType] void
@@ -8426,15 +8426,15 @@ ir.cpp:
 # 1029|         1: [DestructorCall] call to ~PolymorphicBase
 # 1029|             Type = [VoidType] void
 # 1029|             ValueCategory = prvalue
+# 1029|           -1: [Literal] 0
+# 1029|               Type = [NullPointerType] decltype(nullptr)
+# 1029|               Value = [Literal] 0
+# 1029|               ValueCategory = prvalue
 # 1029|           -1: [StaticCast] static_cast<PolymorphicBase *>...
 # 1029|               Conversion = [PointerConversion] pointer conversion
 # 1029|               Type = [PointerType] PolymorphicBase *
 # 1029|               Value = [StaticCast] 0
 # 1029|               ValueCategory = prvalue
-# 1029|             expr: [Literal] 0
-# 1029|                 Type = [NullPointerType] decltype(nullptr)
-# 1029|                 Value = [Literal] 0
-# 1029|                 ValueCategory = prvalue
 # 1030|     5: [ReturnStmt] return ...
 # 1032| [CopyAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct const&)
 # 1032|   params: 
@@ -8501,22 +8501,22 @@ ir.cpp:
 # 1042|           Type = [PlainCharType] char
 # 1042|           Value = [FunctionCall] 65
 # 1042|           ValueCategory = prvalue
-# 1042|         -1: [CStyleCast] (const lambda [] type at line 1041, col. 23)...
+# 1042|         -1: [VariableAccess] lambda_empty
+# 1042|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1042|             ValueCategory = lvalue
+# 1042|         0: [CStyleCast] (const lambda [] type at line 1041, col. 23)...
 # 1042|             Conversion = [GlvalueConversion] glvalue conversion
 # 1042|             Type = [SpecifiedType] const lambda [] type at line 1041, col. 23
 # 1042|             ValueCategory = lvalue
-# 1042|           expr: [VariableAccess] lambda_empty
-# 1042|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1042|               ValueCategory = lvalue
-# 1042|         0: [CStyleCast] (float)...
+# 1042|         0: [Literal] 0
+# 1042|             Type = [IntType] int
+# 1042|             Value = [Literal] 0
+# 1042|             ValueCategory = prvalue
+# 1042|         0 converted: [CStyleCast] (float)...
 # 1042|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1042|             Type = [FloatType] float
 # 1042|             Value = [CStyleCast] 0.0
 # 1042|             ValueCategory = prvalue
-# 1042|           expr: [Literal] 0
-# 1042|               Type = [IntType] int
-# 1042|               Value = [Literal] 0
-# 1042|               ValueCategory = prvalue
 # 1043|     2: [DeclStmt] declaration
 # 1043|       0: [VariableDeclarationEntry] definition of lambda_ref
 # 1043|           Type = [Closure,LocalClass] decltype([...](...){...})
@@ -8527,41 +8527,41 @@ ir.cpp:
 # 1043|             0: [ClassAggregateLiteral] {...}
 # 1043|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1043|                 ValueCategory = prvalue
-# 1043|               .s: [ReferenceToExpr] (reference to)
+# 1043|               .s: [VariableAccess] s
+# 1043|                   Type = [LValueReferenceType] const String &
+# 1043|                   ValueCategory = prvalue(load)
+# 1043|               .x: [VariableAccess] x
+# 1043|                   Type = [IntType] int
+# 1043|                   ValueCategory = lvalue
+# 1043|               .s converted: [ReferenceToExpr] (reference to)
 # 1043|                   Type = [LValueReferenceType] const String &
 # 1043|                   ValueCategory = prvalue
-# 1043|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|                 : [ReferenceDereferenceExpr] (reference dereference)
 # 1043|                     Type = [SpecifiedType] const String
 # 1043|                     ValueCategory = lvalue
-# 1043|                   expr: [VariableAccess] s
-# 1043|                       Type = [LValueReferenceType] const String &
-# 1043|                       ValueCategory = prvalue(load)
-#-----|               .x: [ReferenceToExpr] (reference to)
+#-----|               .x converted: [ReferenceToExpr] (reference to)
 #-----|                   Type = [LValueReferenceType] int &
 #-----|                   ValueCategory = prvalue
-# 1043|                 expr: [VariableAccess] x
-# 1043|                     Type = [IntType] int
-# 1043|                     ValueCategory = lvalue
 # 1044|     3: [ExprStmt] ExprStmt
 # 1044|       0: [FunctionCall] call to operator()
 # 1044|           Type = [PlainCharType] char
 # 1044|           ValueCategory = prvalue
-# 1044|         -1: [CStyleCast] (const lambda [] type at line 1043, col. 21)...
+# 1044|         -1: [VariableAccess] lambda_ref
+# 1044|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1044|             ValueCategory = lvalue
+# 1044|         0: [CStyleCast] (const lambda [] type at line 1043, col. 21)...
 # 1044|             Conversion = [GlvalueConversion] glvalue conversion
 # 1044|             Type = [SpecifiedType] const lambda [] type at line 1043, col. 21
 # 1044|             ValueCategory = lvalue
-# 1044|           expr: [VariableAccess] lambda_ref
-# 1044|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1044|               ValueCategory = lvalue
-# 1044|         0: [CStyleCast] (float)...
+# 1044|         0: [Literal] 1
+# 1044|             Type = [IntType] int
+# 1044|             Value = [Literal] 1
+# 1044|             ValueCategory = prvalue
+# 1044|         0 converted: [CStyleCast] (float)...
 # 1044|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1044|             Type = [FloatType] float
 # 1044|             Value = [CStyleCast] 1.0
 # 1044|             ValueCategory = prvalue
-# 1044|           expr: [Literal] 1
-# 1044|               Type = [IntType] int
-# 1044|               Value = [Literal] 1
-# 1044|               ValueCategory = prvalue
 # 1045|     4: [DeclStmt] declaration
 # 1045|       0: [VariableDeclarationEntry] definition of lambda_val
 # 1045|           Type = [Closure,LocalClass] decltype([...](...){...})
@@ -8582,22 +8582,22 @@ ir.cpp:
 # 1046|       0: [FunctionCall] call to operator()
 # 1046|           Type = [PlainCharType] char
 # 1046|           ValueCategory = prvalue
-# 1046|         -1: [CStyleCast] (const lambda [] type at line 1045, col. 21)...
+# 1046|         -1: [VariableAccess] lambda_val
+# 1046|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1046|             ValueCategory = lvalue
+# 1046|         0: [CStyleCast] (const lambda [] type at line 1045, col. 21)...
 # 1046|             Conversion = [GlvalueConversion] glvalue conversion
 # 1046|             Type = [SpecifiedType] const lambda [] type at line 1045, col. 21
 # 1046|             ValueCategory = lvalue
-# 1046|           expr: [VariableAccess] lambda_val
-# 1046|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1046|               ValueCategory = lvalue
-# 1046|         0: [CStyleCast] (float)...
+# 1046|         0: [Literal] 2
+# 1046|             Type = [IntType] int
+# 1046|             Value = [Literal] 2
+# 1046|             ValueCategory = prvalue
+# 1046|         0 converted: [CStyleCast] (float)...
 # 1046|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1046|             Type = [FloatType] float
 # 1046|             Value = [CStyleCast] 2.0
 # 1046|             ValueCategory = prvalue
-# 1046|           expr: [Literal] 2
-# 1046|               Type = [IntType] int
-# 1046|               Value = [Literal] 2
-# 1046|               ValueCategory = prvalue
 # 1047|     6: [DeclStmt] declaration
 # 1047|       0: [VariableDeclarationEntry] definition of lambda_ref_explicit
 # 1047|           Type = [Closure,LocalClass] decltype([...](...){...})
@@ -8608,35 +8608,35 @@ ir.cpp:
 # 1047|             0: [ClassAggregateLiteral] {...}
 # 1047|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1047|                 ValueCategory = prvalue
-# 1047|               .s: [ReferenceToExpr] (reference to)
+# 1047|               .s: [VariableAccess] s
+# 1047|                   Type = [LValueReferenceType] const String &
+# 1047|                   ValueCategory = prvalue(load)
+# 1047|               .s converted: [ReferenceToExpr] (reference to)
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue
-# 1047|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1047|                 : [ReferenceDereferenceExpr] (reference dereference)
 # 1047|                     Type = [SpecifiedType] const String
 # 1047|                     ValueCategory = lvalue
-# 1047|                   expr: [VariableAccess] s
-# 1047|                       Type = [LValueReferenceType] const String &
-# 1047|                       ValueCategory = prvalue(load)
 # 1048|     7: [ExprStmt] ExprStmt
 # 1048|       0: [FunctionCall] call to operator()
 # 1048|           Type = [PlainCharType] char
 # 1048|           ValueCategory = prvalue
-# 1048|         -1: [CStyleCast] (const lambda [] type at line 1047, col. 30)...
+# 1048|         -1: [VariableAccess] lambda_ref_explicit
+# 1048|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1048|             ValueCategory = lvalue
+# 1048|         0: [CStyleCast] (const lambda [] type at line 1047, col. 30)...
 # 1048|             Conversion = [GlvalueConversion] glvalue conversion
 # 1048|             Type = [SpecifiedType] const lambda [] type at line 1047, col. 30
 # 1048|             ValueCategory = lvalue
-# 1048|           expr: [VariableAccess] lambda_ref_explicit
-# 1048|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1048|               ValueCategory = lvalue
-# 1048|         0: [CStyleCast] (float)...
+# 1048|         0: [Literal] 3
+# 1048|             Type = [IntType] int
+# 1048|             Value = [Literal] 3
+# 1048|             ValueCategory = prvalue
+# 1048|         0 converted: [CStyleCast] (float)...
 # 1048|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1048|             Type = [FloatType] float
 # 1048|             Value = [CStyleCast] 3.0
 # 1048|             ValueCategory = prvalue
-# 1048|           expr: [Literal] 3
-# 1048|               Type = [IntType] int
-# 1048|               Value = [Literal] 3
-# 1048|               ValueCategory = prvalue
 # 1049|     8: [DeclStmt] declaration
 # 1049|       0: [VariableDeclarationEntry] definition of lambda_val_explicit
 # 1049|           Type = [Closure,LocalClass] decltype([...](...){...})
@@ -8654,22 +8654,22 @@ ir.cpp:
 # 1050|       0: [FunctionCall] call to operator()
 # 1050|           Type = [PlainCharType] char
 # 1050|           ValueCategory = prvalue
-# 1050|         -1: [CStyleCast] (const lambda [] type at line 1049, col. 30)...
+# 1050|         -1: [VariableAccess] lambda_val_explicit
+# 1050|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1050|             ValueCategory = lvalue
+# 1050|         0: [CStyleCast] (const lambda [] type at line 1049, col. 30)...
 # 1050|             Conversion = [GlvalueConversion] glvalue conversion
 # 1050|             Type = [SpecifiedType] const lambda [] type at line 1049, col. 30
 # 1050|             ValueCategory = lvalue
-# 1050|           expr: [VariableAccess] lambda_val_explicit
-# 1050|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1050|               ValueCategory = lvalue
-# 1050|         0: [CStyleCast] (float)...
+# 1050|         0: [Literal] 4
+# 1050|             Type = [IntType] int
+# 1050|             Value = [Literal] 4
+# 1050|             ValueCategory = prvalue
+# 1050|         0 converted: [CStyleCast] (float)...
 # 1050|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1050|             Type = [FloatType] float
 # 1050|             Value = [CStyleCast] 4.0
 # 1050|             ValueCategory = prvalue
-# 1050|           expr: [Literal] 4
-# 1050|               Type = [IntType] int
-# 1050|               Value = [Literal] 4
-# 1050|               ValueCategory = prvalue
 # 1051|     10: [DeclStmt] declaration
 # 1051|       0: [VariableDeclarationEntry] definition of lambda_mixed_explicit
 # 1051|           Type = [Closure,LocalClass] decltype([...](...){...})
@@ -8680,38 +8680,38 @@ ir.cpp:
 # 1051|             0: [ClassAggregateLiteral] {...}
 # 1051|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1051|                 ValueCategory = prvalue
-# 1051|               .s: [ReferenceToExpr] (reference to)
+# 1051|               .s: [VariableAccess] s
 # 1051|                   Type = [LValueReferenceType] const String &
-# 1051|                   ValueCategory = prvalue
-# 1051|                 expr: [ReferenceDereferenceExpr] (reference dereference)
-# 1051|                     Type = [SpecifiedType] const String
-# 1051|                     ValueCategory = lvalue
-# 1051|                   expr: [VariableAccess] s
-# 1051|                       Type = [LValueReferenceType] const String &
-# 1051|                       ValueCategory = prvalue(load)
+# 1051|                   ValueCategory = prvalue(load)
 # 1051|               .x: [VariableAccess] x
 # 1051|                   Type = [IntType] int
 # 1051|                   ValueCategory = prvalue(load)
+# 1051|               .s converted: [ReferenceToExpr] (reference to)
+# 1051|                   Type = [LValueReferenceType] const String &
+# 1051|                   ValueCategory = prvalue
+# 1051|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1051|                     Type = [SpecifiedType] const String
+# 1051|                     ValueCategory = lvalue
 # 1052|     11: [ExprStmt] ExprStmt
 # 1052|       0: [FunctionCall] call to operator()
 # 1052|           Type = [PlainCharType] char
 # 1052|           ValueCategory = prvalue
-# 1052|         -1: [CStyleCast] (const lambda [] type at line 1051, col. 32)...
+# 1052|         -1: [VariableAccess] lambda_mixed_explicit
+# 1052|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1052|             ValueCategory = lvalue
+# 1052|         0: [CStyleCast] (const lambda [] type at line 1051, col. 32)...
 # 1052|             Conversion = [GlvalueConversion] glvalue conversion
 # 1052|             Type = [SpecifiedType] const lambda [] type at line 1051, col. 32
 # 1052|             ValueCategory = lvalue
-# 1052|           expr: [VariableAccess] lambda_mixed_explicit
-# 1052|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1052|               ValueCategory = lvalue
-# 1052|         0: [CStyleCast] (float)...
+# 1052|         0: [Literal] 5
+# 1052|             Type = [IntType] int
+# 1052|             Value = [Literal] 5
+# 1052|             ValueCategory = prvalue
+# 1052|         0 converted: [CStyleCast] (float)...
 # 1052|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1052|             Type = [FloatType] float
 # 1052|             Value = [CStyleCast] 5.0
 # 1052|             ValueCategory = prvalue
-# 1052|           expr: [Literal] 5
-# 1052|               Type = [IntType] int
-# 1052|               Value = [Literal] 5
-# 1052|               ValueCategory = prvalue
 # 1053|     12: [DeclStmt] declaration
 # 1053|       0: [VariableDeclarationEntry] definition of r
 # 1053|           Type = [IntType] int
@@ -8736,15 +8736,9 @@ ir.cpp:
 # 1054|             0: [ClassAggregateLiteral] {...}
 # 1054|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1054|                 ValueCategory = prvalue
-# 1054|               .s: [ReferenceToExpr] (reference to)
+# 1054|               .s: [VariableAccess] s
 # 1054|                   Type = [LValueReferenceType] const String &
-# 1054|                   ValueCategory = prvalue
-# 1054|                 expr: [ReferenceDereferenceExpr] (reference dereference)
-# 1054|                     Type = [SpecifiedType] const String
-# 1054|                     ValueCategory = lvalue
-# 1054|                   expr: [VariableAccess] s
-# 1054|                       Type = [LValueReferenceType] const String &
-# 1054|                       ValueCategory = prvalue(load)
+# 1054|                   ValueCategory = prvalue(load)
 # 1054|               .x: [VariableAccess] x
 # 1054|                   Type = [IntType] int
 # 1054|                   ValueCategory = prvalue(load)
@@ -8758,32 +8752,38 @@ ir.cpp:
 # 1054|                     Type = [IntType] int
 # 1054|                     Value = [Literal] 1
 # 1054|                     ValueCategory = prvalue
-# 1054|               .j: [ReferenceToExpr] (reference to)
+# 1054|               .j: [VariableAccess] r
+# 1054|                   Type = [IntType] int
+# 1054|                   ValueCategory = lvalue
+# 1054|               .s converted: [ReferenceToExpr] (reference to)
+# 1054|                   Type = [LValueReferenceType] const String &
+# 1054|                   ValueCategory = prvalue
+# 1054|                 : [ReferenceDereferenceExpr] (reference dereference)
+# 1054|                     Type = [SpecifiedType] const String
+# 1054|                     ValueCategory = lvalue
+# 1054|               .j converted: [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] int &
 # 1054|                   ValueCategory = prvalue
-# 1054|                 expr: [VariableAccess] r
-# 1054|                     Type = [IntType] int
-# 1054|                     ValueCategory = lvalue
 # 1055|     14: [ExprStmt] ExprStmt
 # 1055|       0: [FunctionCall] call to operator()
 # 1055|           Type = [PlainCharType] char
 # 1055|           ValueCategory = prvalue
-# 1055|         -1: [CStyleCast] (const lambda [] type at line 1054, col. 23)...
+# 1055|         -1: [VariableAccess] lambda_inits
+# 1055|             Type = [Closure,LocalClass] decltype([...](...){...})
+# 1055|             ValueCategory = lvalue
+# 1055|         0: [CStyleCast] (const lambda [] type at line 1054, col. 23)...
 # 1055|             Conversion = [GlvalueConversion] glvalue conversion
 # 1055|             Type = [SpecifiedType] const lambda [] type at line 1054, col. 23
 # 1055|             ValueCategory = lvalue
-# 1055|           expr: [VariableAccess] lambda_inits
-# 1055|               Type = [Closure,LocalClass] decltype([...](...){...})
-# 1055|               ValueCategory = lvalue
-# 1055|         0: [CStyleCast] (float)...
+# 1055|         0: [Literal] 6
+# 1055|             Type = [IntType] int
+# 1055|             Value = [Literal] 6
+# 1055|             ValueCategory = prvalue
+# 1055|         0 converted: [CStyleCast] (float)...
 # 1055|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1055|             Type = [FloatType] float
 # 1055|             Value = [CStyleCast] 6.0
 # 1055|             ValueCategory = prvalue
-# 1055|           expr: [Literal] 6
-# 1055|               Type = [IntType] int
-# 1055|               Value = [Literal] 6
-# 1055|               ValueCategory = prvalue
 # 1056|     15: [ReturnStmt] return ...
 # 1041| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
 # 1041|   params: 
@@ -8846,24 +8846,24 @@ ir.cpp:
 # 1043|         0: [FunctionCall] call to c_str
 # 1043|             Type = [PointerType] const char *
 # 1043|             ValueCategory = prvalue
-# 1043|           -1: [ReferenceDereferenceExpr] (reference dereference)
-# 1043|               Type = [SpecifiedType] const String
-# 1043|               ValueCategory = lvalue
-# 1043|             expr: [PointerFieldAccess] s
-# 1043|                 Type = [LValueReferenceType] const String &
-# 1043|                 ValueCategory = prvalue(load)
-# 1043|               -1: [ThisExpr] this
-# 1043|                   Type = [PointerType] const lambda [] type at line 1043, col. 21 *
-# 1043|                   ValueCategory = prvalue(load)
-# 1043|         1: [ReferenceDereferenceExpr] (reference dereference)
-# 1043|             Type = [IntType] int
-# 1043|             ValueCategory = prvalue(load)
-# 1043|           expr: [PointerFieldAccess] x
-# 1043|               Type = [LValueReferenceType] int &
+# 1043|           -1: [PointerFieldAccess] s
+# 1043|               Type = [LValueReferenceType] const String &
 # 1043|               ValueCategory = prvalue(load)
 # 1043|             -1: [ThisExpr] this
 # 1043|                 Type = [PointerType] const lambda [] type at line 1043, col. 21 *
 # 1043|                 ValueCategory = prvalue(load)
+# 1043|           -1: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|               Type = [SpecifiedType] const String
+# 1043|               ValueCategory = lvalue
+# 1043|         1: [PointerFieldAccess] x
+# 1043|             Type = [LValueReferenceType] int &
+# 1043|             ValueCategory = prvalue(load)
+# 1043|           -1: [ThisExpr] this
+# 1043|               Type = [PointerType] const lambda [] type at line 1043, col. 21 *
+# 1043|               ValueCategory = prvalue(load)
+# 1043|         1 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|             Type = [IntType] int
+# 1043|             ValueCategory = prvalue(load)
 # 1045| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
 # 1045|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -8942,15 +8942,15 @@ ir.cpp:
 # 1047|         0: [FunctionCall] call to c_str
 # 1047|             Type = [PointerType] const char *
 # 1047|             ValueCategory = prvalue
+# 1047|           -1: [PointerFieldAccess] s
+# 1047|               Type = [LValueReferenceType] const String &
+# 1047|               ValueCategory = prvalue(load)
+# 1047|             -1: [ThisExpr] this
+# 1047|                 Type = [PointerType] const lambda [] type at line 1047, col. 30 *
+# 1047|                 ValueCategory = prvalue(load)
 # 1047|           -1: [ReferenceDereferenceExpr] (reference dereference)
 # 1047|               Type = [SpecifiedType] const String
 # 1047|               ValueCategory = lvalue
-# 1047|             expr: [PointerFieldAccess] s
-# 1047|                 Type = [LValueReferenceType] const String &
-# 1047|                 ValueCategory = prvalue(load)
-# 1047|               -1: [ThisExpr] this
-# 1047|                   Type = [PointerType] const lambda [] type at line 1047, col. 30 *
-# 1047|                   ValueCategory = prvalue(load)
 # 1047|         1: [Literal] 0
 # 1047|             Type = [IntType] int
 # 1047|             Value = [Literal] 0
@@ -9031,15 +9031,15 @@ ir.cpp:
 # 1051|         0: [FunctionCall] call to c_str
 # 1051|             Type = [PointerType] const char *
 # 1051|             ValueCategory = prvalue
+# 1051|           -1: [PointerFieldAccess] s
+# 1051|               Type = [LValueReferenceType] const String &
+# 1051|               ValueCategory = prvalue(load)
+# 1051|             -1: [ThisExpr] this
+# 1051|                 Type = [PointerType] const lambda [] type at line 1051, col. 32 *
+# 1051|                 ValueCategory = prvalue(load)
 # 1051|           -1: [ReferenceDereferenceExpr] (reference dereference)
 # 1051|               Type = [SpecifiedType] const String
 # 1051|               ValueCategory = lvalue
-# 1051|             expr: [PointerFieldAccess] s
-# 1051|                 Type = [LValueReferenceType] const String &
-# 1051|                 ValueCategory = prvalue(load)
-# 1051|               -1: [ThisExpr] this
-# 1051|                   Type = [PointerType] const lambda [] type at line 1051, col. 32 *
-# 1051|                   ValueCategory = prvalue(load)
 # 1051|         1: [PointerFieldAccess] x
 # 1051|             Type = [IntType] int
 # 1051|             ValueCategory = prvalue(load)
@@ -9072,15 +9072,15 @@ ir.cpp:
 # 1054|         0: [FunctionCall] call to c_str
 # 1054|             Type = [PointerType] const char *
 # 1054|             ValueCategory = prvalue
+# 1054|           -1: [PointerFieldAccess] s
+# 1054|               Type = [LValueReferenceType] const String &
+# 1054|               ValueCategory = prvalue(load)
+# 1054|             -1: [ThisExpr] this
+# 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
+# 1054|                 ValueCategory = prvalue(load)
 # 1054|           -1: [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [SpecifiedType] const String
 # 1054|               ValueCategory = lvalue
-# 1054|             expr: [PointerFieldAccess] s
-# 1054|                 Type = [LValueReferenceType] const String &
-# 1054|                 ValueCategory = prvalue(load)
-# 1054|               -1: [ThisExpr] this
-# 1054|                   Type = [PointerType] const lambda [] type at line 1054, col. 23 *
-# 1054|                   ValueCategory = prvalue(load)
 # 1054|         1: [SubExpr] ... - ...
 # 1054|             Type = [IntType] int
 # 1054|             ValueCategory = prvalue
@@ -9099,15 +9099,15 @@ ir.cpp:
 # 1054|               -1: [ThisExpr] this
 # 1054|                   Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                   ValueCategory = prvalue(load)
-# 1054|           1: [ReferenceDereferenceExpr] (reference dereference)
+# 1054|           1: [PointerFieldAccess] j
+# 1054|               Type = [LValueReferenceType] int &
+# 1054|               ValueCategory = prvalue(load)
+# 1054|             -1: [ThisExpr] this
+# 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
+# 1054|                 ValueCategory = prvalue(load)
+# 1054|           1 converted: [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue(load)
-# 1054|             expr: [PointerFieldAccess] j
-# 1054|                 Type = [LValueReferenceType] int &
-# 1054|                 ValueCategory = prvalue(load)
-# 1054|               -1: [ThisExpr] this
-# 1054|                   Type = [PointerType] const lambda [] type at line 1054, col. 23 *
-# 1054|                   ValueCategory = prvalue(load)
 # 1059| [CopyAssignmentOperator] vector<int>& vector<int>::operator=(vector<int> const&)
 # 1059|   params: 
 #-----|     0: [Parameter] (unnamed parameter 0)
@@ -9171,25 +9171,22 @@ ir.cpp:
 # 1078|       2: [FunctionCall] call to operator!=
 # 1078|           Type = [BoolType] bool
 # 1078|           ValueCategory = prvalue
-#-----|         -1: [CStyleCast] (const iterator)...
+# 1078|         -1: [VariableAccess] (__begin)
+# 1078|             Type = [NestedStruct] iterator
+# 1078|             ValueCategory = lvalue
+#-----|         0: [CStyleCast] (const iterator)...
 #-----|             Conversion = [GlvalueConversion] glvalue conversion
 #-----|             Type = [SpecifiedType] const iterator
 #-----|             ValueCategory = lvalue
-# 1078|           expr: [VariableAccess] (__begin)
-# 1078|               Type = [NestedStruct] iterator
-# 1078|               ValueCategory = lvalue
 # 1078|         0: [VariableAccess] (__end)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = prvalue(load)
-# 1078|       3: [ReferenceDereferenceExpr] (reference dereference)
-# 1078|           Type = [NestedStruct] iterator
-# 1078|           ValueCategory = lvalue
-# 1078|         expr: [FunctionCall] call to operator++
-# 1078|             Type = [LValueReferenceType] iterator &
-# 1078|             ValueCategory = prvalue
-# 1078|           -1: [VariableAccess] (__begin)
-# 1078|               Type = [NestedStruct] iterator
-# 1078|               ValueCategory = lvalue
+# 1078|       3: [FunctionCall] call to operator++
+# 1078|           Type = [LValueReferenceType] iterator &
+# 1078|           ValueCategory = prvalue
+# 1078|         -1: [VariableAccess] (__begin)
+# 1078|             Type = [NestedStruct] iterator
+# 1078|             ValueCategory = lvalue
 # 1078|       4: [DeclStmt] declaration
 # 1078|       5: [BlockStmt] { ... }
 # 1079|         0: [IfStmt] if (...) ... 
@@ -9206,49 +9203,52 @@ ir.cpp:
 # 1079|           1: [BlockStmt] { ... }
 # 1080|             0: [ContinueStmt] continue;
 # 1078|         1: [LabelStmt] label ...:
+# 1078|       3 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1078|           Type = [NestedStruct] iterator
+# 1078|           ValueCategory = lvalue
 # 1084|     1: [RangeBasedForStmt] for(...:...) ...
 # 1084|       0: [DeclStmt] declaration
 # 1084|       1: [DeclStmt] declaration
 # 1084|       2: [FunctionCall] call to operator!=
 # 1084|           Type = [BoolType] bool
 # 1084|           ValueCategory = prvalue
-#-----|         -1: [CStyleCast] (const iterator)...
+# 1084|         -1: [VariableAccess] (__begin)
+# 1084|             Type = [NestedStruct] iterator
+# 1084|             ValueCategory = lvalue
+#-----|         0: [CStyleCast] (const iterator)...
 #-----|             Conversion = [GlvalueConversion] glvalue conversion
 #-----|             Type = [SpecifiedType] const iterator
 #-----|             ValueCategory = lvalue
-# 1084|           expr: [VariableAccess] (__begin)
-# 1084|               Type = [NestedStruct] iterator
-# 1084|               ValueCategory = lvalue
 # 1084|         0: [VariableAccess] (__end)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = prvalue(load)
-# 1084|       3: [ReferenceDereferenceExpr] (reference dereference)
-# 1084|           Type = [NestedStruct] iterator
-# 1084|           ValueCategory = lvalue
-# 1084|         expr: [FunctionCall] call to operator++
-# 1084|             Type = [LValueReferenceType] iterator &
-# 1084|             ValueCategory = prvalue
-# 1084|           -1: [VariableAccess] (__begin)
-# 1084|               Type = [NestedStruct] iterator
-# 1084|               ValueCategory = lvalue
+# 1084|       3: [FunctionCall] call to operator++
+# 1084|           Type = [LValueReferenceType] iterator &
+# 1084|           ValueCategory = prvalue
+# 1084|         -1: [VariableAccess] (__begin)
+# 1084|             Type = [NestedStruct] iterator
+# 1084|             ValueCategory = lvalue
 # 1084|       4: [DeclStmt] declaration
 # 1084|       5: [BlockStmt] { ... }
 # 1085|         0: [IfStmt] if (...) ... 
 # 1085|           0: [LTExpr] ... < ...
 # 1085|               Type = [BoolType] bool
 # 1085|               ValueCategory = prvalue
-# 1085|             0: [ReferenceDereferenceExpr] (reference dereference)
-# 1085|                 Type = [IntType] int
+# 1085|             0: [VariableAccess] e
+# 1085|                 Type = [LValueReferenceType] const int &
 # 1085|                 ValueCategory = prvalue(load)
-# 1085|               expr: [VariableAccess] e
-# 1085|                   Type = [LValueReferenceType] const int &
-# 1085|                   ValueCategory = prvalue(load)
 # 1085|             1: [Literal] 5
 # 1085|                 Type = [IntType] int
 # 1085|                 Value = [Literal] 5
 # 1085|                 ValueCategory = prvalue
+# 1085|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1085|                 Type = [IntType] int
+# 1085|                 ValueCategory = prvalue(load)
 # 1085|           1: [BlockStmt] { ... }
 # 1086|             0: [BreakStmt] break;
+# 1084|       3 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1084|           Type = [NestedStruct] iterator
+# 1084|           ValueCategory = lvalue
 # 1088|     2: [LabelStmt] label ...:
 # 1089|     3: [ReturnStmt] return ...
 # 1108| [TopLevelFunction] int AsmStmt(int)
@@ -9273,22 +9273,22 @@ ir.cpp:
 # 1113|         Type = [IntType] unsigned int
 # 1114|   body: [BlockStmt] { ... }
 # 1115|     0: [AsmStmt] asm statement
-# 1118|       0: [ReferenceDereferenceExpr] (reference dereference)
-# 1118|           Type = [IntType] unsigned int
-# 1118|           ValueCategory = lvalue
-# 1118|         expr: [VariableAccess] a
-# 1118|             Type = [LValueReferenceType] unsigned int &
-# 1118|             ValueCategory = prvalue(load)
+# 1118|       0: [VariableAccess] a
+# 1118|           Type = [LValueReferenceType] unsigned int &
+# 1118|           ValueCategory = prvalue(load)
 # 1118|       1: [VariableAccess] b
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = lvalue
-# 1118|       2: [ReferenceDereferenceExpr] (reference dereference)
+# 1118|       2: [VariableAccess] c
+# 1118|           Type = [LValueReferenceType] unsigned int &
+# 1118|           ValueCategory = prvalue(load)
+# 1118|       3: [VariableAccess] d
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
-# 1118|         expr: [VariableAccess] c
-# 1118|             Type = [LValueReferenceType] unsigned int &
-# 1118|             ValueCategory = prvalue(load)
-# 1118|       3: [VariableAccess] d
+# 1118|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1118|           Type = [IntType] unsigned int
+# 1118|           ValueCategory = lvalue
+# 1118|       2 converted: [ReferenceDereferenceExpr] (reference dereference)
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
 # 1120|     1: [ReturnStmt] return ...
@@ -9390,13 +9390,13 @@ ir.cpp:
 # 1146|               0: [ThrowExpr] throw ...
 # 1146|                   Type = [PointerType] const char *
 # 1146|                   ValueCategory = prvalue
-# 1146|                 0: [ArrayToPointerConversion] array to pointer conversion
+# 1146|                 0: string literal
+# 1146|                     Type = [ArrayType] const char[15]
+# 1146|                     Value = [StringLiteral] "string literal"
+# 1146|                     ValueCategory = lvalue
+# 1146|                 0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1146|                     Type = [PointerType] const char *
 # 1146|                     ValueCategory = prvalue
-# 1146|                   expr: string literal
-# 1146|                       Type = [ArrayType] const char[15]
-# 1146|                       Value = [StringLiteral] "string literal"
-# 1146|                       ValueCategory = lvalue
 # 1148|           2: [IfStmt] if (...) ... 
 # 1148|             0: [LTExpr] ... < ...
 # 1148|                 Type = [BoolType] bool
@@ -9432,13 +9432,13 @@ ir.cpp:
 # 1149|                       0: [ConstructorCall] call to String
 # 1149|                           Type = [VoidType] void
 # 1149|                           ValueCategory = prvalue
-# 1149|                         0: [ArrayToPointerConversion] array to pointer conversion
+# 1149|                         0: String object
+# 1149|                             Type = [ArrayType] const char[14]
+# 1149|                             Value = [StringLiteral] "String object"
+# 1149|                             ValueCategory = lvalue
+# 1149|                         0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1149|                             Type = [PointerType] const char *
 # 1149|                             ValueCategory = prvalue
-# 1149|                           expr: String object
-# 1149|                               Type = [ArrayType] const char[14]
-# 1149|                               Value = [StringLiteral] "String object"
-# 1149|                               ValueCategory = lvalue
 # 1151|         2: [ExprStmt] ExprStmt
 # 1151|           0: [AssignExpr] ... = ...
 # 1151|               Type = [IntType] int
@@ -9596,35 +9596,35 @@ ir.cpp:
 # 1174|       0: [FunctionCall] call to memcpy
 # 1174|           Type = [VoidPointerType] void *
 # 1174|           ValueCategory = prvalue
-# 1174|         0: [CStyleCast] (void *)...
+# 1174|         0: [AddressOfExpr] & ...
+# 1174|             Type = [IntPointerType] int *
+# 1174|             ValueCategory = prvalue
+# 1174|           0: [VariableAccess] y
+# 1174|               Type = [IntType] int
+# 1174|               ValueCategory = lvalue
+# 1174|         1: [AddressOfExpr] & ...
+# 1174|             Type = [IntPointerType] int *
+# 1174|             ValueCategory = prvalue
+# 1174|           0: [VariableAccess] x
+# 1174|               Type = [IntType] int
+# 1174|               ValueCategory = lvalue
+# 1174|         2: [SizeofTypeOperator] sizeof(int)
+# 1174|             Type = [LongType] unsigned long
+# 1174|             Value = [SizeofTypeOperator] 4
+# 1174|             ValueCategory = prvalue
+# 1174|         0 converted: [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|           expr: [AddressOfExpr] & ...
-# 1174|               Type = [IntPointerType] int *
-# 1174|               ValueCategory = prvalue
-# 1174|             0: [VariableAccess] y
-# 1174|                 Type = [IntType] int
-# 1174|                 ValueCategory = lvalue
-# 1174|         1: [CStyleCast] (void *)...
+# 1174|         1 converted: [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|           expr: [AddressOfExpr] & ...
-# 1174|               Type = [IntPointerType] int *
-# 1174|               ValueCategory = prvalue
-# 1174|             0: [VariableAccess] x
-# 1174|                 Type = [IntType] int
-# 1174|                 ValueCategory = lvalue
-# 1174|         2: [CStyleCast] (int)...
+# 1174|         2 converted: [CStyleCast] (int)...
 # 1174|             Conversion = [IntegralConversion] integral conversion
 # 1174|             Type = [IntType] int
 # 1174|             Value = [CStyleCast] 4
 # 1174|             ValueCategory = prvalue
-# 1174|           expr: [SizeofTypeOperator] sizeof(int)
-# 1174|               Type = [LongType] unsigned long
-# 1174|               Value = [SizeofTypeOperator] 4
-# 1174|               ValueCategory = prvalue
 # 1175|     2: [ReturnStmt] return ...
 # 1175|       0: [VariableAccess] y
 # 1175|           Type = [IntType] int
@@ -9636,13 +9636,13 @@ ir.cpp:
 # 1179|       0: [ConstructorCall] call to String
 # 1179|           Type = [Struct] String
 # 1179|           ValueCategory = prvalue
-# 1179|         0: [ArrayToPointerConversion] array to pointer conversion
+# 1179|         0: foo
+# 1179|             Type = [ArrayType] const char[4]
+# 1179|             Value = [StringLiteral] "foo"
+# 1179|             ValueCategory = lvalue
+# 1179|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1179|             Type = [PointerType] const char *
 # 1179|             ValueCategory = prvalue
-# 1179|           expr: foo
-# 1179|               Type = [ArrayType] const char[4]
-# 1179|               Value = [StringLiteral] "foo"
-# 1179|               ValueCategory = lvalue
 # 1182| [TopLevelFunction] void switch1Case(int)
 # 1182|   params: 
 # 1182|     0: [Parameter] x
@@ -9893,21 +9893,21 @@ ir.cpp:
 # 1233|       0: [VariableDeclarationEntry] definition of b
 # 1233|           Type = [IntType] int
 # 1233|         init: [Initializer] initializer for b
-# 1233|           expr: [CStyleCast] (int)...
+# 1233|           expr: [SizeofExprOperator] sizeof(<expr>)
+# 1233|               Type = [LongType] unsigned long
+# 1233|               Value = [SizeofExprOperator] 4
+# 1233|               ValueCategory = prvalue
+# 1233|             0: [VariableAccess] x
+# 1233|                 Type = [IntType] int
+# 1233|                 ValueCategory = lvalue
+# 1233|             0 converted: [ParenthesisExpr] (...)
+# 1233|                 Type = [IntType] int
+# 1233|                 ValueCategory = lvalue
+# 1233|           expr converted: [CStyleCast] (int)...
 # 1233|               Conversion = [IntegralConversion] integral conversion
 # 1233|               Type = [IntType] int
 # 1233|               Value = [CStyleCast] 4
 # 1233|               ValueCategory = prvalue
-# 1233|             expr: [SizeofExprOperator] sizeof(<expr>)
-# 1233|                 Type = [LongType] unsigned long
-# 1233|                 Value = [SizeofExprOperator] 4
-# 1233|                 ValueCategory = prvalue
-# 1233|               0: [ParenthesisExpr] (...)
-# 1233|                   Type = [IntType] int
-# 1233|                   ValueCategory = lvalue
-# 1233|                 expr: [VariableAccess] x
-# 1233|                     Type = [IntType] int
-# 1233|                     ValueCategory = lvalue
 # 1234|     2: [DeclStmt] declaration
 # 1234|       0: [VariableDeclarationEntry] definition of c
 # 1234|           Type = [IntType] int
@@ -9959,13 +9959,13 @@ ir.cpp:
 # 1242|           expr: [ConstructorCall] call to String
 # 1242|               Type = [VoidType] void
 # 1242|               ValueCategory = prvalue
-# 1242|             0: [ArrayToPointerConversion] array to pointer conversion
+# 1242|             0: static
+# 1242|                 Type = [ArrayType] const char[7]
+# 1242|                 Value = [StringLiteral] "static"
+# 1242|                 ValueCategory = lvalue
+# 1242|             0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1242|                 Type = [PointerType] const char *
 # 1242|                 ValueCategory = prvalue
-# 1242|               expr: static
-# 1242|                   Type = [ArrayType] const char[7]
-# 1242|                   Value = [StringLiteral] "static"
-# 1242|                   ValueCategory = lvalue
 # 1243|     2: [DeclStmt] declaration
 # 1243|       0: [VariableDeclarationEntry] definition of c
 # 1243|           Type = [Struct] String
@@ -10003,49 +10003,49 @@ ir.cpp:
 # 1252|           expr: [ArrayAggregateLiteral] {...}
 # 1252|               Type = [ArrayType] char[1024]
 # 1252|               ValueCategory = prvalue
-# 1252|             [0]: [CStyleCast] (char)...
+# 1252|             [0]: [Literal] 0
+# 1252|                 Type = [IntType] int
+# 1252|                 Value = [Literal] 0
+# 1252|                 ValueCategory = prvalue
+# 1252|             [0] converted: [CStyleCast] (char)...
 # 1252|                 Conversion = [IntegralConversion] integral conversion
 # 1252|                 Type = [PlainCharType] char
 # 1252|                 Value = [CStyleCast] 0
 # 1252|                 ValueCategory = prvalue
-# 1252|               expr: [Literal] 0
-# 1252|                   Type = [IntType] int
-# 1252|                   Value = [Literal] 0
-# 1252|                   ValueCategory = prvalue
 # 1254|     1: [ExprStmt] ExprStmt
 # 1254|       0: [FunctionCall] call to strcpy
 # 1254|           Type = [CharPointerType] char *
 # 1254|           ValueCategory = prvalue
-# 1254|         0: [ArrayToPointerConversion] array to pointer conversion
+# 1254|         0: [VariableAccess] buffer
+# 1254|             Type = [ArrayType] char[1024]
+# 1254|             ValueCategory = lvalue
+# 1254|         1: [VariableAccess] s1
+# 1254|             Type = [CharPointerType] char *
+# 1254|             ValueCategory = prvalue(load)
+# 1254|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1254|             Type = [CharPointerType] char *
 # 1254|             ValueCategory = prvalue
-# 1254|           expr: [VariableAccess] buffer
-# 1254|               Type = [ArrayType] char[1024]
-# 1254|               ValueCategory = lvalue
-# 1254|         1: [CStyleCast] (const char *)...
+# 1254|         1 converted: [CStyleCast] (const char *)...
 # 1254|             Conversion = [PointerConversion] pointer conversion
 # 1254|             Type = [PointerType] const char *
 # 1254|             ValueCategory = prvalue
-# 1254|           expr: [VariableAccess] s1
-# 1254|               Type = [CharPointerType] char *
-# 1254|               ValueCategory = prvalue(load)
 # 1255|     2: [ExprStmt] ExprStmt
 # 1255|       0: [FunctionCall] call to strcat
 # 1255|           Type = [CharPointerType] char *
 # 1255|           ValueCategory = prvalue
-# 1255|         0: [ArrayToPointerConversion] array to pointer conversion
+# 1255|         0: [VariableAccess] buffer
+# 1255|             Type = [ArrayType] char[1024]
+# 1255|             ValueCategory = lvalue
+# 1255|         1: [VariableAccess] s2
+# 1255|             Type = [CharPointerType] char *
+# 1255|             ValueCategory = prvalue(load)
+# 1255|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 # 1255|             Type = [CharPointerType] char *
 # 1255|             ValueCategory = prvalue
-# 1255|           expr: [VariableAccess] buffer
-# 1255|               Type = [ArrayType] char[1024]
-# 1255|               ValueCategory = lvalue
-# 1255|         1: [CStyleCast] (const char *)...
+# 1255|         1 converted: [CStyleCast] (const char *)...
 # 1255|             Conversion = [PointerConversion] pointer conversion
 # 1255|             Type = [PointerType] const char *
 # 1255|             ValueCategory = prvalue
-# 1255|           expr: [VariableAccess] s2
-# 1255|               Type = [CharPointerType] char *
-# 1255|               ValueCategory = prvalue(load)
 # 1256|     3: [ReturnStmt] return ...
 # 1258| [CopyAssignmentOperator] A& A::operator=(A const&)
 # 1258|   params: 
@@ -10149,18 +10149,18 @@ ir.cpp:
 # 1279|       0: [FunctionCall] call to static_member
 # 1279|           Type = [VoidType] void
 # 1279|           ValueCategory = prvalue
-# 1279|         -1: [ParenthesisExpr] (...)
+# 1279|         -1: [AddressOfExpr] & ...
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue
-# 1279|           expr: [AddressOfExpr] & ...
-# 1279|               Type = [PointerType] A *
-# 1279|               ValueCategory = prvalue
-# 1279|             0: [VariableAccess] a
-# 1279|                 Type = [Struct] A
-# 1279|                 ValueCategory = lvalue
+# 1279|           0: [VariableAccess] a
+# 1279|               Type = [Struct] A
+# 1279|               ValueCategory = lvalue
 # 1279|         0: [VariableAccess] a_arg
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue(load)
+# 1279|         1: [ParenthesisExpr] (...)
+# 1279|             Type = [PointerType] A *
+# 1279|             ValueCategory = prvalue
 # 1279|         1: [AddExpr] ... + ...
 # 1279|             Type = [IntType] int
 # 1279|             ValueCategory = prvalue
@@ -10175,21 +10175,21 @@ ir.cpp:
 # 1280|       0: [FunctionCall] call to static_member
 # 1280|           Type = [VoidType] void
 # 1280|           ValueCategory = prvalue
-# 1280|         -1: [ParenthesisExpr] (...)
+# 1280|         -1: [PointerDereferenceExpr] * ...
 # 1280|             Type = [Struct] A
 # 1280|             ValueCategory = lvalue
-# 1280|           expr: [PointerDereferenceExpr] * ...
-# 1280|               Type = [Struct] A
-# 1280|               ValueCategory = lvalue
-# 1280|             0: [VariableAccess] a_arg
-# 1280|                 Type = [PointerType] A *
-# 1280|                 ValueCategory = prvalue(load)
+# 1280|           0: [VariableAccess] a_arg
+# 1280|               Type = [PointerType] A *
+# 1280|               ValueCategory = prvalue(load)
 # 1280|         0: [AddressOfExpr] & ...
 # 1280|             Type = [PointerType] A *
 # 1280|             ValueCategory = prvalue
 # 1280|           0: [VariableAccess] a
 # 1280|               Type = [Struct] A
 # 1280|               ValueCategory = lvalue
+# 1280|         1: [ParenthesisExpr] (...)
+# 1280|             Type = [Struct] A
+# 1280|             ValueCategory = lvalue
 # 1280|         1: [Literal] 99
 # 1280|             Type = [IntType] int
 # 1280|             Value = [Literal] 99
@@ -10304,19 +10304,19 @@ ir.cpp:
 # 1302|         0: [VariableAccess] z
 # 1302|             Type = [IntType] int
 # 1302|             ValueCategory = lvalue
-# 1302|         1: [CStyleCast] (int)...
+# 1302|         1: [ConditionalExpr] ... ? ... : ...
+# 1302|             Type = [LongType] long
+# 1302|             ValueCategory = prvalue
+# 1302|           0: [VariableAccess] b
+# 1302|               Type = [BoolType] bool
+# 1302|               ValueCategory = prvalue(load)
+# 1302|           1: [VariableAccess] y
+# 1302|               Type = [LongType] long
+# 1302|               ValueCategory = prvalue(load)
+# 1302|         1 converted: [CStyleCast] (int)...
 # 1302|             Conversion = [IntegralConversion] integral conversion
 # 1302|             Type = [IntType] int
 # 1302|             ValueCategory = prvalue
-# 1302|           expr: [ConditionalExpr] ... ? ... : ...
-# 1302|               Type = [LongType] long
-# 1302|               ValueCategory = prvalue
-# 1302|             0: [VariableAccess] b
-# 1302|                 Type = [BoolType] bool
-# 1302|                 ValueCategory = prvalue(load)
-# 1302|             1: [VariableAccess] y
-# 1302|                 Type = [LongType] long
-# 1302|                 ValueCategory = prvalue(load)
 # 1303|     3: [ExprStmt] ExprStmt
 # 1303|       0: [AssignExpr] ... = ...
 # 1303|           Type = [IntType] int
@@ -10327,16 +10327,16 @@ ir.cpp:
 # 1303|         1: [ConditionalExpr] ... ? ... : ...
 # 1303|             Type = [IntType] int
 # 1303|             ValueCategory = prvalue
-# 1303|           0: [CStyleCast] (bool)...
-# 1303|               Conversion = [BoolConversion] conversion to bool
-# 1303|               Type = [BoolType] bool
-# 1303|               ValueCategory = prvalue
-# 1303|             expr: [VariableAccess] x
-# 1303|                 Type = [IntType] int
-# 1303|                 ValueCategory = prvalue(load)
+# 1303|           0: [VariableAccess] x
+# 1303|               Type = [IntType] int
+# 1303|               ValueCategory = prvalue(load)
 # 1303|           1: [VariableAccess] x
 # 1303|               Type = [IntType] int
 # 1303|               ValueCategory = prvalue(load)
+# 1303|           0 converted: [CStyleCast] (bool)...
+# 1303|               Conversion = [BoolConversion] conversion to bool
+# 1303|               Type = [BoolType] bool
+# 1303|               ValueCategory = prvalue
 # 1304|     4: [ExprStmt] ExprStmt
 # 1304|       0: [AssignExpr] ... = ...
 # 1304|           Type = [IntType] int
@@ -10344,23 +10344,23 @@ ir.cpp:
 # 1304|         0: [VariableAccess] z
 # 1304|             Type = [IntType] int
 # 1304|             ValueCategory = lvalue
-# 1304|         1: [CStyleCast] (int)...
+# 1304|         1: [ConditionalExpr] ... ? ... : ...
+# 1304|             Type = [LongType] long
+# 1304|             ValueCategory = prvalue
+# 1304|           0: [VariableAccess] x
+# 1304|               Type = [IntType] int
+# 1304|               ValueCategory = prvalue(load)
+# 1304|           1: [VariableAccess] y
+# 1304|               Type = [LongType] long
+# 1304|               ValueCategory = prvalue(load)
+# 1304|           0 converted: [CStyleCast] (bool)...
+# 1304|               Conversion = [BoolConversion] conversion to bool
+# 1304|               Type = [BoolType] bool
+# 1304|               ValueCategory = prvalue
+# 1304|         1 converted: [CStyleCast] (int)...
 # 1304|             Conversion = [IntegralConversion] integral conversion
 # 1304|             Type = [IntType] int
 # 1304|             ValueCategory = prvalue
-# 1304|           expr: [ConditionalExpr] ... ? ... : ...
-# 1304|               Type = [LongType] long
-# 1304|               ValueCategory = prvalue
-# 1304|             0: [CStyleCast] (bool)...
-# 1304|                 Conversion = [BoolConversion] conversion to bool
-# 1304|                 Type = [BoolType] bool
-# 1304|                 ValueCategory = prvalue
-# 1304|               expr: [VariableAccess] x
-# 1304|                   Type = [IntType] int
-# 1304|                   ValueCategory = prvalue(load)
-# 1304|             1: [VariableAccess] y
-# 1304|                 Type = [LongType] long
-# 1304|                 ValueCategory = prvalue(load)
 # 1305|     5: [ExprStmt] ExprStmt
 # 1305|       0: [AssignExpr] ... = ...
 # 1305|           Type = [IntType] int
@@ -10368,27 +10368,27 @@ ir.cpp:
 # 1305|         0: [VariableAccess] z
 # 1305|             Type = [IntType] int
 # 1305|             ValueCategory = lvalue
-# 1305|         1: [CStyleCast] (int)...
+# 1305|         1: [ConditionalExpr] ... ? ... : ...
+# 1305|             Type = [LongType] long
+# 1305|             ValueCategory = prvalue
+# 1305|           0: [VariableAccess] y
+# 1305|               Type = [LongType] long
+# 1305|               ValueCategory = prvalue(load)
+# 1305|           1: [VariableAccess] x
+# 1305|               Type = [IntType] int
+# 1305|               ValueCategory = prvalue(load)
+# 1305|           0 converted: [CStyleCast] (bool)...
+# 1305|               Conversion = [BoolConversion] conversion to bool
+# 1305|               Type = [BoolType] bool
+# 1305|               ValueCategory = prvalue
+# 1305|           1 converted: [CStyleCast] (long)...
+# 1305|               Conversion = [IntegralConversion] integral conversion
+# 1305|               Type = [LongType] long
+# 1305|               ValueCategory = prvalue
+# 1305|         1 converted: [CStyleCast] (int)...
 # 1305|             Conversion = [IntegralConversion] integral conversion
 # 1305|             Type = [IntType] int
 # 1305|             ValueCategory = prvalue
-# 1305|           expr: [ConditionalExpr] ... ? ... : ...
-# 1305|               Type = [LongType] long
-# 1305|               ValueCategory = prvalue
-# 1305|             0: [CStyleCast] (bool)...
-# 1305|                 Conversion = [BoolConversion] conversion to bool
-# 1305|                 Type = [BoolType] bool
-# 1305|                 ValueCategory = prvalue
-# 1305|               expr: [VariableAccess] y
-# 1305|                   Type = [LongType] long
-# 1305|                   ValueCategory = prvalue(load)
-# 1305|             1: [CStyleCast] (long)...
-# 1305|                 Conversion = [IntegralConversion] integral conversion
-# 1305|                 Type = [LongType] long
-# 1305|                 ValueCategory = prvalue
-# 1305|               expr: [VariableAccess] x
-# 1305|                   Type = [IntType] int
-# 1305|                   ValueCategory = prvalue(load)
 # 1306|     6: [ExprStmt] ExprStmt
 # 1306|       0: [AssignExpr] ... = ...
 # 1306|           Type = [IntType] int
@@ -10396,23 +10396,23 @@ ir.cpp:
 # 1306|         0: [VariableAccess] z
 # 1306|             Type = [IntType] int
 # 1306|             ValueCategory = lvalue
-# 1306|         1: [CStyleCast] (int)...
+# 1306|         1: [ConditionalExpr] ... ? ... : ...
+# 1306|             Type = [LongType] long
+# 1306|             ValueCategory = prvalue
+# 1306|           0: [VariableAccess] y
+# 1306|               Type = [LongType] long
+# 1306|               ValueCategory = prvalue(load)
+# 1306|           1: [VariableAccess] y
+# 1306|               Type = [LongType] long
+# 1306|               ValueCategory = prvalue(load)
+# 1306|           0 converted: [CStyleCast] (bool)...
+# 1306|               Conversion = [BoolConversion] conversion to bool
+# 1306|               Type = [BoolType] bool
+# 1306|               ValueCategory = prvalue
+# 1306|         1 converted: [CStyleCast] (int)...
 # 1306|             Conversion = [IntegralConversion] integral conversion
 # 1306|             Type = [IntType] int
 # 1306|             ValueCategory = prvalue
-# 1306|           expr: [ConditionalExpr] ... ? ... : ...
-# 1306|               Type = [LongType] long
-# 1306|               ValueCategory = prvalue
-# 1306|             0: [CStyleCast] (bool)...
-# 1306|                 Conversion = [BoolConversion] conversion to bool
-# 1306|                 Type = [BoolType] bool
-# 1306|                 ValueCategory = prvalue
-# 1306|               expr: [VariableAccess] y
-# 1306|                   Type = [LongType] long
-# 1306|                   ValueCategory = prvalue(load)
-# 1306|             1: [VariableAccess] y
-# 1306|                 Type = [LongType] long
-# 1306|                 ValueCategory = prvalue(load)
 # 1308|     7: [ExprStmt] ExprStmt
 # 1308|       0: [AssignExpr] ... = ...
 # 1308|           Type = [IntType] int
@@ -10423,35 +10423,35 @@ ir.cpp:
 # 1308|         1: [ConditionalExpr] ... ? ... : ...
 # 1308|             Type = [IntType] int
 # 1308|             ValueCategory = prvalue
-# 1308|           0: [ParenthesisExpr] (...)
+# 1308|           0: [LogicalOrExpr] ... || ...
 # 1308|               Type = [BoolType] bool
 # 1308|               ValueCategory = prvalue
-# 1308|             expr: [LogicalOrExpr] ... || ...
+# 1308|             0: [LogicalAndExpr] ... && ...
 # 1308|                 Type = [BoolType] bool
 # 1308|                 ValueCategory = prvalue
-# 1308|               0: [LogicalAndExpr] ... && ...
+# 1308|               0: [VariableAccess] x
+# 1308|                   Type = [IntType] int
+# 1308|                   ValueCategory = prvalue(load)
+# 1308|               1: [VariableAccess] b
 # 1308|                   Type = [BoolType] bool
-# 1308|                   ValueCategory = prvalue
-# 1308|                 0: [CStyleCast] (bool)...
-# 1308|                     Conversion = [BoolConversion] conversion to bool
-# 1308|                     Type = [BoolType] bool
-# 1308|                     ValueCategory = prvalue
-# 1308|                   expr: [VariableAccess] x
-# 1308|                       Type = [IntType] int
-# 1308|                       ValueCategory = prvalue(load)
-# 1308|                 1: [VariableAccess] b
-# 1308|                     Type = [BoolType] bool
-# 1308|                     ValueCategory = prvalue(load)
-# 1308|               1: [CStyleCast] (bool)...
+# 1308|                   ValueCategory = prvalue(load)
+# 1308|               0 converted: [CStyleCast] (bool)...
 # 1308|                   Conversion = [BoolConversion] conversion to bool
 # 1308|                   Type = [BoolType] bool
 # 1308|                   ValueCategory = prvalue
-# 1308|                 expr: [VariableAccess] y
-# 1308|                     Type = [LongType] long
-# 1308|                     ValueCategory = prvalue(load)
+# 1308|             1: [VariableAccess] y
+# 1308|                 Type = [LongType] long
+# 1308|                 ValueCategory = prvalue(load)
+# 1308|             1 converted: [CStyleCast] (bool)...
+# 1308|                 Conversion = [BoolConversion] conversion to bool
+# 1308|                 Type = [BoolType] bool
+# 1308|                 ValueCategory = prvalue
 # 1308|           1: [VariableAccess] x
 # 1308|               Type = [IntType] int
 # 1308|               ValueCategory = prvalue(load)
+# 1308|           0 converted: [ParenthesisExpr] (...)
+# 1308|               Type = [BoolType] bool
+# 1308|               ValueCategory = prvalue
 # 1309|     8: [ReturnStmt] return ...
 # 1311| [TopLevelFunction] bool predicateA()
 # 1311|   params: 
@@ -10504,13 +10504,13 @@ ir.cpp:
 # 1322|           0: [ErrorExpr] <error expr>
 # 1322|               Type = [LongType] unsigned long
 # 1322|               ValueCategory = prvalue
-# 1322|           1: [CStyleCast] (void *)...
+# 1322|           1: [VariableAccess] p
+# 1322|               Type = [IntPointerType] int *
+# 1322|               ValueCategory = prvalue(load)
+# 1322|           1 converted: [CStyleCast] (void *)...
 # 1322|               Conversion = [PointerConversion] pointer conversion
 # 1322|               Type = [VoidPointerType] void *
 # 1322|               ValueCategory = prvalue
-# 1322|             expr: [VariableAccess] p
-# 1322|                 Type = [IntPointerType] int *
-# 1322|                 ValueCategory = prvalue(load)
 # 1323|     1: [ReturnStmt] return ...
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
@@ -10604,42 +10604,42 @@ struct_init.cpp:
 #   22|             [0]: [ClassAggregateLiteral] {...}
 #   22|                 Type = [Struct] Info
 #   22|                 ValueCategory = prvalue
-#   22|               .name: [ArrayToPointerConversion] array to pointer conversion
-#   22|                   Type = [PointerType] const char *
-#   22|                   ValueCategory = prvalue
-#   22|                 expr: 1
-#   22|                     Type = [ArrayType] const char[2]
-#   22|                     Value = [StringLiteral] "1"
-#   22|                     ValueCategory = lvalue
+#   22|               .name: 1
+#   22|                   Type = [ArrayType] const char[2]
+#   22|                   Value = [StringLiteral] "1"
+#   22|                   ValueCategory = lvalue
 #   22|               .handler: [FunctionAccess] handler1
 #   22|                   Type = [FunctionPointerType] ..(*)(..)
 #   22|                   ValueCategory = prvalue(load)
+#   22|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   22|                   Type = [PointerType] const char *
+#   22|                   ValueCategory = prvalue
 #   23|             [1]: [ClassAggregateLiteral] {...}
 #   23|                 Type = [Struct] Info
 #   23|                 ValueCategory = prvalue
-#   23|               .name: [ArrayToPointerConversion] array to pointer conversion
-#   23|                   Type = [PointerType] const char *
-#   23|                   ValueCategory = prvalue
-#   23|                 expr: 2
-#   23|                     Type = [ArrayType] const char[2]
-#   23|                     Value = [StringLiteral] "2"
-#   23|                     ValueCategory = lvalue
+#   23|               .name: 2
+#   23|                   Type = [ArrayType] const char[2]
+#   23|                   Value = [StringLiteral] "2"
+#   23|                   ValueCategory = lvalue
 #   23|               .handler: [AddressOfExpr] & ...
 #   23|                   Type = [FunctionPointerType] ..(*)(..)
 #   23|                   ValueCategory = prvalue
 #   23|                 0: [FunctionAccess] handler2
 #   23|                     Type = [RoutineType] ..()(..)
 #   23|                     ValueCategory = lvalue
+#   23|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   23|                   Type = [PointerType] const char *
+#   23|                   ValueCategory = prvalue
 #   25|     1: [ExprStmt] ExprStmt
 #   25|       0: [FunctionCall] call to let_info_escape
 #   25|           Type = [VoidType] void
 #   25|           ValueCategory = prvalue
-#   25|         0: [ArrayToPointerConversion] array to pointer conversion
+#   25|         0: [VariableAccess] static_infos
+#   25|             Type = [ArrayType] Info[2]
+#   25|             ValueCategory = lvalue
+#   25|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #   25|             Type = [PointerType] Info *
 #   25|             ValueCategory = prvalue
-#   25|           expr: [VariableAccess] static_infos
-#   25|               Type = [ArrayType] Info[2]
-#   25|               ValueCategory = lvalue
 #   26|     2: [ReturnStmt] return ...
 #   28| [TopLevelFunction] void declare_local_infos()
 #   28|   params: 
@@ -10654,42 +10654,42 @@ struct_init.cpp:
 #   30|             [0]: [ClassAggregateLiteral] {...}
 #   30|                 Type = [Struct] Info
 #   30|                 ValueCategory = prvalue
-#   30|               .name: [ArrayToPointerConversion] array to pointer conversion
-#   30|                   Type = [PointerType] const char *
-#   30|                   ValueCategory = prvalue
-#   30|                 expr: 1
-#   30|                     Type = [ArrayType] const char[2]
-#   30|                     Value = [StringLiteral] "1"
-#   30|                     ValueCategory = lvalue
+#   30|               .name: 1
+#   30|                   Type = [ArrayType] const char[2]
+#   30|                   Value = [StringLiteral] "1"
+#   30|                   ValueCategory = lvalue
 #   30|               .handler: [FunctionAccess] handler1
 #   30|                   Type = [FunctionPointerType] ..(*)(..)
 #   30|                   ValueCategory = prvalue(load)
+#   30|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   30|                   Type = [PointerType] const char *
+#   30|                   ValueCategory = prvalue
 #   31|             [1]: [ClassAggregateLiteral] {...}
 #   31|                 Type = [Struct] Info
 #   31|                 ValueCategory = prvalue
-#   31|               .name: [ArrayToPointerConversion] array to pointer conversion
-#   31|                   Type = [PointerType] const char *
-#   31|                   ValueCategory = prvalue
-#   31|                 expr: 2
-#   31|                     Type = [ArrayType] const char[2]
-#   31|                     Value = [StringLiteral] "2"
-#   31|                     ValueCategory = lvalue
+#   31|               .name: 2
+#   31|                   Type = [ArrayType] const char[2]
+#   31|                   Value = [StringLiteral] "2"
+#   31|                   ValueCategory = lvalue
 #   31|               .handler: [AddressOfExpr] & ...
 #   31|                   Type = [FunctionPointerType] ..(*)(..)
 #   31|                   ValueCategory = prvalue
 #   31|                 0: [FunctionAccess] handler2
 #   31|                     Type = [RoutineType] ..()(..)
 #   31|                     ValueCategory = lvalue
+#   31|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   31|                   Type = [PointerType] const char *
+#   31|                   ValueCategory = prvalue
 #   33|     1: [ExprStmt] ExprStmt
 #   33|       0: [FunctionCall] call to let_info_escape
 #   33|           Type = [VoidType] void
 #   33|           ValueCategory = prvalue
-#   33|         0: [ArrayToPointerConversion] array to pointer conversion
+#   33|         0: [VariableAccess] local_infos
+#   33|             Type = [ArrayType] Info[2]
+#   33|             ValueCategory = lvalue
+#   33|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #   33|             Type = [PointerType] Info *
 #   33|             ValueCategory = prvalue
-#   33|           expr: [VariableAccess] local_infos
-#   33|               Type = [ArrayType] Info[2]
-#   33|               ValueCategory = lvalue
 #   34|     2: [ReturnStmt] return ...
 #   36| [TopLevelFunction] void declare_static_runtime_infos(char const*)
 #   36|   params: 
@@ -10715,27 +10715,27 @@ struct_init.cpp:
 #   39|             [1]: [ClassAggregateLiteral] {...}
 #   39|                 Type = [Struct] Info
 #   39|                 ValueCategory = prvalue
-#   39|               .name: [ArrayToPointerConversion] array to pointer conversion
-#   39|                   Type = [PointerType] const char *
-#   39|                   ValueCategory = prvalue
-#   39|                 expr: 2
-#   39|                     Type = [ArrayType] const char[2]
-#   39|                     Value = [StringLiteral] "2"
-#   39|                     ValueCategory = lvalue
+#   39|               .name: 2
+#   39|                   Type = [ArrayType] const char[2]
+#   39|                   Value = [StringLiteral] "2"
+#   39|                   ValueCategory = lvalue
 #   39|               .handler: [AddressOfExpr] & ...
 #   39|                   Type = [FunctionPointerType] ..(*)(..)
 #   39|                   ValueCategory = prvalue
 #   39|                 0: [FunctionAccess] handler2
 #   39|                     Type = [RoutineType] ..()(..)
 #   39|                     ValueCategory = lvalue
+#   39|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   39|                   Type = [PointerType] const char *
+#   39|                   ValueCategory = prvalue
 #   41|     1: [ExprStmt] ExprStmt
 #   41|       0: [FunctionCall] call to let_info_escape
 #   41|           Type = [VoidType] void
 #   41|           ValueCategory = prvalue
-#   41|         0: [ArrayToPointerConversion] array to pointer conversion
+#   41|         0: [VariableAccess] static_infos
+#   41|             Type = [ArrayType] Info[2]
+#   41|             ValueCategory = lvalue
+#   41|         0 converted: [ArrayToPointerConversion] array to pointer conversion
 #   41|             Type = [PointerType] Info *
 #   41|             ValueCategory = prvalue
-#   41|           expr: [VariableAccess] static_infos
-#   41|               Type = [ArrayType] Info[2]
-#   41|               ValueCategory = lvalue
 #   42|     2: [ReturnStmt] return ...


### PR DESCRIPTION
This addresses  #4278.

This PR does not add metadata about conversions to the nodes.
The (prior) inclusion of conversion nodes in the tree meant that multiple conversions, i.e.
```
  c = (char *)(void *)(int *)v;
```
were handled correctly.
With just a metadata attribute on the VariableAccess, I do not see how to represent the AST faithfully - just including the inner- or outermost cast would be misleading.

I am not happy with this, and open to suggestions how to better address this problem.
