### PR TITLE
C++: Changes to models library.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Pure.qll
@@ -5,32 +5,9 @@ import semmle.code.cpp.models.interfaces.SideEffect
 
 class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction, SideEffectFunction {
   PureStrFunction() {
-    exists(string name |
-      hasGlobalOrStdName(name) and
-      (
-        name = "atof" or
-        name = "atoi" or
-        name = "atol" or
-        name = "atoll" or
-        name = "strcasestr" or
-        name = "strchnul" or
-        name = "strchr" or
-        name = "strchrnul" or
-        name = "strstr" or
-        name = "strpbrk" or
-        name = "strcmp" or
-        name = "strcspn" or
-        name = "strncmp" or
-        name = "strrchr" or
-        name = "strspn" or
-        name = "strtod" or
-        name = "strtof" or
-        name = "strtol" or
-        name = "strtoll" or
-        name = "strtoq" or
-        name = "strtoul"
-      )
-    )
+    hasGlobalOrStdName(["atof", "atoi", "atol", "atoll", "strcasestr", "strchnul", "strchr",
+          "strchrnul", "strstr", "strpbrk", "strcmp", "strcspn", "strncmp", "strrchr", "strspn",
+          "strtod", "strtof", "strtol", "strtoll", "strtoq", "strtoul"])
   }
 
   override predicate hasArrayInput(int bufParam) {
@@ -81,22 +58,9 @@ class PureStrFunction extends AliasFunction, ArrayFunction, TaintFunction, SideE
 
 class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
   StrLenFunction() {
-    exists(string name |
-      hasGlobalOrStdName(name) and
-      (
-        name = "strlen" or
-        name = "strnlen" or
-        name = "wcslen"
-      )
-      or
-      hasGlobalName(name) and
-      (
-        name = "_mbslen" or
-        name = "_mbslen_l" or
-        name = "_mbstrlen" or
-        name = "_mbstrlen_l"
-      )
-    )
+    hasGlobalOrStdName(["strlen", "strnlen", "wcslen"])
+    or
+    hasGlobalName(["_mbslen", "_mbslen_l", "_mbstrlen", "_mbstrlen_l"])
   }
 
   override predicate hasArrayInput(int bufParam) {
@@ -126,15 +90,7 @@ class StrLenFunction extends AliasFunction, ArrayFunction, SideEffectFunction {
 }
 
 class PureFunction extends TaintFunction, SideEffectFunction {
-  PureFunction() {
-    exists(string name |
-      hasGlobalOrStdName(name) and
-      (
-        name = "abs" or
-        name = "labs"
-      )
-    )
-  }
+  PureFunction() { hasGlobalOrStdName(["abs", "labs"]) }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
     exists(ParameterIndex i |

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/SmartPointer.qll
@@ -17,7 +17,7 @@ class MakeUniqueOrShared extends TaintFunction {
     // Exclude the specializations of `std::make_shared` and `std::make_unique` that allocate arrays
     // since these just take a size argument, which we don't want to propagate taint through.
     not this.isArray() and
-    input.isParameter(_) and
+    input.isParameter([0 .. getNumberOfParameters() - 1]) and
     output.isReturnValue()
   }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -4,45 +4,47 @@
 
 import semmle.code.cpp.models.interfaces.Taint
 
-/**
- * Additional model for `std::pair` constructors.
- */
-private class StdPairConstructor extends Constructor, TaintFunction {
-  StdPairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
+module Std {
+  /**
+   * Additional model for `std::pair` constructors.
+   */
+  private class PairConstructor extends Constructor, TaintFunction {
+    PairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
+
+    /**
+     * Gets the index of a parameter to this function that is a reference to
+     * either value type of the pair.
+     */
+    int getAValueTypeParameterIndex() {
+      getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+        getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
+    }
+
+    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+      // taint flow from second parameter of a value type to the qualifier
+      getAValueTypeParameterIndex() = 1 and
+      input.isParameterDeref(1) and
+      (
+        output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
+        or
+        output.isQualifierObject()
+      )
+    }
+  }
 
   /**
-   * Gets the index of a parameter to this function that is a reference to
-   * either value type of the pair.
+   * The standard pair `swap` function.
    */
-  int getAValueTypeParameterIndex() {
-    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-      getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
-  }
+  private class PairSwap extends TaintFunction {
+    PairSwap() { this.hasQualifiedName("std", "pair", "swap") }
 
-  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    // taint flow from second parameter of a value type to the qualifier
-    getAValueTypeParameterIndex() = 1 and
-    input.isParameterDeref(1) and
-    (
-      output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
+    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+      // container1.swap(container2)
+      input.isQualifierObject() and
+      output.isParameterDeref(0)
       or
+      input.isParameterDeref(0) and
       output.isQualifierObject()
-    )
-  }
-}
-
-/**
- * The standard pair `swap` function.
- */
-private class StdPairSwap extends TaintFunction {
-  StdPairSwap() { this.hasQualifiedName("std", "pair", "swap") }
-
-  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    // container1.swap(container2)
-    input.isQualifierObject() and
-    output.isParameterDeref(0)
-    or
-    input.isParameterDeref(0) and
-    output.isQualifierObject()
+    }
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -4,47 +4,45 @@
 
 import semmle.code.cpp.models.interfaces.Taint
 
-module Std {
+/**
+ * Additional model for `std::pair` constructors.
+ */
+private class StdPairConstructor extends Constructor, TaintFunction {
+  StdPairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
+
   /**
-   * Additional model for `std::pair` constructors.
+   * Gets the index of a parameter to this function that is a reference to
+   * either value type of the pair.
    */
-  private class PairConstructor extends Constructor, TaintFunction {
-    PairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
-
-    /**
-     * Gets the index of a parameter to this function that is a reference to
-     * either value type of the pair.
-     */
-    int getAValueTypeParameterIndex() {
-      getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
-        getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
-    }
-
-    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-      // taint flow from second parameter of a value type to the qualifier
-      getAValueTypeParameterIndex() = 1 and
-      input.isParameterDeref(1) and
-      (
-        output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
-        or
-        output.isQualifierObject()
-      )
-    }
+  int getAValueTypeParameterIndex() {
+    getParameter(result).getUnspecifiedType().(ReferenceType).getBaseType() =
+      getDeclaringType().getTemplateArgument(_).(Type).getUnspecifiedType() // i.e. the `T1` or `T2` of this `std::pair<T1, T2>`
   }
 
-  /**
-   * The standard pair `swap` function.
-   */
-  private class PairSwap extends TaintFunction {
-    PairSwap() { this.hasQualifiedName("std", "pair", "swap") }
-
-    override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-      // container1.swap(container2)
-      input.isQualifierObject() and
-      output.isParameterDeref(0)
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // taint flow from second parameter of a value type to the qualifier
+    getAValueTypeParameterIndex() = 1 and
+    input.isParameterDeref(1) and
+    (
+      output.isReturnValue() // TODO: this is only needed for AST data flow, which treats constructors as returning the new object
       or
-      input.isParameterDeref(0) and
       output.isQualifierObject()
-    }
+    )
+  }
+}
+
+/**
+ * The standard pair `swap` function.
+ */
+private class StdPairSwap extends TaintFunction {
+  StdPairSwap() { this.hasQualifiedName("std", "pair", "swap") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    // container1.swap(container2)
+    input.isQualifierObject() and
+    output.isParameterDeref(0)
+    or
+    input.isParameterDeref(0) and
+    output.isQualifierObject()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdPair.qll
@@ -7,7 +7,7 @@ import semmle.code.cpp.models.interfaces.Taint
 /**
  * Additional model for `std::pair` constructors.
  */
-class StdPairConstructor extends Constructor, TaintFunction {
+private class StdPairConstructor extends Constructor, TaintFunction {
   StdPairConstructor() { this.hasQualifiedName("std", "pair", "pair") }
 
   /**
@@ -34,7 +34,7 @@ class StdPairConstructor extends Constructor, TaintFunction {
 /**
  * The standard pair `swap` function.
  */
-class StdPairSwap extends TaintFunction {
+private class StdPairSwap extends TaintFunction {
   StdPairSwap() { this.hasQualifiedName("std", "pair", "swap") }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {


### PR DESCRIPTION
This is a sort of prototype for changes I intend to make to the entire models library, the intent being to discuss these ideas on a small scale before I spend more time applying them more widely.  Once it's merged I intend to make a second, larger PR applying what is agreed upon to all of `models\implementations`.  The changes are:
 - make the QL classes in `models\implementations` representing library functions `private`; there may be cases where we think using them directly has legitimate value to users (possibly bits of `Allocation.qll`), in which case we should consider migrating sufficient code from `implementations` to `interfaces`.  But in most cases these classes are implementation details, and we may want to change their details in future (for example combining or splitting models).
 - ~add a QL `module` for `Std`, instead of naming lots of classes `StdPairConstructor`, `StdMapInsert` etc.  This was suggested by @tausbn.  I'm not really sure what the pro's and con's will be for us so I'd like to discuss what we want to get out of it before pressing on with this.~
 - avoid the pattern: `getParameter(_)` - because it's believed to be inefficient (I only found one remaining use anyway)
 - more use of `[, ]` syntax; I expect this is uncontroversial at this point.

I'm also open to further suggestions (porting taint models to the upcoming shared flow summary interface is out of scope, however).