### PR TITLE
C++: Improve PrintAST performance if only individual files are printed

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Print.qll
+++ b/cpp/ql/src/semmle/code/cpp/Print.qll
@@ -1,4 +1,17 @@
 import cpp
+private import PrintAST
+
+/**
+ * Print function declarations only if there is a `PrintASTConfiguration`
+ * that requests that function, or no `PrintASTConfiguration` exists.
+ */
+private predicate shouldPrintDeclaration(Declaration decl) {
+  not decl instanceof Function
+  or
+  not exists(PrintASTConfiguration c)
+  or
+  exists(PrintASTConfiguration config | config.shouldPrintFunction(decl))
+}
 
 /**
  * Gets a string containing the scope in which this declaration is declared.
@@ -48,6 +61,8 @@ private string getTemplateArgumentString(Declaration d, int i) {
  * A `Declaration` extended to add methods for generating strings useful only for dumps and debugging.
  */
 abstract private class DumpDeclaration extends Declaration {
+  DumpDeclaration() { shouldPrintDeclaration(this) }
+
   /**
    * Gets a string that uniquely identifies this declaration, suitable for use when debugging queries. Only holds for
    * functions, user-defined types, global and namespace-scope variables, and member variables.


### PR DESCRIPTION
This improves the performance of the printAst.ql query by excluding a lot of string concatenations that happen in files unrelated to the one the user is interested in printing.

This helps the performance of the VSCode AST Viewer on bigger databases.

The performance is not optimal yet, as I did not find a good way to exclude Types that are not relevant to the file at hand.
So we still spend substantial time concatenating strings in `Print::DumpType::getTypeIdentityString()`.
However, there's usually more functions than types in a program, so this PR provides a significant improvement in usability.
