### PR TITLE
JS: Do not extend AdditionalTaintStep in the ldap library

### DIFF
--- a/javascript/ql/src/experimental/Security/CWE-090/LdapInjection.qll
+++ b/javascript/ql/src/experimental/Security/CWE-090/LdapInjection.qll
@@ -14,5 +14,12 @@ module LdapInjection {
     override predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     override predicate isSanitizer(DataFlow::Node node) { node instanceof Sanitizer }
+
+    override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(LdapjsParseFilter filter |
+        pred = filter.getArgument(0) and
+        succ = filter
+      )
+    }
   }
 }

--- a/javascript/ql/src/experimental/Security/CWE-090/LdapInjectionCustomizations.qll
+++ b/javascript/ql/src/experimental/Security/CWE-090/LdapInjectionCustomizations.qll
@@ -5,9 +5,10 @@
  */
 
 import javascript
-import Ldapjs::Ldapjs
 
 module LdapInjection {
+  import Ldapjs::Ldapjs
+
   /**
    * A data flow source for LDAP injection vulnerabilities.
    */
@@ -68,18 +69,6 @@ module LdapInjection {
             .getCalleeName()
             .regexpMatch("(?i)(" + sanitize + input + ")" + "|(" + input + sanitize + ")")
       )
-    }
-  }
-
-  /**
-   * A step through the parseFilter API (https://github.com/ldapjs/node-ldapjs/issues/181).
-   */
-  class StepThroughParseFilter extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
-    StepThroughParseFilter() { this instanceof LdapjsParseFilter }
-
-    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      pred = this.getArgument(0) and
-      succ = this
     }
   }
 }


### PR DESCRIPTION
Extending `AdditionalTaintStep` causes the whole taint-step relation to the recompiled/recomputed when this query is compiled/executed, respectively.