### PR TITLE
C++: Add taint test for memcpy-ing into a vector

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7038,24 +7038,52 @@
 | vector.cpp:399:33:399:35 | i11 [post update] | vector.cpp:400:7:400:9 | v11 |  |
 | vector.cpp:399:33:399:35 | i11 [post update] | vector.cpp:401:1:401:1 | v11 |  |
 | vector.cpp:400:7:400:9 | ref arg v11 | vector.cpp:401:1:401:1 | v11 |  |
-| vector.cpp:407:21:407:24 | call to vector | vector.cpp:411:7:411:7 | v |  |
-| vector.cpp:407:21:407:24 | call to vector | vector.cpp:412:10:412:10 | v |  |
-| vector.cpp:407:21:407:24 | call to vector | vector.cpp:413:7:413:7 | v |  |
-| vector.cpp:407:21:407:24 | call to vector | vector.cpp:414:1:414:1 | v |  |
-| vector.cpp:408:10:408:15 | call to source | vector.cpp:412:17:412:17 | s |  |
-| vector.cpp:409:9:409:10 | 0 | vector.cpp:412:12:412:12 | i |  |
-| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:412:10:412:10 | v |  |
-| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:413:7:413:7 | v |  |
-| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:414:1:414:1 | v |  |
-| vector.cpp:412:9:412:13 | & ... | vector.cpp:412:2:412:7 | call to memcpy |  |
-| vector.cpp:412:9:412:13 | ref arg & ... | vector.cpp:412:11:412:11 | call to operator[] [inner post update] |  |
-| vector.cpp:412:10:412:10 | ref arg v | vector.cpp:413:7:413:7 | v |  |
-| vector.cpp:412:10:412:10 | ref arg v | vector.cpp:414:1:414:1 | v |  |
-| vector.cpp:412:10:412:10 | v | vector.cpp:412:11:412:11 | call to operator[] | TAINT |
-| vector.cpp:412:11:412:11 | call to operator[] | vector.cpp:412:9:412:13 | & ... |  |
-| vector.cpp:412:11:412:11 | call to operator[] [inner post update] | vector.cpp:412:10:412:10 | ref arg v | TAINT |
-| vector.cpp:412:16:412:17 | & ... | vector.cpp:412:2:412:7 | call to memcpy | TAINT |
-| vector.cpp:412:16:412:17 | & ... | vector.cpp:412:9:412:13 | ref arg & ... | TAINT |
-| vector.cpp:412:17:412:17 | s | vector.cpp:412:9:412:13 | ref arg & ... |  |
-| vector.cpp:412:17:412:17 | s | vector.cpp:412:16:412:17 | & ... |  |
-| vector.cpp:413:7:413:7 | ref arg v | vector.cpp:414:1:414:1 | v |  |
+| vector.cpp:416:22:416:25 | call to vector | vector.cpp:420:8:420:8 | v |  |
+| vector.cpp:416:22:416:25 | call to vector | vector.cpp:421:11:421:11 | v |  |
+| vector.cpp:416:22:416:25 | call to vector | vector.cpp:422:8:422:8 | v |  |
+| vector.cpp:416:22:416:25 | call to vector | vector.cpp:423:2:423:2 | v |  |
+| vector.cpp:417:11:417:16 | call to source | vector.cpp:421:18:421:18 | s |  |
+| vector.cpp:418:10:418:11 | 0 | vector.cpp:421:13:421:13 | i |  |
+| vector.cpp:420:8:420:8 | ref arg v | vector.cpp:421:11:421:11 | v |  |
+| vector.cpp:420:8:420:8 | ref arg v | vector.cpp:422:8:422:8 | v |  |
+| vector.cpp:420:8:420:8 | ref arg v | vector.cpp:423:2:423:2 | v |  |
+| vector.cpp:421:10:421:14 | & ... | vector.cpp:421:3:421:8 | call to memcpy |  |
+| vector.cpp:421:10:421:14 | ref arg & ... | vector.cpp:421:12:421:12 | call to operator[] [inner post update] |  |
+| vector.cpp:421:11:421:11 | ref arg v | vector.cpp:422:8:422:8 | v |  |
+| vector.cpp:421:11:421:11 | ref arg v | vector.cpp:423:2:423:2 | v |  |
+| vector.cpp:421:11:421:11 | v | vector.cpp:421:12:421:12 | call to operator[] | TAINT |
+| vector.cpp:421:12:421:12 | call to operator[] | vector.cpp:421:10:421:14 | & ... |  |
+| vector.cpp:421:12:421:12 | call to operator[] [inner post update] | vector.cpp:421:11:421:11 | ref arg v | TAINT |
+| vector.cpp:421:17:421:18 | & ... | vector.cpp:421:3:421:8 | call to memcpy | TAINT |
+| vector.cpp:421:17:421:18 | & ... | vector.cpp:421:10:421:14 | ref arg & ... | TAINT |
+| vector.cpp:421:18:421:18 | s | vector.cpp:421:10:421:14 | ref arg & ... |  |
+| vector.cpp:421:18:421:18 | s | vector.cpp:421:17:421:18 | & ... |  |
+| vector.cpp:422:8:422:8 | ref arg v | vector.cpp:423:2:423:2 | v |  |
+| vector.cpp:426:24:426:27 | call to vector | vector.cpp:432:8:432:9 | cs |  |
+| vector.cpp:426:24:426:27 | call to vector | vector.cpp:433:11:433:12 | cs |  |
+| vector.cpp:426:24:426:27 | call to vector | vector.cpp:435:8:435:9 | cs |  |
+| vector.cpp:426:24:426:27 | call to vector | vector.cpp:436:2:436:2 | cs |  |
+| vector.cpp:427:21:427:37 | call to source | vector.cpp:429:22:429:24 | src |  |
+| vector.cpp:427:21:427:37 | call to source | vector.cpp:431:8:431:10 | src |  |
+| vector.cpp:427:21:427:37 | call to source | vector.cpp:433:25:433:27 | src |  |
+| vector.cpp:427:21:427:37 | call to source | vector.cpp:434:8:434:10 | src |  |
+| vector.cpp:428:23:428:24 | 10 | vector.cpp:433:14:433:17 | offs |  |
+| vector.cpp:429:26:429:31 | call to length | vector.cpp:433:38:433:40 | len |  |
+| vector.cpp:431:8:431:10 | ref arg src | vector.cpp:433:25:433:27 | src |  |
+| vector.cpp:431:8:431:10 | ref arg src | vector.cpp:434:8:434:10 | src |  |
+| vector.cpp:432:8:432:9 | ref arg cs | vector.cpp:433:11:433:12 | cs |  |
+| vector.cpp:432:8:432:9 | ref arg cs | vector.cpp:435:8:435:9 | cs |  |
+| vector.cpp:432:8:432:9 | ref arg cs | vector.cpp:436:2:436:2 | cs |  |
+| vector.cpp:433:10:433:22 | & ... | vector.cpp:433:3:433:8 | call to memcpy |  |
+| vector.cpp:433:10:433:22 | ref arg & ... | vector.cpp:433:13:433:13 | call to operator[] [inner post update] |  |
+| vector.cpp:433:11:433:12 | cs | vector.cpp:433:13:433:13 | call to operator[] | TAINT |
+| vector.cpp:433:11:433:12 | ref arg cs | vector.cpp:435:8:435:9 | cs |  |
+| vector.cpp:433:11:433:12 | ref arg cs | vector.cpp:436:2:436:2 | cs |  |
+| vector.cpp:433:13:433:13 | call to operator[] | vector.cpp:433:10:433:22 | & ... |  |
+| vector.cpp:433:13:433:13 | call to operator[] [inner post update] | vector.cpp:433:11:433:12 | ref arg cs | TAINT |
+| vector.cpp:433:14:433:17 | offs | vector.cpp:433:14:433:21 | ... + ... | TAINT |
+| vector.cpp:433:21:433:21 | 1 | vector.cpp:433:14:433:21 | ... + ... | TAINT |
+| vector.cpp:433:25:433:27 | src | vector.cpp:433:29:433:33 | call to c_str | TAINT |
+| vector.cpp:433:29:433:33 | call to c_str | vector.cpp:433:3:433:8 | call to memcpy | TAINT |
+| vector.cpp:433:29:433:33 | call to c_str | vector.cpp:433:10:433:22 | ref arg & ... | TAINT |
+| vector.cpp:435:8:435:9 | ref arg cs | vector.cpp:436:2:436:2 | cs |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -7038,3 +7038,24 @@
 | vector.cpp:399:33:399:35 | i11 [post update] | vector.cpp:400:7:400:9 | v11 |  |
 | vector.cpp:399:33:399:35 | i11 [post update] | vector.cpp:401:1:401:1 | v11 |  |
 | vector.cpp:400:7:400:9 | ref arg v11 | vector.cpp:401:1:401:1 | v11 |  |
