### PR TITLE
C++: Extend jump-to-def support to template instantiations.

### DIFF
--- a/cpp/ql/src/definitions.ql
+++ b/cpp/ql/src/definitions.ql
@@ -9,5 +9,5 @@
 import definitions
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind)
+where def = definitionOf(e, kind, false)
 select e, def, kind

--- a/cpp/ql/src/definitions.ql
+++ b/cpp/ql/src/definitions.ql
@@ -9,5 +9,7 @@
 import definitions
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind, false)
+where
+  def = definitionOf(e, kind) and
+  not e.isFromTemplateInstantiation(_)
 select e, def, kind

--- a/cpp/ql/src/definitions.ql
+++ b/cpp/ql/src/definitions.ql
@@ -1,7 +1,7 @@
 /**
  * @name Jump-to-definition links
  * @description Generates use-definition pairs that provide the data
- *              for jump-to-definition in the code viewer.
+ *              for jump-to-definition in the code viewer of LGTM.
  * @kind definitions
  * @id cpp/jump-to-definition
  */

--- a/cpp/ql/src/definitions.ql
+++ b/cpp/ql/src/definitions.ql
@@ -11,5 +11,8 @@ import definitions
 from Top e, Top def, string kind
 where
   def = definitionOf(e, kind) and
+  // We need to exclude definitions for elements inside template instantiations,
+  // as these often lead to multiple links to definitions from the same source location.
+  // LGTM does not support this bevaviour.
   not e.isFromTemplateInstantiation(_)
 select e, def, kind

