### PR TITLE
JS: Support moddern assignment expressions in js/implicit-operand-conversion

### DIFF
--- a/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
+++ b/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
@@ -130,7 +130,8 @@ class NumericConversion extends ImplicitConversion {
     or
     parent instanceof ArithmeticExpr and not parent instanceof AddExpr
     or
-    parent instanceof CompoundAssignExpr and not (
+    parent instanceof CompoundAssignExpr and
+    not (
       parent instanceof AssignAddExpr or
       parent instanceof AssignLogOrExpr or
       parent instanceof AssignLogAndExpr or

--- a/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
+++ b/javascript/ql/src/Expressions/ImplicitOperandConversion.ql
@@ -130,7 +130,12 @@ class NumericConversion extends ImplicitConversion {
     or
     parent instanceof ArithmeticExpr and not parent instanceof AddExpr
     or
-    parent instanceof CompoundAssignExpr and not parent instanceof AssignAddExpr
+    parent instanceof CompoundAssignExpr and not (
+      parent instanceof AssignAddExpr or
+      parent instanceof AssignLogOrExpr or
+      parent instanceof AssignLogAndExpr or
+      parent instanceof AssignNullishCoalescingExpr
+    )
     or
     parent instanceof UpdateExpr
   }

--- a/javascript/ql/src/semmle/javascript/Expr.qll
+++ b/javascript/ql/src/semmle/javascript/Expr.qll
@@ -2053,7 +2053,7 @@ class AssignAndExpr extends @assign_and_expr, CompoundAssignExpr { }
  * x ||= y
  * ```
  */
-class AssignLogOrExpr extends @assignlogandexpr, CompoundAssignExpr { }
+class AssignLogOrExpr extends @assignlogorexpr, CompoundAssignExpr { }
 
 /**
  * A logical-'and'-assign expression.
@@ -2064,7 +2064,7 @@ class AssignLogOrExpr extends @assignlogandexpr, CompoundAssignExpr { }
  * x &&= y
  * ```
  */
-class AssignLogAndExpr extends @assignlogorexpr, CompoundAssignExpr { }
+class AssignLogAndExpr extends @assignlogandexpr, CompoundAssignExpr { }
 
 /**
  * A 'nullish-coalescing'-assign expression.

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/ImplicitOperandConversion.expected
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/ImplicitOperandConversion.expected
@@ -13,3 +13,5 @@
 | tst.js:106:5:106:7 | g() | This expression will be implicitly converted from undefined to number. |
 | tst.js:109:13:109:15 | g() | This expression will be implicitly converted from undefined to number. |
 | tst.js:110:13:110:15 | g() | This expression will be implicitly converted from undefined to string. |
+| tst.js:117:8:117:8 | y | This expression will be implicitly converted from string to number. |
+| tst.js:122:10:122:10 | y | This expression will be implicitly converted from string to number. |

--- a/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/ImplicitOperandConversion/tst.js
@@ -110,3 +110,14 @@ function l() {
     var b = g() + "str";
 });
 
+
+function m() {
+  var x = 19, y = "string";
+  
+  x %= y; // NOT OK
+  x += y; // OK 
+  x ||= y; // OK
+  x &&= y; // OK
+  x ??= y; // OK
+  x >>>= y; // NOT OK
+}


### PR DESCRIPTION
The `js/implicit-operand-conversion` query assumed that every compound-assignment-expression that wasn't `+=` was some operation on numbers. 

With the introduction of `??=`, `||=`, and `&&=` that assumption was no longer valid.   

I've added these new operators to  `js/implicit-operand-conversion`.  

Fixes https://github.com/github/codeql/issues/4510

Drive-by-change to `Expr.qll` where two `extends` clauses were flipped.  

No evaluation is planned. 

This change is already covered in the change-notes (`ES2021 features are now supported`). 