+| vector.cpp:407:21:407:24 | call to vector | vector.cpp:411:7:411:7 | v |  |
+| vector.cpp:407:21:407:24 | call to vector | vector.cpp:412:10:412:10 | v |  |
+| vector.cpp:407:21:407:24 | call to vector | vector.cpp:413:7:413:7 | v |  |
+| vector.cpp:407:21:407:24 | call to vector | vector.cpp:414:1:414:1 | v |  |
+| vector.cpp:408:10:408:15 | call to source | vector.cpp:412:17:412:17 | s |  |
+| vector.cpp:409:9:409:10 | 0 | vector.cpp:412:12:412:12 | i |  |
+| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:412:10:412:10 | v |  |
+| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:413:7:413:7 | v |  |
+| vector.cpp:411:7:411:7 | ref arg v | vector.cpp:414:1:414:1 | v |  |
+| vector.cpp:412:9:412:13 | & ... | vector.cpp:412:2:412:7 | call to memcpy |  |
+| vector.cpp:412:9:412:13 | ref arg & ... | vector.cpp:412:11:412:11 | call to operator[] [inner post update] |  |
+| vector.cpp:412:10:412:10 | ref arg v | vector.cpp:413:7:413:7 | v |  |
+| vector.cpp:412:10:412:10 | ref arg v | vector.cpp:414:1:414:1 | v |  |
+| vector.cpp:412:10:412:10 | v | vector.cpp:412:11:412:11 | call to operator[] | TAINT |
+| vector.cpp:412:11:412:11 | call to operator[] | vector.cpp:412:9:412:13 | & ... |  |
+| vector.cpp:412:11:412:11 | call to operator[] [inner post update] | vector.cpp:412:10:412:10 | ref arg v | TAINT |
+| vector.cpp:412:16:412:17 | & ... | vector.cpp:412:2:412:7 | call to memcpy | TAINT |
+| vector.cpp:412:16:412:17 | & ... | vector.cpp:412:9:412:13 | ref arg & ... | TAINT |
+| vector.cpp:412:17:412:17 | s | vector.cpp:412:9:412:13 | ref arg & ... |  |
+| vector.cpp:412:17:412:17 | s | vector.cpp:412:16:412:17 | & ... |  |
+| vector.cpp:413:7:413:7 | ref arg v | vector.cpp:414:1:414:1 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -192,7 +192,7 @@ void *memcpy(void *dest, void *src, int len);
 void test_memcpy(int *source) {
 	int x;
 	memcpy(&x, source, sizeof(int));
-	sink(x);
+	sink(x); // tainted
 }
 
 // --- std::swap ---

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -653,3 +653,4 @@
 | vector.cpp:392:7:392:8 | v9 | vector.cpp:330:10:330:15 | call to source |
 | vector.cpp:392:7:392:8 | v9 | vector.cpp:389:8:389:13 | call to source |
 | vector.cpp:400:7:400:9 | v11 | vector.cpp:399:38:399:43 | call to source |
