### PR TITLE
C++: Make sure getInstructionTagId has a result for `this` related IPA branches

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/InstructionTag.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/InstructionTag.qll
@@ -217,4 +217,8 @@ string getInstructionTagId(TInstructionTag tag) {
   tag = DynamicInitializationFlagConstantTag() and result = "DynInitFlagConst"
   or
   tag = DynamicInitializationFlagStoreTag() and result = "DynInitFlagStore"
+  or
+  tag = ThisAddressTag() and result = "ThisAddres"
+  or
+  tag = ThisLoadTag() and result = "ThisLoad"
 }


### PR DESCRIPTION
Fixes https://github.com/github/codeql-c-analysis-team/issues/176. That issue turned out to be a red herring for my dataflow-debugging purpose, but at least the fix was simple.