### PR TITLE
C#: Remove dead LoggerType class

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/security/dataflow/LogForging.qll
+++ b/csharp/ql/src/semmle/code/csharp/security/dataflow/LogForging.qll
@@ -49,13 +49,6 @@ module LogForging {
   }
 
   /**
-   * A logger type that extends from an ILogger type.
-   */
-  private class LoggerType extends RefType {
-    LoggerType() { getABaseType*().hasName("ILogger") }
-  }
-
-  /**
    * An argument to a call to a method on a logger class.
    */
   class LogForgingLogMessageSink extends Sink, LogMessageSink { }


### PR DESCRIPTION
This appears to have been factored into Loggers.qll but left lying around.