### PR TITLE
JS: add local dataflow to js/template-syntax-in-string-literal

### DIFF
--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.expected
@@ -2,3 +2,4 @@
 | TemplateSyntaxInStringLiteral.js:17:15:17:40 | 'global ... alVar}' | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:14:5:14:13 | globalVar | globalVar |
 | TemplateSyntaxInStringLiteral.js:19:11:19:36 | 'global ... alVar}' | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:14:5:14:13 | globalVar | globalVar |
 | TemplateSyntaxInStringLiteral.js:28:15:28:21 | "${x} " | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:25:14:25:14 | x | x |
+| TemplateSyntaxInStringLiteral.js:42:17:42:57 | "Name:  ... oobar}" | This string is not a template literal, but appears to reference the variable $@. | TemplateSyntaxInStringLiteral.js:37:11:37:16 | foobar | foobar |

--- a/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/TemplateSyntaxInStringLiteral/TemplateSyntaxInStringLiteral.js
@@ -28,3 +28,16 @@ function baz(x){
     log.error("${x} ");
     log.error("${y} ");
 }
+
+
+function foo1() {
+    const aTemplateLitInScope = `Connecting to ${id}`;
+    const name = 2;
+    const date = 3;
+    const foobar = 4;
+
+    const data = {name: name, date: date};
+    writer.emit("Name: ${name}, Date: ${date}.", data); // OK 
+
+    writer.emit("Name: ${name}, Date: ${date}, ${foobar}", data); // NOT OK - `foobar` is not in `data`.     
+}


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/4504. 

Consider this example: 
```JavaScript
const data = {foo: 123};
someCall("bla ${foo}", data). 
```

Before this PR we would not recognize that `data` contains a `foo` property, because we didn't follow any local dataflow. 
This PR adds support for that local dataflow. 