### PR TITLE
JS: Add support for importing files compiled into outDir from tsconfig.json

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeJS.qll
+++ b/javascript/ql/src/semmle/javascript/NodeJS.qll
@@ -235,6 +235,9 @@ class Require extends CallExpr, Import {
 
   override Module resolveImportedPath() {
     moduleInFile(result, load(min(int prio | moduleInFile(_, load(prio)))))
+    or
+    not exists(Module mod | moduleInFile(mod, load(_))) and
+    result = Import.super.resolveImportedPath()
   }
 
   /**

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/index.js
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/index.js
@@ -1,0 +1,4 @@
+var foo1 = require('./lib/src/foo.js');
+var foo1 = require('./lib/src2/foo.js');
+var foo2 = require('./src/foo.ts');
+var foo2 = require('./src2/foo.ts');

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/src/foo.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/src/foo.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/src2/foo.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/src2/foo.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/nonUniqueInclude/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": [
+        "src/**/*.ts",
+        "src2/**/*.ts"
+    ]
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/options
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --include **/tsconfig.json

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/index.js
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/index.js
@@ -1,0 +1,2 @@
+var foo1 = require('./lib/index.js');
+var foo2 = require('./src/index.ts');

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/src/index.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/src/index.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDir/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "src"
+    },
+    "include": [
+        "**/*.ts"
+    ]
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/foo.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/foo.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/index.js
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/index.js
@@ -1,0 +1,2 @@
+var foo1 = require('./lib/foo.js');
+var foo2 = require('./foo.ts');

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/rootDirIsDot/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "outDir": "lib",
+        "rootDir": "."
+    },
+    "include": [
+        "**/*.ts"
+    ]
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/index.js
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/index.js
@@ -1,0 +1,5 @@
+var foo1 = require('./lib/index.js');
+var foo2 = require('./src/index.ts');
+
+var foo3 = require('./lib/index');
+var foo4 = require('./src/index');

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/src/index.ts
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/src/index.ts
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/simpleOutDir/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "outDir": "lib"
+    },
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.expected
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.expected
@@ -1,0 +1,12 @@
+| nonUniqueInclude/index.js:1:12:1:38 | require ... oo.js') | nonUniqueInclude/src/foo.ts:1:1:1:27 | <toplevel> |
+| nonUniqueInclude/index.js:2:12:2:39 | require ... oo.js') | nonUniqueInclude/src2/foo.ts:1:1:1:27 | <toplevel> |
+| nonUniqueInclude/index.js:3:12:3:34 | require ... oo.ts') | nonUniqueInclude/src/foo.ts:1:1:1:27 | <toplevel> |
+| nonUniqueInclude/index.js:4:12:4:35 | require ... oo.ts') | nonUniqueInclude/src2/foo.ts:1:1:1:27 | <toplevel> |
+| rootDir/index.js:1:12:1:36 | require ... ex.js') | rootDir/src/index.ts:1:1:1:27 | <toplevel> |
+| rootDir/index.js:2:12:2:36 | require ... ex.ts') | rootDir/src/index.ts:1:1:1:27 | <toplevel> |
+| rootDirIsDot/index.js:1:12:1:34 | require ... oo.js') | rootDirIsDot/foo.ts:1:1:1:27 | <toplevel> |
+| rootDirIsDot/index.js:2:12:2:30 | require('./foo.ts') | rootDirIsDot/foo.ts:1:1:1:27 | <toplevel> |
+| simpleOutDir/index.js:1:12:1:36 | require ... ex.js') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
+| simpleOutDir/index.js:2:12:2:36 | require ... ex.ts') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
+| simpleOutDir/index.js:4:12:4:33 | require ... index') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |
+| simpleOutDir/index.js:5:12:5:33 | require ... index') | simpleOutDir/src/index.ts:1:1:1:27 | <toplevel> |

--- a/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.ql
+++ b/javascript/ql/test/library-tests/TypeScript/ImportOutDir/tests.ql
@@ -1,0 +1,7 @@
+import javascript
+
+query predicate resolveableImport(Import imp, Module mod) {
+  mod = imp.getImportedModule() and
+  not imp.getTopLevel().isExterns() and
+  not mod.getTopLevel().isExterns()
+}


### PR DESCRIPTION
Gets a TP/TN for CVE-2019-10778

I originally made this as part of [the `js/shell-command-constructed-from-input` query](https://github.com/github/codeql/pull/3447).  
But back then an evaluation came back with mixed results, so I shelved the implementation.  

I dug the implementation up again, refactored it a bit, and added support for `rootDir`. 

[Performance looks fine now](https://docs.google.com/spreadsheets/d/1MmXOJEhHInGBlgXWqXy0-pYXzQS-ab6fCoxHtOr8fdU/edit#gid=0).   