### PR TITLE
JS: add model for Node Redis

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -792,7 +792,7 @@ private module Redis {
      * Thereby the method is vulnerable if parameter `argIndex` is unexpectedly an array instead of a string, as an attacker can control arguments to Redis that the attacker was not supposed to control.
      *
      * Only setters and similar methods are included.
-     * For getter like methods it is not generally possible to gain access "outside" of where you are supposed to have access,
+     * For getter-like methods it is not generally possible to gain access "outside" of where you are supposed to have access,
      * it is at most possible to get a Redis call to return more results than expected (e.g. by adding more members to [`geohash`](https://redis.io/commands/geohash)).
      */
     bindingset[argIndex]

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -816,17 +816,19 @@ private module Redis {
       exists(string method, int argIndex |
         QuerySignatures::argumentIsAmbiguousKey(method, argIndex)
       |
-        this = promisify(redis().getMember(method)).getACall().getArgument(argIndex).asExpr()
+        this =
+          [promisify(redis().getMember(method)), redis().getMember(method)]
+              .getACall()
+              .getArgument(argIndex)
+              .asExpr()
       )
     }
   }
 
   /**
-   * Gets a possibly promisified version of `method`.
+   * Gets a promisified version of `method`.
    */
   private API::Node promisify(API::Node method) {
-    result = method
-    or
     exists(API::Node promisify |
       promisify = API::moduleImport(["util", "bluebird"]).getMember("promisify").getReturn() and
       method

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -737,3 +737,106 @@ private module MarsDB {
     override DataFlow::Node getACodeOperator() { result = qc.getACodeOperator() }
   }
 }
+
+/**
+ * Provides classes modeling the `Node Redis` library.
+ *
+ * Redis is an in-memory key-value store and not a database,
+ * but `Node Redis` can be exploited similarly to a NoSQL database by giving a method an array as argument instead of a string.
+ * As an example the below two invocations of `client.set` are equivalent:
+ *
+ * ```
+ * const redis = require("redis");
+ * const client = redis.createClient();
+ * client.set("key", "value");
+ * client.set(["key", "value"]);
+ * ```
+ *
+ * ioredis is a very similar library. However, ioredis does not support array arguments in the same way, and is therefore not vulnerable to the same kind of type confusion.
+ */
+private module Redis {
+  /**
+   * Gets a `Node Redis` client.
+   */
+  private API::Node client() {
+    result = API::moduleImport("redis").getMember("createClient").getReturn()
+    or
+    result = API::moduleImport("redis").getMember("RedisClient").getInstance()
+    or
+    result = client().getMember("duplicate").getReturn()
+    or
+    result = client().getMember("duplicate").getLastParameter().getParameter(1)
+  }
+
+  /**
+   * Gets a (possibly chained) reference to a batch operation object.
+   * These have the same API as a redis client, except the calls are chained, and the sequence is terminated with a `.exec` call.
+   */
+  private API::Node multi() {
+    result = client().getMember(["multi", "batch"]).getReturn()
+    or
+    result = multi().getAMember().getReturn()
+  }
+
+  /**
+   * Gets a `Node Redis` client instance. Either a client created using `createClient()`, or a batch operation object.
+   */
+  private API::Node redis() { result = [client(), multi()] }
+
+  /**
+   * Provides signatures for the query methods from Node Redis.
+   */
+  module QuerySignatures {
+    /**
+     * Holds if `method` interprets parameter `argIndex` as a key, and a later parameter determines a value/field.
+     * Thereby the method is vulnerable if parameter `argIndex` is unexpectedly an array instead of a string, as an attacker can control arguments to Redis that the attacker was not supposed to control.
+     *
+     * Only setters and similar methods are included.
+     * For getter like methods it is not generally possible to gain access "outside" of where you are supposed to have access,
+     * it is at most possible to get a Redis call to return more results than expected (e.g. by adding more members to [`geohash`](https://redis.io/commands/geohash)).
+     */
+    bindingset[argIndex]
+    predicate argumentIsAmbiguousKey(string method, int argIndex) {
+      method =
+        ["set", "publish", "append", "bitfield", "decrby", "getset", "hincrby", "hincrbyfloat",
+            "hset", "hsetnx", "incrby", "incrbyfloat", "linsert", "lpush", "lpushx", "lset",
+            "ltrim", "rename", "renamenx", "rpushx", "setbit", "setex", "smove", "zincrby",
+            "zinterstore", "hdel", "lpush", "pfadd", "rpush", "sadd", "sdiffstore", "srem"] and
+      argIndex = 0
+      or
+      method = ["bitop", "hmset", "mset", "msetnx", "geoadd"] and argIndex >= 0
+    }
+  }
+
+  /**
+   * An expression that is interpreted as a key in a Node Redis call.
+   */
+  class RedisKeyArgument extends NoSQL::Query {
+    RedisKeyArgument() {
+      exists(string method, int argIndex |
+        QuerySignatures::argumentIsAmbiguousKey(method, argIndex)
+      |
+        this = promisify(redis().getMember(method)).getACall().getArgument(argIndex).asExpr()
+      )
+    }
+  }
+
+  /**
+   * Gets a possibly promisified version of `method`.
+   */
+  private API::Node promisify(API::Node method) {
+    result = method
+    or
+    exists(API::Node promisify |
+      promisify = API::moduleImport(["util", "bluebird"]).getMember("promisify").getReturn() and
+      method
+          .getAnImmediateUse()
+          .flowsTo(promisify.getAnImmediateUse().(DataFlow::CallNode).getArgument(0))
+    |
+      result = promisify
+      or
+      result = promisify.getMember("bind").getReturn() and
+      result.getAnImmediateUse().(DataFlow::CallNode).getNumArgument() = 1
+    )
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -159,6 +159,34 @@ nodes
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:29 | req.body |
 | mongooseModelClient.js:12:22:12:32 | req.body.id |
+| redis.js:10:16:10:23 | req.body |
+| redis.js:10:16:10:23 | req.body |
+| redis.js:10:16:10:27 | req.body.key |
+| redis.js:10:16:10:27 | req.body.key |
+| redis.js:12:9:12:26 | key |
+| redis.js:12:15:12:22 | req.body |
+| redis.js:12:15:12:22 | req.body |
+| redis.js:12:15:12:26 | req.body.key |
+| redis.js:18:16:18:18 | key |
+| redis.js:18:16:18:18 | key |
+| redis.js:19:43:19:45 | key |
+| redis.js:19:43:19:45 | key |
+| redis.js:25:14:25:16 | key |
+| redis.js:25:14:25:16 | key |
+| redis.js:30:23:30:25 | key |
+| redis.js:30:23:30:25 | key |
+| redis.js:32:28:32:30 | key |
+| redis.js:32:28:32:30 | key |
+| redis.js:38:11:38:28 | key |
+| redis.js:38:17:38:24 | req.body |
+| redis.js:38:17:38:24 | req.body |
+| redis.js:38:17:38:28 | req.body.key |
+| redis.js:39:16:39:18 | key |
+| redis.js:39:16:39:18 | key |
+| redis.js:43:27:43:29 | key |
+| redis.js:43:27:43:29 | key |
+| redis.js:46:34:46:36 | key |
+| redis.js:46:34:46:36 | key |
 | socketio.js:10:25:10:30 | handle |
 | socketio.js:10:25:10:30 | handle |
 | socketio.js:11:12:11:53 | `INSERT ... andle}` |
@@ -432,6 +460,32 @@ edges
 | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:22:12:32 | req.body.id |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
 | mongooseModelClient.js:12:22:12:32 | req.body.id | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } |
+| redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
+| redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
+| redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
+| redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key |
+| redis.js:12:9:12:26 | key | redis.js:18:16:18:18 | key |
+| redis.js:12:9:12:26 | key | redis.js:18:16:18:18 | key |
+| redis.js:12:9:12:26 | key | redis.js:19:43:19:45 | key |
+| redis.js:12:9:12:26 | key | redis.js:19:43:19:45 | key |
+| redis.js:12:9:12:26 | key | redis.js:25:14:25:16 | key |
+| redis.js:12:9:12:26 | key | redis.js:25:14:25:16 | key |
+| redis.js:12:9:12:26 | key | redis.js:30:23:30:25 | key |
+| redis.js:12:9:12:26 | key | redis.js:30:23:30:25 | key |
+| redis.js:12:9:12:26 | key | redis.js:32:28:32:30 | key |
+| redis.js:12:9:12:26 | key | redis.js:32:28:32:30 | key |
+| redis.js:12:15:12:22 | req.body | redis.js:12:15:12:26 | req.body.key |
+| redis.js:12:15:12:22 | req.body | redis.js:12:15:12:26 | req.body.key |
+| redis.js:12:15:12:26 | req.body.key | redis.js:12:9:12:26 | key |
+| redis.js:38:11:38:28 | key | redis.js:39:16:39:18 | key |
+| redis.js:38:11:38:28 | key | redis.js:39:16:39:18 | key |
+| redis.js:38:11:38:28 | key | redis.js:43:27:43:29 | key |
+| redis.js:38:11:38:28 | key | redis.js:43:27:43:29 | key |
+| redis.js:38:11:38:28 | key | redis.js:46:34:46:36 | key |
+| redis.js:38:11:38:28 | key | redis.js:46:34:46:36 | key |
+| redis.js:38:17:38:24 | req.body | redis.js:38:17:38:28 | req.body.key |
+| redis.js:38:17:38:24 | req.body | redis.js:38:17:38:28 | req.body.key |
+| redis.js:38:17:38:28 | req.body.key | redis.js:38:11:38:28 | key |
 | socketio.js:10:25:10:30 | handle | socketio.js:11:46:11:51 | handle |
 | socketio.js:10:25:10:30 | handle | socketio.js:11:46:11:51 | handle |
 | socketio.js:11:46:11:51 | handle | socketio.js:11:12:11:53 | `INSERT ... andle}` |
@@ -500,6 +554,15 @@ edges
 | mongooseJsonParse.js:23:19:23:23 | query | mongooseJsonParse.js:20:30:20:43 | req.query.data | mongooseJsonParse.js:23:19:23:23 | query | This query depends on $@. | mongooseJsonParse.js:20:30:20:43 | req.query.data | a user-provided value |
 | mongooseModelClient.js:11:16:11:24 | { id: v } | mongooseModelClient.js:10:22:10:29 | req.body | mongooseModelClient.js:11:16:11:24 | { id: v } | This query depends on $@. | mongooseModelClient.js:10:22:10:29 | req.body | a user-provided value |
 | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | mongooseModelClient.js:12:22:12:29 | req.body | mongooseModelClient.js:12:16:12:34 | { id: req.body.id } | This query depends on $@. | mongooseModelClient.js:12:22:12:29 | req.body | a user-provided value |
+| redis.js:10:16:10:27 | req.body.key | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key | This query depends on $@. | redis.js:10:16:10:23 | req.body | a user-provided value |
+| redis.js:18:16:18:18 | key | redis.js:12:15:12:22 | req.body | redis.js:18:16:18:18 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
+| redis.js:19:43:19:45 | key | redis.js:12:15:12:22 | req.body | redis.js:19:43:19:45 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
+| redis.js:25:14:25:16 | key | redis.js:12:15:12:22 | req.body | redis.js:25:14:25:16 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
+| redis.js:30:23:30:25 | key | redis.js:12:15:12:22 | req.body | redis.js:30:23:30:25 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
+| redis.js:32:28:32:30 | key | redis.js:12:15:12:22 | req.body | redis.js:32:28:32:30 | key | This query depends on $@. | redis.js:12:15:12:22 | req.body | a user-provided value |
+| redis.js:39:16:39:18 | key | redis.js:38:17:38:24 | req.body | redis.js:39:16:39:18 | key | This query depends on $@. | redis.js:38:17:38:24 | req.body | a user-provided value |
+| redis.js:43:27:43:29 | key | redis.js:38:17:38:24 | req.body | redis.js:43:27:43:29 | key | This query depends on $@. | redis.js:38:17:38:24 | req.body | a user-provided value |
+| redis.js:46:34:46:36 | key | redis.js:38:17:38:24 | req.body | redis.js:46:34:46:36 | key | This query depends on $@. | redis.js:38:17:38:24 | req.body | a user-provided value |
 | socketio.js:11:12:11:53 | `INSERT ... andle}` | socketio.js:10:25:10:30 | handle | socketio.js:11:12:11:53 | `INSERT ... andle}` | This query depends on $@. | socketio.js:10:25:10:30 | handle | a user-provided value |
 | tst2.js:9:27:9:84 | "select ... d + "'" | tst2.js:9:66:9:78 | req.params.id | tst2.js:9:27:9:84 | "select ... d + "'" | This query depends on $@. | tst2.js:9:66:9:78 | req.params.id | a user-provided value |
 | tst3.js:9:14:9:19 | query1 | tst3.js:8:16:8:34 | req.params.category | tst3.js:9:14:9:19 | query1 | This query depends on $@. | tst3.js:8:16:8:34 | req.params.category | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/redis.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/redis.js
@@ -44,4 +44,10 @@ app.post('/documents/find', (req, res) => {
 
     client.setAsync = promisify(client.set);
     const foo2 = client.setAsync(key, "value"); // NOT OK
+
+    client.unrelated = promisify(() => {});
+    const foo3 = client.unrelated(key, "value"); // OK
+
+    const unrelated = promisify(client.foobar).bind(client);
+    const foo4 = unrelated(key, "value"); // OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/redis.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/redis.js
@@ -1,0 +1,47 @@
+
+const redis = require("redis");
+const client = redis.createClient();
+
+const Express = require('express');
+const app = Express();
+app.use(require('body-parser').json());
+
+app.post('/documents/find', (req, res) => {
+    client.set(req.body.key, "value"); // NOT OK
+
+    var key = req.body.key;
+    if (typeof key === "string") {
+        client.set(key, "value"); // OK
+        client.set(["key", "value"]);
+    }  
+
+    client.set(key, "value"); // NOT OK
+    client.hmset("key", "field", "value", key, "value2"); // NOT OK
+
+    // chain commands
+    client
+        .multi()
+        .set("constant", "value")
+        .set(key, "value") // NOT OK
+        .get(key) // OK
+        .exec(function (err, replies) { });
+
+    client.duplicate((err, newClient) => {
+        newClient.set(key, "value"); // NOT OK
+    });
+    client.duplicate().set(key, "value"); // NOT OK
+});
+
+
+import { promisify } from 'util';
+app.post('/documents/find', (req, res) => {
+    const key = req.body.key;
+    client.set(key, "value"); // NOT OK
+
+    const setAsync = promisify(client.set).bind(client);
+
+    const foo1 = setAsync(key, "value"); // NOT OK
+
+    client.setAsync = promisify(client.set);
+    const foo2 = client.setAsync(key, "value"); // NOT OK
+});


### PR DESCRIPTION
Redis is vulnerable to a NoSQL like attack. See: https://github.com/NodeRedis/node-redis/issues/1265.  
The problem is known, and [the readme](https://www.npmjs.com/package/redis) warns about it. 
Quote: `Care should be taken with user input if arrays are possible (via body-parser, query string or other method), as single arguments could be unintentionally interpreted as multiple args.`

With this PR we add the vulnerable methods as NoSQL sinks. 

[Here are some example sinks](https://lgtm.com/query/3839652810973180298/). 