### PR TITLE
C++: Annotate IR with partial flow info

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/PrintIRLocalFlow.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/PrintIRLocalFlow.qll
@@ -130,6 +130,23 @@ private string getNodeProperty(DataFlow::Node node, string key) {
     |
       kind, ", "
     )
+  or
+  // Is there partial flow from a source to this node?
+  // This property will only be emitted if partial flow is enabled by overriding
+  // `DataFlow::Configration::explorationLimit()`.
+  key = "pflow" and
+  result =
+    strictconcat(DataFlow::PartialPathNode sourceNode, DataFlow::PartialPathNode destNode, int dist,
+      int order1, int order2 |
+      any(DataFlow::Configuration cfg).hasPartialFlow(sourceNode, destNode, dist) and
+      destNode.getNode() = node and
+      // Only print flow from a source in the same function.
+      sourceNode.getNode().getEnclosingCallable() = node.getEnclosingCallable()
+    |
+      nodeId(sourceNode.getNode(), order1, order2) + "+" + dist.toString(), ", "
+      order by
+        order1, order2, dist desc
+    )
 }
 
 /**


### PR DESCRIPTION

I've added one more property to the annotations provided by `PrintIRLocalFlow.qll`: The `pflow` property will now be emitted for any operand or instruction for which `configuration.hasPartialFlow` determines that there is partial flow to that node. This requires that partial flow be enabled via overriding `Configuration::explorationLimit()` in order to display. Otherwise, you'll still just get the local flow info as before.