### PR TITLE
C#: Fix bad join-order in `System.Tuple` flow-summaries

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/LibraryTypeDataFlow.qll
@@ -1663,9 +1663,14 @@ class SystemTupleFlow extends LibraryTypeDataFlow, ValueOrRefType {
   }
 
   private AccessPath getItemAccessPath(int i) {
-    i in [1 .. count(this.getAMember())] and
-    result in [AccessPath::field(this.getField("Item" + i)),
-          AccessPath::property(this.getProperty("Item" + i))]
+    result =
+      unique(AccessPath ap |
+        i in [1 .. count(this.getAMember())] and
+        ap in [AccessPath::field(this.getField("Item" + i)),
+              AccessPath::property(this.getProperty("Item" + i))]
+      |
+        ap
+      )
   }
 
   override predicate callableFlow(


### PR DESCRIPTION
The nightly performance run revealed a performance regression introduced by https://github.com/github/codeql/pull/4416. Here is a fix.