### PR TITLE
JS: add support for more custom CSRF checking middlewares

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
+++ b/javascript/ql/test/query-tests/Security/CWE-352/MissingCsrfMiddlewareGood2.js
@@ -90,3 +90,30 @@ var passport = require('passport');
         let newEmail = req.cookies["newEmail"];
     })
 });
+
+
+(function () {
+    var app = express()
+
+    app.use(cookieParser())
+    app.use(passport.authorize({ session: true }))
+
+    function checkToken(req) {
+        if (req.headers.xsrfToken !== req.session.xsrfToken) {
+            throw new Error("Halt and catch fire!")
+        }
+    }
+
+    function setCsrfToken(req, response, next) {
+        req.session.xsrfToken = req.csrfToken();
+        next();
+    }
+
+    app.use(checkToken);
+
+    app.post('/changeEmail', function (req, res) {
+        let newEmail = req.cookies["newEmail"];
+    });
+
+    app.use(setCsrfToken); // There is nothing wrong with setting the token late, as long as it is checked early.
+});


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/2476

Expands on my [earlier PR](https://github.com/github/codeql/pull/4478) such that it now recognizes [this CSRF protecting middleware](https://lgtm.com/projects/g/trendmicro/SecureCodingDojo/snapshot/4e37dfd83ddbd42a31e607d17c7d82d4bea8c29d/files/trainingportal/auth.js?sort=name&dir=ASC&mode=heatmap#xbac0e9c9cc880c70:1). 