### PR TITLE
C++: Harden queries against ErroneousType

### DIFF
--- a/cpp/change-notes/2020-10-21-erroneous-types.md
+++ b/cpp/change-notes/2020-10-21-erroneous-types.md
@@ -1,0 +1,2 @@
+lgtm,codescanning
+* The `cpp/wrong-type-format-argument` and `cpp/non-portable-printf` queries have been hardened so that they do not produce nonsensical results on databases that contain errors (specifically the `ErroneousType`).

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -155,7 +155,8 @@ where
     not actual.getUnspecifiedType().(IntegralType).getSize() = sizeof_IntType()
   ) and
   not arg.isAffectedByMacro() and
-  not arg.isFromUninstantiatedTemplate(_)
+  not arg.isFromUninstantiatedTemplate(_) and
+  not actual.getUnspecifiedType() instanceof ErroneousType
 select arg,
   "This argument should be of type '" + expected.getName() + "' but is of type '" +
     actual.getUnspecifiedType().getName() + "'"

--- a/cpp/ql/src/Likely Bugs/Memory Management/Padding/NonPortablePrintf.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/Padding/NonPortablePrintf.ql
@@ -88,7 +88,8 @@ where
   not arg.isAffectedByMacro() and
   size32 = ilp32.paddedSize(actual) and
   size64 = lp64.paddedSize(actual) and
-  size64 != size32
+  size64 != size32 and
+  not actual instanceof ErroneousType
 select arg,
   "This argument should be of type '" + expected.getName() + "' but is of type '" + actual.getName()
     + "' (which changes size from " + size32 + " to " + size64 + " on 64-bit systems)."


### PR DESCRIPTION
The `cpp/wrong-type-format-argument` and `cpp/non-portable-printf` queries were producing strange results such as:
```
This argument should be of type 'int' but is of type 'error'
```
These result from expressions with the `ErroneousType`, which are themselves the result of errors during extraction.

---

See also https://github.com/github/codeql/issues/4505, where the underlying issue could be C++17 support (@igfoo), as we see these `CompilerError`s:
```
namespace 'std' has no member 'optional'
namespace 'std' has no member 'nullopt'
namespace 'std' has no member 'gcd'
```

---

Also seen by @elopezacosta in a C snapshot containing:
```
    char *foo = bar(input);
    for (int i = 0; i <= strlen(input) - 1; i++) {
      printf("%c", foo[i]); // This argument should have type 'char' but has the type 'error'
    }
```
(but I haven't investigated that case)