--- a/cpp/ql/src/definitions.qll
+++ b/cpp/ql/src/definitions.qll
@@ -77,9 +77,9 @@ predicate hasLocationInfo_Include(Include i, string path, int sl, int sc, int el
 
 /** Holds if `e` is a source or a target of jump-to-definition. */
 predicate interestingElement(Element e) {
-  exists(definitionOf(e, _, true))
+  exists(definitionOf(e, _))
   or
-  e = definitionOf(_, _, true)
+  e = definitionOf(_, _)
 }
 
 /**
@@ -124,10 +124,7 @@ private predicate constructorCallTypeMention(ConstructorCall cc, TypeMention tm)
 
 /**
  * Gets an element, of kind `kind`, that element `e` uses, if any.
- * If `includeTemplateInstantiations` is set, include information for
- * elements `e` that are inside of template instantiations.
- * Doing so yields multiple definitions for a single location, which can be
- * undesirably. For example, lgtm.com does not support that.
+ * Attention: This predicate yields multiple definitions for a single location.
  *
  * The `kind` is a string representing what kind of use it is:
  *  - `"M"` for function and method calls
@@ -137,7 +134,7 @@ private predicate constructorCallTypeMention(ConstructorCall cc, TypeMention tm)
  *  - `"I"` for import / include directives
  */
 cached
-Top definitionOf(Top e, string kind, boolean includeTemplateInstantiations) {
+Top definitionOf(Top e, string kind) {
   (
     // call -> function called
     kind = "M" and
@@ -200,13 +197,7 @@ Top definitionOf(Top e, string kind, boolean includeTemplateInstantiations) {
     not e.(Element).isInMacroExpansion() and
     // exclude nested macro invocations, as they will overlap with
     // the top macro invocation.
-    not exists(e.(MacroAccess).getParentInvocation()) and
-    (
-      includeTemplateInstantiations = true
-      or
-      includeTemplateInstantiations = false and
-      not e.isFromTemplateInstantiation(_)
-    )
+    not exists(e.(MacroAccess).getParentInvocation())
   ) and
   // Some entities have many locations. This can arise for an external
   // function that is frequently declared but not defined, or perhaps

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -13,4 +13,4 @@ external string selectedSourceFile();
 
 from Top e, Top def, string kind
 where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
-select e.getLocation(), def.getLocation(), kind
+select e, def, kind

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -1,7 +1,7 @@
 /**
  * @name Jump-to-definition links
  * @description Generates use-definition pairs that provide the data
- *              for jump-to-definition in the code viewer.
+ *              for jump-to-definition in the code viewer of VSCode.
  * @kind definitions
  * @id cpp/ide-jump-to-definition
  * @tags ide-contextual-queries/local-definitions
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind, true) and e.getFile() = getEncodedFile(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/localDefinitions.ql
+++ b/cpp/ql/src/localDefinitions.ql
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind, true) and e.getFile() = getEncodedFile(selectedSourceFile())
-select e, def, kind
+where def = definitionOf(e, kind) and e.getFile() = getEncodedFile(selectedSourceFile())
+select e.getLocation(), def.getLocation(), kind

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind, true) and def.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/src/localReferences.ql
+++ b/cpp/ql/src/localReferences.ql
@@ -1,7 +1,7 @@
 /**
  * @name Find-references links
  * @description Generates use-definition pairs that provide the data
- *              for find-references in the code viewer.
+ *              for find-references in the code viewer of VSCode.
  * @kind definitions
  * @id cpp/ide-find-references
  * @tags ide-contextual-queries/local-references
@@ -12,5 +12,5 @@ import definitions
 external string selectedSourceFile();
 
 from Top e, Top def, string kind
-where def = definitionOf(e, kind) and def.getFile() = getEncodedFile(selectedSourceFile())
+where def = definitionOf(e, kind, true) and def.getFile() = getEncodedFile(selectedSourceFile())
 select e, def, kind

--- a/cpp/ql/test/query-tests/definitions/locationInfo.ql
+++ b/cpp/ql/test/query-tests/definitions/locationInfo.ql
@@ -4,7 +4,7 @@ import definitions
  * An element that is the source of a jump-to-definition link.
  */
 class Link extends Top {
-  Link() { exists(definitionOf(this, _, false)) }
+  Link() { exists(definitionOf(this, _)) }
 }
 
 /**
@@ -31,7 +31,7 @@ predicate linkLocationInfo(Link e, string filepath, int begin, int end) {
  * Gets a string describing a problem with a `Link`.
  */
 string issues(Link e) {
-  strictcount(Top def | def = definitionOf(e, _, false)) > 1 and
+  strictcount(Top def | def = definitionOf(e, _)) > 1 and
   result = "has more than one definition"
   or
   exists(string filepath1, int begin1, int end1, Link e2, string filepath2, int begin2, int end2 |
@@ -40,7 +40,9 @@ string issues(Link e) {
     filepath1 = filepath2 and
     not end1 < begin2 and
     not begin1 > end2 and
-    e != e2
+    e != e2 and
+    not e.isFromTemplateInstantiation(_) and
+    not e2.isFromTemplateInstantiation(_)
   ) and
   result = "overlaps another link"
 }

--- a/cpp/ql/test/query-tests/definitions/locationInfo.ql
+++ b/cpp/ql/test/query-tests/definitions/locationInfo.ql
@@ -4,7 +4,7 @@ import definitions
  * An element that is the source of a jump-to-definition link.
  */
 class Link extends Top {
-  Link() { exists(definitionOf(this, _)) }
+  Link() { exists(definitionOf(this, _, false)) }
 }
 
 /**
@@ -31,7 +31,7 @@ predicate linkLocationInfo(Link e, string filepath, int begin, int end) {
  * Gets a string describing a problem with a `Link`.
  */
 string issues(Link e) {
-  strictcount(Top def | def = definitionOf(e, _)) > 1 and
+  strictcount(Top def | def = definitionOf(e, _, false)) > 1 and
   result = "has more than one definition"
   or
   exists(string filepath1, int begin1, int end1, Link e2, string filepath2, int begin2, int end2 |


### PR DESCRIPTION
This PR extends developers ability to use jump-to-def in C/C++ files opened in the VSCode extension.
Before, jump-to-def we did not display definitions for code in template instantiations.

Furthermore, this PR fixes a bug, as the list of all references to a location did not include references inside template instantiations.

### Details ###
As part of the PR, this old comment is removed:
```
    // exclude results from template instantiations, as:
    // (1) these dependencies will often be caused by a choice of
    // template parameter, which is non-local to this part of code; and
    // (2) overlapping results pointing to different locations will
    // be very common.
    // It's possible we could allow a subset of these dependencies
    // in future, if we're careful to ensure the above don't apply.
```
Unfortunately, due to a limited history in the git repo, it is not clear when that comment was introduced.
* re (1): Non-locality is kinda the point of jump-to-def queries, so that should not be an issue.
* re (2): That is an issue on LGTM.com, VSCode has first-class support for a location having multiple definitions.

In the extension, the multiple definitions show up in a popup like this:
![2020-10-21-164446_751x334_scrot](https://user-images.githubusercontent.com/70492/96774469-4ff82380-13e6-11eb-99bb-4455774e9b0c.png)


### Questions from my side ###

* I need guidance on how to write test for these changes, as the interplay of the query and VSCode cannot be easily tested.
  So far, the one existing test has been adapted to test the old (LGTM.com) behaviour.

* Does this PR need some documentation/changelog entry?
  If yes, where?
  The change is user-visible, but only using the vscode extension and does not happen with a vscode extension release.
* I added a bit more context information to the top-level queries in ql/cpp/src, somebody needs to verify that it is correct/ the only places we use these queries indeed is VSCode or lgtm.com.

CC @github/codeql-core because the PR contains changes visible to VSCode extension users
