### PR TITLE
JavaScript: Include .github hidden folders in autobuild

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -117,7 +117,7 @@ import com.semmle.util.trap.TrapWriter;
  * or "metadata" becomes an exclude path. Note that there are no implicit exclude paths.
  *
  * <p>The walking phase starts at each include path in turn and recursively traverses folders and
- * files. Symlinks and hidden folders are skipped, but not hidden files. If it encounters a
+ * files. Symlinks and most hidden folders are skipped, but not hidden files. If it encounters a
  * sub-folder whose path is excluded, traversal stops. If it encounters a file, that file becomes a
  * candidate, unless its path is excluded. If the path of a file is both an include path and an
  * exclude path, the inclusion takes precedence, and the file becomes a candidate after all.
@@ -1010,10 +1010,19 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
             return super.visitFile(file, attrs);
           }
 
+          /**
+           * Returns {@code true} if {@code dir} is a hidden directory
+           * that should be skipped by default.
+           */
+          private boolean isSkippedHiddenDirectory(Path dir) {
+            // Allow .github folders as they may contain YAML files relevant to GitHub repositories.
+            return dir.toFile().isHidden() && !dir.getFileName().toString().equals(".github");
+          }
+
           @Override
           public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
               throws IOException {
-            if (!dir.equals(currentRoot[0]) && (excludes.contains(dir) || dir.toFile().isHidden()))
+            if (!dir.equals(currentRoot[0]) && (excludes.contains(dir) || isSkippedHiddenDirectory(dir)))
               return FileVisitResult.SKIP_SUBTREE;
             if (Files.exists(dir.resolve("codeql-database.yml"))) {
               return FileVisitResult.SKIP_SUBTREE;

--- a/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/test/AutoBuildTests.java
@@ -608,4 +608,19 @@ public class AutoBuildTests {
     addFile(false, LGTM_SRC, "db/foo.js");
     runTest();
   }
+
+  @Test
+  public void hiddenGitHubFoldersAreIncluded() throws IOException {
+    Path tst_yml = addFile(true, LGTM_SRC, ".github", "workflows", "test.yml");
+    hide(tst_yml.getParent().getParent());
+    runTest();
+  }
+
+  @Test
+  public void hiddenGitHubFoldersCanBeExcluded() throws IOException {
+    envVars.put("LGTM_INDEX_FILTERS", "exclude:**/.github");
+    Path tst_yml = addFile(false, LGTM_SRC, ".github", "workflows", "test.yml");
+    hide(tst_yml.getParent().getParent());
+    runTest();
+  }
 }


### PR DESCRIPTION
These folders are likely to contain GitHub-specific YAML files, such as Actions workflow configurations.
Including them by default allows analysis of such code without further configuration.
User-configured exclusions will still be respected for these folders.