### PR TITLE
Python: Prevent early join on `argName` in `getArg`

### DIFF
--- a/python/ql/src/experimental/dataflow/internal/DataFlowPrivate.qll
+++ b/python/ql/src/experimental/dataflow/internal/DataFlowPrivate.qll
@@ -400,7 +400,7 @@ module ArgumentPassing {
       exists(Function f, string argName |
         f = callable.getScope() and
         f.getArgName(paramN) = argName and
-        result = TCfgNode(call.getArgByName(argName))
+        result = TCfgNode(call.getArgByName(unbind_string(argName)))
       )
       or
       // a synthezised argument passed to the starred parameter (at position -1)
@@ -420,6 +420,10 @@ module ArgumentPassing {
       )
     )
   }
+
+  /** Currently required in `getArg` in order to prevent a bad join. */
+  bindingset[result, s]
+  private string unbind_string(string s) { result <= s and s <= result }
 
   /** Gets the control flow node that is passed as the `n`th overflow positional argument. */
   ControlFlowNode getPositionalOverflowArg(CallNode call, CallableValue callable, int n) {


### PR DESCRIPTION
A temporary fix using a manual `unbind`. I'm still running a few performance tests on this, but it should be ready to merge once the CI tests pass.

Edit: And since @RasmusWL asked nicely, here's the change in tuple counts:

Before:

```
Tuple counts for DataFlowPrivate::ArgumentPassing::getArg#fffff:
546248   ~0%       {4} r1 = JOIN DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS L WITH Flow::CallNode::getArg_dispred#fff AS R CARTESIAN PRODUCT OUTPUT R.<2>, L.<0>, R.<0>, R.<1>
546248   ~0%       {4} r2 = JOIN r1 WITH DataFlowPublic::TCfgNode#ff AS R ON FIRST 1 OUTPUT r1.<1>, r1.<2>, r1.<3>, R.<1>
273124   ~0%       {4} r3 = JOIN r2 WITH DataFlowPrivate::ArgumentPassing::TNoShift#f AS R ON FIRST 1 OUTPUT r2.<1>, r2.<0>, r2.<3>, r2.<2>
273124   ~0%       {4} r4 = JOIN r2 WITH DataFlowPrivate::ArgumentPassing::TShiftOneUp#f AS R ON FIRST 1 OUTPUT r2.<1>, r2.<0>, r2.<3>, (r2.<2> + 1)
546248   ~2%       {4} r5 = r3 \/ r4
115578   ~1%       {5} r6 = JOIN r5 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 1 OUTPUT r5.<0>, r5.<1>, R.<1>, r5.<3>, r5.<2>
118430   ~0%       {4} r7 = JOIN DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS L WITH Flow::CallNode::getArgByName_dispred#fff AS R CARTESIAN PRODUCT OUTPUT R.<2>, L.<0>, R.<0>, R.<1>
118430   ~5%       {4} r8 = JOIN r7 WITH DataFlowPublic::TCfgNode#ff AS R ON FIRST 1 OUTPUT r7.<3>, r7.<1>, r7.<2>, R.<1>
19169954 ~0%       {5} r9 = JOIN r8 WITH Function::Function::getArgName_dispred#fff_201#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r8.<1>, r8.<2>, r8.<3>, R.<2>
19191648 ~0%       {5} r10 = JOIN r9 WITH ObjectAPI::CallableValue::getScope_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r9.<2>, R.<1>, r9.<1>, r9.<3>, r9.<4>
13876    ~0%       {5} r11 = JOIN r10 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r10.<0>, r10.<2>, r10.<1>, r10.<4>, r10.<3>
129454   ~3%       {5} r12 = r6 \/ r11
2        ~0%       {2} r13 = SCAN DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS I OUTPUT I.<0>, -1
2390     ~0%       {3} r14 = JOIN r13 WITH project#AstGenerated::Function_::getVararg_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r13.<0>, -1
2452     ~6%       {3} r15 = JOIN r14 WITH ObjectAPI::CallableValue::getScope_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r14.<1>, -1
1696     ~5%       {5} r16 = JOIN r15 WITH DataFlowPublic::TPosOverflowNode#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r15.<0>, r15.<1>, -1, R.<2>
1696     ~0%       {5} r17 = JOIN r16 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r16.<0>, r16.<2>, r16.<1>, -1, r16.<4>
131150   ~3%       {5} r18 = r12 \/ r17
2        ~0%       {2} r19 = SCAN DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS I OUTPUT I.<0>, -2
2770     ~1%       {3} r20 = JOIN r19 WITH project#AstGenerated::Function_::getKwarg_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r19.<0>, -2
2832     ~0%       {3} r21 = JOIN r20 WITH ObjectAPI::CallableValue::getScope_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r20.<1>, -2
6720     ~0%       {5} r22 = JOIN r21 WITH DataFlowPublic::TKwOverflowNode#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r21.<0>, r21.<1>, -2, R.<2>
6720     ~0%       {5} r23 = JOIN r22 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r22.<0>, r22.<2>, r22.<1>, -2, r22.<4>
137870   ~1%       {5} r24 = r18 \/ r23
1179     ~0%       {5} r25 = SCAN DataFlowPrivate::ArgumentPassing::call_unpacks#fffff AS I OUTPUT I.<1>, I.<0>, I.<2>, I.<3>, I.<4>
1179     ~0%       {5} r26 = JOIN r25 WITH DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS R ON FIRST 1 OUTPUT r25.<1>, r25.<2>, R.<0>, r25.<3>, r25.<4>
1179     ~2%       {5} r27 = JOIN r26 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r26.<0>, r26.<1>, r26.<3>, r26.<2>, r26.<4>
1179     ~4%       {5} r28 = JOIN r27 WITH DataFlowPublic::TKwUnpacked#ffff AS R ON FIRST 3 OUTPUT r27.<0>, r27.<3>, r27.<1>, r27.<4>, R.<3>
139049   ~1%       {5} r29 = r24 \/ r28
                   return r29
```

After:
```
Tuple counts for DataFlowPrivate::ArgumentPassing::getArg#fbfff:
2       ~0%     {1} r1 = JOIN m#DataFlowPrivate::ArgumentPassing::getArg#fbfff AS L WITH DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS R ON FIRST 1 OUTPUT L.<0>
546248  ~0%     {4} r2 = JOIN r1 WITH Flow::CallNode::getArg_dispred#fff AS R CARTESIAN PRODUCT OUTPUT R.<2>, r1.<0>, R.<0>, R.<1>
546248  ~0%     {4} r3 = JOIN r2 WITH DataFlowPublic::TCfgNode#ff AS R ON FIRST 1 OUTPUT r2.<1>, r2.<2>, r2.<3>, R.<1>
273124  ~0%     {4} r4 = JOIN r3 WITH DataFlowPrivate::ArgumentPassing::TNoShift#f AS R ON FIRST 1 OUTPUT r3.<1>, r3.<0>, r3.<3>, r3.<2>
273124  ~0%     {4} r5 = JOIN r3 WITH DataFlowPrivate::ArgumentPassing::TShiftOneUp#f AS R ON FIRST 1 OUTPUT r3.<1>, r3.<0>, r3.<3>, (r3.<2> + 1)
546248  ~2%     {4} r6 = r4 \/ r5
115578  ~1%     {5} r7 = JOIN r6 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 1 OUTPUT r6.<0>, r6.<1>, R.<1>, r6.<3>, r6.<2>
73330   ~0%     {3} r8 = JOIN r1 WITH ObjectAPI::CallableValue::getScope_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<1>, r1.<0>, R.<0>
147744  ~2%     {4} r9 = JOIN r8 WITH Function::Function::getArgName_dispred#fff AS R ON FIRST 1 OUTPUT r8.<2>, r8.<1>, R.<1>, R.<2>
207076  ~1%     {5} r10 = JOIN r9 WITH DataFlowPrivate::ArgumentPassing::connects#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r9.<1>, r9.<0>, r9.<2>, r9.<3>
100502  ~0%     {7} r11 = JOIN r10 WITH Flow::CallNode::getArgByName_dispred#fff AS R ON FIRST 1 OUTPUT r10.<1>, r10.<2>, r10.<3>, r10.<4>, r10.<0>, R.<1>, R.<2>
62718   ~0%     {7} r12 = SELECT r11 ON r11.<5> <= r11.<3>
13876   ~0%     {7} r13 = SELECT r12 ON r12.<3> <= r12.<5>
13876   ~1%     {5} r14 = SCAN r13 OUTPUT r13.<6>, r13.<0>, r13.<1>, r13.<2>, r13.<4>
13876   ~0%     {5} r15 = JOIN r14 WITH DataFlowPublic::TCfgNode#ff AS R ON FIRST 1 OUTPUT r14.<4>, r14.<1>, r14.<2>, r14.<3>, R.<1>
129454  ~3%     {5} r16 = r7 \/ r15
2       ~0%     {2} r17 = JOIN m#DataFlowPrivate::ArgumentPassing::getArg#fbfff AS L WITH DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS R ON FIRST 1 OUTPUT L.<0>, -1
2390    ~0%     {3} r18 = JOIN r17 WITH project#AstGenerated::Function_::getVararg_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r17.<0>, -1
2452    ~6%     {3} r19 = JOIN r18 WITH ObjectAPI::CallableValue::getScope_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r18.<1>, -1
1696    ~5%     {5} r20 = JOIN r19 WITH DataFlowPublic::TPosOverflowNode#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r19.<0>, r19.<1>, -1, R.<2>
1696    ~0%     {5} r21 = JOIN r20 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r20.<0>, r20.<2>, r20.<1>, -1, r20.<4>
131150  ~3%     {5} r22 = r16 \/ r21
2       ~0%     {2} r23 = JOIN m#DataFlowPrivate::ArgumentPassing::getArg#fbfff AS L WITH DataFlowPrivate::ArgumentPassing::ArgParamMapping#class#f AS R ON FIRST 1 OUTPUT L.<0>, -2
2770    ~1%     {3} r24 = JOIN r23 WITH project#AstGenerated::Function_::getKwarg_dispred#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r23.<0>, -2
2832    ~0%     {3} r25 = JOIN r24 WITH ObjectAPI::CallableValue::getScope_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r24.<1>, -2
6720    ~0%     {5} r26 = JOIN r25 WITH DataFlowPublic::TKwOverflowNode#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r25.<0>, r25.<1>, -2, R.<2>
6720    ~0%     {5} r27 = JOIN r26 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r26.<0>, r26.<2>, r26.<1>, -2, r26.<4>
137870  ~1%     {5} r28 = r22 \/ r27
1179    ~0%     {5} r29 = JOIN r1 WITH DataFlowPrivate::ArgumentPassing::call_unpacks#fffff_10234#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, R.<2>, r1.<0>, R.<3>, R.<4>
1179    ~2%     {5} r30 = JOIN r29 WITH DataFlowPrivate::ArgumentPassing::connects#ff AS R ON FIRST 2 OUTPUT r29.<0>, r29.<1>, r29.<3>, r29.<2>, r29.<4>
1179    ~4%     {5} r31 = JOIN r30 WITH DataFlowPublic::TKwUnpacked#ffff AS R ON FIRST 3 OUTPUT r30.<0>, r30.<3>, r30.<1>, r30.<4>, R.<3>
139049  ~1%     {5} r32 = r28 \/ r31
                return r32
```