### PR TITLE
JavaScript: Add modelling for `Module.prototype._compile`.

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/CodeInjectionCustomizations.qll
@@ -124,4 +124,15 @@ module CodeInjection {
   class NoSQLCodeInjectionSink extends Sink {
     NoSQLCodeInjectionSink() { any(NoSQL::Query q).getACodeOperator() = this }
   }
+
+  /**
+   * The first argument to `Module.prototype._compile` from the Node.js built-in module `module`,
+   * considered as a code-injection sink.
+   */
+  class ModuleCompileSink extends Sink {
+    ModuleCompileSink() {
+      this =
+        API::moduleImport("module").getInstance().getMember("_compile").getACall().getArgument(0)
+    }
+  }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/CodeInjection.expected
@@ -108,6 +108,9 @@ nodes
 | express.js:21:19:21:48 | req.par ... ntext") |
 | express.js:21:19:21:48 | req.par ... ntext") |
 | express.js:21:19:21:48 | req.par ... ntext") |
+| module.js:9:16:9:29 | req.query.code |
+| module.js:9:16:9:29 | req.query.code |
+| module.js:9:16:9:29 | req.query.code |
 | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
@@ -246,6 +249,7 @@ edges
 | express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") |
 | express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") |
 | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") |
+| module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |
@@ -308,6 +312,7 @@ edges
 | express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") | $@ flows to here and is interpreted as code. | express.js:17:30:17:53 | req.par ... cript") | User-provided value |
 | express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") | $@ flows to here and is interpreted as code. | express.js:19:37:19:70 | req.par ... odule") | User-provided value |
 | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") | $@ flows to here and is interpreted as code. | express.js:21:19:21:48 | req.par ... ntext") | User-provided value |
+| module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code | $@ flows to here and is interpreted as code. | module.js:9:16:9:29 | req.query.code | User-provided value |
 | react-native.js:8:32:8:38 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:8:32:8:38 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | react-native.js:10:23:10:29 | tainted | react-native.js:7:17:7:33 | req.param("code") | react-native.js:10:23:10:29 | tainted | $@ flows to here and is interpreted as code. | react-native.js:7:17:7:33 | req.param("code") | User-provided value |
 | tst.js:2:6:2:83 | documen ... t=")+8) | tst.js:2:6:2:22 | document.location | tst.js:2:6:2:83 | documen ... t=")+8) | $@ flows to here and is interpreted as code. | tst.js:2:6:2:22 | document.location | User-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/HeuristicSourceCodeInjection.expected
@@ -112,6 +112,9 @@ nodes
 | express.js:21:19:21:48 | req.par ... ntext") |
 | express.js:21:19:21:48 | req.par ... ntext") |
 | express.js:21:19:21:48 | req.par ... ntext") |
+| module.js:9:16:9:29 | req.query.code |
+| module.js:9:16:9:29 | req.query.code |
+| module.js:9:16:9:29 | req.query.code |
 | react-native.js:7:7:7:33 | tainted |
 | react-native.js:7:17:7:33 | req.param("code") |
 | react-native.js:7:17:7:33 | req.param("code") |
@@ -254,6 +257,7 @@ edges
 | express.js:17:30:17:53 | req.par ... cript") | express.js:17:30:17:53 | req.par ... cript") |
 | express.js:19:37:19:70 | req.par ... odule") | express.js:19:37:19:70 | req.par ... odule") |
 | express.js:21:19:21:48 | req.par ... ntext") | express.js:21:19:21:48 | req.par ... ntext") |
+| module.js:9:16:9:29 | req.query.code | module.js:9:16:9:29 | req.query.code |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:8:32:8:38 | tainted |
 | react-native.js:7:7:7:33 | tainted | react-native.js:10:23:10:29 | tainted |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/module.js
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/module.js
@@ -1,0 +1,10 @@
+var express = require('express'),
+    Module = require('module');
+
+var app = express();
+
+app.get('/some/path', function (req, res) {
+    let filename = req.query.filename;
+    var m = new Module(filename, module.parent);
+    m._compile(req.query.code, filename); // NOT OK
+});


### PR DESCRIPTION
Undocumented API, so one might question whether it is worth it. On the other hand, it would allow us to derive a sink summary for [this](https://github.com/floatdrop/require-from-string/blob/master/index.js) unaccountably popular npm module (>2M weekly downloads).