+| vector.cpp:413:7:413:7 | v | vector.cpp:408:10:408:15 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -653,4 +653,7 @@
 | vector.cpp:392:7:392:8 | v9 | vector.cpp:330:10:330:15 | call to source |
 | vector.cpp:392:7:392:8 | v9 | vector.cpp:389:8:389:13 | call to source |
 | vector.cpp:400:7:400:9 | v11 | vector.cpp:399:38:399:43 | call to source |
-| vector.cpp:413:7:413:7 | v | vector.cpp:408:10:408:15 | call to source |
+| vector.cpp:422:8:422:8 | v | vector.cpp:417:11:417:16 | call to source |
+| vector.cpp:431:8:431:10 | src | vector.cpp:427:21:427:37 | call to source |
+| vector.cpp:434:8:434:10 | src | vector.cpp:427:21:427:37 | call to source |
+| vector.cpp:435:8:435:9 | cs | vector.cpp:427:21:427:37 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -379,3 +379,4 @@
 | vector.cpp:392:7:392:8 | vector.cpp:330:10:330:15 | AST only |
 | vector.cpp:392:7:392:8 | vector.cpp:389:8:389:13 | AST only |
 | vector.cpp:400:7:400:9 | vector.cpp:399:38:399:43 | AST only |
+| vector.cpp:413:7:413:7 | vector.cpp:408:10:408:15 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -379,4 +379,5 @@
 | vector.cpp:392:7:392:8 | vector.cpp:330:10:330:15 | AST only |
 | vector.cpp:392:7:392:8 | vector.cpp:389:8:389:13 | AST only |
 | vector.cpp:400:7:400:9 | vector.cpp:399:38:399:43 | AST only |
-| vector.cpp:413:7:413:7 | vector.cpp:408:10:408:15 | AST only |
+| vector.cpp:422:8:422:8 | vector.cpp:417:11:417:16 | AST only |
+| vector.cpp:435:8:435:9 | vector.cpp:427:21:427:37 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -416,3 +416,5 @@
 | vector.cpp:312:7:312:7 | Argument 0 indirection | vector.cpp:303:14:303:19 | call to source |
 | vector.cpp:324:7:324:8 | Argument 0 indirection | vector.cpp:318:15:318:20 | call to source |
 | vector.cpp:326:7:326:8 | Argument 0 indirection | vector.cpp:318:15:318:20 | call to source |
+| vector.cpp:431:8:431:10 | Argument 0 indirection | vector.cpp:427:21:427:37 | call to source |
+| vector.cpp:434:8:434:10 | Argument 0 indirection | vector.cpp:427:21:427:37 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -402,13 +402,36 @@ void test_vector_output_iterator(int b) {
 
 void *memcpy(void *s1, const void *s2, size_t n);
 
+namespace ns_string
+{
+	std::string source();
+}
+
+void sink(std::vector<char> &);
+void sink(std::string &);
+
 void test_vector_memcpy()
 {
-	std::vector<int> v(100);
-	int s = source();
-	int i = 0;
+	{
+		std::vector<int> v(100);
+		int s = source();
+		int i = 0;
 
-	sink(v);
-	memcpy(&v[i], &s, sizeof(int));
-	sink(v); // tainted [NOT DETECTED by IR]
+		sink(v);
+		memcpy(&v[i], &s, sizeof(int));
+		sink(v); // tainted [NOT DETECTED by IR]
+	}
+
+	{
+		std::vector<char> cs(100);
+		std::string src = ns_string::source();
+		const size_t offs = 10;
+		const size_t len = src.length();
+
+		sink(src); // tainted
+		sink(cs);
+		memcpy(&cs[offs + 1], src.c_str(), len);
+		sink(src); // tainted
+		sink(cs); // tainted [NOT DETECTED by IR]
+	}
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -399,3 +399,16 @@ void test_vector_output_iterator(int b) {
 	vector_iterator_assign_wrapper(i11, source());
 	sink(v11); // tainted [NOT DETECTED by IR]
 }
+
+void *memcpy(void *s1, const void *s2, size_t n);
+
+void test_vector_memcpy()
+{
+	std::vector<int> v(100);
+	int s = source();
+	int i = 0;
+
+	sink(v);
+	memcpy(&v[i], &s, sizeof(int));
+	sink(v); // tainted [NOT DETECTED by IR]
+}


### PR DESCRIPTION
Taint test for a case involving `memcpy` and `std::vector` together.