### PR TITLE
C++: Provide the predicates that can be used to traverse the AST as metadata to PrintAST

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -182,6 +182,8 @@ class PrintASTNode extends TPrintASTNode {
     result = childIndex.toString()
   }
 
+  abstract string getChildAccessorPredicate(int childIndex);
+
   /**
    * Gets the label for the edge from this node to the specified child,
    * including labels for edges to nodes that represent conversions.
@@ -261,6 +263,10 @@ class ExprNode extends ASTNode {
     result = expr.getValueCategoryString()
   }
 
+  override string getChildAccessorPredicate(int childIndex) {
+  result = getChildAccessor(ast, getChildInternal(childIndex).getAST())
+  }
+
   /**
    * Gets the value of this expression, if it is a constant.
    */
@@ -322,6 +328,8 @@ class DeclarationEntryNode extends BaseASTNode, TDeclarationEntryNode {
 
   override PrintASTNode getChildInternal(int childIndex) { none() }
 
+  override string getChildAccessorPredicate(int childIndex) { none() }
+
   override string getProperty(string key) {
     result = BaseASTNode.super.getProperty(key)
     or
@@ -339,6 +347,11 @@ class VariableDeclarationEntryNode extends DeclarationEntryNode {
   override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
     result.getAST() = ast.getVariable().getInitializer()
+  }
+
+  override string getChildAccessorPredicate(int childIndex) {
+    childIndex = 0 and
+    result = "getVariable().getInitializer()"
   }
 
   override string getChildEdgeLabelInternal(int childIndex) { childIndex = 0 and result = "init" }
@@ -360,6 +373,10 @@ class StmtNode extends ASTNode {
         result.getAST() = child.(Stmt)
       )
     )
+  }
+
+  override string getChildAccessorPredicate(int childIndex) {
+    result = getChildAccessor(ast, getChildInternal(childIndex).getAST())
   }
 }
 
@@ -389,6 +406,8 @@ class ParameterNode extends ASTNode {
 
   final override PrintASTNode getChildInternal(int childIndex) { none() }
 
+  final override string getChildAccessorPredicate(int childIndex) { none() }
+
   final override string getProperty(string key) {
     result = super.getProperty(key)
     or
@@ -408,6 +427,11 @@ class InitializerNode extends ASTNode {
   override ASTNode getChildInternal(int childIndex) {
     childIndex = 0 and
     result.getAST() = init.getExpr()
+  }
+
+  override string getChildAccessorPredicate(int childIndex) {
+    childIndex = 0 and
+    result = "getExpr()"
   }
 
   override string getChildEdgeLabelInternal(int childIndex) {
@@ -432,6 +456,11 @@ class ParametersNode extends PrintASTNode, TParametersNode {
     result.getAST() = func.getParameter(childIndex)
   }
 
+  override string getChildAccessorPredicate(int childIndex) {
+    exists(getChild(childIndex)) and
+    result = "getParameter(" + childIndex.toString() + ")"
+  }
+
   /**
    * Gets the `Function` for which this node represents the parameters.
    */
@@ -454,6 +483,11 @@ class ConstructorInitializersNode extends PrintASTNode, TConstructorInitializers
     result.getAST() = ctor.getInitializer(childIndex)
   }
 
+  final override string getChildAccessorPredicate(int childIndex) {
+    exists(getChild(childIndex)) and
+    result = "getInitializer(" + childIndex.toString() + ")"
+  }
+
   /**
    * Gets the `Constructor` for which this node represents the initializer list.
    */
@@ -474,6 +508,11 @@ class DestructorDestructionsNode extends PrintASTNode, TDestructorDestructionsNo
 
   final override ASTNode getChildInternal(int childIndex) {
     result.getAST() = dtor.getDestruction(childIndex)
+  }
+
+  final override string getChildAccessorPredicate(int childIndex) {
+    exists(getChild(childIndex)) and
+    result = "getDestruction(" + childIndex.toString() + ")"
   }
 
   /**
@@ -504,6 +543,20 @@ class FunctionNode extends ASTNode {
     or
     childIndex = 3 and
     result.(DestructorDestructionsNode).getDestructor() = func
+  }
+
+  override string getChildAccessorPredicate(int childIndex) {
+    childIndex = 0 and
+    result = "..."
+    or
+    childIndex = 1 and
+    result = "..."
+    or
+    childIndex = 2 and
+    result = "getEntryPoint()"
+    or
+    childIndex = 3 and
+    result = "..."
   }
 
   override string getChildEdgeLabelInternal(int childIndex) {
@@ -570,6 +623,239 @@ class ArrayAggregateLiteralNode extends ExprNode {
   }
 }
 
+string getChildAccessor(Locatable parent, Element child) {
+  shouldPrintFunction(getEnclosingFunction(parent)) and
+  (
+    exists(Stmt s | s = parent.(Stmt) |
+      namedStmtChildPredicates(s, child, result)
+      or
+      not exists(string p | namedStmtChildPredicates(s, child, p)) and
+      exists(int n | s.getChild(n) = child and result = "getChild(" + n + ")")
+    )
+    or
+    exists(Expr expr | expr = parent.(Expr) |
+      namedExprChildPredicates(expr, child, result)
+      or
+      not exists(string p | namedExprChildPredicates(expr, child, p)) and
+      exists(int n | expr.getChild(n) = child and result = "getChild(" + n + ")")
+    )
+  )
+}
+
+predicate namedStmtChildPredicates(Locatable s, Element e, string pred) {
+  shouldPrintFunction(getEnclosingFunction(s)) and
+  (
+    exists(int n | s.(BlockStmt).getStmt(n) = e and pred = "getStmt(" + n + ")")
+    or
+    s.(ComputedGotoStmt).getExpr() = e and pred = "getExpr()"
+    or
+    s.(ConstexprIfStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(ConstexprIfStmt).getThen() = e and pred = "getThen()"
+    or
+    s.(ConstexprIfStmt).getElse() = e and pred = "getElse()"
+    or
+    s.(IfStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(IfStmt).getThen() = e and pred = "getThen()"
+    or
+    s.(IfStmt).getElse() = e and pred = "getElse()"
+    or
+    s.(SwitchStmt).getExpr() = e and pred = "getExpr()"
+    or
+    s.(SwitchStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(DoStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(DoStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(ForStmt).getInitialization() = e and pred = "getInitialization()"
+    or
+    s.(ForStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(ForStmt).getUpdate() = e and pred = "getUpdate()"
+    or
+    s.(ForStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(RangeBasedForStmt).getChild(0) = e and pred = "getChild(0)" // TODO: could be omitted
+    or
+    s.(RangeBasedForStmt).getBeginEndDeclaration() = e and pred = "getBeginEndDeclaration()"
+    or
+    s.(RangeBasedForStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(RangeBasedForStmt).getUpdate() = e and pred = "getUpdate()"
+    or
+    s.(RangeBasedForStmt).getChild(4) = e and pred = "getChild(4)" // TODO: could be omitted
+    or
+    s.(RangeBasedForStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(WhileStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(WhileStmt).getStmt() = e and pred = "getStmt()"
+    or
+    exists(int n |
+      s.(DeclStmt).getDeclarationEntry(n) = e and pred = "getDeclarationEntry(" + n.toString() + ")"
+    )
+    or
+    // EmptyStmt does not have children
+    s.(ExprStmt).getExpr() = e and pred = "getExpr()"
+    or
+    s.(Handler).getBlock() = e and pred = "getBlock()"
+    or
+    s.(JumpStmt).getTarget() = e and pred = "getTarget()"
+    or
+    s.(MicrosoftTryStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(MicrosoftTryExceptStmt).getCondition() = e and pred = "getCondition()"
+    or
+    s.(MicrosoftTryExceptStmt).getExcept() = e and pred = "getExcept()"
+    or
+    s.(MicrosoftTryFinallyStmt).getFinally() = e and pred = "getFinally()"
+    or
+    s.(ReturnStmt).getExpr() = e and pred = "getExpr()"
+    or
+    s.(SwitchCase).getExpr() = e and pred = "getExpr()"
+    or
+    s.(SwitchCase).getEndExpr() = e and pred = "getEndExpr()"
+    or
+    s.(TryStmt).getStmt() = e and pred = "getStmt()"
+    or
+    s.(VlaDimensionStmt).getDimensionExpr() = e and pred = "getDimensionExpr()"
+  )
+}
+
+predicate namedExprChildPredicates(Expr expr, Element ele, string pred) {
+  shouldPrintFunction(expr.getEnclosingFunction()) and
+  (
+    expr.(Access).getTarget() = ele and pred = "getTarget()"
+    or
+    expr.(VariableAccess).getQualifier() = ele and pred = "getQualifier()"
+    or
+    exists(Field f |
+      expr.(ClassAggregateLiteral).getFieldExpr(f) = ele and
+      pred = "getFieldExpr(" + f.toString() + ")"
+    )
+    or
+    exists(int n |
+      expr.(ArrayOrVectorAggregateLiteral).getElementExpr(n) = ele and
+      pred = "getElementExpr(" + n.toString() + ")"
+    )
+    or
+    expr.(AlignofExprOperator).getExprOperand() = ele and pred = "getExprOperand()"
+    or
+    expr.(ArrayExpr).getArrayBase() = ele and pred = "getArrayBase()"
+    or
+    expr.(ArrayExpr).getArrayOffset() = ele and pred = "getArrayOffset()"
+    or
+    expr.(AssumeExpr).getOperand() = ele and pred = "getOperand()"
+    or
+    expr.(BuiltInComplexOperation).getRealOperand() = ele and pred = "getRealOperand()"
+    or
+    expr.(BuiltInComplexOperation).getImaginaryOperand() = ele and pred = "getImaginaryOperand()"
+    or
+    expr.(BuiltInVarArg).getVAList() = ele and pred = "getVAList()"
+    or
+    expr.(BuiltInVarArgCopy).getDestinationVAList() = ele and pred = "getDestinationVAList()"
+    or
+    expr.(BuiltInVarArgCopy).getSourceVAList() = ele and pred = "getSourceVAList()"
+    or
+    expr.(BuiltInVarArgsEnd).getVAList() = ele and pred = "getVAList()"
+    or
+    expr.(BuiltInVarArgsStart).getVAList() = ele and pred = "getVAList()"
+    or
+    expr.(BuiltInVarArgsStart).getLastNamedParameter() = ele and pred = "getLastNamedParameter()"
+    or
+    expr.(Call).getQualifier() = ele and pred = "getQualifier()"
+    or
+    exists(int n | expr.(Call).getArgument(n) = ele and pred = "getArgument(" + n.toString() + ")")
+    or
+    expr.(ExprCall).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(OverloadedArrayExpr).getArrayBase() = ele and pred = "getArrayBase()"
+    or
+    expr.(OverloadedArrayExpr).getArrayOffset() = ele and pred = "getArrayOffset()"
+    or
+    expr.(OverloadedPointerDereferenceExpr).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(CommaExpr).getLeftOperand() = ele and pred = "getLeftOperand()"
+    or
+    expr.(CommaExpr).getRightOperand() = ele and pred = "getRightOperand()"
+    or
+    expr.(ConditionDeclExpr).getVariableAccess() = ele and pred = "getVariableAccess()"
+    or
+    expr.(ConstructorFieldInit).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(Conversion).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(DeleteArrayExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
+    or
+    expr.(DeleteArrayExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
+    or
+    expr.(DeleteArrayExpr).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(DeleteExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
+    or
+    expr.(DeleteExpr).getDestructorCall() = ele and pred = "getDestructorCall()"
+    or
+    expr.(DeleteExpr).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(DestructorFieldDestruction).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(FoldExpr).getInitExpr() = ele and pred = "getInitExpr()"
+    or
+    expr.(FoldExpr).getPackExpr() = ele and pred = "getPackExpr()"
+    or
+    expr.(LambdaExpression).getInitializer() = ele and pred = "getInitializer()"
+    or
+    expr.(NewOrNewArrayExpr).getAllocatorCall() = ele and pred = "getAllocatorCall()"
+    or
+    expr.(NewOrNewArrayExpr).getAlignmentArgument() = ele and pred = "getAlignmentArgument()"
+    or
+    expr.(NewArrayExpr).getInitializer() = ele and pred = "getInitializer()"
+    or
+    expr.(NewArrayExpr).getExtent() = ele and pred = "getExtent()"
+    or
+    expr.(NewExpr).getInitializer() = ele and pred = "getInitializer()"
+    or
+    expr.(NoExceptExpr).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(Assignment).getLValue() = ele and pred = "getLValue()"
+    or
+    expr.(Assignment).getRValue() = ele and pred = "getRValue()"
+    or
+    not expr instanceof RelationalOperation and
+    expr.(BinaryOperation).getLeftOperand() = ele and
+    pred = "getLeftOperand()"
+    or
+    not expr instanceof RelationalOperation and
+    expr.(BinaryOperation).getRightOperand() = ele and
+    pred = "getRightOperand()"
+    or
+    expr.(RelationalOperation).getGreaterOperand() = ele and pred = "getGreaterOperand()"
+    or
+    expr.(RelationalOperation).getLesserOperand() = ele and pred = "getLesserOperand()"
+    or
+    expr.(ConditionalExpr).getCondition() = ele and pred = "getCondition()"
+    or
+    // If ConditionalExpr is in two-operand form, getThen() = getCondition() holds
+    not expr.(ConditionalExpr).isTwoOperand() and
+    expr.(ConditionalExpr).getThen() = ele and
+    pred = "getThen()"
+    or
+    expr.(ConditionalExpr).getElse() = ele and pred = "getElse()"
+    or
+    expr.(UnaryOperation).getOperand() = ele and pred = "getOperand()"
+    or
+    expr.(SizeofExprOperator).getExprOperand() = ele and pred = "getExprOperand()"
+    or
+    //expr.(StmtExpr).getStmt() = ele and pred = "getStmt()" // TODO confirm via test that this is a/the child
+    //or
+    expr.(ThrowExpr).getExpr() = ele and pred = "getExpr()"
+    or
+    expr.(TypeidOperator).getExpr() = ele and pred = "getExpr()"
+  )
+}
+
 /** Holds if `node` belongs to the output tree, and its property `key` has the given `value`. */
 query predicate nodes(PrintASTNode node, string key, string value) {
   node.shouldPrint() and
@@ -586,9 +872,12 @@ query predicate edges(PrintASTNode source, PrintASTNode target, string key, stri
     target.shouldPrint() and
     target = source.getChild(childIndex) and
     (
-      key = "semmle.label" and value = source.getChildEdgeLabel(childIndex)
+      key = "semmle.label" and value = source.getChildAccessorPredicate(childIndex) //source.getChildEdgeLabel(childIndex)
       or
       key = "semmle.order" and value = childIndex.toString()
+      or
+      key = "semmle.predicate" and
+      value = source.getChildAccessorPredicate(childIndex)
     )
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -546,17 +546,8 @@ class FunctionNode extends ASTNode {
   }
 
   override string getChildAccessorPredicate(int childIndex) {
-    childIndex = 0 and
-    result = "..."
-    or
-    childIndex = 1 and
-    result = "..."
-    or
     childIndex = 2 and
     result = "getEntryPoint()"
-    or
-    childIndex = 3 and
-    result = "..."
   }
 
   override string getChildEdgeLabelInternal(int childIndex) {
@@ -642,7 +633,7 @@ string getChildAccessor(Locatable parent, Element child) {
   )
 }
 
-predicate namedStmtChildPredicates(Locatable s, Element e, string pred) {
+private predicate namedStmtChildPredicates(Locatable s, Element e, string pred) {
   shouldPrintFunction(getEnclosingFunction(s)) and
   (
     exists(int n | s.(BlockStmt).getStmt(n) = e and pred = "getStmt(" + n + ")")
@@ -724,7 +715,7 @@ predicate namedStmtChildPredicates(Locatable s, Element e, string pred) {
   )
 }
 
-predicate namedExprChildPredicates(Expr expr, Element ele, string pred) {
+private predicate namedExprChildPredicates(Expr expr, Element ele, string pred) {
   shouldPrintFunction(expr.getEnclosingFunction()) and
   (
     expr.(Access).getTarget() = ele and pred = "getTarget()"

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -125,7 +125,7 @@ class PrintASTNode extends TPrintASTNode {
    */
   final PrintASTNode getChild(int childIndex) {
     exists(int nonConvertedIndex, boolean isConverted |
-      deconstructIndex(childIndex, nonConvertedIndex, isConverted)
+      mapIndex(childIndex, nonConvertedIndex, isConverted)
     |
       if isConverted = false
       then result = getChildInternal(childIndex)
@@ -177,7 +177,7 @@ class PrintASTNode extends TPrintASTNode {
   final string getChildAccessorPredicate(int childIndex) {
     exists(getChild(childIndex)) and
     exists(int nonConvertedIndex, boolean isConverted |
-      deconstructIndex(childIndex, nonConvertedIndex, isConverted)
+      mapIndex(childIndex, nonConvertedIndex, isConverted)
     |
       if isConverted = false
       then result = getChildAccessorPredicateInternal(childIndex)
@@ -198,7 +198,7 @@ class PrintASTNode extends TPrintASTNode {
    * Note: This predicate contains the mapping between the converted and nonconverted indexes, but
    * if `nonConvertedIndex` does not have conversions attached, there will be no node at `childIndex`.
    */
-  final predicate deconstructIndex(int childIndex, int nonConvertedIndex, boolean isConverted) {
+  final predicate mapIndex(int childIndex, int nonConvertedIndex, boolean isConverted) {
     exists(getChildInternal(childIndex)) and
     nonConvertedIndex = childIndex and
     isConverted = false

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -546,6 +546,8 @@ class FunctionNode extends ASTNode {
   }
 
   override string getChildAccessorPredicate(int childIndex) {
+    // all other children of this node are not reachable via the AST `getChild` relation
+    // or other getters. Thus, this predicate does not hold for them.
     childIndex = 2 and
     result = "getEntryPoint()"
   }

--- a/cpp/ql/src/semmle/code/cpp/PrintAST.qll
+++ b/cpp/ql/src/semmle/code/cpp/PrintAST.qll
@@ -182,6 +182,10 @@ class PrintASTNode extends TPrintASTNode {
     result = childIndex.toString()
   }
 
+  /**
+   * Gets the QL predicate that can be used to access the child at `childIndex`.
+   * May not hold for all children, see for example `FunctionNode`.
+   */
   abstract string getChildAccessorPredicate(int childIndex);
 
   /**
@@ -616,7 +620,7 @@ class ArrayAggregateLiteralNode extends ExprNode {
   }
 }
 
-string getChildAccessor(Locatable parent, Element child) {
+private string getChildAccessor(Locatable parent, Element child) {
   shouldPrintFunction(getEnclosingFunction(parent)) and
   (
     exists(Stmt s | s = parent.(Stmt) |

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -1,1558 +1,1558 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 AddressOf.c:
 #    1| [TopLevelFunction] void AddressOf(int)
-#    1|   params: 
-#    1|     0: [Parameter] i
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of j
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
 #    2|           Type = [IntPointerType] int *
-#    2|         init: [Initializer] initializer for j
-#    2|           expr: [AddressOfExpr] & ...
+#    2|         getVariable().getInitializer(): [Initializer] initializer for j
+#    2|           getExpr(): [AddressOfExpr] & ...
 #    2|               Type = [IntPointerType] int *
 #    2|               ValueCategory = prvalue
-#    2|             0: [VariableAccess] i
+#    2|             getOperand(): [VariableAccess] i
 #    2|                 Type = [IntType] int
 #    2|                 ValueCategory = lvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 ArrayToPointer.c:
 #    5| [TopLevelFunction] void ArrayToPointer()
-#    5|   params: 
-#    6|   body: [BlockStmt] { ... }
-#    7|     0: [DeclStmt] declaration
-#    7|       0: [VariableDeclarationEntry] definition of c
+#    5|   ...: 
+#    6|   getEntryPoint(): [BlockStmt] { ... }
+#    7|     getStmt(0): [DeclStmt] declaration
+#    7|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 #    7|           Type = [ArrayType] char[]
-#    7|         init: [Initializer] initializer for c
-#    7|           expr: hello
+#    7|         getVariable().getInitializer(): [Initializer] initializer for c
+#    7|           getExpr(): hello
 #    7|               Type = [ArrayType] char[6]
 #    7|               Value = [StringLiteral] "hello"
 #    7|               ValueCategory = lvalue
-#    8|     1: [DeclStmt] declaration
-#    8|       0: [VariableDeclarationEntry] definition of s
+#    8|     getStmt(1): [DeclStmt] declaration
+#    8|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 #    8|           Type = [Struct] S
-#    9|     2: [ExprStmt] ExprStmt
-#    9|       0: [AssignExpr] ... = ...
+#    9|     getStmt(2): [ExprStmt] ExprStmt
+#    9|       getExpr(): [AssignExpr] ... = ...
 #    9|           Type = [CharPointerType] char *
 #    9|           ValueCategory = prvalue
-#    9|         0: [ValueFieldAccess] name
+#    9|         getLValue(): [ValueFieldAccess] name
 #    9|             Type = [CharPointerType] char *
 #    9|             ValueCategory = lvalue
-#    9|           -1: [VariableAccess] s
+#    9|           getQualifier(): [VariableAccess] s
 #    9|               Type = [Struct] S
 #    9|               ValueCategory = lvalue
-#    9|         1: [VariableAccess] c
+#    9|         getRValue(): [VariableAccess] c
 #    9|             Type = [ArrayType] char[6]
 #    9|             ValueCategory = lvalue
-#    9|         1 converted: [ArrayToPointerConversion] array to pointer conversion
+#    9|         : [ArrayToPointerConversion] array to pointer conversion
 #    9|             Type = [CharPointerType] char *
 #    9|             ValueCategory = prvalue
-#   10|     3: [ReturnStmt] return ...
+#   10|     getStmt(3): [ReturnStmt] return ...
 Cast.c:
 #    1| [TopLevelFunction] void Cast(char*, void*)
-#    1|   params: 
-#    1|     0: [Parameter] c
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] c
 #    1|         Type = [CharPointerType] char *
-#    1|     1: [Parameter] v
+#    1|     getParameter(1): [Parameter] v
 #    1|         Type = [VoidPointerType] void *
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [CharPointerType] char *
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] c
+#    2|         getLValue(): [VariableAccess] c
 #    2|             Type = [CharPointerType] char *
 #    2|             ValueCategory = lvalue
-#    2|         1: [VariableAccess] v
+#    2|         getRValue(): [VariableAccess] v
 #    2|             Type = [VoidPointerType] void *
 #    2|             ValueCategory = prvalue(load)
-#    2|         1 converted: [CStyleCast] (char *)...
+#    2|         : [CStyleCast] (char *)...
 #    2|             Conversion = [PointerConversion] pointer conversion
 #    2|             Type = [CharPointerType] char *
 #    2|             ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 ConditionDecl.cpp:
 #    1| [TopLevelFunction] void ConditionDecl()
-#    1|   params: 
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of j
+#    1|   ...: 
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
 #    2|           Type = [IntType] int
-#    2|         init: [Initializer] initializer for j
-#    2|           expr: [Literal] 0
+#    2|         getVariable().getInitializer(): [Initializer] initializer for j
+#    2|           getExpr(): [Literal] 0
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 0
 #    2|               ValueCategory = prvalue
-#    3|     1: [WhileStmt] while (...) ...
-#    3|       0: [ConditionDeclExpr] (condition decl)
+#    3|     getStmt(1): [WhileStmt] while (...) ...
+#    3|       getCondition(): [ConditionDeclExpr] (condition decl)
 #    3|           Type = [BoolType] bool
 #    3|           ValueCategory = prvalue
-#    3|         0: [VariableAccess] k
+#    3|         getVariableAccess(): [VariableAccess] k
 #    3|             Type = [IntType] int
 #    3|             ValueCategory = prvalue(load)
-#    3|         0 converted: [CStyleCast] (bool)...
+#    3|         : [CStyleCast] (bool)...
 #    3|             Conversion = [BoolConversion] conversion to bool
 #    3|             Type = [BoolType] bool
 #    3|             ValueCategory = prvalue
-#    3|       1: [BlockStmt] { ... }
-#    5|     2: [ReturnStmt] return ...
+#    3|       getStmt(): [BlockStmt] { ... }
+#    5|     getStmt(2): [ReturnStmt] return ...
 ConstructorCall.cpp:
 #    1| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    1| [CopyConstructor] void C::C(C const&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveConstructor] void C::C(C&&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    3| [ConversionConstructor] void C::C(int)
-#    3|   params: 
-#    3|     0: [Parameter] i
+#    3|   ...: 
+#    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
-#    3|   initializations: 
-#    3|   body: [BlockStmt] { ... }
-#    4|     0: [ReturnStmt] return ...
+#    3|   ...: 
+#    3|   getEntryPoint(): [BlockStmt] { ... }
+#    4|     getStmt(0): [ReturnStmt] return ...
 #    7| [CopyAssignmentOperator] D& D::operator=(D const&)
-#    7|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    7|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveAssignmentOperator] D& D::operator=(D&&)
-#    7|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    7|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    7| [CopyConstructor] void D::D(D const&)
-#    7|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    7|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveConstructor] void D::D(D&&)
-#    7|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    7|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    9| [Constructor] void D::D()
-#    9|   params: 
-#    9|   initializations: 
-#    9|   body: [BlockStmt] { ... }
-#   10|     0: [ReturnStmt] return ...
+#    9|   ...: 
+#    9|   ...: 
+#    9|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [ReturnStmt] return ...
 #   13| [CopyAssignmentOperator] E& E::operator=(E const&)
-#   13|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   13|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const E &
 #   13| [MoveAssignmentOperator] E& E::operator=(E&&)
-#   13|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   13|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] E &&
 #   17| [TopLevelFunction] void ConstructorCall(C*, D*, E*)
-#   17|   params: 
-#   17|     0: [Parameter] c
+#   17|   ...: 
+#   17|     getParameter(0): [Parameter] c
 #   17|         Type = [PointerType] C *
-#   17|     1: [Parameter] d
+#   17|     getParameter(1): [Parameter] d
 #   17|         Type = [PointerType] D *
-#   17|     2: [Parameter] e
+#   17|     getParameter(2): [Parameter] e
 #   17|         Type = [PointerType] E *
-#   17|   body: [BlockStmt] { ... }
-#   18|     0: [ExprStmt] ExprStmt
-#   18|       0: [AssignExpr] ... = ...
+#   17|   getEntryPoint(): [BlockStmt] { ... }
+#   18|     getStmt(0): [ExprStmt] ExprStmt
+#   18|       getExpr(): [AssignExpr] ... = ...
 #   18|           Type = [PointerType] C *
 #   18|           ValueCategory = lvalue
-#   18|         0: [VariableAccess] c
+#   18|         getLValue(): [VariableAccess] c
 #   18|             Type = [PointerType] C *
 #   18|             ValueCategory = lvalue
-#   18|         1: [NewExpr] new
+#   18|         getRValue(): [NewExpr] new
 #   18|             Type = [PointerType] C *
 #   18|             ValueCategory = prvalue
-#   18|           1: [ConstructorCall] call to C
+#   18|           getInitializer(): [ConstructorCall] call to C
 #   18|               Type = [VoidType] void
 #   18|               ValueCategory = prvalue
-#   18|             0: [Literal] 5
+#   18|             getArgument(0): [Literal] 5
 #   18|                 Type = [IntType] int
 #   18|                 Value = [Literal] 5
 #   18|                 ValueCategory = prvalue
-#   19|     1: [ExprStmt] ExprStmt
-#   19|       0: [AssignExpr] ... = ...
+#   19|     getStmt(1): [ExprStmt] ExprStmt
+#   19|       getExpr(): [AssignExpr] ... = ...
 #   19|           Type = [PointerType] D *
 #   19|           ValueCategory = lvalue
-#   19|         0: [VariableAccess] d
+#   19|         getLValue(): [VariableAccess] d
 #   19|             Type = [PointerType] D *
 #   19|             ValueCategory = lvalue
-#   19|         1: [NewExpr] new
+#   19|         getRValue(): [NewExpr] new
 #   19|             Type = [PointerType] D *
 #   19|             ValueCategory = prvalue
-#   19|           1: [ConstructorCall] call to D
+#   19|           getInitializer(): [ConstructorCall] call to D
 #   19|               Type = [VoidType] void
 #   19|               ValueCategory = prvalue
-#   20|     2: [ExprStmt] ExprStmt
-#   20|       0: [AssignExpr] ... = ...
+#   20|     getStmt(2): [ExprStmt] ExprStmt
+#   20|       getExpr(): [AssignExpr] ... = ...
 #   20|           Type = [PointerType] E *
 #   20|           ValueCategory = lvalue
-#   20|         0: [VariableAccess] e
+#   20|         getLValue(): [VariableAccess] e
 #   20|             Type = [PointerType] E *
 #   20|             ValueCategory = lvalue
-#   20|         1: [NewExpr] new
+#   20|         getRValue(): [NewExpr] new
 #   20|             Type = [PointerType] E *
 #   20|             ValueCategory = prvalue
-#   20|           1: [Literal] 0
+#   20|           getInitializer(): [Literal] 0
 #   20|               Type = [Class] E
 #   20|               Value = [Literal] 0
 #   20|               ValueCategory = prvalue
-#   21|     3: [ReturnStmt] return ...
+#   21|     getStmt(3): [ReturnStmt] return ...
 Conversion1.c:
 #    1| [TopLevelFunction] void Conversion1()
-#    1|   params: 
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of i
+#    1|   ...: 
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #    2|           Type = [IntType] int
-#    2|         init: [Initializer] initializer for i
-#    2|           expr: [Literal] 1
+#    2|         getVariable().getInitializer(): [Initializer] initializer for i
+#    2|           getExpr(): [Literal] 1
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 1
 #    2|               ValueCategory = prvalue
-#    2|           expr converted: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 Conversion2.c:
 #    1| [TopLevelFunction] void Conversion2(int)
-#    1|   params: 
-#    1|     0: [Parameter] x
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] x
+#    2|         getLValue(): [VariableAccess] x
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [AddExpr] ... + ...
+#    2|         getRValue(): [AddExpr] ... + ...
 #    2|             Type = [IntType] int
 #    2|             Value = [AddExpr] 12
 #    2|             ValueCategory = prvalue
-#    2|           0: [Literal] 5
+#    2|           getLeftOperand(): [Literal] 5
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 5
 #    2|               ValueCategory = prvalue
-#    2|           1: [Literal] 7
+#    2|           getRightOperand(): [Literal] 7
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 7
 #    2|               ValueCategory = prvalue
-#    2|           0 converted: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 5
 #    2|               ValueCategory = prvalue
-#    2|           1 converted: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 Conversion3.cpp:
 #    1| [TopLevelFunction] void Conversion3(int)
-#    1|   params: 
-#    1|     0: [Parameter] x
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = lvalue
-#    2|         0: [VariableAccess] x
+#    2|         getLValue(): [VariableAccess] x
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [AddExpr] ... + ...
+#    2|         getRValue(): [AddExpr] ... + ...
 #    2|             Type = [IntType] int
 #    2|             Value = [AddExpr] 8
 #    2|             ValueCategory = prvalue
-#    2|           0: [Literal] 5
+#    2|           getLeftOperand(): [Literal] 5
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 5
 #    2|               ValueCategory = prvalue
-#    2|           1: [Literal] 7
+#    2|           getRightOperand(): [Literal] 7
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 7
 #    2|               ValueCategory = prvalue
-#    2|           0 converted: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    2|             expr: [CStyleCast] (bool)...
+#    2|             getExpr(): [CStyleCast] (bool)...
 #    2|                 Conversion = [BoolConversion] conversion to bool
 #    2|                 Type = [BoolType] bool
 #    2|                 Value = [CStyleCast] 1
 #    2|                 ValueCategory = prvalue
-#    2|               expr: [CStyleCast] (int)...
+#    2|               getExpr(): [CStyleCast] (int)...
 #    2|                   Conversion = [IntegralConversion] integral conversion
 #    2|                   Type = [IntType] int
 #    2|                   Value = [CStyleCast] 1
 #    2|                   ValueCategory = prvalue
-#    2|           1 converted: [ParenthesisExpr] (...)
+#    2|           : [ParenthesisExpr] (...)
 #    2|               Type = [IntType] int
 #    2|               Value = [ParenthesisExpr] 7
 #    2|               ValueCategory = prvalue
-#    2|             expr: [CStyleCast] (int)...
+#    2|             getExpr(): [CStyleCast] (int)...
 #    2|                 Conversion = [IntegralConversion] integral conversion
 #    2|                 Type = [IntType] int
 #    2|                 Value = [CStyleCast] 7
 #    2|                 ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 Conversion4.c:
 #    1| [TopLevelFunction] void Conversion4(int)
-#    1|   params: 
-#    1|     0: [Parameter] x
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] x
+#    2|         getLValue(): [VariableAccess] x
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [Literal] 7
+#    2|         getRValue(): [Literal] 7
 #    2|             Type = [IntType] int
 #    2|             Value = [Literal] 7
 #    2|             ValueCategory = prvalue
-#    2|         1 converted: [ParenthesisExpr] (...)
+#    2|         : [ParenthesisExpr] (...)
 #    2|             Type = [IntType] int
 #    2|             Value = [ParenthesisExpr] 7
 #    2|             ValueCategory = prvalue
-#    2|           expr: [CStyleCast] (int)...
+#    2|           getExpr(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 #    5| [TopLevelFunction] char* retfn(void*)
-#    5|   params: 
-#    5|     0: [Parameter] v
+#    5|   ...: 
+#    5|     getParameter(0): [Parameter] v
 #    5|         Type = [VoidPointerType] void *
-#    5|   body: [BlockStmt] { ... }
-#    6|     0: [ReturnStmt] return ...
-#    6|       0: [VariableAccess] v
+#    5|   getEntryPoint(): [BlockStmt] { ... }
+#    6|     getStmt(0): [ReturnStmt] return ...
+#    6|       getExpr(): [VariableAccess] v
 #    6|           Type = [VoidPointerType] void *
 #    6|           ValueCategory = prvalue(load)
-#    6|       0 converted: [CStyleCast] (char *)...
+#    6|       : [CStyleCast] (char *)...
 #    6|           Conversion = [PointerConversion] pointer conversion
 #    6|           Type = [CharPointerType] char *
 #    6|           ValueCategory = prvalue
-#    6|         expr: [CStyleCast] (void *)...
+#    6|         getExpr(): [CStyleCast] (void *)...
 #    6|             Conversion = [PointerConversion] pointer conversion
 #    6|             Type = [VoidPointerType] void *
 #    6|             ValueCategory = prvalue
-#    6|           expr: [CStyleCast] (int *)...
+#    6|           getExpr(): [CStyleCast] (int *)...
 #    6|               Conversion = [PointerConversion] pointer conversion
 #    6|               Type = [IntPointerType] int *
 #    6|               ValueCategory = prvalue
 #    9| [TopLevelFunction] void Conversion4_vardecl(int)
-#    9|   params: 
-#    9|     0: [Parameter] x
+#    9|   ...: 
+#    9|     getParameter(0): [Parameter] x
 #    9|         Type = [IntType] int
-#    9|   body: [BlockStmt] { ... }
-#   10|     0: [DeclStmt] declaration
-#   10|       0: [VariableDeclarationEntry] definition of y
+#    9|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [DeclStmt] declaration
+#   10|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #   10|           Type = [LongType] long
-#   10|         init: [Initializer] initializer for y
-#   10|           expr: [VariableAccess] x
+#   10|         getVariable().getInitializer(): [Initializer] initializer for y
+#   10|           getExpr(): [VariableAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|           expr converted: [CStyleCast] (long)...
+#   10|           : [CStyleCast] (long)...
 #   10|               Conversion = [IntegralConversion] integral conversion
 #   10|               Type = [LongType] long
 #   10|               ValueCategory = prvalue
-#   11|     1: [ReturnStmt] return ...
+#   11|     getStmt(1): [ReturnStmt] return ...
 DestructorCall.cpp:
 #    1| [Constructor] void C::C()
-#    1|   params: 
+#    1|   ...: 
 #    3| [Destructor] void C::~C()
-#    3|   params: 
-#    3|   body: [BlockStmt] { ... }
-#    4|     0: [ReturnStmt] return ...
-#    3|   destructions: 
+#    3|   ...: 
+#    3|   getEntryPoint(): [BlockStmt] { ... }
+#    4|     getStmt(0): [ReturnStmt] return ...
+#    3|   ...: 
 #   11| [TopLevelFunction] void DestructorCall(C*, D*)
-#   11|   params: 
-#   11|     0: [Parameter] c
+#   11|   ...: 
+#   11|     getParameter(0): [Parameter] c
 #   11|         Type = [PointerType] C *
-#   11|     1: [Parameter] d
+#   11|     getParameter(1): [Parameter] d
 #   11|         Type = [PointerType] D *
-#   11|   body: [BlockStmt] { ... }
-#   12|     0: [ExprStmt] ExprStmt
-#   12|       0: [DeleteExpr] delete
+#   11|   getEntryPoint(): [BlockStmt] { ... }
+#   12|     getStmt(0): [ExprStmt] ExprStmt
+#   12|       getExpr(): [DeleteExpr] delete
 #   12|           Type = [VoidType] void
 #   12|           ValueCategory = prvalue
-#   12|         1: [DestructorCall] call to ~C
+#   12|         getDestructorCall(): [DestructorCall] call to ~C
 #   12|             Type = [VoidType] void
 #   12|             ValueCategory = prvalue
-#   12|           -1: [VariableAccess] c
+#   12|           getQualifier(): [VariableAccess] c
 #   12|               Type = [PointerType] C *
 #   12|               ValueCategory = prvalue(load)
-#   13|     1: [ExprStmt] ExprStmt
-#   13|       0: [DeleteExpr] delete
+#   13|     getStmt(1): [ExprStmt] ExprStmt
+#   13|       getExpr(): [DeleteExpr] delete
 #   13|           Type = [VoidType] void
 #   13|           ValueCategory = prvalue
-#   13|         3: [VariableAccess] d
+#   13|         getExpr(): [VariableAccess] d
 #   13|             Type = [PointerType] D *
 #   13|             ValueCategory = prvalue(load)
-#   14|     2: [ReturnStmt] return ...
+#   14|     getStmt(2): [ReturnStmt] return ...
 DynamicCast.cpp:
 #    1| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ReturnStmt] return ...
-#-----|       0: [PointerDereferenceExpr] * ...
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ReturnStmt] return ...
+#-----|       getExpr(): [PointerDereferenceExpr] * ...
 #-----|           Type = [Class] Base
 #-----|           ValueCategory = lvalue
-#-----|         0: [ThisExpr] this
+#-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue(load)
-#-----|       0 converted: [ReferenceToExpr] (reference to)
+#-----|       : [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #    1| [MoveAssignmentOperator] Base& Base::operator=(Base&&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    1| [Constructor] void Base::Base()
-#    1|   params: 
+#    1|   ...: 
 #    1| [CopyConstructor] void Base::Base(Base const&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #    1| [MoveConstructor] void Base::Base(Base&&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    2| [VirtualFunction] void Base::f()
-#    2|   params: 
-#    2|   body: [BlockStmt] { ... }
-#    2|     0: [ReturnStmt] return ...
+#    2|   ...: 
+#    2|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ExprStmt] ExprStmt
-#    4|       0: [FunctionCall] call to operator=
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ExprStmt] ExprStmt
+#    4|       getExpr(): [FunctionCall] call to operator=
 #    4|           Type = [LValueReferenceType] Base &
 #    4|           ValueCategory = prvalue
-#    4|         -1: [ThisExpr] this
+#    4|         getQualifier(): [ThisExpr] this
 #    4|             Type = [PointerType] Derived *
 #    4|             ValueCategory = prvalue(load)
-#-----|         0: [CStyleCast] (Base *)...
+#-----|         getArgument(0): [CStyleCast] (Base *)...
 #-----|             Conversion = [BaseClassConversion] base class conversion
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue
-#    4|         0: [PointerDereferenceExpr] * ...
+#    4|         getArgument(0): [PointerDereferenceExpr] * ...
 #    4|             Type = [SpecifiedType] const Base
 #    4|             ValueCategory = lvalue
-#    4|           0: [AddressOfExpr] & ...
+#    4|           getOperand(): [AddressOfExpr] & ...
 #    4|               Type = [PointerType] const Derived *
 #    4|               ValueCategory = prvalue
-#    4|             0: [VariableAccess] (unnamed parameter 0)
+#    4|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #    4|                 Type = [LValueReferenceType] const Derived &
 #    4|                 ValueCategory = prvalue(load)
-#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|             : [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Derived
 #-----|                 ValueCategory = lvalue
-#-----|           0 converted: [CStyleCast] (const Base *)...
+#-----|           : [CStyleCast] (const Base *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Base *
 #-----|               ValueCategory = prvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Base &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Class] Base
 #-----|           ValueCategory = lvalue
-#-----|     1: [ReturnStmt] return ...
-#-----|       0: [PointerDereferenceExpr] * ...
+#-----|     getStmt(1): [ReturnStmt] return ...
+#-----|       getExpr(): [PointerDereferenceExpr] * ...
 #-----|           Type = [Class] Derived
 #-----|           ValueCategory = lvalue
-#-----|         0: [ThisExpr] this
+#-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Derived *
 #-----|             ValueCategory = prvalue(load)
-#-----|       0 converted: [ReferenceToExpr] (reference to)
+#-----|       : [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #    4| [MoveAssignmentOperator] Derived& Derived::operator=(Derived&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    4| [Constructor] void Derived::Derived()
-#    4|   params: 
+#    4|   ...: 
 #    4| [CopyConstructor] void Derived::Derived(Derived const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #    4| [MoveConstructor] void Derived::Derived(Derived&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    5| [VirtualFunction] void Derived::f()
-#    5|   params: 
-#    5|   body: [BlockStmt] { ... }
-#    5|     0: [ReturnStmt] return ...
+#    5|   ...: 
+#    5|   getEntryPoint(): [BlockStmt] { ... }
+#    5|     getStmt(0): [ReturnStmt] return ...
 #    8| [TopLevelFunction] void DynamicCast(Base*, Derived*)
-#    8|   params: 
-#    8|     0: [Parameter] bp
+#    8|   ...: 
+#    8|     getParameter(0): [Parameter] bp
 #    8|         Type = [PointerType] Base *
-#    8|     1: [Parameter] d
+#    8|     getParameter(1): [Parameter] d
 #    8|         Type = [PointerType] Derived *
-#    8|   body: [BlockStmt] { ... }
-#    9|     0: [ExprStmt] ExprStmt
-#    9|       0: [AssignExpr] ... = ...
+#    8|   getEntryPoint(): [BlockStmt] { ... }
+#    9|     getStmt(0): [ExprStmt] ExprStmt
+#    9|       getExpr(): [AssignExpr] ... = ...
 #    9|           Type = [PointerType] Derived *
 #    9|           ValueCategory = lvalue
-#    9|         0: [VariableAccess] d
+#    9|         getLValue(): [VariableAccess] d
 #    9|             Type = [PointerType] Derived *
 #    9|             ValueCategory = lvalue
-#    9|         1: [VariableAccess] bp
+#    9|         getRValue(): [VariableAccess] bp
 #    9|             Type = [PointerType] Base *
 #    9|             ValueCategory = prvalue(load)
-#    9|         1 converted: [DynamicCast] dynamic_cast<Derived *>...
+#    9|         : [DynamicCast] dynamic_cast<Derived *>...
 #    9|             Conversion = [DynamicCast] dynamic_cast
 #    9|             Type = [PointerType] Derived *
 #    9|             ValueCategory = prvalue
-#   10|     1: [ReturnStmt] return ...
+#   10|     getStmt(1): [ReturnStmt] return ...
 #   12| [TopLevelFunction] void DynamicCastRef(Base&, Derived&)
-#   12|   params: 
-#   12|     0: [Parameter] bp
+#   12|   ...: 
+#   12|     getParameter(0): [Parameter] bp
 #   12|         Type = [LValueReferenceType] Base &
-#   12|     1: [Parameter] d
+#   12|     getParameter(1): [Parameter] d
 #   12|         Type = [LValueReferenceType] Derived &
-#   12|   body: [BlockStmt] { ... }
-#   13|     0: [ExprStmt] ExprStmt
-#   13|       0: [FunctionCall] call to operator=
+#   12|   getEntryPoint(): [BlockStmt] { ... }
+#   13|     getStmt(0): [ExprStmt] ExprStmt
+#   13|       getExpr(): [FunctionCall] call to operator=
 #   13|           Type = [LValueReferenceType] Derived &
 #   13|           ValueCategory = prvalue
-#   13|         -1: [VariableAccess] d
+#   13|         getQualifier(): [VariableAccess] d
 #   13|             Type = [LValueReferenceType] Derived &
 #   13|             ValueCategory = prvalue(load)
-#   13|         0: [ReferenceDereferenceExpr] (reference dereference)
+#   13|         getArgument(0): [ReferenceDereferenceExpr] (reference dereference)
 #   13|             Type = [Class] Derived
 #   13|             ValueCategory = lvalue
-#   13|         0: [VariableAccess] bp
+#   13|         getArgument(0): [VariableAccess] bp
 #   13|             Type = [LValueReferenceType] Base &
 #   13|             ValueCategory = prvalue(load)
-#   13|         0 converted: [ReferenceToExpr] (reference to)
+#   13|         : [ReferenceToExpr] (reference to)
 #   13|             Type = [LValueReferenceType] const Derived &
 #   13|             ValueCategory = prvalue
-#   13|           expr: [CStyleCast] (const Derived)...
+#   13|           getExpr(): [CStyleCast] (const Derived)...
 #   13|               Conversion = [GlvalueConversion] glvalue conversion
 #   13|               Type = [SpecifiedType] const Derived
 #   13|               ValueCategory = lvalue
-#   13|             expr: [DynamicCast] dynamic_cast<Derived>...
+#   13|             getExpr(): [DynamicCast] dynamic_cast<Derived>...
 #   13|                 Conversion = [DynamicCast] dynamic_cast
 #   13|                 Type = [Class] Derived
 #   13|                 ValueCategory = lvalue
-#   13|               expr: [ReferenceDereferenceExpr] (reference dereference)
+#   13|               getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #   13|                   Type = [Class] Base
 #   13|                   ValueCategory = lvalue
-#   13|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#   13|       : [ReferenceDereferenceExpr] (reference dereference)
 #   13|           Type = [Class] Derived
 #   13|           ValueCategory = lvalue
-#   14|     1: [ReturnStmt] return ...
+#   14|     getStmt(1): [ReturnStmt] return ...
 Parenthesis.c:
 #    1| [TopLevelFunction] void Parenthesis(int)
-#    1|   params: 
-#    1|     0: [Parameter] i
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] i
+#    2|         getLValue(): [VariableAccess] i
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [MulExpr] ... * ...
+#    2|         getRValue(): [MulExpr] ... * ...
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = prvalue
-#    2|           0: [AddExpr] ... + ...
+#    2|           getLeftOperand(): [AddExpr] ... + ...
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
-#    2|             0: [VariableAccess] i
+#    2|             getLeftOperand(): [VariableAccess] i
 #    2|                 Type = [IntType] int
 #    2|                 ValueCategory = prvalue(load)
-#    2|             1: [Literal] 1
+#    2|             getRightOperand(): [Literal] 1
 #    2|                 Type = [IntType] int
 #    2|                 Value = [Literal] 1
 #    2|                 ValueCategory = prvalue
-#    2|           1: [Literal] 2
+#    2|           getRightOperand(): [Literal] 2
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 2
 #    2|               ValueCategory = prvalue
-#    2|           0 converted: [ParenthesisExpr] (...)
+#    2|           : [ParenthesisExpr] (...)
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 PointerDereference.c:
 #    1| [TopLevelFunction] void PointerDereference(int*, int)
-#    1|   params: 
-#    1|     0: [Parameter] i
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
-#    1|     1: [Parameter] j
+#    1|     getParameter(1): [Parameter] j
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] j
+#    2|         getLValue(): [VariableAccess] j
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [PointerDereferenceExpr] * ...
+#    2|         getRValue(): [PointerDereferenceExpr] * ...
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = prvalue(load)
-#    2|           0: [VariableAccess] i
+#    2|           getOperand(): [VariableAccess] i
 #    2|               Type = [IntPointerType] int *
 #    2|               ValueCategory = prvalue(load)
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 ReferenceDereference.cpp:
 #    4| [TopLevelFunction] void ReferenceDereference(int&, int)
-#    4|   params: 
-#    4|     0: [Parameter] i
+#    4|   ...: 
+#    4|     getParameter(0): [Parameter] i
 #    4|         Type = [LValueReferenceType] int &
-#    4|     1: [Parameter] j
+#    4|     getParameter(1): [Parameter] j
 #    4|         Type = [IntType] int
-#    4|   body: [BlockStmt] { ... }
-#    5|     0: [ExprStmt] ExprStmt
-#    5|       0: [AssignExpr] ... = ...
+#    4|   getEntryPoint(): [BlockStmt] { ... }
+#    5|     getStmt(0): [ExprStmt] ExprStmt
+#    5|       getExpr(): [AssignExpr] ... = ...
 #    5|           Type = [IntType] int
 #    5|           ValueCategory = lvalue
-#    5|         0: [VariableAccess] j
+#    5|         getLValue(): [VariableAccess] j
 #    5|             Type = [IntType] int
 #    5|             ValueCategory = lvalue
-#    5|         1: [VariableAccess] i
+#    5|         getRValue(): [VariableAccess] i
 #    5|             Type = [LValueReferenceType] int &
 #    5|             ValueCategory = prvalue(load)
-#    5|         1 converted: [ReferenceDereferenceExpr] (reference dereference)
+#    5|         : [ReferenceDereferenceExpr] (reference dereference)
 #    5|             Type = [IntType] int
 #    5|             ValueCategory = prvalue(load)
-#    6|     1: [ReturnStmt] return ...
+#    6|     getStmt(1): [ReturnStmt] return ...
 ReferenceTo.cpp:
 #    1| [TopLevelFunction] int& ReferenceTo(int*)
-#    1|   params: 
-#    1|     0: [Parameter] i
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ReturnStmt] return ...
-#    2|       0: [PointerDereferenceExpr] * ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ReturnStmt] return ...
+#    2|       getExpr(): [PointerDereferenceExpr] * ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = lvalue
-#    2|         0: [VariableAccess] i
+#    2|         getOperand(): [VariableAccess] i
 #    2|             Type = [IntPointerType] int *
 #    2|             ValueCategory = prvalue(load)
-#    2|       0 converted: [ReferenceToExpr] (reference to)
+#    2|       : [ReferenceToExpr] (reference to)
 #    2|           Type = [LValueReferenceType] int &
 #    2|           ValueCategory = prvalue
 Sizeof.c:
 #    1| [TopLevelFunction] void Sizeof(int[])
-#    1|   params: 
-#    1|     0: [Parameter] array
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] array
 #    1|         Type = [ArrayType] int[]
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of i
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #    2|           Type = [IntType] int
-#    2|         init: [Initializer] initializer for i
-#    2|           expr: [SizeofTypeOperator] sizeof(int)
+#    2|         getVariable().getInitializer(): [Initializer] initializer for i
+#    2|           getExpr(): [SizeofTypeOperator] sizeof(int)
 #    2|               Type = [LongType] unsigned long
 #    2|               Value = [SizeofTypeOperator] 4
 #    2|               ValueCategory = prvalue
-#    2|           expr converted: [CStyleCast] (int)...
+#    2|           : [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 4
 #    2|               ValueCategory = prvalue
-#    3|     1: [DeclStmt] declaration
-#    3|       0: [VariableDeclarationEntry] definition of j
+#    3|     getStmt(1): [DeclStmt] declaration
+#    3|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
 #    3|           Type = [IntType] int
-#    3|         init: [Initializer] initializer for j
-#    3|           expr: [SizeofExprOperator] sizeof(<expr>)
+#    3|         getVariable().getInitializer(): [Initializer] initializer for j
+#    3|           getExpr(): [SizeofExprOperator] sizeof(<expr>)
 #    3|               Type = [LongType] unsigned long
 #    3|               Value = [SizeofExprOperator] 8
 #    3|               ValueCategory = prvalue
-#    3|             0: [VariableAccess] array
+#    3|             getExprOperand(): [VariableAccess] array
 #    3|                 Type = [IntPointerType] int *
 #    3|                 ValueCategory = lvalue
-#    3|             0 converted: [ParenthesisExpr] (...)
+#    3|             : [ParenthesisExpr] (...)
 #    3|                 Type = [IntPointerType] int *
 #    3|                 ValueCategory = lvalue
-#    3|           expr converted: [CStyleCast] (int)...
+#    3|           : [CStyleCast] (int)...
 #    3|               Conversion = [IntegralConversion] integral conversion
 #    3|               Type = [IntType] int
 #    3|               Value = [CStyleCast] 8
 #    3|               ValueCategory = prvalue
-#    4|     2: [ReturnStmt] return ...
+#    4|     getStmt(2): [ReturnStmt] return ...
 StatementExpr.c:
 #    1| [TopLevelFunction] void StatementExpr()
-#    1|   params: 
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of j
+#    1|   ...: 
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
 #    2|           Type = [IntType] int
-#    2|         init: [Initializer] initializer for j
-#    2|           expr: [StmtExpr] (statement expression)
+#    2|         getVariable().getInitializer(): [Initializer] initializer for j
+#    2|           getExpr(): [StmtExpr] (statement expression)
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 StaticMemberAccess.cpp:
 #    1| [CopyAssignmentOperator] X& X::operator=(X const&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const X &
 #    1| [MoveAssignmentOperator] X& X::operator=(X&&)
-#    1|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    1|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] X &&
 #    5| [TopLevelFunction] void StaticMemberAccess(int, X&)
-#    5|   params: 
-#    5|     0: [Parameter] i
+#    5|   ...: 
+#    5|     getParameter(0): [Parameter] i
 #    5|         Type = [IntType] int
-#    5|     1: [Parameter] xref
+#    5|     getParameter(1): [Parameter] xref
 #    5|         Type = [LValueReferenceType] X &
-#    5|   body: [BlockStmt] { ... }
-#    7|     0: [ExprStmt] ExprStmt
-#    7|       0: [AssignExpr] ... = ...
+#    5|   getEntryPoint(): [BlockStmt] { ... }
+#    7|     getStmt(0): [ExprStmt] ExprStmt
+#    7|       getExpr(): [AssignExpr] ... = ...
 #    7|           Type = [IntType] int
 #    7|           ValueCategory = lvalue
-#    7|         0: [VariableAccess] i
+#    7|         getLValue(): [VariableAccess] i
 #    7|             Type = [IntType] int
 #    7|             ValueCategory = lvalue
-#    7|         1: [VariableAccess] i
+#    7|         getRValue(): [VariableAccess] i
 #    7|             Type = [IntType] int
 #    7|             ValueCategory = prvalue
-#    7|           -1: [VariableAccess] xref
+#    7|           getQualifier(): [VariableAccess] xref
 #    7|               Type = [LValueReferenceType] X &
 #    7|               ValueCategory = prvalue(load)
-#    7|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#    7|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 #    7|               Type = [Struct] X
 #    7|               ValueCategory = lvalue
-#    9|     1: [ReturnStmt] return ...
+#    9|     getStmt(1): [ReturnStmt] return ...
 Subscript.c:
 #    1| [TopLevelFunction] void Subscript(int[], int)
-#    1|   params: 
-#    1|     0: [Parameter] i
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] i
 #    1|         Type = [ArrayType] int[]
-#    1|     1: [Parameter] j
+#    1|     getParameter(1): [Parameter] j
 #    1|         Type = [IntType] int
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [ExprStmt] ExprStmt
-#    2|       0: [AssignExpr] ... = ...
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ExprStmt] ExprStmt
+#    2|       getExpr(): [AssignExpr] ... = ...
 #    2|           Type = [IntType] int
 #    2|           ValueCategory = prvalue
-#    2|         0: [VariableAccess] j
+#    2|         getLValue(): [VariableAccess] j
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = lvalue
-#    2|         1: [ArrayExpr] access to array
+#    2|         getRValue(): [ArrayExpr] access to array
 #    2|             Type = [IntType] int
 #    2|             ValueCategory = prvalue(load)
-#    2|           0: [VariableAccess] i
+#    2|           getArrayBase(): [VariableAccess] i
 #    2|               Type = [IntPointerType] int *
 #    2|               ValueCategory = prvalue(load)
-#    2|           1: [Literal] 5
+#    2|           getArrayOffset(): [Literal] 5
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 5
 #    2|               ValueCategory = prvalue
-#    3|     1: [ReturnStmt] return ...
+#    3|     getStmt(1): [ReturnStmt] return ...
 Throw.cpp:
 #    2| [CopyAssignmentOperator] F& F::operator=(F const&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveAssignmentOperator] F& F::operator=(F&&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
 #    2| [CopyConstructor] void F::F(F const&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveConstructor] void F::F(F&&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
-#    2|   initializations: 
-#    2|   body: [BlockStmt] { ... }
-#    2|     0: [ReturnStmt] return ...
+#    2|   ...: 
+#    2|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [Constructor] void F::F()
-#    4|   params: 
-#    4|   initializations: 
-#    4|   body: [BlockStmt] { ... }
-#    4|     0: [ReturnStmt] return ...
+#    4|   ...: 
+#    4|   ...: 
+#    4|   getEntryPoint(): [BlockStmt] { ... }
+#    4|     getStmt(0): [ReturnStmt] return ...
 #    6| [TopLevelFunction] void Throw(int)
-#    6|   params: 
-#    6|     0: [Parameter] i
+#    6|   ...: 
+#    6|     getParameter(0): [Parameter] i
 #    6|         Type = [IntType] int
-#    6|   body: [BlockStmt] { ... }
-#    7|     0: [TryStmt] try { ... }
-#    7|       0: [BlockStmt] { ... }
-#    8|         0: [IfStmt] if (...) ... 
-#    8|           0: [VariableAccess] i
+#    6|   getEntryPoint(): [BlockStmt] { ... }
+#    7|     getStmt(0): [TryStmt] try { ... }
+#    7|       getStmt(): [BlockStmt] { ... }
+#    8|         getStmt(0): [IfStmt] if (...) ... 
+#    8|           getCondition(): [VariableAccess] i
 #    8|               Type = [IntType] int
 #    8|               ValueCategory = prvalue(load)
-#    9|           1: [ExprStmt] ExprStmt
-#    9|             0: [ThrowExpr] throw ...
+#    9|           getThen(): [ExprStmt] ExprStmt
+#    9|             getExpr(): [ThrowExpr] throw ...
 #    9|                 Type = [Class] E
 #    9|                 ValueCategory = prvalue
-#    9|               0: [Literal] 0
+#    9|               getExpr(): [Literal] 0
 #    9|                   Type = [Class] E
 #    9|                   Value = [Literal] 0
 #    9|                   ValueCategory = prvalue
-#   11|           2: [ExprStmt] ExprStmt
-#   11|             0: [ThrowExpr] throw ...
+#   11|           getElse(): [ExprStmt] ExprStmt
+#   11|             getExpr(): [ThrowExpr] throw ...
 #   11|                 Type = [Class] F
 #   11|                 ValueCategory = prvalue
-#   11|               0: [ConstructorCall] call to F
+#   11|               getExpr(): [ConstructorCall] call to F
 #   11|                   Type = [VoidType] void
 #   11|                   ValueCategory = prvalue
-#    8|           0 converted: [CStyleCast] (bool)...
+#    8|           : [CStyleCast] (bool)...
 #    8|               Conversion = [BoolConversion] conversion to bool
 #    8|               Type = [BoolType] bool
 #    8|               ValueCategory = prvalue
-#   12|       1: [Handler] <handler>
-#   12|         0: [CatchBlock] { ... }
-#   13|           0: [ExprStmt] ExprStmt
-#   13|             0: [ReThrowExpr] re-throw exception 
+#   12|       getChild(1): [Handler] <handler>
+#   12|         getBlock(): [CatchBlock] { ... }
+#   13|           getStmt(0): [ExprStmt] ExprStmt
+#   13|             getExpr(): [ReThrowExpr] re-throw exception 
 #   13|                 Type = [VoidType] void
 #   13|                 ValueCategory = prvalue
 Typeid.cpp:
 #    4| [CopyAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const type_info &
 #    4| [MoveAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] type_info &&
 #    7| [ConstMemberFunction] char const* std::type_info::name() const
-#    7|   params: 
+#    7|   ...: 
 #   13| [VirtualFunction] void Base::v()
-#   13|   params: 
-#   13|   body: [BlockStmt] { ... }
-#   13|     0: [ReturnStmt] return ...
+#   13|   ...: 
+#   13|   getEntryPoint(): [BlockStmt] { ... }
+#   13|     getStmt(0): [ReturnStmt] return ...
 #   18| [TopLevelFunction] void TypeId(Base*)
-#   18|   params: 
-#   18|     0: [Parameter] bp
+#   18|   ...: 
+#   18|     getParameter(0): [Parameter] bp
 #   18|         Type = [PointerType] Base *
-#   18|   body: [BlockStmt] { ... }
-#   19|     0: [DeclStmt] declaration
-#   19|       0: [VariableDeclarationEntry] definition of name
+#   18|   getEntryPoint(): [BlockStmt] { ... }
+#   19|     getStmt(0): [DeclStmt] declaration
+#   19|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of name
 #   19|           Type = [PointerType] const char *
-#   19|         init: [Initializer] initializer for name
-#   19|           expr: [FunctionCall] call to name
+#   19|         getVariable().getInitializer(): [Initializer] initializer for name
+#   19|           getExpr(): [FunctionCall] call to name
 #   19|               Type = [PointerType] const char *
 #   19|               ValueCategory = prvalue
-#   19|             -1: [TypeidOperator] typeid ...
+#   19|             getQualifier(): [TypeidOperator] typeid ...
 #   19|                 Type = [SpecifiedType] const type_info
 #   19|                 ValueCategory = lvalue
-#   19|               0: [VariableAccess] bp
+#   19|               getExpr(): [VariableAccess] bp
 #   19|                   Type = [PointerType] Base *
 #   19|                   ValueCategory = lvalue
-#   20|     1: [ReturnStmt] return ...
+#   20|     getStmt(1): [ReturnStmt] return ...
 VacuousDestructorCall.cpp:
 #    2| [TemplateFunction,TopLevelFunction] void CallDestructor<T>(T, T*)
-#    2|   params: 
-#    2|     0: [Parameter] x
+#    2|   ...: 
+#    2|     getParameter(0): [Parameter] x
 #    2|         Type = [TemplateParameter] T
-#    2|     1: [Parameter] y
+#    2|     getParameter(1): [Parameter] y
 #    2|         Type = [PointerType] T *
-#    2|   body: [BlockStmt] { ... }
-#    3|     0: [ExprStmt] ExprStmt
-#    3|       0: [ExprCall] call to expression
+#    2|   getEntryPoint(): [BlockStmt] { ... }
+#    3|     getStmt(0): [ExprStmt] ExprStmt
+#    3|       getExpr(): [ExprCall] call to expression
 #    3|           Type = [UnknownType] unknown
 #    3|           ValueCategory = prvalue
-#    3|         0: [Literal] Unknown literal
+#    3|         getExpr(): [Literal] Unknown literal
 #    3|             Type = [UnknownType] unknown
 #    3|             ValueCategory = prvalue
-#    3|           -1: [VariableAccess] x
+#    3|           getChild(-1): [VariableAccess] x
 #    3|               Type = [TemplateParameter] T
 #    3|               ValueCategory = lvalue
-#    4|     1: [ExprStmt] ExprStmt
-#    4|       0: [ExprCall] call to expression
+#    4|     getStmt(1): [ExprStmt] ExprStmt
+#    4|       getExpr(): [ExprCall] call to expression
 #    4|           Type = [UnknownType] unknown
 #    4|           ValueCategory = prvalue
-#    4|         0: [Literal] Unknown literal
+#    4|         getExpr(): [Literal] Unknown literal
 #    4|             Type = [UnknownType] unknown
 #    4|             ValueCategory = prvalue
-#    4|           -1: [VariableAccess] y
+#    4|           getChild(-1): [VariableAccess] y
 #    4|               Type = [PointerType] T *
 #    4|               ValueCategory = prvalue(load)
-#    5|     2: [ReturnStmt] return ...
+#    5|     getStmt(2): [ReturnStmt] return ...
 #    2| [FunctionTemplateInstantiation,TopLevelFunction] void CallDestructor<int>(int, int*)
-#    2|   params: 
-#    2|     0: [Parameter] x
+#    2|   ...: 
+#    2|     getParameter(0): [Parameter] x
 #    2|         Type = [IntType] int
-#    2|     1: [Parameter] y
+#    2|     getParameter(1): [Parameter] y
 #    2|         Type = [IntPointerType] int *
-#    2|   body: [BlockStmt] { ... }
-#    3|     0: [ExprStmt] ExprStmt
-#    3|       0: [VacuousDestructorCall] (vacuous destructor call)
+#    2|   getEntryPoint(): [BlockStmt] { ... }
+#    3|     getStmt(0): [ExprStmt] ExprStmt
+#    3|       getExpr(): [VacuousDestructorCall] (vacuous destructor call)
 #    3|           Type = [VoidType] void
 #    3|           ValueCategory = prvalue
-#    3|         0: [VariableAccess] x
+#    3|         getChild(0): [VariableAccess] x
 #    3|             Type = [IntType] int
 #    3|             ValueCategory = lvalue
-#    4|     1: [ExprStmt] ExprStmt
-#    4|       0: [VacuousDestructorCall] (vacuous destructor call)
+#    4|     getStmt(1): [ExprStmt] ExprStmt
+#    4|       getExpr(): [VacuousDestructorCall] (vacuous destructor call)
 #    4|           Type = [VoidType] void
 #    4|           ValueCategory = prvalue
-#    4|         0: [VariableAccess] y
+#    4|         getChild(0): [VariableAccess] y
 #    4|             Type = [IntPointerType] int *
 #    4|             ValueCategory = prvalue(load)
-#    5|     2: [ReturnStmt] return ...
+#    5|     getStmt(2): [ReturnStmt] return ...
 #    7| [TopLevelFunction] void Vacuous(int)
-#    7|   params: 
-#    7|     0: [Parameter] i
+#    7|   ...: 
+#    7|     getParameter(0): [Parameter] i
 #    7|         Type = [IntType] int
-#    7|   body: [BlockStmt] { ... }
-#   10|     0: [ExprStmt] ExprStmt
-#   10|       0: [FunctionCall] call to CallDestructor
+#    7|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [ExprStmt] ExprStmt
+#   10|       getExpr(): [FunctionCall] call to CallDestructor
 #   10|           Type = [VoidType] void
 #   10|           ValueCategory = prvalue
-#   10|         0: [VariableAccess] i
+#   10|         getArgument(0): [VariableAccess] i
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
-#   10|         1: [AddressOfExpr] & ...
+#   10|         getArgument(1): [AddressOfExpr] & ...
 #   10|             Type = [IntPointerType] int *
 #   10|             ValueCategory = prvalue
-#   10|           0: [VariableAccess] i
+#   10|           getOperand(): [VariableAccess] i
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = lvalue
-#   11|     1: [ReturnStmt] return ...
+#   11|     getStmt(1): [ReturnStmt] return ...
 Varargs.c:
 #    8| [TopLevelFunction] void VarArgs(char const*)
-#    8|   params: 
-#    8|     0: [Parameter] text
+#    8|   ...: 
+#    8|     getParameter(0): [Parameter] text
 #    8|         Type = [PointerType] const char *
-#    8|   body: [BlockStmt] { ... }
-#    9|     0: [DeclStmt] declaration
-#    9|       0: [VariableDeclarationEntry] definition of args
+#    8|   getEntryPoint(): [BlockStmt] { ... }
+#    9|     getStmt(0): [DeclStmt] declaration
+#    9|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of args
 #    9|           Type = [CTypedefType] va_list
-#   10|     1: [ExprStmt] ExprStmt
-#   10|       0: [BuiltInVarArgsStart] __builtin_va_start
+#   10|     getStmt(1): [ExprStmt] ExprStmt
+#   10|       getExpr(): [BuiltInVarArgsStart] __builtin_va_start
 #   10|           Type = [VoidType] void
 #   10|           ValueCategory = prvalue
-#   10|         0: [VariableAccess] args
+#   10|         getVAList(): [VariableAccess] args
 #   10|             Type = [CTypedefType] va_list
 #   10|             ValueCategory = lvalue
-#   10|         1: [VariableAccess] text
+#   10|         getLastNamedParameter(): [VariableAccess] text
 #   10|             Type = [PointerType] const char *
 #   10|             ValueCategory = lvalue
-#   10|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   10|         : [ArrayToPointerConversion] array to pointer conversion
 #   10|             Type = [PointerType] __va_list_tag *
 #   10|             ValueCategory = prvalue
-#   11|     2: [ExprStmt] ExprStmt
-#   11|       0: [BuiltInVarArgsEnd] __builtin_va_end
+#   11|     getStmt(2): [ExprStmt] ExprStmt
+#   11|       getExpr(): [BuiltInVarArgsEnd] __builtin_va_end
 #   11|           Type = [VoidType] void
 #   11|           ValueCategory = prvalue
-#   11|         0: [VariableAccess] args
+#   11|         getVAList(): [VariableAccess] args
 #   11|             Type = [CTypedefType] va_list
 #   11|             ValueCategory = lvalue
-#   11|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   11|         : [ArrayToPointerConversion] array to pointer conversion
 #   11|             Type = [PointerType] __va_list_tag *
 #   11|             ValueCategory = prvalue
-#   12|     3: [ReturnStmt] return ...
+#   12|     getStmt(3): [ReturnStmt] return ...
 macro_etc.c:
 #    3| [TopLevelFunction] int bar(int)
-#    3|   params: 
-#    3|     0: [Parameter] i
+#    3|   ...: 
+#    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
-#    3|   body: [BlockStmt] { ... }
-#    4|     0: [DeclStmt] declaration
-#    4|       0: [TypeDeclarationEntry] definition of u
+#    3|   getEntryPoint(): [BlockStmt] { ... }
+#    4|     getStmt(0): [DeclStmt] declaration
+#    4|       getDeclarationEntry(0): [TypeDeclarationEntry] definition of u
 #    4|           Type = [LocalUnion] u
-#    8|       1: [VariableDeclarationEntry] definition of uu
+#    8|       getDeclarationEntry(1): [VariableDeclarationEntry] definition of uu
 #    8|           Type = [LocalUnion] u
-#    9|     1: [ExprStmt] ExprStmt
-#    9|       0: [AssignExpr] ... = ...
+#    9|     getStmt(1): [ExprStmt] ExprStmt
+#    9|       getExpr(): [AssignExpr] ... = ...
 #    9|           Type = [IntType] int
 #    9|           ValueCategory = prvalue
-#    9|         0: [ValueFieldAccess] b
+#    9|         getLValue(): [ValueFieldAccess] b
 #    9|             Type = [IntType] int
 #    9|             ValueCategory = lvalue
-#    9|           -1: [VariableAccess] uu
+#    9|           getQualifier(): [VariableAccess] uu
 #    9|               Type = [LocalUnion] u
 #    9|               ValueCategory = lvalue
-#    9|         1: [AddExpr] ... + ...
+#    9|         getRValue(): [AddExpr] ... + ...
 #    9|             Type = [IntType] int
 #    9|             ValueCategory = prvalue
-#    9|           0: [VariableAccess] i
+#    9|           getLeftOperand(): [VariableAccess] i
 #    9|               Type = [IntType] int
 #    9|               ValueCategory = prvalue(load)
-#    9|           1: [ValueFieldAccess] a
+#    9|           getRightOperand(): [ValueFieldAccess] a
 #    9|               Type = [IntType] int
 #    9|               ValueCategory = prvalue(load)
-#    9|             -1: [VariableAccess] uu
+#    9|             getQualifier(): [VariableAccess] uu
 #    9|                 Type = [LocalUnion] u
 #    9|                 ValueCategory = lvalue
-#   10|     2: [ReturnStmt] return ...
-#   10|       0: [AddExpr] ... + ...
+#   10|     getStmt(2): [ReturnStmt] return ...
+#   10|       getExpr(): [AddExpr] ... + ...
 #   10|           Type = [IntType] int
 #   10|           ValueCategory = prvalue
-#   10|         0: [AddExpr] ... + ...
+#   10|         getLeftOperand(): [AddExpr] ... + ...
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue
-#   10|           0: [ValueFieldAccess] b
+#   10|           getLeftOperand(): [ValueFieldAccess] b
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|             -1: [VariableAccess] uu
+#   10|             getQualifier(): [VariableAccess] uu
 #   10|                 Type = [LocalUnion] u
 #   10|                 ValueCategory = lvalue
-#   10|           1: [VariableAccess] i
+#   10|           getRightOperand(): [VariableAccess] i
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|         1: [Literal] 2
+#   10|         getRightOperand(): [Literal] 2
 #   10|             Type = [IntType] int
 #   10|             Value = [Literal] 2
 #   10|             ValueCategory = prvalue
 #   22| [TopLevelFunction] int foo()
-#   22|   params: 
-#   22|   body: [BlockStmt] { ... }
-#   23|     0: [DeclStmt] declaration
-#   23|       0: [VariableDeclarationEntry] definition of t
+#   22|   ...: 
+#   22|   getEntryPoint(): [BlockStmt] { ... }
+#   23|     getStmt(0): [DeclStmt] declaration
+#   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of t
 #   23|           Type = [IntType] int
-#   23|         init: [Initializer] initializer for t
-#   23|           expr: [Literal] 4
+#   23|         getVariable().getInitializer(): [Initializer] initializer for t
+#   23|           getExpr(): [Literal] 4
 #   23|               Type = [IntType] int
 #   23|               Value = [Literal] 4
 #   23|               ValueCategory = prvalue
-#   24|     1: [DeclStmt] declaration
-#   24|       0: [VariableDeclarationEntry] definition of bp
+#   24|     getStmt(1): [DeclStmt] declaration
+#   24|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of bp
 #   24|           Type = [FunctionPointerType] ..(*)(..)
-#   25|     2: [DeclStmt] declaration
-#   25|       0: [VariableDeclarationEntry] definition of bt
+#   25|     getStmt(2): [DeclStmt] declaration
+#   25|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of bt
 #   25|           Type = [CharPointerType] char *
-#   25|       1: [VariableDeclarationEntry] definition of i
+#   25|       getDeclarationEntry(1): [VariableDeclarationEntry] definition of i
 #   25|           Type = [PlainCharType] char
-#   26|     3: [DeclStmt] declaration
-#   26|       0: [VariableDeclarationEntry] definition of arr
+#   26|     getStmt(3): [DeclStmt] declaration
+#   26|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of arr
 #   26|           Type = [ArrayType] char[]
-#   26|     4: [VlaDimensionStmt] VLA dimension size
-#   26|       0: [VariableAccess] t
+#   26|     getStmt(4): [VlaDimensionStmt] VLA dimension size
+#   26|       getDimensionExpr(): [VariableAccess] t
 #   26|           Type = [IntType] int
 #   26|           ValueCategory = prvalue(load)
-#   26|     5: [VlaDeclStmt] VLA declaration
-#   27|     6: [ForStmt] for(...;...;...) ...
-#   27|       0: [ExprStmt] ExprStmt
-#   27|         0: [AssignExpr] ... = ...
+#   26|     getStmt(5): [VlaDeclStmt] VLA declaration
+#   27|     getStmt(6): [ForStmt] for(...;...;...) ...
+#   27|       getInitialization(): [ExprStmt] ExprStmt
+#   27|         getExpr(): [AssignExpr] ... = ...
 #   27|             Type = [PlainCharType] char
 #   27|             ValueCategory = prvalue
-#   27|           0: [VariableAccess] i
+#   27|           getLValue(): [VariableAccess] i
 #   27|               Type = [PlainCharType] char
 #   27|               ValueCategory = lvalue
-#   27|           1: [Literal] 0
+#   27|           getRValue(): [Literal] 0
 #   27|               Type = [IntType] int
 #   27|               Value = [Literal] 0
 #   27|               ValueCategory = prvalue
-#   27|           1 converted: [CStyleCast] (char)...
+#   27|           : [CStyleCast] (char)...
 #   27|               Conversion = [IntegralConversion] integral conversion
 #   27|               Type = [PlainCharType] char
 #   27|               Value = [CStyleCast] 0
 #   27|               ValueCategory = prvalue
-#   27|       1: [LTExpr] ... < ...
+#   27|       getCondition(): [LTExpr] ... < ...
 #   27|           Type = [IntType] int
 #   27|           ValueCategory = prvalue
-#   27|         0: [VariableAccess] i
+#   27|         getLesserOperand(): [VariableAccess] i
 #   27|             Type = [PlainCharType] char
 #   27|             ValueCategory = prvalue(load)
-#   27|         1: [Literal] 6
+#   27|         getGreaterOperand(): [Literal] 6
 #   27|             Type = [IntType] int
 #   27|             Value = [Literal] 6
 #   27|             ValueCategory = prvalue
-#   27|         0 converted: [CStyleCast] (int)...
+#   27|         : [CStyleCast] (int)...
 #   27|             Conversion = [IntegralConversion] integral conversion
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
-#   27|       2: [PrefixIncrExpr] ++ ...
+#   27|       getUpdate(): [PrefixIncrExpr] ++ ...
 #   27|           Type = [PlainCharType] char
 #   27|           ValueCategory = prvalue
-#   27|         0: [VariableAccess] i
+#   27|         getOperand(): [VariableAccess] i
 #   27|             Type = [PlainCharType] char
 #   27|             ValueCategory = lvalue
-#   27|       3: [BlockStmt] { ... }
-#   27|         0: [ExprStmt] ExprStmt
-#   27|           0: [AssignAddExpr] ... += ...
+#   27|       getStmt(): [BlockStmt] { ... }
+#   27|         getStmt(0): [ExprStmt] ExprStmt
+#   27|           getExpr(): [AssignAddExpr] ... += ...
 #   27|               Type = [IntType] int
 #   27|               ValueCategory = prvalue
-#   27|             0: [VariableAccess] t
+#   27|             getLValue(): [VariableAccess] t
 #   27|                 Type = [IntType] int
 #   27|                 ValueCategory = lvalue
-#   27|             1: [VariableAccess] i
+#   27|             getRValue(): [VariableAccess] i
 #   27|                 Type = [PlainCharType] char
 #   27|                 ValueCategory = prvalue(load)
-#   27|             1 converted: [CStyleCast] (int)...
+#   27|             : [CStyleCast] (int)...
 #   27|                 Conversion = [IntegralConversion] integral conversion
 #   27|                 Type = [IntType] int
 #   27|                 ValueCategory = prvalue
-#   28|     7: [ForStmt] for(...;...;...) ...
-#   28|       0: [ExprStmt] ExprStmt
-#   28|         0: [AssignExpr] ... = ...
+#   28|     getStmt(7): [ForStmt] for(...;...;...) ...
+#   28|       getInitialization(): [ExprStmt] ExprStmt
+#   28|         getExpr(): [AssignExpr] ... = ...
 #   28|             Type = [PlainCharType] char
 #   28|             ValueCategory = prvalue
-#   28|           0: [VariableAccess] i
+#   28|           getLValue(): [VariableAccess] i
 #   28|               Type = [PlainCharType] char
 #   28|               ValueCategory = lvalue
-#   28|           1: [Literal] 0
+#   28|           getRValue(): [Literal] 0
 #   28|               Type = [IntType] int
 #   28|               Value = [Literal] 0
 #   28|               ValueCategory = prvalue
-#   28|           1 converted: [CStyleCast] (char)...
+#   28|           : [CStyleCast] (char)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [PlainCharType] char
 #   28|               Value = [CStyleCast] 0
 #   28|               ValueCategory = prvalue
-#   28|       1: [LTExpr] ... < ...
+#   28|       getCondition(): [LTExpr] ... < ...
 #   28|           Type = [IntType] int
 #   28|           ValueCategory = prvalue
-#   28|         0: [VariableAccess] i
+#   28|         getLesserOperand(): [VariableAccess] i
 #   28|             Type = [PlainCharType] char
 #   28|             ValueCategory = prvalue(load)
-#   28|         1: [Literal] 6
+#   28|         getGreaterOperand(): [Literal] 6
 #   28|             Type = [IntType] int
 #   28|             Value = [Literal] 6
 #   28|             ValueCategory = prvalue
-#   28|         0 converted: [CStyleCast] (int)...
+#   28|         : [CStyleCast] (int)...
 #   28|             Conversion = [IntegralConversion] integral conversion
 #   28|             Type = [IntType] int
 #   28|             ValueCategory = prvalue
-#   28|       2: [PrefixIncrExpr] ++ ...
+#   28|       getUpdate(): [PrefixIncrExpr] ++ ...
 #   28|           Type = [PlainCharType] char
 #   28|           ValueCategory = prvalue
-#   28|         0: [VariableAccess] i
+#   28|         getOperand(): [VariableAccess] i
 #   28|             Type = [PlainCharType] char
 #   28|             ValueCategory = lvalue
-#   28|       3: [BlockStmt] { ... }
-#   28|         0: [ExprStmt] ExprStmt
-#   28|           0: [AssignAddExpr] ... += ...
+#   28|       getStmt(): [BlockStmt] { ... }
+#   28|         getStmt(0): [ExprStmt] ExprStmt
+#   28|           getExpr(): [AssignAddExpr] ... += ...
 #   28|               Type = [IntType] int
 #   28|               ValueCategory = prvalue
-#   28|             0: [VariableAccess] t
+#   28|             getLValue(): [VariableAccess] t
 #   28|                 Type = [IntType] int
 #   28|                 ValueCategory = lvalue
-#   28|             1: [VariableAccess] i
+#   28|             getRValue(): [VariableAccess] i
 #   28|                 Type = [PlainCharType] char
 #   28|                 ValueCategory = prvalue(load)
-#   28|             1 converted: [CStyleCast] (int)...
+#   28|             : [CStyleCast] (int)...
 #   28|                 Conversion = [IntegralConversion] integral conversion
 #   28|                 Type = [IntType] int
 #   28|                 ValueCategory = prvalue
-#   29|     8: [ExprStmt] ExprStmt
-#   29|       0: [AssignExpr] ... = ...
+#   29|     getStmt(8): [ExprStmt] ExprStmt
+#   29|       getExpr(): [AssignExpr] ... = ...
 #   29|           Type = [CharPointerType] char *
 #   29|           ValueCategory = prvalue
-#   29|         0: [VariableAccess] bt
+#   29|         getLValue(): [VariableAccess] bt
 #   29|             Type = [CharPointerType] char *
 #   29|             ValueCategory = lvalue
-#   29|         1: b
+#   29|         getRValue(): b
 #   29|             Type = [ArrayType] char[2]
 #   29|             Value = [StringLiteral] "b"
 #   29|             ValueCategory = lvalue
-#   29|         1 converted: [ArrayToPointerConversion] array to pointer conversion
+#   29|         : [ArrayToPointerConversion] array to pointer conversion
 #   29|             Type = [CharPointerType] char *
 #   29|             ValueCategory = prvalue
-#   30|     9: [ExprStmt] ExprStmt
-#   30|       0: [AssignExpr] ... = ...
+#   30|     getStmt(9): [ExprStmt] ExprStmt
+#   30|       getExpr(): [AssignExpr] ... = ...
 #   30|           Type = [PlainCharType] char
 #   30|           ValueCategory = prvalue
-#   30|         0: [ArrayExpr] access to array
+#   30|         getLValue(): [ArrayExpr] access to array
 #   30|             Type = [PlainCharType] char
 #   30|             ValueCategory = lvalue
-#   30|           0: [VariableAccess] arr
+#   30|           getArrayBase(): [VariableAccess] arr
 #   30|               Type = [ArrayType] char[]
 #   30|               ValueCategory = lvalue
-#   30|           1: [Literal] 0
+#   30|           getArrayOffset(): [Literal] 0
 #   30|               Type = [IntType] int
 #   30|               Value = [Literal] 0
 #   30|               ValueCategory = prvalue
-#   30|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   30|           : [ArrayToPointerConversion] array to pointer conversion
 #   30|               Type = [CharPointerType] char *
 #   30|               ValueCategory = prvalue
-#   30|         1: [VariableAccess] t
+#   30|         getRValue(): [VariableAccess] t
 #   30|             Type = [IntType] int
 #   30|             ValueCategory = prvalue(load)
-#   30|         1 converted: [CStyleCast] (char)...
+#   30|         : [CStyleCast] (char)...
 #   30|             Conversion = [IntegralConversion] integral conversion
 #   30|             Type = [PlainCharType] char
 #   30|             ValueCategory = prvalue
-#   31|     10: [ExprStmt] ExprStmt
-#   31|       0: [AssignExpr] ... = ...
+#   31|     getStmt(10): [ExprStmt] ExprStmt
+#   31|       getExpr(): [AssignExpr] ... = ...
 #   31|           Type = [FunctionPointerType] ..(*)(..)
 #   31|           ValueCategory = prvalue
-#   31|         0: [VariableAccess] bp
+#   31|         getLValue(): [VariableAccess] bp
 #   31|             Type = [FunctionPointerType] ..(*)(..)
 #   31|             ValueCategory = lvalue
-#   31|         1: [FunctionAccess] bar
+#   31|         getRValue(): [FunctionAccess] bar
 #   31|             Type = [FunctionPointerType] ..(*)(..)
 #   31|             ValueCategory = prvalue(load)
-#   32|     11: [ReturnStmt] return ...
-#   32|       0: [AddExpr] ... + ...
+#   32|     getStmt(11): [ReturnStmt] return ...
+#   32|       getExpr(): [AddExpr] ... + ...
 #   32|           Type = [IntType] int
 #   32|           ValueCategory = prvalue
-#   32|         0: [VariableAccess] t
+#   32|         getLeftOperand(): [VariableAccess] t
 #   32|             Type = [IntType] int
 #   32|             ValueCategory = prvalue(load)
-#   32|         1: [ArrayExpr] access to array
+#   32|         getRightOperand(): [ArrayExpr] access to array
 #   32|             Type = [PlainCharType] char
 #   32|             ValueCategory = prvalue(load)
-#   32|           0: [VariableAccess] arr
+#   32|           getArrayBase(): [VariableAccess] arr
 #   32|               Type = [ArrayType] char[]
 #   32|               ValueCategory = lvalue
-#   32|           1: [Literal] 1
+#   32|           getArrayOffset(): [Literal] 1
 #   32|               Type = [IntType] int
 #   32|               Value = [Literal] 1
 #   32|               ValueCategory = prvalue
-#   32|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   32|           : [ArrayToPointerConversion] array to pointer conversion
 #   32|               Type = [CharPointerType] char *
 #   32|               ValueCategory = prvalue
-#   32|         1 converted: [CStyleCast] (int)...
+#   32|         : [CStyleCast] (int)...
 #   32|             Conversion = [IntegralConversion] integral conversion
 #   32|             Type = [IntType] int
 #   32|             ValueCategory = prvalue
 union_etc.cpp:
 #    2| [CopyAssignmentOperator] S& S::operator=(S const&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveAssignmentOperator] S& S::operator=(S&&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    2| [Constructor] void S::S()
-#    2|   params: 
-#    2|   initializations: 
-#    2|   body: [BlockStmt] { ... }
-#    2|     0: [ReturnStmt] return ...
+#    2|   ...: 
+#    2|   ...: 
+#    2|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [ReturnStmt] return ...
 #    2| [CopyConstructor] void S::S(S const&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveConstructor] void S::S(S&&)
-#    2|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    2|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    3| [CopyAssignmentOperator] S::U& S::U::operator=(S::U const public&)
-#    3|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    3|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #    3| [MoveAssignmentOperator] S::U& S::U::operator=(S::U&&)
-#    3|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    3|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #    4| [CopyAssignmentOperator] S::C& S::C::operator=(S::C const public&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    4| [MoveAssignmentOperator] S::C& S::C::operator=(S::C&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    6| [VirtualFunction] void S::set_q(int)
-#    6|   params: 
-#    6|     0: [Parameter] val
+#    6|   ...: 
+#    6|     getParameter(0): [Parameter] val
 #    6|         Type = [IntType] int
-#    6|   body: [BlockStmt] { ... }
-#    6|     0: [ExprStmt] ExprStmt
-#    6|       0: [AssignExpr] ... = ...
+#    6|   getEntryPoint(): [BlockStmt] { ... }
+#    6|     getStmt(0): [ExprStmt] ExprStmt
+#    6|       getExpr(): [AssignExpr] ... = ...
 #    6|           Type = [IntType] int
 #    6|           ValueCategory = lvalue
-#    6|         0: [PointerFieldAccess] x
+#    6|         getLValue(): [PointerFieldAccess] x
 #    6|             Type = [IntType] int
 #    6|             ValueCategory = lvalue
-#    6|           -1: [ThisExpr] this
+#    6|           getQualifier(): [ThisExpr] this
 #    6|               Type = [PointerType] S *
 #    6|               ValueCategory = prvalue(load)
-#    6|         1: [VariableAccess] val
+#    6|         getRValue(): [VariableAccess] val
 #    6|             Type = [IntType] int
 #    6|             ValueCategory = prvalue(load)
-#    6|     1: [ReturnStmt] return ...
+#    6|     getStmt(1): [ReturnStmt] return ...
 #    9| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    9|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    9|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    9| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    9|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    9|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   11| [CopyAssignmentOperator] C::S& C::S::operator=(C::S const public&)
-#   11|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   11|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   11| [MoveAssignmentOperator] C::S& C::S::operator=(C::S&&)
-#   11|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   11|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   12| [CopyAssignmentOperator] C::U& C::U::operator=(C::U const public&)
-#   12|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   12|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   12| [MoveAssignmentOperator] C::U& C::U::operator=(C::U&&)
-#   12|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   12|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   16| [CopyAssignmentOperator] U& U::operator=(U const&)
-#   16|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   16|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   16| [MoveAssignmentOperator] U& U::operator=(U&&)
-#   16|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   16|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   17| [CopyAssignmentOperator] U::S& U::S::operator=(U::S const public&)
-#   17|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   17|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   17| [MoveAssignmentOperator] U::S& U::S::operator=(U::S&&)
-#   17|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   17|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   18| [CopyAssignmentOperator] U::C& U::C::operator=(U::C const public&)
-#   18|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   18|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #   18| [MoveAssignmentOperator] U::C& U::C::operator=(U::C&&)
-#   18|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   18|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   22| [TopLevelFunction] int foo()
-#   22|   params: 
-#   22|   body: [BlockStmt] { ... }
-#   23|     0: [DeclStmt] declaration
-#   23|       0: [VariableDeclarationEntry] definition of s
+#   22|   ...: 
+#   22|   getEntryPoint(): [BlockStmt] { ... }
+#   23|     getStmt(0): [DeclStmt] declaration
+#   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 #   23|           Type = [Struct] S
-#   23|         init: [Initializer] initializer for s
-#   23|           expr: [ConstructorCall] call to S
+#   23|         getVariable().getInitializer(): [Initializer] initializer for s
+#   23|           getExpr(): [ConstructorCall] call to S
 #   23|               Type = [VoidType] void
 #   23|               ValueCategory = prvalue
-#   24|     1: [DeclStmt] declaration
-#   24|       0: [VariableDeclarationEntry] definition of c
+#   24|     getStmt(1): [DeclStmt] declaration
+#   24|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 #   24|           Type = [Class] C
-#   25|     2: [DeclStmt] declaration
-#   25|       0: [VariableDeclarationEntry] definition of u
+#   25|     getStmt(2): [DeclStmt] declaration
+#   25|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of u
 #   25|           Type = [Union] U
-#   26|     3: [ExprStmt] ExprStmt
-#   26|       0: [AssignExpr] ... = ...
+#   26|     getStmt(3): [ExprStmt] ExprStmt
+#   26|       getExpr(): [AssignExpr] ... = ...
 #   26|           Type = [IntType] int
 #   26|           ValueCategory = lvalue
-#   26|         0: [ValueFieldAccess] a
+#   26|         getLValue(): [ValueFieldAccess] a
 #   26|             Type = [IntType] int
 #   26|             ValueCategory = lvalue
-#   26|           -1: [ValueFieldAccess] u
+#   26|           getQualifier(): [ValueFieldAccess] u
 #   26|               Type = [NestedUnion] U
 #   26|               ValueCategory = lvalue
-#   26|             -1: [VariableAccess] s
+#   26|             getQualifier(): [VariableAccess] s
 #   26|                 Type = [Struct] S
 #   26|                 ValueCategory = lvalue
-#   26|         1: [AssignExpr] ... = ...
+#   26|         getRValue(): [AssignExpr] ... = ...
 #   26|             Type = [IntType] int
 #   26|             ValueCategory = prvalue
-#   26|           0: [ValueFieldAccess] e
+#   26|           getLValue(): [ValueFieldAccess] e
 #   26|               Type = [IntType] int
 #   26|               ValueCategory = lvalue
-#   26|             -1: [ValueFieldAccess] s
+#   26|             getQualifier(): [ValueFieldAccess] s
 #   26|                 Type = [NestedStruct] S
 #   26|                 ValueCategory = lvalue
-#   26|               -1: [VariableAccess] c
+#   26|               getQualifier(): [VariableAccess] c
 #   26|                   Type = [Class] C
 #   26|                   ValueCategory = lvalue
-#   26|           1: [AssignExpr] ... = ...
+#   26|           getRValue(): [AssignExpr] ... = ...
 #   26|               Type = [IntType] int
 #   26|               ValueCategory = prvalue
-#   26|             0: [ValueFieldAccess] i
+#   26|             getLValue(): [ValueFieldAccess] i
 #   26|                 Type = [IntType] int
 #   26|                 ValueCategory = lvalue
-#   26|               -1: [ValueFieldAccess] c
+#   26|               getQualifier(): [ValueFieldAccess] c
 #   26|                   Type = [NestedClass] C
 #   26|                   ValueCategory = lvalue
-#   26|                 -1: [VariableAccess] u
+#   26|                 getQualifier(): [VariableAccess] u
 #   26|                     Type = [Union] U
 #   26|                     ValueCategory = lvalue
-#   26|             1: [Literal] 43
+#   26|             getRValue(): [Literal] 43
 #   26|                 Type = [IntType] int
 #   26|                 Value = [Literal] 43
 #   26|                 ValueCategory = prvalue
-#   27|     4: [ExprStmt] ExprStmt
-#   27|       0: [AssignAddExpr] ... += ...
+#   27|     getStmt(4): [ExprStmt] ExprStmt
+#   27|       getExpr(): [AssignAddExpr] ... += ...
 #   27|           Type = [IntType] int
 #   27|           ValueCategory = lvalue
-#   27|         0: [ValueFieldAccess] b
+#   27|         getLValue(): [ValueFieldAccess] b
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = lvalue
-#   27|           -1: [ValueFieldAccess] u
+#   27|           getQualifier(): [ValueFieldAccess] u
 #   27|               Type = [NestedUnion] U
 #   27|               ValueCategory = lvalue
-#   27|             -1: [VariableAccess] s
+#   27|             getQualifier(): [VariableAccess] s
 #   27|                 Type = [Struct] S
 #   27|                 ValueCategory = lvalue
-#   27|         1: [AddExpr] ... + ...
+#   27|         getRValue(): [AddExpr] ... + ...
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
-#   27|           0: [ValueFieldAccess] i
+#   27|           getLeftOperand(): [ValueFieldAccess] i
 #   27|               Type = [IntType] int
 #   27|               ValueCategory = prvalue(load)
-#   27|             -1: [ValueFieldAccess] c
+#   27|             getQualifier(): [ValueFieldAccess] c
 #   27|                 Type = [NestedClass] C
 #   27|                 ValueCategory = lvalue
-#   27|               -1: [VariableAccess] u
+#   27|               getQualifier(): [VariableAccess] u
 #   27|                   Type = [Union] U
 #   27|                   ValueCategory = lvalue
-#   27|           1: [ValueFieldAccess] j
+#   27|           getRightOperand(): [ValueFieldAccess] j
 #   27|               Type = [IntType] int
 #   27|               ValueCategory = prvalue(load)
-#   27|             -1: [VariableAccess] u
+#   27|             getQualifier(): [VariableAccess] u
 #   27|                 Type = [Union] U
 #   27|                 ValueCategory = lvalue
-#   27|         1 converted: [ParenthesisExpr] (...)
+#   27|         : [ParenthesisExpr] (...)
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
-#   28|     5: [ReturnStmt] return ...
-#   28|       0: [ValueFieldAccess] g
+#   28|     getStmt(5): [ReturnStmt] return ...
+#   28|       getExpr(): [ValueFieldAccess] g
 #   28|           Type = [IntType] int
 #   28|           ValueCategory = prvalue(load)
-#   28|         -1: [VariableAccess] c
+#   28|         getQualifier(): [VariableAccess] c
 #   28|             Type = [Class] C
 #   28|             ValueCategory = lvalue
 #   31| [CopyAssignmentOperator] T& T::operator=(T const&)
-#   31|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   31|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveAssignmentOperator] T& T::operator=(T&&)
-#   31|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   31|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   31| [Constructor] void T::T()
-#   31|   params: 
+#   31|   ...: 
 #   31| [CopyConstructor] void T::T(T const&)
-#   31|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   31|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveConstructor] void T::T(T&&)
-#   31|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   31|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   33| [VirtualFunction] void T::set_q(int)
-#   33|   params: 
-#   33|     0: [Parameter] val
+#   33|   ...: 
+#   33|     getParameter(0): [Parameter] val
 #   33|         Type = [IntType] int
-#   33|   body: [BlockStmt] { ... }
-#   33|     0: [ExprStmt] ExprStmt
-#   33|       0: [AssignExpr] ... = ...
+#   33|   getEntryPoint(): [BlockStmt] { ... }
+#   33|     getStmt(0): [ExprStmt] ExprStmt
+#   33|       getExpr(): [AssignExpr] ... = ...
 #   33|           Type = [IntType] int
 #   33|           ValueCategory = lvalue
-#   33|         0: [PointerFieldAccess] q
+#   33|         getLValue(): [PointerFieldAccess] q
 #   33|             Type = [IntType] int
 #   33|             ValueCategory = lvalue
-#   33|           -1: [ThisExpr] this
+#   33|           getQualifier(): [ThisExpr] this
 #   33|               Type = [PointerType] T *
 #   33|               ValueCategory = prvalue(load)
-#   33|         1: [VariableAccess] val
+#   33|         getRValue(): [VariableAccess] val
 #   33|             Type = [IntType] int
 #   33|             ValueCategory = prvalue(load)
-#   33|     1: [ReturnStmt] return ...
+#   33|     getStmt(1): [ReturnStmt] return ...
 #   36| [TopLevelFunction] int bar()
-#   36|   params: 
-#   36|   body: [BlockStmt] { ... }
-#   37|     0: [DeclStmt] declaration
-#   37|       0: [VariableDeclarationEntry] definition of s
+#   36|   ...: 
+#   36|   getEntryPoint(): [BlockStmt] { ... }
+#   37|     getStmt(0): [DeclStmt] declaration
+#   37|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 #   37|           Type = [PointerType] const T *
-#   37|         init: [Initializer] initializer for s
-#   37|           expr: [AddressOfExpr] & ...
+#   37|         getVariable().getInitializer(): [Initializer] initializer for s
+#   37|           getExpr(): [AddressOfExpr] & ...
 #   37|               Type = [PointerType] C *
 #   37|               ValueCategory = prvalue
-#   37|             0: [VariableAccess] c
+#   37|             getOperand(): [VariableAccess] c
 #   37|                 Type = [Class] C
 #   37|                 ValueCategory = lvalue
-#   37|           expr converted: [CStyleCast] (const T *)...
+#   37|           : [CStyleCast] (const T *)...
 #   37|               Conversion = [PointerConversion] pointer conversion
 #   37|               Type = [PointerType] const T *
 #   37|               ValueCategory = prvalue
-#   38|     1: [DeclStmt] declaration
-#   38|       0: [VariableDeclarationEntry] definition of t
+#   38|     getStmt(1): [DeclStmt] declaration
+#   38|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of t
 #   38|           Type = [PointerType] const S *
-#   38|         init: [Initializer] initializer for t
-#   38|           expr: [VariableAccess] s
+#   38|         getVariable().getInitializer(): [Initializer] initializer for t
+#   38|           getExpr(): [VariableAccess] s
 #   38|               Type = [PointerType] const T *
 #   38|               ValueCategory = prvalue(load)
-#   38|           expr converted: [StaticCast] static_cast<const S *>...
+#   38|           : [StaticCast] static_cast<const S *>...
 #   38|               Conversion = [BaseClassConversion] base class conversion
 #   38|               Type = [PointerType] const S *
 #   38|               ValueCategory = prvalue
-#   39|     2: [DeclStmt] declaration
-#   39|       0: [VariableDeclarationEntry] definition of x
+#   39|     getStmt(2): [DeclStmt] declaration
+#   39|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #   39|           Type = [PointerType] T *
-#   39|         init: [Initializer] initializer for x
-#   39|           expr: [VariableAccess] s
+#   39|         getVariable().getInitializer(): [Initializer] initializer for x
+#   39|           getExpr(): [VariableAccess] s
 #   39|               Type = [PointerType] const T *
 #   39|               ValueCategory = prvalue(load)
-#   39|           expr converted: [ConstCast] const_cast<T *>...
+#   39|           : [ConstCast] const_cast<T *>...
 #   39|               Conversion = [PointerConversion] pointer conversion
 #   39|               Type = [PointerType] T *
 #   39|               ValueCategory = prvalue
-#   40|     3: [DeclStmt] declaration
-#   40|       0: [VariableDeclarationEntry] definition of v
+#   40|     getStmt(3): [DeclStmt] declaration
+#   40|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of v
 #   40|           Type = [PointerType] const T *
-#   40|         init: [Initializer] initializer for v
-#   40|           expr: [VariableAccess] t
+#   40|         getVariable().getInitializer(): [Initializer] initializer for v
+#   40|           getExpr(): [VariableAccess] t
 #   40|               Type = [PointerType] const S *
 #   40|               ValueCategory = prvalue(load)
-#   40|           expr converted: [DynamicCast] dynamic_cast<const T *>...
+#   40|           : [DynamicCast] dynamic_cast<const T *>...
 #   40|               Conversion = [DynamicCast] dynamic_cast
 #   40|               Type = [PointerType] const T *
 #   40|               ValueCategory = prvalue
-#   41|     4: [DeclStmt] declaration
-#   41|       0: [VariableDeclarationEntry] definition of w
+#   41|     getStmt(4): [DeclStmt] declaration
+#   41|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of w
 #   41|           Type = [PointerType] S *
-#   41|         init: [Initializer] initializer for w
-#   41|           expr: [AddressOfExpr] & ...
+#   41|         getVariable().getInitializer(): [Initializer] initializer for w
+#   41|           getExpr(): [AddressOfExpr] & ...
 #   41|               Type = [PointerType] C *
 #   41|               ValueCategory = prvalue
-#   41|             0: [VariableAccess] c
+#   41|             getOperand(): [VariableAccess] c
 #   41|                 Type = [Class] C
 #   41|                 ValueCategory = lvalue
-#   41|           expr converted: [ReinterpretCast] reinterpret_cast<S *>...
+#   41|           : [ReinterpretCast] reinterpret_cast<S *>...
 #   41|               Conversion = [PointerConversion] pointer conversion
 #   41|               Type = [PointerType] S *
 #   41|               ValueCategory = prvalue
-#   42|     5: [ReturnStmt] return ...
-#   42|       0: [ValueFieldAccess] b
+#   42|     getStmt(5): [ReturnStmt] return ...
+#   42|       getExpr(): [ValueFieldAccess] b
 #   42|           Type = [IntType] int
 #   42|           ValueCategory = prvalue(load)
-#   42|         -1: [PointerFieldAccess] c
+#   42|         getQualifier(): [PointerFieldAccess] c
 #   42|             Type = [NestedClass] C
 #   42|             ValueCategory = lvalue
-#   42|           -1: [VariableAccess] x
+#   42|           getQualifier(): [VariableAccess] x
 #   42|               Type = [PointerType] T *
 #   42|               ValueCategory = prvalue(load)
-#   42|           -1: [CStyleCast] (S *)...
+#   42|           getQualifier(): [CStyleCast] (S *)...
 #   42|               Conversion = [BaseClassConversion] base class conversion
 #   42|               Type = [PointerType] S *
 #   42|               ValueCategory = prvalue

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -1,22 +1,22 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 AddressOf.c:
 #    1| [TopLevelFunction] void AddressOf(int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -33,7 +33,7 @@ AddressOf.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 ArrayToPointer.c:
 #    5| [TopLevelFunction] void ArrayToPointer()
-#    5|   : 
+#    5|   <params>: 
 #    6|   getEntryPoint(): [BlockStmt] { ... }
 #    7|     getStmt(0): [DeclStmt] declaration
 #    7|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
@@ -59,13 +59,13 @@ ArrayToPointer.c:
 #    9|         getRValue(): [VariableAccess] c
 #    9|             Type = [ArrayType] char[6]
 #    9|             ValueCategory = lvalue
-#    9|         : [ArrayToPointerConversion] array to pointer conversion
+#    9|         getRValue().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #    9|             Type = [CharPointerType] char *
 #    9|             ValueCategory = prvalue
 #   10|     getStmt(3): [ReturnStmt] return ...
 Cast.c:
 #    1| [TopLevelFunction] void Cast(char*, void*)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] c
 #    1|         Type = [CharPointerType] char *
 #    1|     getParameter(1): [Parameter] v
@@ -81,14 +81,14 @@ Cast.c:
 #    2|         getRValue(): [VariableAccess] v
 #    2|             Type = [VoidPointerType] void *
 #    2|             ValueCategory = prvalue(load)
-#    2|         : [CStyleCast] (char *)...
+#    2|         getRValue().getFullyConverted(): [CStyleCast] (char *)...
 #    2|             Conversion = [PointerConversion] pointer conversion
 #    2|             Type = [CharPointerType] char *
 #    2|             ValueCategory = prvalue
 #    3|     getStmt(1): [ReturnStmt] return ...
 ConditionDecl.cpp:
 #    1| [TopLevelFunction] void ConditionDecl()
-#    1|   : 
+#    1|   <params>: 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -105,7 +105,7 @@ ConditionDecl.cpp:
 #    3|         getVariableAccess(): [VariableAccess] k
 #    3|             Type = [IntType] int
 #    3|             ValueCategory = prvalue(load)
-#    3|         : [CStyleCast] (bool)...
+#    3|         getVariableAccess().getFullyConverted(): [CStyleCast] (bool)...
 #    3|             Conversion = [BoolConversion] conversion to bool
 #    3|             Type = [BoolType] bool
 #    3|             ValueCategory = prvalue
@@ -113,59 +113,59 @@ ConditionDecl.cpp:
 #    5|     getStmt(2): [ReturnStmt] return ...
 ConstructorCall.cpp:
 #    1| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    1| [CopyConstructor] void C::C(C const&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveConstructor] void C::C(C&&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    3| [ConversionConstructor] void C::C(int)
-#    3|   : 
+#    3|   <params>: 
 #    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
-#    3|   : 
+#    3|   <initializations>: 
 #    3|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
 #    7| [CopyAssignmentOperator] D& D::operator=(D const&)
-#    7|   : 
+#    7|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveAssignmentOperator] D& D::operator=(D&&)
-#    7|   : 
+#    7|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    7| [CopyConstructor] void D::D(D const&)
-#    7|   : 
+#    7|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveConstructor] void D::D(D&&)
-#    7|   : 
+#    7|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    9| [Constructor] void D::D()
-#    9|   : 
-#    9|   : 
+#    9|   <params>: 
+#    9|   <initializations>: 
 #    9|   getEntryPoint(): [BlockStmt] { ... }
 #   10|     getStmt(0): [ReturnStmt] return ...
 #   13| [CopyAssignmentOperator] E& E::operator=(E const&)
-#   13|   : 
+#   13|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const E &
 #   13| [MoveAssignmentOperator] E& E::operator=(E&&)
-#   13|   : 
+#   13|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] E &&
 #   17| [TopLevelFunction] void ConstructorCall(C*, D*, E*)
-#   17|   : 
+#   17|   <params>: 
 #   17|     getParameter(0): [Parameter] c
 #   17|         Type = [PointerType] C *
 #   17|     getParameter(1): [Parameter] d
@@ -220,7 +220,7 @@ ConstructorCall.cpp:
 #   21|     getStmt(3): [ReturnStmt] return ...
 Conversion1.c:
 #    1| [TopLevelFunction] void Conversion1()
-#    1|   : 
+#    1|   <params>: 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -230,7 +230,7 @@ Conversion1.c:
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 1
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
@@ -238,7 +238,7 @@ Conversion1.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion2.c:
 #    1| [TopLevelFunction] void Conversion2(int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -261,12 +261,12 @@ Conversion2.c:
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 7
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           getLeftOperand().getFullyConverted(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 5
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           getRightOperand().getFullyConverted(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 7
@@ -274,7 +274,7 @@ Conversion2.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion3.cpp:
 #    1| [TopLevelFunction] void Conversion3(int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -297,7 +297,7 @@ Conversion3.cpp:
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 7
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           getLeftOperand().getFullyConverted(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 1
@@ -312,7 +312,7 @@ Conversion3.cpp:
 #    2|                   Type = [IntType] int
 #    2|                   Value = [CStyleCast] 1
 #    2|                   ValueCategory = prvalue
-#    2|           : [ParenthesisExpr] (...)
+#    2|           getRightOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #    2|               Type = [IntType] int
 #    2|               Value = [ParenthesisExpr] 7
 #    2|               ValueCategory = prvalue
@@ -324,7 +324,7 @@ Conversion3.cpp:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion4.c:
 #    1| [TopLevelFunction] void Conversion4(int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -339,7 +339,7 @@ Conversion4.c:
 #    2|             Type = [IntType] int
 #    2|             Value = [Literal] 7
 #    2|             ValueCategory = prvalue
-#    2|         : [ParenthesisExpr] (...)
+#    2|         getRValue().getFullyConverted(): [ParenthesisExpr] (...)
 #    2|             Type = [IntType] int
 #    2|             Value = [ParenthesisExpr] 7
 #    2|             ValueCategory = prvalue
@@ -350,7 +350,7 @@ Conversion4.c:
 #    2|               ValueCategory = prvalue
 #    3|     getStmt(1): [ReturnStmt] return ...
 #    5| [TopLevelFunction] char* retfn(void*)
-#    5|   ...: 
+#    5|   <params>: 
 #    5|     getParameter(0): [Parameter] v
 #    5|         Type = [VoidPointerType] void *
 #    5|   getEntryPoint(): [BlockStmt] { ... }
@@ -358,7 +358,7 @@ Conversion4.c:
 #    6|       getExpr(): [VariableAccess] v
 #    6|           Type = [VoidPointerType] void *
 #    6|           ValueCategory = prvalue(load)
-#    6|       : [CStyleCast] (char *)...
+#    6|       getExpr().getFullyConverted(): [CStyleCast] (char *)...
 #    6|           Conversion = [PointerConversion] pointer conversion
 #    6|           Type = [CharPointerType] char *
 #    6|           ValueCategory = prvalue
@@ -371,7 +371,7 @@ Conversion4.c:
 #    6|               Type = [IntPointerType] int *
 #    6|               ValueCategory = prvalue
 #    9| [TopLevelFunction] void Conversion4_vardecl(int)
-#    9|   ...: 
+#    9|   <params>: 
 #    9|     getParameter(0): [Parameter] x
 #    9|         Type = [IntType] int
 #    9|   getEntryPoint(): [BlockStmt] { ... }
@@ -382,21 +382,21 @@ Conversion4.c:
 #   10|           getExpr(): [VariableAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|           : [CStyleCast] (long)...
+#   10|           getExpr().getFullyConverted(): [CStyleCast] (long)...
 #   10|               Conversion = [IntegralConversion] integral conversion
 #   10|               Type = [LongType] long
 #   10|               ValueCategory = prvalue
 #   11|     getStmt(1): [ReturnStmt] return ...
 DestructorCall.cpp:
 #    1| [Constructor] void C::C()
-#    1|   : 
+#    1|   <params>: 
 #    3| [Destructor] void C::~C()
-#    3|   : 
+#    3|   <params>: 
 #    3|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
-#    3|   : 
+#    3|   <destructions>: 
 #   11| [TopLevelFunction] void DestructorCall(C*, D*)
-#   11|   : 
+#   11|   <params>: 
 #   11|     getParameter(0): [Parameter] c
 #   11|         Type = [PointerType] C *
 #   11|     getParameter(1): [Parameter] d
@@ -422,7 +422,7 @@ DestructorCall.cpp:
 #   14|     getStmt(2): [ReturnStmt] return ...
 DynamicCast.cpp:
 #    1| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -433,29 +433,29 @@ DynamicCast.cpp:
 #-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue(load)
-#-----|       : [ReferenceToExpr] (reference to)
+#-----|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #    1| [MoveAssignmentOperator] Base& Base::operator=(Base&&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    1| [Constructor] void Base::Base()
-#    1|   : 
+#    1|   <params>: 
 #    1| [CopyConstructor] void Base::Base(Base const&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #    1| [MoveConstructor] void Base::Base(Base&&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    2| [VirtualFunction] void Base::f()
-#    2|   : 
+#    2|   <params>: 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -466,10 +466,6 @@ DynamicCast.cpp:
 #    4|         getQualifier(): [ThisExpr] this
 #    4|             Type = [PointerType] Derived *
 #    4|             ValueCategory = prvalue(load)
-#-----|         getArgument(0): [CStyleCast] (Base *)...
-#-----|             Conversion = [BaseClassConversion] base class conversion
-#-----|             Type = [PointerType] Base *
-#-----|             ValueCategory = prvalue
 #    4|         getArgument(0): [PointerDereferenceExpr] * ...
 #    4|             Type = [SpecifiedType] const Base
 #    4|             ValueCategory = lvalue
@@ -479,17 +475,21 @@ DynamicCast.cpp:
 #    4|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #    4|                 Type = [LValueReferenceType] const Derived &
 #    4|                 ValueCategory = prvalue(load)
-#-----|             : [ReferenceDereferenceExpr] (reference dereference)
+#-----|             getOperand().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Derived
 #-----|                 ValueCategory = lvalue
-#-----|           : [CStyleCast] (const Base *)...
+#-----|           getOperand().getFullyConverted(): [CStyleCast] (const Base *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Base *
 #-----|               ValueCategory = prvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getQualifier().getFullyConverted(): [CStyleCast] (Base *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Base &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Class] Base
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(1): [ReturnStmt] return ...
@@ -499,29 +499,29 @@ DynamicCast.cpp:
 #-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Derived *
 #-----|             ValueCategory = prvalue(load)
-#-----|       : [ReferenceToExpr] (reference to)
+#-----|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #    4| [MoveAssignmentOperator] Derived& Derived::operator=(Derived&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    4| [Constructor] void Derived::Derived()
-#    4|   : 
+#    4|   <params>: 
 #    4| [CopyConstructor] void Derived::Derived(Derived const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #    4| [MoveConstructor] void Derived::Derived(Derived&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    5| [VirtualFunction] void Derived::f()
-#    5|   : 
+#    5|   <params>: 
 #    5|   getEntryPoint(): [BlockStmt] { ... }
 #    5|     getStmt(0): [ReturnStmt] return ...
 #    8| [TopLevelFunction] void DynamicCast(Base*, Derived*)
-#    8|   : 
+#    8|   <params>: 
 #    8|     getParameter(0): [Parameter] bp
 #    8|         Type = [PointerType] Base *
 #    8|     getParameter(1): [Parameter] d
@@ -537,13 +537,13 @@ DynamicCast.cpp:
 #    9|         getRValue(): [VariableAccess] bp
 #    9|             Type = [PointerType] Base *
 #    9|             ValueCategory = prvalue(load)
-#    9|         : [DynamicCast] dynamic_cast<Derived *>...
+#    9|         getRValue().getFullyConverted(): [DynamicCast] dynamic_cast<Derived *>...
 #    9|             Conversion = [DynamicCast] dynamic_cast
 #    9|             Type = [PointerType] Derived *
 #    9|             ValueCategory = prvalue
 #   10|     getStmt(1): [ReturnStmt] return ...
 #   12| [TopLevelFunction] void DynamicCastRef(Base&, Derived&)
-#   12|   : 
+#   12|   <params>: 
 #   12|     getParameter(0): [Parameter] bp
 #   12|         Type = [LValueReferenceType] Base &
 #   12|     getParameter(1): [Parameter] d
@@ -556,13 +556,13 @@ DynamicCast.cpp:
 #   13|         getQualifier(): [VariableAccess] d
 #   13|             Type = [LValueReferenceType] Derived &
 #   13|             ValueCategory = prvalue(load)
-#   13|         getArgument(0): [ReferenceDereferenceExpr] (reference dereference)
-#   13|             Type = [Class] Derived
-#   13|             ValueCategory = lvalue
 #   13|         getArgument(0): [VariableAccess] bp
 #   13|             Type = [LValueReferenceType] Base &
 #   13|             ValueCategory = prvalue(load)
-#   13|         : [ReferenceToExpr] (reference to)
+#   13|         getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
+#   13|             Type = [Class] Derived
+#   13|             ValueCategory = lvalue
+#   13|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #   13|             Type = [LValueReferenceType] const Derived &
 #   13|             ValueCategory = prvalue
 #   13|           getExpr(): [CStyleCast] (const Derived)...
@@ -576,13 +576,13 @@ DynamicCast.cpp:
 #   13|               getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #   13|                   Type = [Class] Base
 #   13|                   ValueCategory = lvalue
-#   13|       : [ReferenceDereferenceExpr] (reference dereference)
+#   13|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #   13|           Type = [Class] Derived
 #   13|           ValueCategory = lvalue
 #   14|     getStmt(1): [ReturnStmt] return ...
 Parenthesis.c:
 #    1| [TopLevelFunction] void Parenthesis(int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -610,13 +610,13 @@ Parenthesis.c:
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 2
 #    2|               ValueCategory = prvalue
-#    2|           : [ParenthesisExpr] (...)
+#    2|           getLeftOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #    2|               Type = [IntType] int
 #    2|               ValueCategory = prvalue
 #    3|     getStmt(1): [ReturnStmt] return ...
 PointerDereference.c:
 #    1| [TopLevelFunction] void PointerDereference(int*, int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
 #    1|     getParameter(1): [Parameter] j
@@ -638,7 +638,7 @@ PointerDereference.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 ReferenceDereference.cpp:
 #    4| [TopLevelFunction] void ReferenceDereference(int&, int)
-#    4|   : 
+#    4|   <params>: 
 #    4|     getParameter(0): [Parameter] i
 #    4|         Type = [LValueReferenceType] int &
 #    4|     getParameter(1): [Parameter] j
@@ -654,13 +654,13 @@ ReferenceDereference.cpp:
 #    5|         getRValue(): [VariableAccess] i
 #    5|             Type = [LValueReferenceType] int &
 #    5|             ValueCategory = prvalue(load)
-#    5|         : [ReferenceDereferenceExpr] (reference dereference)
+#    5|         getRValue().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #    5|             Type = [IntType] int
 #    5|             ValueCategory = prvalue(load)
 #    6|     getStmt(1): [ReturnStmt] return ...
 ReferenceTo.cpp:
 #    1| [TopLevelFunction] int& ReferenceTo(int*)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -671,12 +671,12 @@ ReferenceTo.cpp:
 #    2|         getOperand(): [VariableAccess] i
 #    2|             Type = [IntPointerType] int *
 #    2|             ValueCategory = prvalue(load)
-#    2|       : [ReferenceToExpr] (reference to)
+#    2|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #    2|           Type = [LValueReferenceType] int &
 #    2|           ValueCategory = prvalue
 Sizeof.c:
 #    1| [TopLevelFunction] void Sizeof(int[])
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] array
 #    1|         Type = [ArrayType] int[]
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -688,7 +688,7 @@ Sizeof.c:
 #    2|               Type = [LongType] unsigned long
 #    2|               Value = [SizeofTypeOperator] 4
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (int)...
+#    2|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [IntType] int
 #    2|               Value = [CStyleCast] 4
@@ -704,10 +704,10 @@ Sizeof.c:
 #    3|             getExprOperand(): [VariableAccess] array
 #    3|                 Type = [IntPointerType] int *
 #    3|                 ValueCategory = lvalue
-#    3|             : [ParenthesisExpr] (...)
+#    3|             getExprOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #    3|                 Type = [IntPointerType] int *
 #    3|                 ValueCategory = lvalue
-#    3|           : [CStyleCast] (int)...
+#    3|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 #    3|               Conversion = [IntegralConversion] integral conversion
 #    3|               Type = [IntType] int
 #    3|               Value = [CStyleCast] 8
@@ -715,7 +715,7 @@ Sizeof.c:
 #    4|     getStmt(2): [ReturnStmt] return ...
 StatementExpr.c:
 #    1| [TopLevelFunction] void StatementExpr()
-#    1|   : 
+#    1|   <params>: 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -727,15 +727,15 @@ StatementExpr.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 StaticMemberAccess.cpp:
 #    1| [CopyAssignmentOperator] X& X::operator=(X const&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const X &
 #    1| [MoveAssignmentOperator] X& X::operator=(X&&)
-#    1|   : 
+#    1|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] X &&
 #    5| [TopLevelFunction] void StaticMemberAccess(int, X&)
-#    5|   : 
+#    5|   <params>: 
 #    5|     getParameter(0): [Parameter] i
 #    5|         Type = [IntType] int
 #    5|     getParameter(1): [Parameter] xref
@@ -754,13 +754,13 @@ StaticMemberAccess.cpp:
 #    7|           getQualifier(): [VariableAccess] xref
 #    7|               Type = [LValueReferenceType] X &
 #    7|               ValueCategory = prvalue(load)
-#    7|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+#    7|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #    7|               Type = [Struct] X
 #    7|               ValueCategory = lvalue
 #    9|     getStmt(1): [ReturnStmt] return ...
 Subscript.c:
 #    1| [TopLevelFunction] void Subscript(int[], int)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [ArrayType] int[]
 #    1|     getParameter(1): [Parameter] j
@@ -786,31 +786,31 @@ Subscript.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Throw.cpp:
 #    2| [CopyAssignmentOperator] F& F::operator=(F const&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveAssignmentOperator] F& F::operator=(F&&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
 #    2| [CopyConstructor] void F::F(F const&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveConstructor] void F::F(F&&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
-#    2|   : 
+#    2|   <initializations>: 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [Constructor] void F::F()
-#    4|   : 
-#    4|   : 
+#    4|   <params>: 
+#    4|   <initializations>: 
 #    4|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
 #    6| [TopLevelFunction] void Throw(int)
-#    6|   : 
+#    6|   <params>: 
 #    6|     getParameter(0): [Parameter] i
 #    6|         Type = [IntType] int
 #    6|   getEntryPoint(): [BlockStmt] { ... }
@@ -835,7 +835,7 @@ Throw.cpp:
 #   11|               getExpr(): [ConstructorCall] call to F
 #   11|                   Type = [VoidType] void
 #   11|                   ValueCategory = prvalue
-#    8|           : [CStyleCast] (bool)...
+#    8|           getCondition().getFullyConverted(): [CStyleCast] (bool)...
 #    8|               Conversion = [BoolConversion] conversion to bool
 #    8|               Type = [BoolType] bool
 #    8|               ValueCategory = prvalue
@@ -847,21 +847,21 @@ Throw.cpp:
 #   13|                 ValueCategory = prvalue
 Typeid.cpp:
 #    4| [CopyAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const type_info &
 #    4| [MoveAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] type_info &&
 #    7| [ConstMemberFunction] char const* std::type_info::name() const
-#    7|   : 
+#    7|   <params>: 
 #   13| [VirtualFunction] void Base::v()
-#   13|   : 
+#   13|   <params>: 
 #   13|   getEntryPoint(): [BlockStmt] { ... }
 #   13|     getStmt(0): [ReturnStmt] return ...
 #   18| [TopLevelFunction] void TypeId(Base*)
-#   18|   : 
+#   18|   <params>: 
 #   18|     getParameter(0): [Parameter] bp
 #   18|         Type = [PointerType] Base *
 #   18|   getEntryPoint(): [BlockStmt] { ... }
@@ -881,7 +881,7 @@ Typeid.cpp:
 #   20|     getStmt(1): [ReturnStmt] return ...
 VacuousDestructorCall.cpp:
 #    2| [TemplateFunction,TopLevelFunction] void CallDestructor<T>(T, T*)
-#    2|   : 
+#    2|   <params>: 
 #    2|     getParameter(0): [Parameter] x
 #    2|         Type = [TemplateParameter] T
 #    2|     getParameter(1): [Parameter] y
@@ -909,7 +909,7 @@ VacuousDestructorCall.cpp:
 #    4|               ValueCategory = prvalue(load)
 #    5|     getStmt(2): [ReturnStmt] return ...
 #    2| [FunctionTemplateInstantiation,TopLevelFunction] void CallDestructor<int>(int, int*)
-#    2|   : 
+#    2|   <params>: 
 #    2|     getParameter(0): [Parameter] x
 #    2|         Type = [IntType] int
 #    2|     getParameter(1): [Parameter] y
@@ -931,7 +931,7 @@ VacuousDestructorCall.cpp:
 #    4|             ValueCategory = prvalue(load)
 #    5|     getStmt(2): [ReturnStmt] return ...
 #    7| [TopLevelFunction] void Vacuous(int)
-#    7|   : 
+#    7|   <params>: 
 #    7|     getParameter(0): [Parameter] i
 #    7|         Type = [IntType] int
 #    7|   getEntryPoint(): [BlockStmt] { ... }
@@ -951,7 +951,7 @@ VacuousDestructorCall.cpp:
 #   11|     getStmt(1): [ReturnStmt] return ...
 Varargs.c:
 #    8| [TopLevelFunction] void VarArgs(char const*)
-#    8|   : 
+#    8|   <params>: 
 #    8|     getParameter(0): [Parameter] text
 #    8|         Type = [PointerType] const char *
 #    8|   getEntryPoint(): [BlockStmt] { ... }
@@ -968,7 +968,7 @@ Varargs.c:
 #   10|         getLastNamedParameter(): [VariableAccess] text
 #   10|             Type = [PointerType] const char *
 #   10|             ValueCategory = lvalue
-#   10|         : [ArrayToPointerConversion] array to pointer conversion
+#   10|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   10|             Type = [PointerType] __va_list_tag *
 #   10|             ValueCategory = prvalue
 #   11|     getStmt(2): [ExprStmt] ExprStmt
@@ -978,13 +978,13 @@ Varargs.c:
 #   11|         getVAList(): [VariableAccess] args
 #   11|             Type = [CTypedefType] va_list
 #   11|             ValueCategory = lvalue
-#   11|         : [ArrayToPointerConversion] array to pointer conversion
+#   11|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   11|             Type = [PointerType] __va_list_tag *
 #   11|             ValueCategory = prvalue
 #   12|     getStmt(3): [ReturnStmt] return ...
 macro_etc.c:
 #    3| [TopLevelFunction] int bar(int)
-#    3|   : 
+#    3|   <params>: 
 #    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
 #    3|   getEntryPoint(): [BlockStmt] { ... }
@@ -1036,7 +1036,7 @@ macro_etc.c:
 #   10|             Value = [Literal] 2
 #   10|             ValueCategory = prvalue
 #   22| [TopLevelFunction] int foo()
-#   22|   : 
+#   22|   <params>: 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [DeclStmt] declaration
 #   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of t
@@ -1074,7 +1074,7 @@ macro_etc.c:
 #   27|               Type = [IntType] int
 #   27|               Value = [Literal] 0
 #   27|               ValueCategory = prvalue
-#   27|           : [CStyleCast] (char)...
+#   27|           getRValue().getFullyConverted(): [CStyleCast] (char)...
 #   27|               Conversion = [IntegralConversion] integral conversion
 #   27|               Type = [PlainCharType] char
 #   27|               Value = [CStyleCast] 0
@@ -1089,7 +1089,7 @@ macro_etc.c:
 #   27|             Type = [IntType] int
 #   27|             Value = [Literal] 6
 #   27|             ValueCategory = prvalue
-#   27|         : [CStyleCast] (int)...
+#   27|         getLesserOperand().getFullyConverted(): [CStyleCast] (int)...
 #   27|             Conversion = [IntegralConversion] integral conversion
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
@@ -1110,7 +1110,7 @@ macro_etc.c:
 #   27|             getRValue(): [VariableAccess] i
 #   27|                 Type = [PlainCharType] char
 #   27|                 ValueCategory = prvalue(load)
-#   27|             : [CStyleCast] (int)...
+#   27|             getRValue().getFullyConverted(): [CStyleCast] (int)...
 #   27|                 Conversion = [IntegralConversion] integral conversion
 #   27|                 Type = [IntType] int
 #   27|                 ValueCategory = prvalue
@@ -1126,7 +1126,7 @@ macro_etc.c:
 #   28|               Type = [IntType] int
 #   28|               Value = [Literal] 0
 #   28|               ValueCategory = prvalue
-#   28|           : [CStyleCast] (char)...
+#   28|           getRValue().getFullyConverted(): [CStyleCast] (char)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [PlainCharType] char
 #   28|               Value = [CStyleCast] 0
@@ -1141,7 +1141,7 @@ macro_etc.c:
 #   28|             Type = [IntType] int
 #   28|             Value = [Literal] 6
 #   28|             ValueCategory = prvalue
-#   28|         : [CStyleCast] (int)...
+#   28|         getLesserOperand().getFullyConverted(): [CStyleCast] (int)...
 #   28|             Conversion = [IntegralConversion] integral conversion
 #   28|             Type = [IntType] int
 #   28|             ValueCategory = prvalue
@@ -1162,7 +1162,7 @@ macro_etc.c:
 #   28|             getRValue(): [VariableAccess] i
 #   28|                 Type = [PlainCharType] char
 #   28|                 ValueCategory = prvalue(load)
-#   28|             : [CStyleCast] (int)...
+#   28|             getRValue().getFullyConverted(): [CStyleCast] (int)...
 #   28|                 Conversion = [IntegralConversion] integral conversion
 #   28|                 Type = [IntType] int
 #   28|                 ValueCategory = prvalue
@@ -1177,7 +1177,7 @@ macro_etc.c:
 #   29|             Type = [ArrayType] char[2]
 #   29|             Value = [StringLiteral] "b"
 #   29|             ValueCategory = lvalue
-#   29|         : [ArrayToPointerConversion] array to pointer conversion
+#   29|         getRValue().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   29|             Type = [CharPointerType] char *
 #   29|             ValueCategory = prvalue
 #   30|     getStmt(9): [ExprStmt] ExprStmt
@@ -1194,13 +1194,13 @@ macro_etc.c:
 #   30|               Type = [IntType] int
 #   30|               Value = [Literal] 0
 #   30|               ValueCategory = prvalue
-#   30|           : [ArrayToPointerConversion] array to pointer conversion
+#   30|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   30|               Type = [CharPointerType] char *
 #   30|               ValueCategory = prvalue
 #   30|         getRValue(): [VariableAccess] t
 #   30|             Type = [IntType] int
 #   30|             ValueCategory = prvalue(load)
-#   30|         : [CStyleCast] (char)...
+#   30|         getRValue().getFullyConverted(): [CStyleCast] (char)...
 #   30|             Conversion = [IntegralConversion] integral conversion
 #   30|             Type = [PlainCharType] char
 #   30|             ValueCategory = prvalue
@@ -1231,53 +1231,53 @@ macro_etc.c:
 #   32|               Type = [IntType] int
 #   32|               Value = [Literal] 1
 #   32|               ValueCategory = prvalue
-#   32|           : [ArrayToPointerConversion] array to pointer conversion
+#   32|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   32|               Type = [CharPointerType] char *
 #   32|               ValueCategory = prvalue
-#   32|         : [CStyleCast] (int)...
+#   32|         getRightOperand().getFullyConverted(): [CStyleCast] (int)...
 #   32|             Conversion = [IntegralConversion] integral conversion
 #   32|             Type = [IntType] int
 #   32|             ValueCategory = prvalue
 union_etc.cpp:
 #    2| [CopyAssignmentOperator] S& S::operator=(S const&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveAssignmentOperator] S& S::operator=(S&&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    2| [Constructor] void S::S()
-#    2|   : 
-#    2|   : 
+#    2|   <params>: 
+#    2|   <initializations>: 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    2| [CopyConstructor] void S::S(S const&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveConstructor] void S::S(S&&)
-#    2|   : 
+#    2|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    3| [CopyAssignmentOperator] S::U& S::U::operator=(S::U const public&)
-#    3|   : 
+#    3|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #    3| [MoveAssignmentOperator] S::U& S::U::operator=(S::U&&)
-#    3|   : 
+#    3|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #    4| [CopyAssignmentOperator] S::C& S::C::operator=(S::C const public&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    4| [MoveAssignmentOperator] S::C& S::C::operator=(S::C&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    6| [VirtualFunction] void S::set_q(int)
-#    6|   : 
+#    6|   <params>: 
 #    6|     getParameter(0): [Parameter] val
 #    6|         Type = [IntType] int
 #    6|   getEntryPoint(): [BlockStmt] { ... }
@@ -1296,55 +1296,55 @@ union_etc.cpp:
 #    6|             ValueCategory = prvalue(load)
 #    6|     getStmt(1): [ReturnStmt] return ...
 #    9| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    9|   : 
+#    9|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    9| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    9|   : 
+#    9|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   11| [CopyAssignmentOperator] C::S& C::S::operator=(C::S const public&)
-#   11|   : 
+#   11|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   11| [MoveAssignmentOperator] C::S& C::S::operator=(C::S&&)
-#   11|   : 
+#   11|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   12| [CopyAssignmentOperator] C::U& C::U::operator=(C::U const public&)
-#   12|   : 
+#   12|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   12| [MoveAssignmentOperator] C::U& C::U::operator=(C::U&&)
-#   12|   : 
+#   12|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   16| [CopyAssignmentOperator] U& U::operator=(U const&)
-#   16|   : 
+#   16|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   16| [MoveAssignmentOperator] U& U::operator=(U&&)
-#   16|   : 
+#   16|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   17| [CopyAssignmentOperator] U::S& U::S::operator=(U::S const public&)
-#   17|   : 
+#   17|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   17| [MoveAssignmentOperator] U::S& U::S::operator=(U::S&&)
-#   17|   : 
+#   17|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   18| [CopyAssignmentOperator] U::C& U::C::operator=(U::C const public&)
-#   18|   : 
+#   18|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #   18| [MoveAssignmentOperator] U::C& U::C::operator=(U::C&&)
-#   18|   : 
+#   18|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   22| [TopLevelFunction] int foo()
-#   22|   : 
+#   22|   <params>: 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [DeclStmt] declaration
 #   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -1431,7 +1431,7 @@ union_etc.cpp:
 #   27|             getQualifier(): [VariableAccess] u
 #   27|                 Type = [Union] U
 #   27|                 ValueCategory = lvalue
-#   27|         : [ParenthesisExpr] (...)
+#   27|         getRValue().getFullyConverted(): [ParenthesisExpr] (...)
 #   27|             Type = [IntType] int
 #   27|             ValueCategory = prvalue
 #   28|     getStmt(5): [ReturnStmt] return ...
@@ -1442,25 +1442,25 @@ union_etc.cpp:
 #   28|             Type = [Class] C
 #   28|             ValueCategory = lvalue
 #   31| [CopyAssignmentOperator] T& T::operator=(T const&)
-#   31|   : 
+#   31|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveAssignmentOperator] T& T::operator=(T&&)
-#   31|   : 
+#   31|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   31| [Constructor] void T::T()
-#   31|   : 
+#   31|   <params>: 
 #   31| [CopyConstructor] void T::T(T const&)
-#   31|   : 
+#   31|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveConstructor] void T::T(T&&)
-#   31|   : 
+#   31|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   33| [VirtualFunction] void T::set_q(int)
-#   33|   : 
+#   33|   <params>: 
 #   33|     getParameter(0): [Parameter] val
 #   33|         Type = [IntType] int
 #   33|   getEntryPoint(): [BlockStmt] { ... }
@@ -1479,7 +1479,7 @@ union_etc.cpp:
 #   33|             ValueCategory = prvalue(load)
 #   33|     getStmt(1): [ReturnStmt] return ...
 #   36| [TopLevelFunction] int bar()
-#   36|   : 
+#   36|   <params>: 
 #   36|   getEntryPoint(): [BlockStmt] { ... }
 #   37|     getStmt(0): [DeclStmt] declaration
 #   37|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -1491,7 +1491,7 @@ union_etc.cpp:
 #   37|             getOperand(): [VariableAccess] c
 #   37|                 Type = [Class] C
 #   37|                 ValueCategory = lvalue
-#   37|           : [CStyleCast] (const T *)...
+#   37|           getExpr().getFullyConverted(): [CStyleCast] (const T *)...
 #   37|               Conversion = [PointerConversion] pointer conversion
 #   37|               Type = [PointerType] const T *
 #   37|               ValueCategory = prvalue
@@ -1502,7 +1502,7 @@ union_etc.cpp:
 #   38|           getExpr(): [VariableAccess] s
 #   38|               Type = [PointerType] const T *
 #   38|               ValueCategory = prvalue(load)
-#   38|           : [StaticCast] static_cast<const S *>...
+#   38|           getExpr().getFullyConverted(): [StaticCast] static_cast<const S *>...
 #   38|               Conversion = [BaseClassConversion] base class conversion
 #   38|               Type = [PointerType] const S *
 #   38|               ValueCategory = prvalue
@@ -1513,7 +1513,7 @@ union_etc.cpp:
 #   39|           getExpr(): [VariableAccess] s
 #   39|               Type = [PointerType] const T *
 #   39|               ValueCategory = prvalue(load)
-#   39|           : [ConstCast] const_cast<T *>...
+#   39|           getExpr().getFullyConverted(): [ConstCast] const_cast<T *>...
 #   39|               Conversion = [PointerConversion] pointer conversion
 #   39|               Type = [PointerType] T *
 #   39|               ValueCategory = prvalue
@@ -1524,7 +1524,7 @@ union_etc.cpp:
 #   40|           getExpr(): [VariableAccess] t
 #   40|               Type = [PointerType] const S *
 #   40|               ValueCategory = prvalue(load)
-#   40|           : [DynamicCast] dynamic_cast<const T *>...
+#   40|           getExpr().getFullyConverted(): [DynamicCast] dynamic_cast<const T *>...
 #   40|               Conversion = [DynamicCast] dynamic_cast
 #   40|               Type = [PointerType] const T *
 #   40|               ValueCategory = prvalue
@@ -1538,7 +1538,7 @@ union_etc.cpp:
 #   41|             getOperand(): [VariableAccess] c
 #   41|                 Type = [Class] C
 #   41|                 ValueCategory = lvalue
-#   41|           : [ReinterpretCast] reinterpret_cast<S *>...
+#   41|           getExpr().getFullyConverted(): [ReinterpretCast] reinterpret_cast<S *>...
 #   41|               Conversion = [PointerConversion] pointer conversion
 #   41|               Type = [PointerType] S *
 #   41|               ValueCategory = prvalue
@@ -1552,7 +1552,7 @@ union_etc.cpp:
 #   42|           getQualifier(): [VariableAccess] x
 #   42|               Type = [PointerType] T *
 #   42|               ValueCategory = prvalue(load)
-#   42|           getQualifier(): [CStyleCast] (S *)...
+#   42|           getQualifier().getFullyConverted(): [CStyleCast] (S *)...
 #   42|               Conversion = [BaseClassConversion] base class conversion
 #   42|               Type = [PointerType] S *
 #   42|               ValueCategory = prvalue

--- a/cpp/ql/test/examples/expressions/PrintAST.expected
+++ b/cpp/ql/test/examples/expressions/PrintAST.expected
@@ -1,22 +1,22 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 AddressOf.c:
 #    1| [TopLevelFunction] void AddressOf(int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -33,7 +33,7 @@ AddressOf.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 ArrayToPointer.c:
 #    5| [TopLevelFunction] void ArrayToPointer()
-#    5|   ...: 
+#    5|   : 
 #    6|   getEntryPoint(): [BlockStmt] { ... }
 #    7|     getStmt(0): [DeclStmt] declaration
 #    7|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
@@ -65,7 +65,7 @@ ArrayToPointer.c:
 #   10|     getStmt(3): [ReturnStmt] return ...
 Cast.c:
 #    1| [TopLevelFunction] void Cast(char*, void*)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] c
 #    1|         Type = [CharPointerType] char *
 #    1|     getParameter(1): [Parameter] v
@@ -88,7 +88,7 @@ Cast.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 ConditionDecl.cpp:
 #    1| [TopLevelFunction] void ConditionDecl()
-#    1|   ...: 
+#    1|   : 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -113,59 +113,59 @@ ConditionDecl.cpp:
 #    5|     getStmt(2): [ReturnStmt] return ...
 ConstructorCall.cpp:
 #    1| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    1| [CopyConstructor] void C::C(C const&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    1| [MoveConstructor] void C::C(C&&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    3| [ConversionConstructor] void C::C(int)
-#    3|   ...: 
+#    3|   : 
 #    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
-#    3|   ...: 
+#    3|   : 
 #    3|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
 #    7| [CopyAssignmentOperator] D& D::operator=(D const&)
-#    7|   ...: 
+#    7|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveAssignmentOperator] D& D::operator=(D&&)
-#    7|   ...: 
+#    7|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    7| [CopyConstructor] void D::D(D const&)
-#    7|   ...: 
+#    7|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const D &
 #    7| [MoveConstructor] void D::D(D&&)
-#    7|   ...: 
+#    7|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] D &&
 #    9| [Constructor] void D::D()
-#    9|   ...: 
-#    9|   ...: 
+#    9|   : 
+#    9|   : 
 #    9|   getEntryPoint(): [BlockStmt] { ... }
 #   10|     getStmt(0): [ReturnStmt] return ...
 #   13| [CopyAssignmentOperator] E& E::operator=(E const&)
-#   13|   ...: 
+#   13|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const E &
 #   13| [MoveAssignmentOperator] E& E::operator=(E&&)
-#   13|   ...: 
+#   13|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] E &&
 #   17| [TopLevelFunction] void ConstructorCall(C*, D*, E*)
-#   17|   ...: 
+#   17|   : 
 #   17|     getParameter(0): [Parameter] c
 #   17|         Type = [PointerType] C *
 #   17|     getParameter(1): [Parameter] d
@@ -220,7 +220,7 @@ ConstructorCall.cpp:
 #   21|     getStmt(3): [ReturnStmt] return ...
 Conversion1.c:
 #    1| [TopLevelFunction] void Conversion1()
-#    1|   ...: 
+#    1|   : 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -238,7 +238,7 @@ Conversion1.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion2.c:
 #    1| [TopLevelFunction] void Conversion2(int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -274,7 +274,7 @@ Conversion2.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion3.cpp:
 #    1| [TopLevelFunction] void Conversion3(int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -324,7 +324,7 @@ Conversion3.cpp:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Conversion4.c:
 #    1| [TopLevelFunction] void Conversion4(int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] x
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -389,14 +389,14 @@ Conversion4.c:
 #   11|     getStmt(1): [ReturnStmt] return ...
 DestructorCall.cpp:
 #    1| [Constructor] void C::C()
-#    1|   ...: 
+#    1|   : 
 #    3| [Destructor] void C::~C()
-#    3|   ...: 
+#    3|   : 
 #    3|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
-#    3|   ...: 
+#    3|   : 
 #   11| [TopLevelFunction] void DestructorCall(C*, D*)
-#   11|   ...: 
+#   11|   : 
 #   11|     getParameter(0): [Parameter] c
 #   11|         Type = [PointerType] C *
 #   11|     getParameter(1): [Parameter] d
@@ -422,7 +422,7 @@ DestructorCall.cpp:
 #   14|     getStmt(2): [ReturnStmt] return ...
 DynamicCast.cpp:
 #    1| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -437,25 +437,25 @@ DynamicCast.cpp:
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #    1| [MoveAssignmentOperator] Base& Base::operator=(Base&&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    1| [Constructor] void Base::Base()
-#    1|   ...: 
+#    1|   : 
 #    1| [CopyConstructor] void Base::Base(Base const&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #    1| [MoveConstructor] void Base::Base(Base&&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Base &&
 #    2| [VirtualFunction] void Base::f()
-#    2|   ...: 
+#    2|   : 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -503,25 +503,25 @@ DynamicCast.cpp:
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #    4| [MoveAssignmentOperator] Derived& Derived::operator=(Derived&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    4| [Constructor] void Derived::Derived()
-#    4|   ...: 
+#    4|   : 
 #    4| [CopyConstructor] void Derived::Derived(Derived const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #    4| [MoveConstructor] void Derived::Derived(Derived&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Derived &&
 #    5| [VirtualFunction] void Derived::f()
-#    5|   ...: 
+#    5|   : 
 #    5|   getEntryPoint(): [BlockStmt] { ... }
 #    5|     getStmt(0): [ReturnStmt] return ...
 #    8| [TopLevelFunction] void DynamicCast(Base*, Derived*)
-#    8|   ...: 
+#    8|   : 
 #    8|     getParameter(0): [Parameter] bp
 #    8|         Type = [PointerType] Base *
 #    8|     getParameter(1): [Parameter] d
@@ -543,7 +543,7 @@ DynamicCast.cpp:
 #    9|             ValueCategory = prvalue
 #   10|     getStmt(1): [ReturnStmt] return ...
 #   12| [TopLevelFunction] void DynamicCastRef(Base&, Derived&)
-#   12|   ...: 
+#   12|   : 
 #   12|     getParameter(0): [Parameter] bp
 #   12|         Type = [LValueReferenceType] Base &
 #   12|     getParameter(1): [Parameter] d
@@ -582,7 +582,7 @@ DynamicCast.cpp:
 #   14|     getStmt(1): [ReturnStmt] return ...
 Parenthesis.c:
 #    1| [TopLevelFunction] void Parenthesis(int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntType] int
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -616,7 +616,7 @@ Parenthesis.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 PointerDereference.c:
 #    1| [TopLevelFunction] void PointerDereference(int*, int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
 #    1|     getParameter(1): [Parameter] j
@@ -638,7 +638,7 @@ PointerDereference.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 ReferenceDereference.cpp:
 #    4| [TopLevelFunction] void ReferenceDereference(int&, int)
-#    4|   ...: 
+#    4|   : 
 #    4|     getParameter(0): [Parameter] i
 #    4|         Type = [LValueReferenceType] int &
 #    4|     getParameter(1): [Parameter] j
@@ -660,7 +660,7 @@ ReferenceDereference.cpp:
 #    6|     getStmt(1): [ReturnStmt] return ...
 ReferenceTo.cpp:
 #    1| [TopLevelFunction] int& ReferenceTo(int*)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [IntPointerType] int *
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -676,7 +676,7 @@ ReferenceTo.cpp:
 #    2|           ValueCategory = prvalue
 Sizeof.c:
 #    1| [TopLevelFunction] void Sizeof(int[])
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] array
 #    1|         Type = [ArrayType] int[]
 #    1|   getEntryPoint(): [BlockStmt] { ... }
@@ -715,7 +715,7 @@ Sizeof.c:
 #    4|     getStmt(2): [ReturnStmt] return ...
 StatementExpr.c:
 #    1| [TopLevelFunction] void StatementExpr()
-#    1|   ...: 
+#    1|   : 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -727,15 +727,15 @@ StatementExpr.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 StaticMemberAccess.cpp:
 #    1| [CopyAssignmentOperator] X& X::operator=(X const&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const X &
 #    1| [MoveAssignmentOperator] X& X::operator=(X&&)
-#    1|   ...: 
+#    1|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] X &&
 #    5| [TopLevelFunction] void StaticMemberAccess(int, X&)
-#    5|   ...: 
+#    5|   : 
 #    5|     getParameter(0): [Parameter] i
 #    5|         Type = [IntType] int
 #    5|     getParameter(1): [Parameter] xref
@@ -760,7 +760,7 @@ StaticMemberAccess.cpp:
 #    9|     getStmt(1): [ReturnStmt] return ...
 Subscript.c:
 #    1| [TopLevelFunction] void Subscript(int[], int)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] i
 #    1|         Type = [ArrayType] int[]
 #    1|     getParameter(1): [Parameter] j
@@ -786,31 +786,31 @@ Subscript.c:
 #    3|     getStmt(1): [ReturnStmt] return ...
 Throw.cpp:
 #    2| [CopyAssignmentOperator] F& F::operator=(F const&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveAssignmentOperator] F& F::operator=(F&&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
 #    2| [CopyConstructor] void F::F(F const&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const F &
 #    2| [MoveConstructor] void F::F(F&&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] F &&
-#    2|   ...: 
+#    2|   : 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    4| [Constructor] void F::F()
-#    4|   ...: 
-#    4|   ...: 
+#    4|   : 
+#    4|   : 
 #    4|   getEntryPoint(): [BlockStmt] { ... }
 #    4|     getStmt(0): [ReturnStmt] return ...
 #    6| [TopLevelFunction] void Throw(int)
-#    6|   ...: 
+#    6|   : 
 #    6|     getParameter(0): [Parameter] i
 #    6|         Type = [IntType] int
 #    6|   getEntryPoint(): [BlockStmt] { ... }
@@ -847,21 +847,21 @@ Throw.cpp:
 #   13|                 ValueCategory = prvalue
 Typeid.cpp:
 #    4| [CopyAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const type_info &
 #    4| [MoveAssignmentOperator] std::type_info& std::type_info::operator=(std::type_info&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] type_info &&
 #    7| [ConstMemberFunction] char const* std::type_info::name() const
-#    7|   ...: 
+#    7|   : 
 #   13| [VirtualFunction] void Base::v()
-#   13|   ...: 
+#   13|   : 
 #   13|   getEntryPoint(): [BlockStmt] { ... }
 #   13|     getStmt(0): [ReturnStmt] return ...
 #   18| [TopLevelFunction] void TypeId(Base*)
-#   18|   ...: 
+#   18|   : 
 #   18|     getParameter(0): [Parameter] bp
 #   18|         Type = [PointerType] Base *
 #   18|   getEntryPoint(): [BlockStmt] { ... }
@@ -881,7 +881,7 @@ Typeid.cpp:
 #   20|     getStmt(1): [ReturnStmt] return ...
 VacuousDestructorCall.cpp:
 #    2| [TemplateFunction,TopLevelFunction] void CallDestructor<T>(T, T*)
-#    2|   ...: 
+#    2|   : 
 #    2|     getParameter(0): [Parameter] x
 #    2|         Type = [TemplateParameter] T
 #    2|     getParameter(1): [Parameter] y
@@ -909,7 +909,7 @@ VacuousDestructorCall.cpp:
 #    4|               ValueCategory = prvalue(load)
 #    5|     getStmt(2): [ReturnStmt] return ...
 #    2| [FunctionTemplateInstantiation,TopLevelFunction] void CallDestructor<int>(int, int*)
-#    2|   ...: 
+#    2|   : 
 #    2|     getParameter(0): [Parameter] x
 #    2|         Type = [IntType] int
 #    2|     getParameter(1): [Parameter] y
@@ -931,7 +931,7 @@ VacuousDestructorCall.cpp:
 #    4|             ValueCategory = prvalue(load)
 #    5|     getStmt(2): [ReturnStmt] return ...
 #    7| [TopLevelFunction] void Vacuous(int)
-#    7|   ...: 
+#    7|   : 
 #    7|     getParameter(0): [Parameter] i
 #    7|         Type = [IntType] int
 #    7|   getEntryPoint(): [BlockStmt] { ... }
@@ -951,7 +951,7 @@ VacuousDestructorCall.cpp:
 #   11|     getStmt(1): [ReturnStmt] return ...
 Varargs.c:
 #    8| [TopLevelFunction] void VarArgs(char const*)
-#    8|   ...: 
+#    8|   : 
 #    8|     getParameter(0): [Parameter] text
 #    8|         Type = [PointerType] const char *
 #    8|   getEntryPoint(): [BlockStmt] { ... }
@@ -984,7 +984,7 @@ Varargs.c:
 #   12|     getStmt(3): [ReturnStmt] return ...
 macro_etc.c:
 #    3| [TopLevelFunction] int bar(int)
-#    3|   ...: 
+#    3|   : 
 #    3|     getParameter(0): [Parameter] i
 #    3|         Type = [IntType] int
 #    3|   getEntryPoint(): [BlockStmt] { ... }
@@ -1036,7 +1036,7 @@ macro_etc.c:
 #   10|             Value = [Literal] 2
 #   10|             ValueCategory = prvalue
 #   22| [TopLevelFunction] int foo()
-#   22|   ...: 
+#   22|   : 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [DeclStmt] declaration
 #   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of t
@@ -1240,44 +1240,44 @@ macro_etc.c:
 #   32|             ValueCategory = prvalue
 union_etc.cpp:
 #    2| [CopyAssignmentOperator] S& S::operator=(S const&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveAssignmentOperator] S& S::operator=(S&&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    2| [Constructor] void S::S()
-#    2|   ...: 
-#    2|   ...: 
+#    2|   : 
+#    2|   : 
 #    2|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [ReturnStmt] return ...
 #    2| [CopyConstructor] void S::S(S const&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    2| [MoveConstructor] void S::S(S&&)
-#    2|   ...: 
+#    2|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    3| [CopyAssignmentOperator] S::U& S::U::operator=(S::U const public&)
-#    3|   ...: 
+#    3|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #    3| [MoveAssignmentOperator] S::U& S::U::operator=(S::U&&)
-#    3|   ...: 
+#    3|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #    4| [CopyAssignmentOperator] S::C& S::C::operator=(S::C const public&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    4| [MoveAssignmentOperator] S::C& S::C::operator=(S::C&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #    6| [VirtualFunction] void S::set_q(int)
-#    6|   ...: 
+#    6|   : 
 #    6|     getParameter(0): [Parameter] val
 #    6|         Type = [IntType] int
 #    6|   getEntryPoint(): [BlockStmt] { ... }
@@ -1296,55 +1296,55 @@ union_etc.cpp:
 #    6|             ValueCategory = prvalue(load)
 #    6|     getStmt(1): [ReturnStmt] return ...
 #    9| [CopyAssignmentOperator] C& C::operator=(C const&)
-#    9|   ...: 
+#    9|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #    9| [MoveAssignmentOperator] C& C::operator=(C&&)
-#    9|   ...: 
+#    9|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   11| [CopyAssignmentOperator] C::S& C::S::operator=(C::S const public&)
-#   11|   ...: 
+#   11|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   11| [MoveAssignmentOperator] C::S& C::S::operator=(C::S&&)
-#   11|   ...: 
+#   11|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   12| [CopyAssignmentOperator] C::U& C::U::operator=(C::U const public&)
-#   12|   ...: 
+#   12|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   12| [MoveAssignmentOperator] C::U& C::U::operator=(C::U&&)
-#   12|   ...: 
+#   12|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   16| [CopyAssignmentOperator] U& U::operator=(U const&)
-#   16|   ...: 
+#   16|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #   16| [MoveAssignmentOperator] U& U::operator=(U&&)
-#   16|   ...: 
+#   16|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #   17| [CopyAssignmentOperator] U::S& U::S::operator=(U::S const public&)
-#   17|   ...: 
+#   17|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #   17| [MoveAssignmentOperator] U::S& U::S::operator=(U::S&&)
-#   17|   ...: 
+#   17|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #   18| [CopyAssignmentOperator] U::C& U::C::operator=(U::C const public&)
-#   18|   ...: 
+#   18|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #   18| [MoveAssignmentOperator] U::C& U::C::operator=(U::C&&)
-#   18|   ...: 
+#   18|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #   22| [TopLevelFunction] int foo()
-#   22|   ...: 
+#   22|   : 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [DeclStmt] declaration
 #   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -1442,25 +1442,25 @@ union_etc.cpp:
 #   28|             Type = [Class] C
 #   28|             ValueCategory = lvalue
 #   31| [CopyAssignmentOperator] T& T::operator=(T const&)
-#   31|   ...: 
+#   31|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveAssignmentOperator] T& T::operator=(T&&)
-#   31|   ...: 
+#   31|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   31| [Constructor] void T::T()
-#   31|   ...: 
+#   31|   : 
 #   31| [CopyConstructor] void T::T(T const&)
-#   31|   ...: 
+#   31|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const T &
 #   31| [MoveConstructor] void T::T(T&&)
-#   31|   ...: 
+#   31|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] T &&
 #   33| [VirtualFunction] void T::set_q(int)
-#   33|   ...: 
+#   33|   : 
 #   33|     getParameter(0): [Parameter] val
 #   33|         Type = [IntType] int
 #   33|   getEntryPoint(): [BlockStmt] { ... }
@@ -1479,7 +1479,7 @@ union_etc.cpp:
 #   33|             ValueCategory = prvalue(load)
 #   33|     getStmt(1): [ReturnStmt] return ...
 #   36| [TopLevelFunction] int bar()
-#   36|   ...: 
+#   36|   : 
 #   36|   getEntryPoint(): [BlockStmt] { ... }
 #   37|     getStmt(0): [DeclStmt] declaration
 #   37|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -1,23 +1,23 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long, std::align_val_t)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -25,13 +25,13 @@
 #-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long, std::align_val_t)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -39,36 +39,36 @@
 #-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long, std::align_val_t)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long, std::align_val_t)
-#-----|   ...: 
+#-----|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 bad_asts.cpp:
 #    5| [CopyAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S const&)
-#    5|   ...: 
+#    5|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    5| [MoveAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S&&)
-#    5|   ...: 
+#    5|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    9| [FunctionTemplateInstantiation,MemberFunction] int Bad::S::MemberFunction<int 6>(int)
-#    9|   ...: 
+#    9|   : 
 #    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
 #    9|   getEntryPoint(): [BlockStmt] { ... }
@@ -93,7 +93,7 @@ bad_asts.cpp:
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #    9| [MemberFunction,TemplateFunction] int Bad::S::MemberFunction<int t>(int)
-#    9|   ...: 
+#    9|   : 
 #    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
 #    9|   getEntryPoint(): [BlockStmt] { ... }
@@ -118,7 +118,7 @@ bad_asts.cpp:
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #   14| [TopLevelFunction] void Bad::CallBadMemberFunction()
-#   14|   ...: 
+#   14|   : 
 #   14|   getEntryPoint(): [BlockStmt] { ... }
 #   15|     getStmt(0): [DeclStmt] declaration
 #   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -140,18 +140,18 @@ bad_asts.cpp:
 #   16|             ValueCategory = prvalue
 #   17|     getStmt(2): [ReturnStmt] return ...
 #   19| [CopyAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point const&)
-#   19|   ...: 
+#   19|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #   19| [MoveAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point&&)
-#   19|   ...: 
+#   19|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   19| [CopyConstructor] void Bad::Point::Point(Bad::Point const&)
-#   19|   ...: 
+#   19|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
-#   19|   ...: 
+#   19|   : 
 #   19|     getInitializer(0): [ConstructorFieldInit] constructor init of field x
 #   19|         Type = [IntType] int
 #   19|         ValueCategory = prvalue
@@ -167,16 +167,16 @@ bad_asts.cpp:
 #   19|   getEntryPoint(): [BlockStmt] { ... }
 #   19|     getStmt(0): [ReturnStmt] return ...
 #   19| [MoveConstructor] void Bad::Point::Point(Bad::Point&&)
-#   19|   ...: 
+#   19|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   22| [Constructor] void Bad::Point::Point()
-#   22|   ...: 
-#   22|   ...: 
+#   22|   : 
+#   22|   : 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [ReturnStmt] return ...
 #   26| [TopLevelFunction] void Bad::CallCopyConstructor(Bad::Point const&)
-#   26|   ...: 
+#   26|   : 
 #   26|     getParameter(0): [Parameter] a
 #   26|         Type = [LValueReferenceType] const Point &
 #   26|   getEntryPoint(): [BlockStmt] { ... }
@@ -196,7 +196,7 @@ bad_asts.cpp:
 #   27|                 ValueCategory = lvalue
 #   28|     getStmt(1): [ReturnStmt] return ...
 #   30| [TopLevelFunction] void Bad::errorExpr()
-#   30|   ...: 
+#   30|   : 
 #   30|   getEntryPoint(): [BlockStmt] { ... }
 #   31|     getStmt(0): [DeclStmt] declaration
 #   31|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of intref
@@ -225,7 +225,7 @@ bad_asts.cpp:
 #   34|     getStmt(3): [ReturnStmt] return ...
 clang.cpp:
 #    5| [TopLevelFunction] int* globalIntAddress()
-#    5|   ...: 
+#    5|   : 
 #    5|   getEntryPoint(): [BlockStmt] { ... }
 #    6|     getStmt(0): [ReturnStmt] return ...
 #    6|       getExpr(): [BuiltInOperationBuiltInAddressOf] __builtin_addressof ...
@@ -236,7 +236,7 @@ clang.cpp:
 #    6|             ValueCategory = lvalue
 complex.c:
 #    1| [TopLevelFunction] void complex_literals()
-#    1|   ...: 
+#    1|   : 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf
@@ -353,7 +353,7 @@ complex.c:
 #   11|               ValueCategory = prvalue
 #   12|     getStmt(9): [ReturnStmt] return ...
 #   14| [TopLevelFunction] void complex_arithmetic()
-#   14|   ...: 
+#   14|   : 
 #   14|   getEntryPoint(): [BlockStmt] { ... }
 #   15|     getStmt(0): [DeclStmt] declaration
 #   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f1
@@ -740,7 +740,7 @@ complex.c:
 #   55|               ValueCategory = prvalue(load)
 #   56|     getStmt(29): [ReturnStmt] return ...
 #   58| [TopLevelFunction] void complex_conversions()
-#   58|   ...: 
+#   58|   : 
 #   58|   getEntryPoint(): [BlockStmt] { ... }
 #   59|     getStmt(0): [DeclStmt] declaration
 #   59|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
@@ -1717,7 +1717,7 @@ complex.c:
 #  145|     getStmt(72): [ReturnStmt] return ...
 ir.cpp:
 #    1| [TopLevelFunction] void Constants()
-#    1|   ...: 
+#    1|   : 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c_i
@@ -2034,7 +2034,7 @@ ir.cpp:
 #   40|               ValueCategory = prvalue
 #   41|     getStmt(28): [ReturnStmt] return ...
 #   43| [TopLevelFunction] void Foo()
-#   43|   ...: 
+#   43|   : 
 #   43|   getEntryPoint(): [BlockStmt] { ... }
 #   44|     getStmt(0): [DeclStmt] declaration
 #   44|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -2111,7 +2111,7 @@ ir.cpp:
 #   47|               ValueCategory = prvalue
 #   48|     getStmt(4): [ReturnStmt] return ...
 #   50| [TopLevelFunction] void IntegerOps(int, int)
-#   50|   ...: 
+#   50|   : 
 #   50|     getParameter(0): [Parameter] x
 #   50|         Type = [IntType] int
 #   50|     getParameter(1): [Parameter] y
@@ -2452,7 +2452,7 @@ ir.cpp:
 #   84|             ValueCategory = prvalue
 #   85|     getStmt(26): [ReturnStmt] return ...
 #   87| [TopLevelFunction] void IntegerCompare(int, int)
-#   87|   ...: 
+#   87|   : 
 #   87|     getParameter(0): [Parameter] x
 #   87|         Type = [IntType] int
 #   87|     getParameter(1): [Parameter] y
@@ -2559,7 +2559,7 @@ ir.cpp:
 #   95|               ValueCategory = prvalue(load)
 #   96|     getStmt(7): [ReturnStmt] return ...
 #   98| [TopLevelFunction] void IntegerCrement(int)
-#   98|   ...: 
+#   98|   : 
 #   98|     getParameter(0): [Parameter] x
 #   98|         Type = [IntType] int
 #   98|   getEntryPoint(): [BlockStmt] { ... }
@@ -2620,7 +2620,7 @@ ir.cpp:
 #  104|               ValueCategory = lvalue
 #  105|     getStmt(5): [ReturnStmt] return ...
 #  107| [TopLevelFunction] void IntegerCrement_LValue(int)
-#  107|   ...: 
+#  107|   : 
 #  107|     getParameter(0): [Parameter] x
 #  107|         Type = [IntType] int
 #  107|   getEntryPoint(): [BlockStmt] { ... }
@@ -2667,7 +2667,7 @@ ir.cpp:
 #  111|               ValueCategory = lvalue
 #  112|     getStmt(3): [ReturnStmt] return ...
 #  114| [TopLevelFunction] void FloatOps(double, double)
-#  114|   ...: 
+#  114|   : 
 #  114|     getParameter(0): [Parameter] x
 #  114|         Type = [DoubleType] double
 #  114|     getParameter(1): [Parameter] y
@@ -2818,7 +2818,7 @@ ir.cpp:
 #  130|               ValueCategory = prvalue(load)
 #  131|     getStmt(12): [ReturnStmt] return ...
 #  133| [TopLevelFunction] void FloatCompare(double, double)
-#  133|   ...: 
+#  133|   : 
 #  133|     getParameter(0): [Parameter] x
 #  133|         Type = [DoubleType] double
 #  133|     getParameter(1): [Parameter] y
@@ -2925,7 +2925,7 @@ ir.cpp:
 #  141|               ValueCategory = prvalue(load)
 #  142|     getStmt(7): [ReturnStmt] return ...
 #  144| [TopLevelFunction] void FloatCrement(float)
-#  144|   ...: 
+#  144|   : 
 #  144|     getParameter(0): [Parameter] x
 #  144|         Type = [FloatType] float
 #  144|   getEntryPoint(): [BlockStmt] { ... }
@@ -2986,7 +2986,7 @@ ir.cpp:
 #  150|               ValueCategory = lvalue
 #  151|     getStmt(5): [ReturnStmt] return ...
 #  153| [TopLevelFunction] void PointerOps(int*, int)
-#  153|   ...: 
+#  153|   : 
 #  153|     getParameter(0): [Parameter] p
 #  153|         Type = [IntPointerType] int *
 #  153|     getParameter(1): [Parameter] i
@@ -3129,7 +3129,7 @@ ir.cpp:
 #  168|               ValueCategory = prvalue
 #  169|     getStmt(11): [ReturnStmt] return ...
 #  171| [TopLevelFunction] void ArrayAccess(int*, int)
-#  171|   ...: 
+#  171|   : 
 #  171|     getParameter(0): [Parameter] p
 #  171|         Type = [IntPointerType] int *
 #  171|     getParameter(1): [Parameter] i
@@ -3283,7 +3283,7 @@ ir.cpp:
 #  184|             ValueCategory = prvalue(load)
 #  185|     getStmt(10): [ReturnStmt] return ...
 #  187| [TopLevelFunction] void StringLiteral(int)
-#  187|   ...: 
+#  187|   : 
 #  187|     getParameter(0): [Parameter] i
 #  187|         Type = [IntType] int
 #  187|   getEntryPoint(): [BlockStmt] { ... }
@@ -3334,7 +3334,7 @@ ir.cpp:
 #  190|                 ValueCategory = prvalue(load)
 #  191|     getStmt(3): [ReturnStmt] return ...
 #  193| [TopLevelFunction] void PointerCompare(int*, int*)
-#  193|   ...: 
+#  193|   : 
 #  193|     getParameter(0): [Parameter] p
 #  193|         Type = [IntPointerType] int *
 #  193|     getParameter(1): [Parameter] q
@@ -3441,7 +3441,7 @@ ir.cpp:
 #  201|               ValueCategory = prvalue(load)
 #  202|     getStmt(7): [ReturnStmt] return ...
 #  204| [TopLevelFunction] void PointerCrement(int*)
-#  204|   ...: 
+#  204|   : 
 #  204|     getParameter(0): [Parameter] p
 #  204|         Type = [IntPointerType] int *
 #  204|   getEntryPoint(): [BlockStmt] { ... }
@@ -3502,7 +3502,7 @@ ir.cpp:
 #  210|               ValueCategory = lvalue
 #  211|     getStmt(5): [ReturnStmt] return ...
 #  213| [TopLevelFunction] void CompoundAssignment()
-#  213|   ...: 
+#  213|   : 
 #  213|   getEntryPoint(): [BlockStmt] { ... }
 #  215|     getStmt(0): [DeclStmt] declaration
 #  215|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -3583,7 +3583,7 @@ ir.cpp:
 #  227|             ValueCategory = prvalue
 #  228|     getStmt(7): [ReturnStmt] return ...
 #  230| [TopLevelFunction] void UninitializedVariables()
-#  230|   ...: 
+#  230|   : 
 #  230|   getEntryPoint(): [BlockStmt] { ... }
 #  231|     getStmt(0): [DeclStmt] declaration
 #  231|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -3597,7 +3597,7 @@ ir.cpp:
 #  232|               ValueCategory = prvalue(load)
 #  233|     getStmt(2): [ReturnStmt] return ...
 #  235| [TopLevelFunction] int Parameters(int, int)
-#  235|   ...: 
+#  235|   : 
 #  235|     getParameter(0): [Parameter] x
 #  235|         Type = [IntType] int
 #  235|     getParameter(1): [Parameter] y
@@ -3614,7 +3614,7 @@ ir.cpp:
 #  236|             Type = [IntType] int
 #  236|             ValueCategory = prvalue(load)
 #  239| [TopLevelFunction] void IfStatements(bool, int, int)
-#  239|   ...: 
+#  239|   : 
 #  239|     getParameter(0): [Parameter] b
 #  239|         Type = [BoolType] bool
 #  239|     getParameter(1): [Parameter] x
@@ -3677,7 +3677,7 @@ ir.cpp:
 #  250|               ValueCategory = prvalue
 #  251|     getStmt(3): [ReturnStmt] return ...
 #  253| [TopLevelFunction] void WhileStatements(int)
-#  253|   ...: 
+#  253|   : 
 #  253|     getParameter(0): [Parameter] n
 #  253|         Type = [IntType] int
 #  253|   getEntryPoint(): [BlockStmt] { ... }
@@ -3706,7 +3706,7 @@ ir.cpp:
 #  255|                 ValueCategory = prvalue
 #  257|     getStmt(1): [ReturnStmt] return ...
 #  259| [TopLevelFunction] void DoStatements(int)
-#  259|   ...: 
+#  259|   : 
 #  259|     getParameter(0): [Parameter] n
 #  259|         Type = [IntType] int
 #  259|   getEntryPoint(): [BlockStmt] { ... }
@@ -3735,7 +3735,7 @@ ir.cpp:
 #  261|                 ValueCategory = prvalue
 #  263|     getStmt(1): [ReturnStmt] return ...
 #  265| [TopLevelFunction] void For_Empty()
-#  265|   ...: 
+#  265|   : 
 #  265|   getEntryPoint(): [BlockStmt] { ... }
 #  266|     getStmt(0): [DeclStmt] declaration
 #  266|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -3744,7 +3744,7 @@ ir.cpp:
 #  267|       getStmt(): [BlockStmt] { ... }
 #  268|         getStmt(0): [EmptyStmt] ;
 #  272| [TopLevelFunction] void For_Init()
-#  272|   ...: 
+#  272|   : 
 #  272|   getEntryPoint(): [BlockStmt] { ... }
 #  273|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  273|       getInitialization(): [DeclStmt] declaration
@@ -3758,7 +3758,7 @@ ir.cpp:
 #  273|       getStmt(): [BlockStmt] { ... }
 #  274|         getStmt(0): [EmptyStmt] ;
 #  278| [TopLevelFunction] void For_Condition()
-#  278|   ...: 
+#  278|   : 
 #  278|   getEntryPoint(): [BlockStmt] { ... }
 #  279|     getStmt(0): [DeclStmt] declaration
 #  279|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3783,7 +3783,7 @@ ir.cpp:
 #  281|         getStmt(0): [EmptyStmt] ;
 #  283|     getStmt(2): [ReturnStmt] return ...
 #  285| [TopLevelFunction] void For_Update()
-#  285|   ...: 
+#  285|   : 
 #  285|   getEntryPoint(): [BlockStmt] { ... }
 #  286|     getStmt(0): [DeclStmt] declaration
 #  286|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3807,7 +3807,7 @@ ir.cpp:
 #  287|       getStmt(): [BlockStmt] { ... }
 #  288|         getStmt(0): [EmptyStmt] ;
 #  292| [TopLevelFunction] void For_InitCondition()
-#  292|   ...: 
+#  292|   : 
 #  292|   getEntryPoint(): [BlockStmt] { ... }
 #  293|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  293|       getInitialization(): [DeclStmt] declaration
@@ -3832,7 +3832,7 @@ ir.cpp:
 #  294|         getStmt(0): [EmptyStmt] ;
 #  296|     getStmt(1): [ReturnStmt] return ...
 #  298| [TopLevelFunction] void For_InitUpdate()
-#  298|   ...: 
+#  298|   : 
 #  298|   getEntryPoint(): [BlockStmt] { ... }
 #  299|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  299|       getInitialization(): [DeclStmt] declaration
@@ -3856,7 +3856,7 @@ ir.cpp:
 #  299|       getStmt(): [BlockStmt] { ... }
 #  300|         getStmt(0): [EmptyStmt] ;
 #  304| [TopLevelFunction] void For_ConditionUpdate()
-#  304|   ...: 
+#  304|   : 
 #  304|   getEntryPoint(): [BlockStmt] { ... }
 #  305|     getStmt(0): [DeclStmt] declaration
 #  305|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3891,7 +3891,7 @@ ir.cpp:
 #  307|         getStmt(0): [EmptyStmt] ;
 #  309|     getStmt(2): [ReturnStmt] return ...
 #  311| [TopLevelFunction] void For_InitConditionUpdate()
-#  311|   ...: 
+#  311|   : 
 #  311|   getEntryPoint(): [BlockStmt] { ... }
 #  312|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  312|       getInitialization(): [DeclStmt] declaration
@@ -3926,7 +3926,7 @@ ir.cpp:
 #  313|         getStmt(0): [EmptyStmt] ;
 #  315|     getStmt(1): [ReturnStmt] return ...
 #  317| [TopLevelFunction] void For_Break()
-#  317|   ...: 
+#  317|   : 
 #  317|   getEntryPoint(): [BlockStmt] { ... }
 #  318|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  318|       getInitialization(): [DeclStmt] declaration
@@ -3974,7 +3974,7 @@ ir.cpp:
 #  322|     getStmt(1): [LabelStmt] label ...:
 #  323|     getStmt(2): [ReturnStmt] return ...
 #  325| [TopLevelFunction] void For_Continue_Update()
-#  325|   ...: 
+#  325|   : 
 #  325|   getEntryPoint(): [BlockStmt] { ... }
 #  326|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  326|       getInitialization(): [DeclStmt] declaration
@@ -4022,7 +4022,7 @@ ir.cpp:
 #  326|         getStmt(1): [LabelStmt] label ...:
 #  331|     getStmt(1): [ReturnStmt] return ...
 #  333| [TopLevelFunction] void For_Continue_NoUpdate()
-#  333|   ...: 
+#  333|   : 
 #  333|   getEntryPoint(): [BlockStmt] { ... }
 #  334|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  334|       getInitialization(): [DeclStmt] declaration
@@ -4060,7 +4060,7 @@ ir.cpp:
 #  334|         getStmt(1): [LabelStmt] label ...:
 #  339|     getStmt(1): [ReturnStmt] return ...
 #  341| [TopLevelFunction] int Dereference(int*)
-#  341|   ...: 
+#  341|   : 
 #  341|     getParameter(0): [Parameter] p
 #  341|         Type = [IntPointerType] int *
 #  341|   getEntryPoint(): [BlockStmt] { ... }
@@ -4086,7 +4086,7 @@ ir.cpp:
 #  343|             Type = [IntPointerType] int *
 #  343|             ValueCategory = prvalue(load)
 #  348| [TopLevelFunction] int* AddressOf()
-#  348|   ...: 
+#  348|   : 
 #  348|   getEntryPoint(): [BlockStmt] { ... }
 #  349|     getStmt(0): [ReturnStmt] return ...
 #  349|       getExpr(): [AddressOfExpr] & ...
@@ -4096,7 +4096,7 @@ ir.cpp:
 #  349|             Type = [IntType] int
 #  349|             ValueCategory = lvalue
 #  352| [TopLevelFunction] void Break(int)
-#  352|   ...: 
+#  352|   : 
 #  352|     getParameter(0): [Parameter] n
 #  352|         Type = [IntType] int
 #  352|   getEntryPoint(): [BlockStmt] { ... }
@@ -4138,7 +4138,7 @@ ir.cpp:
 #  357|     getStmt(1): [LabelStmt] label ...:
 #  358|     getStmt(2): [ReturnStmt] return ...
 #  360| [TopLevelFunction] void Continue(int)
-#  360|   ...: 
+#  360|   : 
 #  360|     getParameter(0): [Parameter] n
 #  360|         Type = [IntType] int
 #  360|   getEntryPoint(): [BlockStmt] { ... }
@@ -4181,15 +4181,15 @@ ir.cpp:
 #  361|         getStmt(2): [LabelStmt] label ...:
 #  367|     getStmt(1): [ReturnStmt] return ...
 #  369| [TopLevelFunction] void VoidFunc()
-#  369|   ...: 
+#  369|   : 
 #  370| [TopLevelFunction] int Add(int, int)
-#  370|   ...: 
+#  370|   : 
 #  370|     getParameter(0): [Parameter] x
 #  370|         Type = [IntType] int
 #  370|     getParameter(1): [Parameter] y
 #  370|         Type = [IntType] int
 #  372| [TopLevelFunction] void Call()
-#  372|   ...: 
+#  372|   : 
 #  372|   getEntryPoint(): [BlockStmt] { ... }
 #  373|     getStmt(0): [ExprStmt] ExprStmt
 #  373|       getExpr(): [FunctionCall] call to VoidFunc
@@ -4197,7 +4197,7 @@ ir.cpp:
 #  373|           ValueCategory = prvalue
 #  374|     getStmt(1): [ReturnStmt] return ...
 #  376| [TopLevelFunction] int CallAdd(int, int)
-#  376|   ...: 
+#  376|   : 
 #  376|     getParameter(0): [Parameter] x
 #  376|         Type = [IntType] int
 #  376|     getParameter(1): [Parameter] y
@@ -4214,7 +4214,7 @@ ir.cpp:
 #  377|             Type = [IntType] int
 #  377|             ValueCategory = prvalue(load)
 #  380| [TopLevelFunction] int Comma(int, int)
-#  380|   ...: 
+#  380|   : 
 #  380|     getParameter(0): [Parameter] x
 #  380|         Type = [IntType] int
 #  380|     getParameter(1): [Parameter] y
@@ -4237,7 +4237,7 @@ ir.cpp:
 #  381|               Type = [IntType] int
 #  381|               ValueCategory = prvalue(load)
 #  384| [TopLevelFunction] void Switch(int)
-#  384|   ...: 
+#  384|   : 
 #  384|     getParameter(0): [Parameter] x
 #  384|         Type = [IntType] int
 #  384|   getEntryPoint(): [BlockStmt] { ... }
@@ -4367,23 +4367,23 @@ ir.cpp:
 #  409|     getStmt(2): [LabelStmt] label ...:
 #  410|     getStmt(3): [ReturnStmt] return ...
 #  412| [CopyAssignmentOperator] Point& Point::operator=(Point const&)
-#  412|   ...: 
+#  412|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #  412| [MoveAssignmentOperator] Point& Point::operator=(Point&&)
-#  412|   ...: 
+#  412|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #  417| [CopyAssignmentOperator] Rect& Rect::operator=(Rect const&)
-#  417|   ...: 
+#  417|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Rect &
 #  417| [MoveAssignmentOperator] Rect& Rect::operator=(Rect&&)
-#  417|   ...: 
+#  417|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Rect &&
 #  422| [TopLevelFunction] Point ReturnStruct(Point)
-#  422|   ...: 
+#  422|   : 
 #  422|     getParameter(0): [Parameter] pt
 #  422|         Type = [Struct] Point
 #  422|   getEntryPoint(): [BlockStmt] { ... }
@@ -4392,7 +4392,7 @@ ir.cpp:
 #  423|           Type = [Struct] Point
 #  423|           ValueCategory = prvalue(load)
 #  426| [TopLevelFunction] void FieldAccess()
-#  426|   ...: 
+#  426|   : 
 #  426|   getEntryPoint(): [BlockStmt] { ... }
 #  427|     getStmt(0): [DeclStmt] declaration
 #  427|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt
@@ -4442,7 +4442,7 @@ ir.cpp:
 #  430|                   ValueCategory = lvalue
 #  431|     getStmt(4): [ReturnStmt] return ...
 #  433| [TopLevelFunction] void LogicalOr(bool, bool)
-#  433|   ...: 
+#  433|   : 
 #  433|     getParameter(0): [Parameter] a
 #  433|         Type = [BoolType] bool
 #  433|     getParameter(1): [Parameter] b
@@ -4509,7 +4509,7 @@ ir.cpp:
 #  443|                 ValueCategory = prvalue
 #  445|     getStmt(3): [ReturnStmt] return ...
 #  447| [TopLevelFunction] void LogicalAnd(bool, bool)
-#  447|   ...: 
+#  447|   : 
 #  447|     getParameter(0): [Parameter] a
 #  447|         Type = [BoolType] bool
 #  447|     getParameter(1): [Parameter] b
@@ -4576,7 +4576,7 @@ ir.cpp:
 #  457|                 ValueCategory = prvalue
 #  459|     getStmt(3): [ReturnStmt] return ...
 #  461| [TopLevelFunction] void LogicalNot(bool, bool)
-#  461|   ...: 
+#  461|   : 
 #  461|     getParameter(0): [Parameter] a
 #  461|         Type = [BoolType] bool
 #  461|     getParameter(1): [Parameter] b
@@ -4646,7 +4646,7 @@ ir.cpp:
 #  471|                 ValueCategory = prvalue
 #  473|     getStmt(3): [ReturnStmt] return ...
 #  475| [TopLevelFunction] void ConditionValues(bool, bool)
-#  475|   ...: 
+#  475|   : 
 #  475|     getParameter(0): [Parameter] a
 #  475|         Type = [BoolType] bool
 #  475|     getParameter(1): [Parameter] b
@@ -4711,7 +4711,7 @@ ir.cpp:
 #  479|               ValueCategory = prvalue
 #  480|     getStmt(4): [ReturnStmt] return ...
 #  482| [TopLevelFunction] void Conditional(bool, int, int)
-#  482|   ...: 
+#  482|   : 
 #  482|     getParameter(0): [Parameter] a
 #  482|         Type = [BoolType] bool
 #  482|     getParameter(1): [Parameter] x
@@ -4737,7 +4737,7 @@ ir.cpp:
 #  483|                 ValueCategory = prvalue(load)
 #  484|     getStmt(1): [ReturnStmt] return ...
 #  486| [TopLevelFunction] void Conditional_LValue(bool)
-#  486|   ...: 
+#  486|   : 
 #  486|     getParameter(0): [Parameter] a
 #  486|         Type = [BoolType] bool
 #  486|   getEntryPoint(): [BlockStmt] { ... }
@@ -4772,7 +4772,7 @@ ir.cpp:
 #  489|             ValueCategory = lvalue
 #  490|     getStmt(3): [ReturnStmt] return ...
 #  492| [TopLevelFunction] void Conditional_Void(bool)
-#  492|   ...: 
+#  492|   : 
 #  492|     getParameter(0): [Parameter] a
 #  492|         Type = [BoolType] bool
 #  492|   getEntryPoint(): [BlockStmt] { ... }
@@ -4791,7 +4791,7 @@ ir.cpp:
 #  493|             ValueCategory = prvalue
 #  494|     getStmt(1): [ReturnStmt] return ...
 #  496| [TopLevelFunction] void Nullptr()
-#  496|   ...: 
+#  496|   : 
 #  496|   getEntryPoint(): [BlockStmt] { ... }
 #  497|     getStmt(0): [DeclStmt] declaration
 #  497|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
@@ -4853,7 +4853,7 @@ ir.cpp:
 #  500|             ValueCategory = prvalue
 #  501|     getStmt(4): [ReturnStmt] return ...
 #  503| [TopLevelFunction] void InitList(int, float)
-#  503|   ...: 
+#  503|   : 
 #  503|     getParameter(0): [Parameter] x
 #  503|         Type = [IntType] int
 #  503|     getParameter(1): [Parameter] f
@@ -4911,7 +4911,7 @@ ir.cpp:
 #  509|               ValueCategory = prvalue
 #  510|     getStmt(5): [ReturnStmt] return ...
 #  512| [TopLevelFunction] void NestedInitList(int, float)
-#  512|   ...: 
+#  512|   : 
 #  512|     getParameter(0): [Parameter] x
 #  512|         Type = [IntType] int
 #  512|     getParameter(1): [Parameter] f
@@ -4998,7 +4998,7 @@ ir.cpp:
 #  516|                   ValueCategory = prvalue(load)
 #  517|     getStmt(4): [ReturnStmt] return ...
 #  519| [TopLevelFunction] void ArrayInit(int, float)
-#  519|   ...: 
+#  519|   : 
 #  519|     getParameter(0): [Parameter] x
 #  519|         Type = [IntType] int
 #  519|     getParameter(1): [Parameter] f
@@ -5044,15 +5044,15 @@ ir.cpp:
 #  522|                 ValueCategory = prvalue(load)
 #  523|     getStmt(3): [ReturnStmt] return ...
 #  525| [CopyAssignmentOperator] U& U::operator=(U const&)
-#  525|   ...: 
+#  525|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #  525| [MoveAssignmentOperator] U& U::operator=(U&&)
-#  525|   ...: 
+#  525|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #  530| [TopLevelFunction] void UnionInit(int, float)
-#  530|   ...: 
+#  530|   : 
 #  530|     getParameter(0): [Parameter] x
 #  530|         Type = [IntType] int
 #  530|     getParameter(1): [Parameter] f
@@ -5074,7 +5074,7 @@ ir.cpp:
 #  531|                 ValueCategory = prvalue
 #  533|     getStmt(1): [ReturnStmt] return ...
 #  535| [TopLevelFunction] void EarlyReturn(int, int)
-#  535|   ...: 
+#  535|   : 
 #  535|     getParameter(0): [Parameter] x
 #  535|         Type = [IntType] int
 #  535|     getParameter(1): [Parameter] y
@@ -5104,7 +5104,7 @@ ir.cpp:
 #  540|             ValueCategory = prvalue(load)
 #  541|     getStmt(2): [ReturnStmt] return ...
 #  543| [TopLevelFunction] int EarlyReturnValue(int, int)
-#  543|   ...: 
+#  543|   : 
 #  543|     getParameter(0): [Parameter] x
 #  543|         Type = [IntType] int
 #  543|     getParameter(1): [Parameter] y
@@ -5136,7 +5136,7 @@ ir.cpp:
 #  548|             Type = [IntType] int
 #  548|             ValueCategory = prvalue(load)
 #  551| [TopLevelFunction] int CallViaFuncPtr(int(*)(int))
-#  551|   ...: 
+#  551|   : 
 #  551|     getParameter(0): [Parameter] pfn
 #  551|         Type = [FunctionPointerType] ..(*)(..)
 #  551|   getEntryPoint(): [BlockStmt] { ... }
@@ -5152,7 +5152,7 @@ ir.cpp:
 #  552|             Value = [Literal] 5
 #  552|             ValueCategory = prvalue
 #  560| [TopLevelFunction] int EnumSwitch(E)
-#  560|   ...: 
+#  560|   : 
 #  560|     getParameter(0): [Parameter] e
 #  560|         Type = [CTypedefType] E
 #  560|   getEntryPoint(): [BlockStmt] { ... }
@@ -5206,7 +5206,7 @@ ir.cpp:
 #  561|           Type = [IntType] int
 #  561|           ValueCategory = prvalue
 #  571| [TopLevelFunction] void InitArray()
-#  571|   ...: 
+#  571|   : 
 #  571|   getEntryPoint(): [BlockStmt] { ... }
 #  572|     getStmt(0): [DeclStmt] declaration
 #  572|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a_pad
@@ -5301,11 +5301,11 @@ ir.cpp:
 #  579|                 ValueCategory = prvalue
 #  580|     getStmt(8): [ReturnStmt] return ...
 #  582| [TopLevelFunction] void VarArgFunction(char const*)
-#  582|   ...: 
+#  582|   : 
 #  582|     getParameter(0): [Parameter] s
 #  582|         Type = [PointerType] const char *
 #  584| [TopLevelFunction] void VarArgs()
-#  584|   ...: 
+#  584|   : 
 #  584|   getEntryPoint(): [BlockStmt] { ... }
 #  585|     getStmt(0): [ExprStmt] ExprStmt
 #  585|       getExpr(): [FunctionCall] call to VarArgFunction
@@ -5331,11 +5331,11 @@ ir.cpp:
 #  585|             ValueCategory = prvalue
 #  586|     getStmt(1): [ReturnStmt] return ...
 #  588| [TopLevelFunction] int FuncPtrTarget(int)
-#  588|   ...: 
+#  588|   : 
 #  588|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  588|         Type = [IntType] int
 #  590| [TopLevelFunction] void SetFuncPtr()
-#  590|   ...: 
+#  590|   : 
 #  590|   getEntryPoint(): [BlockStmt] { ... }
 #  591|     getStmt(0): [DeclStmt] declaration
 #  591|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pfn
@@ -5394,33 +5394,33 @@ ir.cpp:
 #  594|                     ValueCategory = lvalue
 #  595|     getStmt(4): [ReturnStmt] return ...
 #  599| [CopyConstructor] void String::String(String const&)
-#  599|   ...: 
+#  599|   : 
 #  599|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  599|         Type = [LValueReferenceType] const String &
 #  600| [MoveConstructor] void String::String(String&&)
-#  600|   ...: 
+#  600|   : 
 #  600|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  600|         Type = [RValueReferenceType] String &&
 #  601| [ConversionConstructor] void String::String(char const*)
-#  601|   ...: 
+#  601|   : 
 #  601|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  601|         Type = [PointerType] const char *
 #  602| [Destructor] void String::~String()
-#  602|   ...: 
+#  602|   : 
 #  604| [CopyAssignmentOperator] String& String::operator=(String const&)
-#  604|   ...: 
+#  604|   : 
 #  604|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  604|         Type = [LValueReferenceType] const String &
 #  605| [MoveAssignmentOperator] String& String::operator=(String&&)
-#  605|   ...: 
+#  605|   : 
 #  605|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  605|         Type = [RValueReferenceType] String &&
 #  607| [ConstMemberFunction] char const* String::c_str() const
-#  607|   ...: 
+#  607|   : 
 #  613| [TopLevelFunction] String ReturnObject()
-#  613|   ...: 
+#  613|   : 
 #  615| [TopLevelFunction] void DeclareObject()
-#  615|   ...: 
+#  615|   : 
 #  615|   getEntryPoint(): [BlockStmt] { ... }
 #  616|     getStmt(0): [DeclStmt] declaration
 #  616|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s1
@@ -5466,7 +5466,7 @@ ir.cpp:
 #  619|                 ValueCategory = prvalue
 #  620|     getStmt(4): [ReturnStmt] return ...
 #  622| [TopLevelFunction] void CallMethods(String&, String*, String)
-#  622|   ...: 
+#  622|   : 
 #  622|     getParameter(0): [Parameter] r
 #  622|         Type = [LValueReferenceType] String &
 #  622|     getParameter(1): [Parameter] p
@@ -5512,26 +5512,26 @@ ir.cpp:
 #  625|             ValueCategory = lvalue
 #  626|     getStmt(3): [ReturnStmt] return ...
 #  628| [CopyAssignmentOperator] C& C::operator=(C const&)
-#  628|   ...: 
+#  628|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveAssignmentOperator] C& C::operator=(C&&)
-#  628|   ...: 
+#  628|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [CopyConstructor] void C::C(C const&)
-#  628|   ...: 
+#  628|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveConstructor] void C::C(C&&)
-#  628|   ...: 
+#  628|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [Destructor] void C::~C()
-#  628|   ...: 
+#  628|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-#  628|   ...: 
+#  628|   : 
 #  628|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of m_f
 #  628|         Type = [Struct] String
 #  628|         ValueCategory = prvalue
@@ -5551,7 +5551,7 @@ ir.cpp:
 #  628|             Type = [Struct] String
 #  628|             ValueCategory = lvalue
 #  630| [MemberFunction] int C::StaticMemberFunction(int)
-#  630|   ...: 
+#  630|   : 
 #  630|     getParameter(0): [Parameter] x
 #  630|         Type = [IntType] int
 #  630|   getEntryPoint(): [BlockStmt] { ... }
@@ -5560,7 +5560,7 @@ ir.cpp:
 #  631|           Type = [IntType] int
 #  631|           ValueCategory = prvalue(load)
 #  634| [MemberFunction] int C::InstanceMemberFunction(int)
-#  634|   ...: 
+#  634|   : 
 #  634|     getParameter(0): [Parameter] x
 #  634|         Type = [IntType] int
 #  634|   getEntryPoint(): [BlockStmt] { ... }
@@ -5569,7 +5569,7 @@ ir.cpp:
 #  635|           Type = [IntType] int
 #  635|           ValueCategory = prvalue(load)
 #  638| [VirtualFunction] int C::VirtualMemberFunction(int)
-#  638|   ...: 
+#  638|   : 
 #  638|     getParameter(0): [Parameter] x
 #  638|         Type = [IntType] int
 #  638|   getEntryPoint(): [BlockStmt] { ... }
@@ -5578,7 +5578,7 @@ ir.cpp:
 #  639|           Type = [IntType] int
 #  639|           ValueCategory = prvalue(load)
 #  642| [MemberFunction] void C::FieldAccess()
-#  642|   ...: 
+#  642|   : 
 #  642|   getEntryPoint(): [BlockStmt] { ... }
 #  643|     getStmt(0): [ExprStmt] ExprStmt
 #  643|       getExpr(): [AssignExpr] ... = ...
@@ -5678,7 +5678,7 @@ ir.cpp:
 #  649|               ValueCategory = prvalue(load)
 #  650|     getStmt(7): [ReturnStmt] return ...
 #  652| [MemberFunction] void C::MethodCalls()
-#  652|   ...: 
+#  652|   : 
 #  652|   getEntryPoint(): [BlockStmt] { ... }
 #  653|     getStmt(0): [ExprStmt] ExprStmt
 #  653|       getExpr(): [FunctionCall] call to InstanceMemberFunction
@@ -5721,8 +5721,8 @@ ir.cpp:
 #  655|             ValueCategory = prvalue
 #  656|     getStmt(3): [ReturnStmt] return ...
 #  658| [Constructor] void C::C()
-#  658|   ...: 
-#  658|   ...: 
+#  658|   : 
+#  658|   : 
 #  659|     getInitializer(0): [ConstructorFieldInit] constructor init of field m_a
 #  659|         Type = [IntType] int
 #  659|         ValueCategory = prvalue
@@ -5771,7 +5771,7 @@ ir.cpp:
 #  663|   getEntryPoint(): [BlockStmt] { ... }
 #  664|     getStmt(0): [ReturnStmt] return ...
 #  675| [TopLevelFunction] int DerefReference(int&)
-#  675|   ...: 
+#  675|   : 
 #  675|     getParameter(0): [Parameter] r
 #  675|         Type = [LValueReferenceType] int &
 #  675|   getEntryPoint(): [BlockStmt] { ... }
@@ -5783,7 +5783,7 @@ ir.cpp:
 #  676|           Type = [IntType] int
 #  676|           ValueCategory = prvalue(load)
 #  679| [TopLevelFunction] int& TakeReference()
-#  679|   ...: 
+#  679|   : 
 #  679|   getEntryPoint(): [BlockStmt] { ... }
 #  680|     getStmt(0): [ReturnStmt] return ...
 #  680|       getExpr(): [VariableAccess] g
@@ -5793,9 +5793,9 @@ ir.cpp:
 #  680|           Type = [LValueReferenceType] int &
 #  680|           ValueCategory = prvalue
 #  683| [TopLevelFunction] String& ReturnReference()
-#  683|   ...: 
+#  683|   : 
 #  685| [TopLevelFunction] void InitReference(int)
-#  685|   ...: 
+#  685|   : 
 #  685|     getParameter(0): [Parameter] x
 #  685|         Type = [IntType] int
 #  685|   getEntryPoint(): [BlockStmt] { ... }
@@ -5841,7 +5841,7 @@ ir.cpp:
 #  688|                   ValueCategory = lvalue
 #  689|     getStmt(3): [ReturnStmt] return ...
 #  691| [TopLevelFunction] void ArrayReferences()
-#  691|   ...: 
+#  691|   : 
 #  691|   getEntryPoint(): [BlockStmt] { ... }
 #  692|     getStmt(0): [DeclStmt] declaration
 #  692|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
@@ -5878,7 +5878,7 @@ ir.cpp:
 #  694|                   ValueCategory = lvalue
 #  695|     getStmt(3): [ReturnStmt] return ...
 #  697| [TopLevelFunction] void FunctionReferences()
-#  697|   ...: 
+#  697|   : 
 #  697|   getEntryPoint(): [BlockStmt] { ... }
 #  698|     getStmt(0): [DeclStmt] declaration
 #  698|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rfn
@@ -5916,7 +5916,7 @@ ir.cpp:
 #  700|             ValueCategory = prvalue(load)
 #  701|     getStmt(3): [ReturnStmt] return ...
 #  704| [TemplateFunction,TopLevelFunction] T min<T>(T, T)
-#  704|   ...: 
+#  704|   : 
 #  704|     getParameter(0): [Parameter] x
 #  704|         Type = [TemplateParameter] T
 #  704|     getParameter(1): [Parameter] y
@@ -5949,7 +5949,7 @@ ir.cpp:
 #  705|               Type = [UnknownType] unknown
 #  705|               ValueCategory = prvalue
 #  704| [FunctionTemplateInstantiation,TopLevelFunction] int min<int>(int, int)
-#  704|   ...: 
+#  704|   : 
 #  704|     getParameter(0): [Parameter] x
 #  704|         Type = [IntType] int
 #  704|     getParameter(1): [Parameter] y
@@ -5978,7 +5978,7 @@ ir.cpp:
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
 #  708| [TopLevelFunction] int CallMin(int, int)
-#  708|   ...: 
+#  708|   : 
 #  708|     getParameter(0): [Parameter] x
 #  708|         Type = [IntType] int
 #  708|     getParameter(1): [Parameter] y
@@ -5995,15 +5995,15 @@ ir.cpp:
 #  709|             Type = [IntType] int
 #  709|             ValueCategory = prvalue(load)
 #  713| [CopyAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long> const&)
-#  713|   ...: 
+#  713|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Outer<long> &
 #  713| [MoveAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long>&&)
-#  713|   ...: 
+#  713|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Outer<long> &&
 #  715| [MemberFunction,TemplateFunction] T Outer<T>::Func<U, V>(U, V)
-#  715|   ...: 
+#  715|   : 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
 #  715|     getParameter(1): [Parameter] y
@@ -6015,13 +6015,13 @@ ir.cpp:
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  715| [MemberFunction,TemplateFunction] long Outer<long>::Func<U, V>(U, V)
-#  715|   ...: 
+#  715|   : 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
 #  715|     getParameter(1): [Parameter] y
 #  715|         Type = [TemplateParameter] V
 #  715| [FunctionTemplateInstantiation,MemberFunction] long Outer<long>::Func<void*, char>(void*, char)
-#  715|   ...: 
+#  715|   : 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [VoidPointerType] void *
 #  715|     getParameter(1): [Parameter] y
@@ -6033,7 +6033,7 @@ ir.cpp:
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  720| [TopLevelFunction] double CallNestedTemplateFunc()
-#  720|   ...: 
+#  720|   : 
 #  720|   getEntryPoint(): [BlockStmt] { ... }
 #  721|     getStmt(0): [ReturnStmt] return ...
 #  721|       getExpr(): [FunctionCall] call to Func
@@ -6057,7 +6057,7 @@ ir.cpp:
 #  721|           Type = [DoubleType] double
 #  721|           ValueCategory = prvalue
 #  724| [TopLevelFunction] void TryCatch(bool)
-#  724|   ...: 
+#  724|   : 
 #  724|     getParameter(0): [Parameter] b
 #  724|         Type = [BoolType] bool
 #  724|   getEntryPoint(): [BlockStmt] { ... }
@@ -6162,7 +6162,7 @@ ir.cpp:
 #  741|                 ValueCategory = prvalue
 #  743|     getStmt(1): [ReturnStmt] return ...
 #  745| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#  745|   ...: 
+#  745|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6205,10 +6205,10 @@ ir.cpp:
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #  745| [CopyConstructor] void Base::Base(Base const&)
-#  745|   ...: 
+#  745|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
-#  745|   ...: 
+#  745|   : 
 #  745|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  745|         Type = [Struct] String
 #  745|         ValueCategory = prvalue
@@ -6218,8 +6218,8 @@ ir.cpp:
 #  745|   getEntryPoint(): [BlockStmt] { ... }
 #  745|     getStmt(0): [ReturnStmt] return ...
 #  748| [Constructor] void Base::Base()
-#  748|   ...: 
-#  748|   ...: 
+#  748|   : 
+#  748|   : 
 #  748|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  748|         Type = [Struct] String
 #  748|         ValueCategory = prvalue
@@ -6229,10 +6229,10 @@ ir.cpp:
 #  748|   getEntryPoint(): [BlockStmt] { ... }
 #  749|     getStmt(0): [ReturnStmt] return ...
 #  750| [Destructor] void Base::~Base()
-#  750|   ...: 
+#  750|   : 
 #  750|   getEntryPoint(): [BlockStmt] { ... }
 #  751|     getStmt(0): [ReturnStmt] return ...
-#  750|   ...: 
+#  750|   : 
 #  751|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of base_s
 #  751|         Type = [Struct] String
 #  751|         ValueCategory = prvalue
@@ -6243,7 +6243,7 @@ ir.cpp:
 #  751|             Type = [Struct] String
 #  751|             ValueCategory = lvalue
 #  754| [CopyAssignmentOperator] Middle& Middle::operator=(Middle const&)
-#  754|   ...: 
+#  754|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6319,12 +6319,12 @@ ir.cpp:
 #-----|           Type = [LValueReferenceType] Middle &
 #-----|           ValueCategory = prvalue
 #  754| [CopyConstructor] void Middle::Middle(Middle const&)
-#  754|   ...: 
+#  754|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
 #  757| [Constructor] void Middle::Middle()
-#  757|   ...: 
-#  757|   ...: 
+#  757|   : 
+#  757|   : 
 #  757|     getInitializer(0): [ConstructorDirectInit] call to Base
 #  757|         Type = [VoidType] void
 #  757|         ValueCategory = prvalue
@@ -6337,10 +6337,10 @@ ir.cpp:
 #  757|   getEntryPoint(): [BlockStmt] { ... }
 #  758|     getStmt(0): [ReturnStmt] return ...
 #  759| [Destructor] void Middle::~Middle()
-#  759|   ...: 
+#  759|   : 
 #  759|   getEntryPoint(): [BlockStmt] { ... }
 #  760|     getStmt(0): [ReturnStmt] return ...
-#  759|   ...: 
+#  759|   : 
 #  760|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middle_s
 #  760|         Type = [Struct] String
 #  760|         ValueCategory = prvalue
@@ -6354,7 +6354,7 @@ ir.cpp:
 #  760|         Type = [VoidType] void
 #  760|         ValueCategory = prvalue
 #  763| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#  763|   ...: 
+#  763|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6430,12 +6430,12 @@ ir.cpp:
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #  763| [CopyConstructor] void Derived::Derived(Derived const&)
-#  763|   ...: 
+#  763|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #  766| [Constructor] void Derived::Derived()
-#  766|   ...: 
-#  766|   ...: 
+#  766|   : 
+#  766|   : 
 #  766|     getInitializer(0): [ConstructorDirectInit] call to Middle
 #  766|         Type = [VoidType] void
 #  766|         ValueCategory = prvalue
@@ -6448,10 +6448,10 @@ ir.cpp:
 #  766|   getEntryPoint(): [BlockStmt] { ... }
 #  767|     getStmt(0): [ReturnStmt] return ...
 #  768| [Destructor] void Derived::~Derived()
-#  768|   ...: 
+#  768|   : 
 #  768|   getEntryPoint(): [BlockStmt] { ... }
 #  769|     getStmt(0): [ReturnStmt] return ...
-#  768|   ...: 
+#  768|   : 
 #  769|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derived_s
 #  769|         Type = [Struct] String
 #  769|         ValueCategory = prvalue
@@ -6465,16 +6465,16 @@ ir.cpp:
 #  769|         Type = [VoidType] void
 #  769|         ValueCategory = prvalue
 #  772| [CopyAssignmentOperator] MiddleVB1& MiddleVB1::operator=(MiddleVB1 const&)
-#  772|   ...: 
+#  772|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  772| [CopyConstructor] void MiddleVB1::MiddleVB1(MiddleVB1 const&)
-#  772|   ...: 
+#  772|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  775| [Constructor] void MiddleVB1::MiddleVB1()
-#  775|   ...: 
-#  775|   ...: 
+#  775|   : 
+#  775|   : 
 #  775|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  775|         Type = [VoidType] void
 #  775|         ValueCategory = prvalue
@@ -6487,10 +6487,10 @@ ir.cpp:
 #  775|   getEntryPoint(): [BlockStmt] { ... }
 #  776|     getStmt(0): [ReturnStmt] return ...
 #  777| [Destructor] void MiddleVB1::~MiddleVB1()
-#  777|   ...: 
+#  777|   : 
 #  777|   getEntryPoint(): [BlockStmt] { ... }
 #  778|     getStmt(0): [ReturnStmt] return ...
-#  777|   ...: 
+#  777|   : 
 #  778|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb1_s
 #  778|         Type = [Struct] String
 #  778|         ValueCategory = prvalue
@@ -6504,16 +6504,16 @@ ir.cpp:
 #  778|         Type = [VoidType] void
 #  778|         ValueCategory = prvalue
 #  781| [CopyAssignmentOperator] MiddleVB2& MiddleVB2::operator=(MiddleVB2 const&)
-#  781|   ...: 
+#  781|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  781| [CopyConstructor] void MiddleVB2::MiddleVB2(MiddleVB2 const&)
-#  781|   ...: 
+#  781|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  784| [Constructor] void MiddleVB2::MiddleVB2()
-#  784|   ...: 
-#  784|   ...: 
+#  784|   : 
+#  784|   : 
 #  784|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  784|         Type = [VoidType] void
 #  784|         ValueCategory = prvalue
@@ -6526,10 +6526,10 @@ ir.cpp:
 #  784|   getEntryPoint(): [BlockStmt] { ... }
 #  785|     getStmt(0): [ReturnStmt] return ...
 #  786| [Destructor] void MiddleVB2::~MiddleVB2()
-#  786|   ...: 
+#  786|   : 
 #  786|   getEntryPoint(): [BlockStmt] { ... }
 #  787|     getStmt(0): [ReturnStmt] return ...
-#  786|   ...: 
+#  786|   : 
 #  787|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb2_s
 #  787|         Type = [Struct] String
 #  787|         ValueCategory = prvalue
@@ -6543,16 +6543,16 @@ ir.cpp:
 #  787|         Type = [VoidType] void
 #  787|         ValueCategory = prvalue
 #  790| [CopyAssignmentOperator] DerivedVB& DerivedVB::operator=(DerivedVB const&)
-#  790|   ...: 
+#  790|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  790| [CopyConstructor] void DerivedVB::DerivedVB(DerivedVB const&)
-#  790|   ...: 
+#  790|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  793| [Constructor] void DerivedVB::DerivedVB()
-#  793|   ...: 
-#  793|   ...: 
+#  793|   : 
+#  793|   : 
 #  793|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  793|         Type = [VoidType] void
 #  793|         ValueCategory = prvalue
@@ -6571,10 +6571,10 @@ ir.cpp:
 #  793|   getEntryPoint(): [BlockStmt] { ... }
 #  794|     getStmt(0): [ReturnStmt] return ...
 #  795| [Destructor] void DerivedVB::~DerivedVB()
-#  795|   ...: 
+#  795|   : 
 #  795|   getEntryPoint(): [BlockStmt] { ... }
 #  796|     getStmt(0): [ReturnStmt] return ...
-#  795|   ...: 
+#  795|   : 
 #  796|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derivedvb_s
 #  796|         Type = [Struct] String
 #  796|         ValueCategory = prvalue
@@ -6594,7 +6594,7 @@ ir.cpp:
 #  796|         Type = [VoidType] void
 #  796|         ValueCategory = prvalue
 #  799| [TopLevelFunction] void HierarchyConversions()
-#  799|   ...: 
+#  799|   : 
 #  799|   getEntryPoint(): [BlockStmt] { ... }
 #  800|     getStmt(0): [DeclStmt] declaration
 #  800|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
@@ -7195,54 +7195,54 @@ ir.cpp:
 #  839|             ValueCategory = prvalue
 #  840|     getStmt(34): [ReturnStmt] return ...
 #  842| [CopyAssignmentOperator] PolymorphicBase& PolymorphicBase::operator=(PolymorphicBase const&)
-#  842|   ...: 
+#  842|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  842| [Constructor] void PolymorphicBase::PolymorphicBase()
-#  842|   ...: 
-#  842|   ...: 
+#  842|   : 
+#  842|   : 
 #  842|   getEntryPoint(): [BlockStmt] { ... }
 #  842|     getStmt(0): [ReturnStmt] return ...
 #  842| [CopyConstructor] void PolymorphicBase::PolymorphicBase(PolymorphicBase const&)
-#  842|   ...: 
+#  842|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  843| [Destructor,VirtualFunction] void PolymorphicBase::~PolymorphicBase()
-#  843|   ...: 
+#  843|   : 
 #  846| [CopyAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived const&)
-#  846|   ...: 
+#  846|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived&&)
-#  846|   ...: 
+#  846|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Constructor] void PolymorphicDerived::PolymorphicDerived()
-#  846|   ...: 
-#  846|   ...: 
+#  846|   : 
+#  846|   : 
 #  846|     getInitializer(0): [ConstructorDirectInit] call to PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
 #  846|   getEntryPoint(): [BlockStmt] { ... }
 #  846|     getStmt(0): [ReturnStmt] return ...
 #  846| [CopyConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived const&)
-#  846|   ...: 
+#  846|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived&&)
-#  846|   ...: 
+#  846|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Destructor,VirtualFunction] void PolymorphicDerived::~PolymorphicDerived()
-#  846|   ...: 
+#  846|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-#  846|   ...: 
+#  846|   : 
 #  846|     getDestruction(0): [DestructorDirectDestruction] call to ~PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
 #  849| [TopLevelFunction] void DynamicCast()
-#  849|   ...: 
+#  849|   : 
 #  849|   getEntryPoint(): [BlockStmt] { ... }
 #  850|     getStmt(0): [DeclStmt] declaration
 #  850|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
@@ -7358,8 +7358,8 @@ ir.cpp:
 #  864|               ValueCategory = prvalue
 #  865|     getStmt(10): [ReturnStmt] return ...
 #  867| [Constructor] void String::String()
-#  867|   ...: 
-#  867|   ...: 
+#  867|   : 
+#  867|   : 
 #  868|     getInitializer(0): [ConstructorDelegationInit] call to String
 #  868|         Type = [VoidType] void
 #  868|         ValueCategory = prvalue
@@ -7373,7 +7373,7 @@ ir.cpp:
 #  868|   getEntryPoint(): [BlockStmt] { ... }
 #  869|     getStmt(0): [ReturnStmt] return ...
 #  871| [TopLevelFunction] void ArrayConversions()
-#  871|   ...: 
+#  871|   : 
 #  871|   getEntryPoint(): [BlockStmt] { ... }
 #  872|     getStmt(0): [DeclStmt] declaration
 #  872|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
@@ -7508,7 +7508,7 @@ ir.cpp:
 #  880|               ValueCategory = lvalue
 #  881|     getStmt(9): [ReturnStmt] return ...
 #  883| [TopLevelFunction] void FuncPtrConversions(int(*)(int), void*)
-#  883|   ...: 
+#  883|   : 
 #  883|     getParameter(0): [Parameter] pfn
 #  883|         Type = [FunctionPointerType] ..(*)(..)
 #  883|     getParameter(1): [Parameter] p
@@ -7544,7 +7544,7 @@ ir.cpp:
 #  885|             ValueCategory = prvalue
 #  886|     getStmt(2): [ReturnStmt] return ...
 #  888| [TopLevelFunction] void VAListUsage(int, __va_list_tag[1])
-#  888|   ...: 
+#  888|   : 
 #  888|     getParameter(0): [Parameter] x
 #  888|         Type = [IntType] int
 #  888|     getParameter(1): [Parameter] args
@@ -7602,7 +7602,7 @@ ir.cpp:
 #  893|             ValueCategory = prvalue
 #  894|     getStmt(5): [ReturnStmt] return ...
 #  896| [TopLevelFunction] void VarArgUsage(int)
-#  896|   ...: 
+#  896|   : 
 #  896|     getParameter(0): [Parameter] x
 #  896|         Type = [IntType] int
 #  896|   getEntryPoint(): [BlockStmt] { ... }
@@ -7706,7 +7706,7 @@ ir.cpp:
 #  906|             ValueCategory = prvalue
 #  907|     getStmt(9): [ReturnStmt] return ...
 #  909| [TopLevelFunction] void CastToVoid(int)
-#  909|   ...: 
+#  909|   : 
 #  909|     getParameter(0): [Parameter] x
 #  909|         Type = [IntType] int
 #  909|   getEntryPoint(): [BlockStmt] { ... }
@@ -7720,7 +7720,7 @@ ir.cpp:
 #  910|           ValueCategory = prvalue
 #  911|     getStmt(1): [ReturnStmt] return ...
 #  913| [TopLevelFunction] void ConstantConditions(int)
-#  913|   ...: 
+#  913|   : 
 #  913|     getParameter(0): [Parameter] x
 #  913|         Type = [IntType] int
 #  913|   getEntryPoint(): [BlockStmt] { ... }
@@ -7763,19 +7763,19 @@ ir.cpp:
 #  915|                 ValueCategory = prvalue
 #  916|     getStmt(2): [ReturnStmt] return ...
 #  924| [Operator,TopLevelFunction] void* operator new(size_t, float)
-#  924|   ...: 
+#  924|   : 
 #  924|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  924|         Type = [CTypedefType,Size_t] size_t
 #  924|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  924|         Type = [FloatType] float
 #  925| [Operator,TopLevelFunction] void* operator new[](size_t, float)
-#  925|   ...: 
+#  925|   : 
 #  925|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  925|         Type = [CTypedefType,Size_t] size_t
 #  925|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  925|         Type = [FloatType] float
 #  926| [Operator,TopLevelFunction] void* operator new(size_t, std::align_val_t, float)
-#  926|   ...: 
+#  926|   : 
 #  926|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  926|         Type = [CTypedefType,Size_t] size_t
 #  926|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7783,7 +7783,7 @@ ir.cpp:
 #  926|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  926|         Type = [FloatType] float
 #  927| [Operator,TopLevelFunction] void* operator new[](size_t, std::align_val_t, float)
-#  927|   ...: 
+#  927|   : 
 #  927|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  927|         Type = [CTypedefType,Size_t] size_t
 #  927|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7791,19 +7791,19 @@ ir.cpp:
 #  927|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  927|         Type = [FloatType] float
 #  928| [Operator,TopLevelFunction] void operator delete(void*, float)
-#  928|   ...: 
+#  928|   : 
 #  928|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  928|         Type = [VoidPointerType] void *
 #  928|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  928|         Type = [FloatType] float
 #  929| [Operator,TopLevelFunction] void operator delete[](void*, float)
-#  929|   ...: 
+#  929|   : 
 #  929|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  929|         Type = [VoidPointerType] void *
 #  929|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  929|         Type = [FloatType] float
 #  930| [Operator,TopLevelFunction] void operator delete(void*, std::align_val_t, float)
-#  930|   ...: 
+#  930|   : 
 #  930|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  930|         Type = [VoidPointerType] void *
 #  930|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7811,7 +7811,7 @@ ir.cpp:
 #  930|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  930|         Type = [FloatType] float
 #  931| [Operator,TopLevelFunction] void operator delete[](void*, std::align_val_t, float)
-#  931|   ...: 
+#  931|   : 
 #  931|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  931|         Type = [VoidPointerType] void *
 #  931|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7819,63 +7819,63 @@ ir.cpp:
 #  931|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  931|         Type = [FloatType] float
 #  933| [CopyAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc const&)
-#  933|   ...: 
+#  933|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const SizedDealloc &
 #  933| [MoveAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc&&)
-#  933|   ...: 
+#  933|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] SizedDealloc &&
 #  935| [MemberFunction] void* SizedDealloc::operator new(size_t)
-#  935|   ...: 
+#  935|   : 
 #  935|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  935|         Type = [CTypedefType,Size_t] size_t
 #  936| [MemberFunction] void* SizedDealloc::operator new[](size_t)
-#  936|   ...: 
+#  936|   : 
 #  936|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  936|         Type = [CTypedefType,Size_t] size_t
 #  937| [MemberFunction] void SizedDealloc::operator delete(void*, size_t)
-#  937|   ...: 
+#  937|   : 
 #  937|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  937|         Type = [VoidPointerType] void *
 #  937|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  937|         Type = [CTypedefType,Size_t] size_t
 #  938| [MemberFunction] void SizedDealloc::operator delete[](void*, size_t)
-#  938|   ...: 
+#  938|   : 
 #  938|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  938|         Type = [VoidPointerType] void *
 #  938|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  938|         Type = [CTypedefType,Size_t] size_t
 #  941| [CopyAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned const&)
-#  941|   ...: 
+#  941|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Overaligned &
 #  941| [MoveAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned&&)
-#  941|   ...: 
+#  941|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Overaligned &&
 #  945| [CopyAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam const&)
-#  945|   ...: 
+#  945|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam&&)
-#  945|   ...: 
+#  945|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  945| [CopyConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam const&)
-#  945|   ...: 
+#  945|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam&&)
-#  945|   ...: 
+#  945|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  946| [Constructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(double)
-#  946|   ...: 
+#  946|   : 
 #  946|     getParameter(0): [Parameter] d
 #  946|         Type = [DoubleType] double
 #  949| [TopLevelFunction] void OperatorNew()
-#  949|   ...: 
+#  949|   : 
 #  949|   getEntryPoint(): [BlockStmt] { ... }
 #  950|     getStmt(0): [ExprStmt] ExprStmt
 #  950|       getExpr(): [NewExpr] new
@@ -7966,7 +7966,7 @@ ir.cpp:
 #  956|             ValueCategory = prvalue
 #  957|     getStmt(7): [ReturnStmt] return ...
 #  959| [TopLevelFunction] void OperatorNewArray(int)
-#  959|   ...: 
+#  959|   : 
 #  959|     getParameter(0): [Parameter] n
 #  959|         Type = [IntType] int
 #  959|   getEntryPoint(): [BlockStmt] { ... }
@@ -8077,7 +8077,7 @@ ir.cpp:
 #  967|             ValueCategory = prvalue(load)
 #  968|     getStmt(8): [ReturnStmt] return ...
 #  970| [TopLevelFunction] int designatedInit()
-#  970|   ...: 
+#  970|   : 
 #  970|   getEntryPoint(): [BlockStmt] { ... }
 #  971|     getStmt(0): [DeclStmt] declaration
 #  971|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a1
@@ -8109,7 +8109,7 @@ ir.cpp:
 #  972|             Type = [IntPointerType] int *
 #  972|             ValueCategory = prvalue
 #  975| [TopLevelFunction] void IfStmtWithDeclaration(int, int)
-#  975|   ...: 
+#  975|   : 
 #  975|     getParameter(0): [Parameter] x
 #  975|         Type = [IntType] int
 #  975|     getParameter(1): [Parameter] y
@@ -8185,7 +8185,7 @@ ir.cpp:
 #  983|                     ValueCategory = prvalue
 #  985|     getStmt(1): [ReturnStmt] return ...
 #  987| [TopLevelFunction] void WhileStmtWithDeclaration(int, int)
-#  987|   ...: 
+#  987|   : 
 #  987|     getParameter(0): [Parameter] x
 #  987|         Type = [IntType] int
 #  987|     getParameter(1): [Parameter] y
@@ -8225,7 +8225,7 @@ ir.cpp:
 #  992|       getStmt(): [BlockStmt] { ... }
 #  994|     getStmt(3): [ReturnStmt] return ...
 #  996| [TopLevelFunction] int PointerDecay(int[], int(float))
-#  996|   ...: 
+#  996|   : 
 #  996|     getParameter(0): [Parameter] a
 #  996|         Type = [ArrayType] int[]
 #  996|     getParameter(1): [Parameter] fn
@@ -8261,7 +8261,7 @@ ir.cpp:
 #  997|               Value = [CStyleCast] 1.0
 #  997|               ValueCategory = prvalue
 # 1000| [TopLevelFunction] int ExprStmt(int, int, int)
-# 1000|   ...: 
+# 1000|   : 
 # 1000|     getParameter(0): [Parameter] b
 # 1000|         Type = [IntType] int
 # 1000|     getParameter(1): [Parameter] y
@@ -8281,7 +8281,7 @@ ir.cpp:
 # 1011|           Type = [IntType] int
 # 1011|           ValueCategory = prvalue
 # 1015| [TopLevelFunction] void OperatorDelete()
-# 1015|   ...: 
+# 1015|   : 
 # 1015|   getEntryPoint(): [BlockStmt] { ... }
 # 1016|     getStmt(0): [ExprStmt] ExprStmt
 # 1016|       getExpr(): [DeleteExpr] delete
@@ -8359,7 +8359,7 @@ ir.cpp:
 # 1020|               ValueCategory = prvalue
 # 1021|     getStmt(5): [ReturnStmt] return ...
 # 1024| [TopLevelFunction] void OperatorDeleteArray()
-# 1024|   ...: 
+# 1024|   : 
 # 1024|   getEntryPoint(): [BlockStmt] { ... }
 # 1025|     getStmt(0): [ExprStmt] ExprStmt
 # 1025|       getExpr(): [DeleteArrayExpr] delete[]
@@ -8437,15 +8437,15 @@ ir.cpp:
 # 1029|               ValueCategory = prvalue
 # 1030|     getStmt(5): [ReturnStmt] return ...
 # 1032| [CopyAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct const&)
-# 1032|   ...: 
+# 1032|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const EmptyStruct &
 # 1032| [MoveAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct&&)
-# 1032|   ...: 
+# 1032|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] EmptyStruct &&
 # 1034| [TopLevelFunction] void EmptyStructInit()
-# 1034|   ...: 
+# 1034|   : 
 # 1034|   getEntryPoint(): [BlockStmt] { ... }
 # 1035|     getStmt(0): [DeclStmt] declaration
 # 1035|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -8456,34 +8456,34 @@ ir.cpp:
 # 1035|               ValueCategory = prvalue
 # 1036|     getStmt(1): [ReturnStmt] return ...
 # 1038| [CopyAssignmentOperator] (lambda [] type at line 1038, col. 12)& (lambda [] type at line 1038, col. 12)::operator=((lambda [] type at line 1038, col. 12) const&)
-# 1038|   ...: 
+# 1038|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [CopyConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12) const&)
-# 1038|   ...: 
+# 1038|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [MoveConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12)&&)
-# 1038|   ...: 
+# 1038|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1038, col. 12 &&
 # 1038| [Constructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)()
-# 1038|   ...: 
+# 1038|   : 
 # 1038| [MemberFunction] void (lambda [] type at line 1038, col. 12)::_FUN()
-# 1038|   ...: 
+# 1038|   : 
 # 1038| [ConstMemberFunction] void (lambda [] type at line 1038, col. 12)::operator()() const
-# 1038|   ...: 
+# 1038|   : 
 # 1038|   getEntryPoint(): [BlockStmt] { ... }
 # 1038|     getStmt(0): [ReturnStmt] return ...
 # 1038| [ConstMemberFunction,ConversionOperator] void(* (lambda [] type at line 1038, col. 12)::operator void (*)()() const)()
-# 1038|   ...: 
+# 1038|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 # 1038|     getStmt(0): [ReturnStmt] return ...
 # 1038|       getExpr(): [FunctionAccess] _FUN
 # 1038|           Type = [FunctionPointerType] ..(*)(..)
 # 1038|           ValueCategory = prvalue(load)
 # 1040| [TopLevelFunction] void Lambda(int, String const&)
-# 1040|   ...: 
+# 1040|   : 
 # 1040|     getParameter(0): [Parameter] x
 # 1040|         Type = [IntType] int
 # 1040|     getParameter(1): [Parameter] s
@@ -8786,25 +8786,25 @@ ir.cpp:
 # 1055|             ValueCategory = prvalue
 # 1056|     getStmt(15): [ReturnStmt] return ...
 # 1041| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   ...: 
+# 1041|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   ...: 
+# 1041|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)&&)
-# 1041|   ...: 
+# 1041|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1041, col. 23 &&
 # 1041| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)()
-# 1041|   ...: 
+# 1041|   : 
 # 1041| [MemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::_FUN(float)
-# 1041|   ...: 
+# 1041|   : 
 # 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
 # 1041| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator()(float) const
-# 1041|   ...: 
+# 1041|   : 
 # 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
 # 1041|   getEntryPoint(): [BlockStmt] { ... }
@@ -8814,28 +8814,28 @@ ir.cpp:
 # 1041|           Value = [CharLiteral] 65
 # 1041|           ValueCategory = prvalue
 # 1041| [ConstMemberFunction,ConversionOperator] char(* (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator char (*)(float)() const)(float)
-# 1041|   ...: 
+# 1041|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 # 1041|     getStmt(0): [ReturnStmt] return ...
 # 1041|       getExpr(): [FunctionAccess] _FUN
 # 1041|           Type = [FunctionPointerType] ..(*)(..)
 # 1041|           ValueCategory = prvalue(load)
 # 1043| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   ...: 
+# 1043|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   ...: 
+# 1043|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)&&)
-# 1043|   ...: 
+# 1043|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1043, col. 21 &&
 # 1043| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)()
-# 1043|   ...: 
+# 1043|   : 
 # 1043| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator()(float) const
-# 1043|   ...: 
+# 1043|   : 
 # 1043|     getParameter(0): [Parameter] f
 # 1043|         Type = [FloatType] float
 # 1043|   getEntryPoint(): [BlockStmt] { ... }
@@ -8865,24 +8865,24 @@ ir.cpp:
 # 1043|             Type = [IntType] int
 # 1043|             ValueCategory = prvalue(load)
 # 1045| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   ...: 
+# 1045|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   ...: 
+# 1045|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)&&)
-# 1045|   ...: 
+# 1045|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1045, col. 21 &&
 # 1045| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)()
-# 1045|   ...: 
+# 1045|   : 
 # 1045| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::~<unnamed>()
-# 1045|   ...: 
+# 1045|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-# 1045|   ...: 
+# 1045|   : 
 # 1045|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1045|         Type = [SpecifiedType] const String
 # 1045|         ValueCategory = prvalue
@@ -8893,7 +8893,7 @@ ir.cpp:
 # 1045|             Type = [SpecifiedType] const String
 # 1045|             ValueCategory = lvalue
 # 1045| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator()(float) const
-# 1045|   ...: 
+# 1045|   : 
 # 1045|     getParameter(0): [Parameter] f
 # 1045|         Type = [FloatType] float
 # 1045|   getEntryPoint(): [BlockStmt] { ... }
@@ -8917,21 +8917,21 @@ ir.cpp:
 # 1045|               Type = [PointerType] const lambda [] type at line 1045, col. 21 *
 # 1045|               ValueCategory = prvalue(load)
 # 1047| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   ...: 
+# 1047|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   ...: 
+# 1047|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)&&)
-# 1047|   ...: 
+# 1047|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1047, col. 30 &&
 # 1047| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)()
-# 1047|   ...: 
+# 1047|   : 
 # 1047| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator()(float) const
-# 1047|   ...: 
+# 1047|   : 
 # 1047|     getParameter(0): [Parameter] f
 # 1047|         Type = [FloatType] float
 # 1047|   getEntryPoint(): [BlockStmt] { ... }
@@ -8956,24 +8956,24 @@ ir.cpp:
 # 1047|             Value = [Literal] 0
 # 1047|             ValueCategory = prvalue
 # 1049| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   ...: 
+# 1049|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   ...: 
+# 1049|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)&&)
-# 1049|   ...: 
+# 1049|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1049, col. 30 &&
 # 1049| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)()
-# 1049|   ...: 
+# 1049|   : 
 # 1049| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::~<unnamed>()
-# 1049|   ...: 
+# 1049|   : 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-# 1049|   ...: 
+# 1049|   : 
 # 1049|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1049|         Type = [SpecifiedType] const String
 # 1049|         ValueCategory = prvalue
@@ -8984,7 +8984,7 @@ ir.cpp:
 # 1049|             Type = [SpecifiedType] const String
 # 1049|             ValueCategory = lvalue
 # 1049| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator()(float) const
-# 1049|   ...: 
+# 1049|   : 
 # 1049|     getParameter(0): [Parameter] f
 # 1049|         Type = [FloatType] float
 # 1049|   getEntryPoint(): [BlockStmt] { ... }
@@ -9006,21 +9006,21 @@ ir.cpp:
 # 1049|             Value = [Literal] 0
 # 1049|             ValueCategory = prvalue
 # 1051| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)& (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   ...: 
+# 1051|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   ...: 
+# 1051|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)&&)
-# 1051|   ...: 
+# 1051|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1051, col. 32 &&
 # 1051| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)()
-# 1051|   ...: 
+# 1051|   : 
 # 1051| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator()(float) const
-# 1051|   ...: 
+# 1051|   : 
 # 1051|     getParameter(0): [Parameter] f
 # 1051|         Type = [FloatType] float
 # 1051|   getEntryPoint(): [BlockStmt] { ... }
@@ -9047,21 +9047,21 @@ ir.cpp:
 # 1051|               Type = [PointerType] const lambda [] type at line 1051, col. 32 *
 # 1051|               ValueCategory = prvalue(load)
 # 1054| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   ...: 
+# 1054|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   ...: 
+# 1054|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)&&)
-# 1054|   ...: 
+# 1054|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1054, col. 23 &&
 # 1054| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)()
-# 1054|   ...: 
+# 1054|   : 
 # 1054| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator()(float) const
-# 1054|   ...: 
+# 1054|   : 
 # 1054|     getParameter(0): [Parameter] f
 # 1054|         Type = [FloatType] float
 # 1054|   getEntryPoint(): [BlockStmt] { ... }
@@ -9109,59 +9109,59 @@ ir.cpp:
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue(load)
 # 1059| [CopyAssignmentOperator] vector<int>& vector<int>::operator=(vector<int> const&)
-# 1059|   ...: 
+# 1059|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const vector<int> &
 # 1059| [MoveAssignmentOperator] vector<int>& vector<int>::operator=(vector<int>&&)
-# 1059|   ...: 
+# 1059|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] vector<int> &&
 # 1060| [CopyAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator const public&)
-# 1060|   ...: 
+# 1060|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const iterator &
 # 1060| [MoveAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator&&)
-# 1060|   ...: 
+# 1060|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] iterator &&
 # 1062| [MemberFunction] vector<T>::iterator& vector<T>::iterator::operator++()
-# 1062|   ...: 
+# 1062|   : 
 # 1062| [MemberFunction] vector<int>::iterator& vector<int>::iterator::operator++()
-# 1062|   ...: 
+# 1062|   : 
 # 1063| [ConstMemberFunction] T& vector<T>::iterator::operator*() const
-# 1063|   ...: 
+# 1063|   : 
 # 1063| [ConstMemberFunction] int& vector<int>::iterator::operator*() const
-# 1063|   ...: 
+# 1063|   : 
 # 1065| [ConstMemberFunction] bool vector<T>::iterator::operator!=(vector<T>::iterator) const
-# 1065|   ...: 
+# 1065|   : 
 # 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedClass,TemplateClass] iterator
 # 1065| [ConstMemberFunction] bool vector<int>::iterator::operator!=(vector<int>::iterator) const
-# 1065|   ...: 
+# 1065|   : 
 # 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedStruct] iterator
 # 1068| [ConstMemberFunction] vector<T>::iterator vector<T>::begin() const
-# 1068|   ...: 
+# 1068|   : 
 # 1068| [ConstMemberFunction] vector<int>::iterator vector<int>::begin() const
-# 1068|   ...: 
+# 1068|   : 
 # 1069| [ConstMemberFunction] vector<T>::iterator vector<T>::end() const
-# 1069|   ...: 
+# 1069|   : 
 # 1069| [ConstMemberFunction] vector<int>::iterator vector<int>::end() const
-# 1069|   ...: 
+# 1069|   : 
 # 1073| [Operator,TemplateFunction,TopLevelFunction] bool operator==<T>(iterator, iterator)
-# 1073|   ...: 
+# 1073|   : 
 # 1073|     getParameter(0): [Parameter] left
 # 1073|         Type = [TemplateParameter] iterator
 # 1073|     getParameter(1): [Parameter] right
 # 1073|         Type = [TemplateParameter] iterator
 # 1075| [Operator,TemplateFunction,TopLevelFunction] bool operator!=<T>(iterator, iterator)
-# 1075|   ...: 
+# 1075|   : 
 # 1075|     getParameter(0): [Parameter] left
 # 1075|         Type = [TemplateParameter] iterator
 # 1075|     getParameter(1): [Parameter] right
 # 1075|         Type = [TemplateParameter] iterator
 # 1077| [TopLevelFunction] void RangeBasedFor(vector<int> const&)
-# 1077|   ...: 
+# 1077|   : 
 # 1077|     getParameter(0): [Parameter] v
 # 1077|         Type = [LValueReferenceType] const vector<int> &
 # 1077|   getEntryPoint(): [BlockStmt] { ... }
@@ -9252,7 +9252,7 @@ ir.cpp:
 # 1088|     getStmt(2): [LabelStmt] label ...:
 # 1089|     getStmt(3): [ReturnStmt] return ...
 # 1108| [TopLevelFunction] int AsmStmt(int)
-# 1108|   ...: 
+# 1108|   : 
 # 1108|     getParameter(0): [Parameter] x
 # 1108|         Type = [IntType] int
 # 1108|   getEntryPoint(): [BlockStmt] { ... }
@@ -9262,7 +9262,7 @@ ir.cpp:
 # 1110|           Type = [IntType] int
 # 1110|           ValueCategory = prvalue(load)
 # 1113| [TopLevelFunction] void AsmStmtWithOutputs(unsigned int&, unsigned int, unsigned int&, unsigned int)
-# 1113|   ...: 
+# 1113|   : 
 # 1113|     getParameter(0): [Parameter] a
 # 1113|         Type = [LValueReferenceType] unsigned int &
 # 1113|     getParameter(1): [Parameter] b
@@ -9293,7 +9293,7 @@ ir.cpp:
 # 1118|           ValueCategory = prvalue(load)
 # 1120|     getStmt(1): [ReturnStmt] return ...
 # 1122| [TopLevelFunction] void ExternDeclarations()
-# 1122|   ...: 
+# 1122|   : 
 # 1123|   getEntryPoint(): [BlockStmt] { ... }
 # 1124|     getStmt(0): [DeclStmt] declaration
 # 1124|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
@@ -9318,19 +9318,19 @@ ir.cpp:
 # 1128|           Type = [CTypedefType,LocalTypedefType] d
 # 1129|     getStmt(5): [ReturnStmt] return ...
 # 1126| [TopLevelFunction] int f(float)
-# 1126|   ...: 
+# 1126|   : 
 # 1126|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1126|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int z(float)
-# 1127|   ...: 
+# 1127|   : 
 # 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int w(float)
-# 1127|   ...: 
+# 1127|   : 
 # 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1137| [TopLevelFunction] void ExternDeclarationsInMacro()
-# 1137|   ...: 
+# 1137|   : 
 # 1138|   getEntryPoint(): [BlockStmt] { ... }
 # 1139|     getStmt(0): [DeclStmt] declaration
 # 1139|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
@@ -9367,7 +9367,7 @@ ir.cpp:
 # 1139|     getStmt(2): [EmptyStmt] ;
 # 1140|     getStmt(3): [ReturnStmt] return ...
 # 1142| [TopLevelFunction] void TryCatchNoCatchAny(bool)
-# 1142|   ...: 
+# 1142|   : 
 # 1142|     getParameter(0): [Parameter] b
 # 1142|         Type = [BoolType] bool
 # 1142|   getEntryPoint(): [BlockStmt] { ... }
@@ -9466,7 +9466,7 @@ ir.cpp:
 # 1156|         getBlock(): [CatchBlock] { ... }
 # 1158|     getStmt(1): [ReturnStmt] return ...
 # 1162| [TopLevelFunction] void VectorTypes(int)
-# 1162|   ...: 
+# 1162|   : 
 # 1162|     getParameter(0): [Parameter] i
 # 1162|         Type = [IntType] int
 # 1162|   getEntryPoint(): [BlockStmt] { ... }
@@ -9577,7 +9577,7 @@ ir.cpp:
 # 1167|               ValueCategory = prvalue(load)
 # 1168|     getStmt(5): [ReturnStmt] return ...
 # 1170| [TopLevelFunction] void* memcpy(void*, void*, int)
-# 1170|   ...: 
+# 1170|   : 
 # 1170|     getParameter(0): [Parameter] dst
 # 1170|         Type = [VoidPointerType] void *
 # 1170|     getParameter(1): [Parameter] src
@@ -9585,7 +9585,7 @@ ir.cpp:
 # 1170|     getParameter(2): [Parameter] size
 # 1170|         Type = [IntType] int
 # 1172| [TopLevelFunction] int ModeledCallTarget(int)
-# 1172|   ...: 
+# 1172|   : 
 # 1172|     getParameter(0): [Parameter] x
 # 1172|         Type = [IntType] int
 # 1172|   getEntryPoint(): [BlockStmt] { ... }
@@ -9630,7 +9630,7 @@ ir.cpp:
 # 1175|           Type = [IntType] int
 # 1175|           ValueCategory = prvalue(load)
 # 1178| [TopLevelFunction] String ReturnObjectImpl()
-# 1178|   ...: 
+# 1178|   : 
 # 1178|   getEntryPoint(): [BlockStmt] { ... }
 # 1179|     getStmt(0): [ReturnStmt] return ...
 # 1179|       getExpr(): [ConstructorCall] call to String
@@ -9644,7 +9644,7 @@ ir.cpp:
 # 1179|             Type = [PointerType] const char *
 # 1179|             ValueCategory = prvalue
 # 1182| [TopLevelFunction] void switch1Case(int)
-# 1182|   ...: 
+# 1182|   : 
 # 1182|     getParameter(0): [Parameter] x
 # 1182|         Type = [IntType] int
 # 1182|   getEntryPoint(): [BlockStmt] { ... }
@@ -9686,7 +9686,7 @@ ir.cpp:
 # 1188|               ValueCategory = prvalue(load)
 # 1189|     getStmt(3): [ReturnStmt] return ...
 # 1191| [TopLevelFunction] void switch2Case_fallthrough(int)
-# 1191|   ...: 
+# 1191|   : 
 # 1191|     getParameter(0): [Parameter] x
 # 1191|         Type = [IntType] int
 # 1191|   getEntryPoint(): [BlockStmt] { ... }
@@ -9744,7 +9744,7 @@ ir.cpp:
 # 1199|               ValueCategory = prvalue(load)
 # 1200|     getStmt(3): [ReturnStmt] return ...
 # 1202| [TopLevelFunction] void switch2Case(int)
-# 1202|   ...: 
+# 1202|   : 
 # 1202|     getParameter(0): [Parameter] x
 # 1202|         Type = [IntType] int
 # 1202|   getEntryPoint(): [BlockStmt] { ... }
@@ -9804,7 +9804,7 @@ ir.cpp:
 # 1211|               ValueCategory = prvalue(load)
 # 1212|     getStmt(4): [ReturnStmt] return ...
 # 1214| [TopLevelFunction] void switch2Case_default(int)
-# 1214|   ...: 
+# 1214|   : 
 # 1214|     getParameter(0): [Parameter] x
 # 1214|         Type = [IntType] int
 # 1214|   getEntryPoint(): [BlockStmt] { ... }
@@ -9877,7 +9877,7 @@ ir.cpp:
 # 1228|               ValueCategory = prvalue(load)
 # 1229|     getStmt(4): [ReturnStmt] return ...
 # 1231| [TopLevelFunction] int staticLocalInit(int)
-# 1231|   ...: 
+# 1231|   : 
 # 1231|     getParameter(0): [Parameter] x
 # 1231|         Type = [IntType] int
 # 1231|   getEntryPoint(): [BlockStmt] { ... }
@@ -9941,7 +9941,7 @@ ir.cpp:
 # 1237|             Type = [IntType] int
 # 1237|             ValueCategory = prvalue(load)
 # 1240| [TopLevelFunction] void staticLocalWithConstructor(char const*)
-# 1240|   ...: 
+# 1240|   : 
 # 1240|     getParameter(0): [Parameter] dynamic
 # 1240|         Type = [PointerType] const char *
 # 1240|   getEntryPoint(): [BlockStmt] { ... }
@@ -9978,19 +9978,19 @@ ir.cpp:
 # 1243|                 ValueCategory = prvalue(load)
 # 1244|     getStmt(3): [ReturnStmt] return ...
 # 1248| [TopLevelFunction] char* strcpy(char*, char const*)
-# 1248|   ...: 
+# 1248|   : 
 # 1248|     getParameter(0): [Parameter] destination
 # 1248|         Type = [CharPointerType] char *
 # 1248|     getParameter(1): [Parameter] source
 # 1248|         Type = [PointerType] const char *
 # 1249| [TopLevelFunction] char* strcat(char*, char const*)
-# 1249|   ...: 
+# 1249|   : 
 # 1249|     getParameter(0): [Parameter] destination
 # 1249|         Type = [CharPointerType] char *
 # 1249|     getParameter(1): [Parameter] source
 # 1249|         Type = [PointerType] const char *
 # 1251| [TopLevelFunction] void test_strings(char*, char*)
-# 1251|   ...: 
+# 1251|   : 
 # 1251|     getParameter(0): [Parameter] s1
 # 1251|         Type = [CharPointerType] char *
 # 1251|     getParameter(1): [Parameter] s2
@@ -10048,15 +10048,15 @@ ir.cpp:
 # 1255|             ValueCategory = prvalue
 # 1256|     getStmt(3): [ReturnStmt] return ...
 # 1258| [CopyAssignmentOperator] A& A::operator=(A const&)
-# 1258|   ...: 
+# 1258|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const A &
 # 1258| [MoveAssignmentOperator] A& A::operator=(A&&)
-# 1258|   ...: 
+# 1258|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] A &&
 # 1261| [MemberFunction] void A::static_member(A*, int)
-# 1261|   ...: 
+# 1261|   : 
 # 1261|     getParameter(0): [Parameter] a
 # 1261|         Type = [PointerType] A *
 # 1261|     getParameter(1): [Parameter] x
@@ -10077,11 +10077,11 @@ ir.cpp:
 # 1262|             ValueCategory = prvalue(load)
 # 1263|     getStmt(1): [ReturnStmt] return ...
 # 1265| [MemberFunction] void A::static_member_without_def()
-# 1265|   ...: 
+# 1265|   : 
 # 1268| [TopLevelFunction] A* getAnInstanceOfA()
-# 1268|   ...: 
+# 1268|   : 
 # 1270| [TopLevelFunction] void test_static_member_functions(int, A*)
-# 1270|   ...: 
+# 1270|   : 
 # 1270|     getParameter(0): [Parameter] int_arg
 # 1270|         Type = [IntType] int
 # 1270|     getParameter(1): [Parameter] a_arg
@@ -10232,7 +10232,7 @@ ir.cpp:
 # 1286|             ValueCategory = prvalue
 # 1287|     getStmt(12): [ReturnStmt] return ...
 # 1289| [TopLevelFunction] int missingReturnValue(bool, int)
-# 1289|   ...: 
+# 1289|   : 
 # 1289|     getParameter(0): [Parameter] b
 # 1289|         Type = [BoolType] bool
 # 1289|     getParameter(1): [Parameter] x
@@ -10249,7 +10249,7 @@ ir.cpp:
 # 1291|               ValueCategory = prvalue(load)
 # 1293|     getStmt(1): [ReturnStmt] return ...
 # 1295| [TopLevelFunction] void returnVoid(int, int)
-# 1295|   ...: 
+# 1295|   : 
 # 1295|     getParameter(0): [Parameter] x
 # 1295|         Type = [IntType] int
 # 1295|     getParameter(1): [Parameter] y
@@ -10266,7 +10266,7 @@ ir.cpp:
 # 1296|             Type = [IntType] int
 # 1296|             ValueCategory = prvalue(load)
 # 1299| [TopLevelFunction] void gccBinaryConditional(bool, int, long)
-# 1299|   ...: 
+# 1299|   : 
 # 1299|     getParameter(0): [Parameter] b
 # 1299|         Type = [BoolType] bool
 # 1299|     getParameter(1): [Parameter] x
@@ -10454,11 +10454,11 @@ ir.cpp:
 # 1308|               ValueCategory = prvalue
 # 1309|     getStmt(8): [ReturnStmt] return ...
 # 1311| [TopLevelFunction] bool predicateA()
-# 1311|   ...: 
+# 1311|   : 
 # 1312| [TopLevelFunction] bool predicateB()
-# 1312|   ...: 
+# 1312|   : 
 # 1314| [TopLevelFunction] int shortCircuitConditional(int, int)
-# 1314|   ...: 
+# 1314|   : 
 # 1314|     getParameter(0): [Parameter] x
 # 1314|         Type = [IntType] int
 # 1314|     getParameter(1): [Parameter] y
@@ -10484,13 +10484,13 @@ ir.cpp:
 # 1315|             Type = [IntType] int
 # 1315|             ValueCategory = prvalue(load)
 # 1318| [Operator,TopLevelFunction] void* operator new(size_t, void*)
-# 1318|   ...: 
+# 1318|   : 
 # 1318|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1318|         Type = [CTypedefType,Size_t] size_t
 # 1318|     getParameter(1): [Parameter] (unnamed parameter 1)
 # 1318|         Type = [VoidPointerType] void *
 # 1320| [TopLevelFunction] void f(int*)
-# 1320|   ...: 
+# 1320|   : 
 # 1320|     getParameter(0): [Parameter] p
 # 1320|         Type = [IntPointerType] int *
 # 1321|   getEntryPoint(): [BlockStmt] { ... }
@@ -10514,24 +10514,24 @@ ir.cpp:
 # 1323|     getStmt(1): [ReturnStmt] return ...
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveAssignmentOperator] Big& Big::operator=(Big&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    4| [CopyConstructor] void Big::Big(Big const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveConstructor] void Big::Big(Big&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    6| [Constructor] void Big::Big()
-#    6|   ...: 
-#    6|   ...: 
+#    6|   : 
+#    6|   : 
 #    6|     getInitializer(0): [ConstructorFieldInit] constructor init of field buffer
 #    6|         Type = [ArrayType] char[1073741824]
 #    6|         ValueCategory = prvalue
@@ -10541,7 +10541,7 @@ perf-regression.cpp:
 #    6|   getEntryPoint(): [BlockStmt] { ... }
 #    6|     getStmt(0): [ReturnStmt] return ...
 #    9| [TopLevelFunction] int main()
-#    9|   ...: 
+#    9|   : 
 #    9|   getEntryPoint(): [BlockStmt] { ... }
 #   10|     getStmt(0): [DeclStmt] declaration
 #   10|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of big
@@ -10560,23 +10560,23 @@ perf-regression.cpp:
 #   12|           ValueCategory = prvalue
 struct_init.cpp:
 #    1| [TopLevelFunction] int handler1(void*)
-#    1|   ...: 
+#    1|   : 
 #    1|     getParameter(0): [Parameter] p
 #    1|         Type = [VoidPointerType] void *
 #    2| [TopLevelFunction] int handler2(void*)
-#    2|   ...: 
+#    2|   : 
 #    2|     getParameter(0): [Parameter] p
 #    2|         Type = [VoidPointerType] void *
 #    4| [CopyAssignmentOperator] Info& Info::operator=(Info const&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Info &
 #    4| [MoveAssignmentOperator] Info& Info::operator=(Info&&)
-#    4|   ...: 
+#    4|   : 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Info &&
 #   16| [TopLevelFunction] void let_info_escape(Info*)
-#   16|   ...: 
+#   16|   : 
 #   16|     getParameter(0): [Parameter] info
 #   16|         Type = [PointerType] Info *
 #   16|   getEntryPoint(): [BlockStmt] { ... }
@@ -10592,7 +10592,7 @@ struct_init.cpp:
 #   17|             ValueCategory = prvalue(load)
 #   18|     getStmt(1): [ReturnStmt] return ...
 #   20| [TopLevelFunction] void declare_static_infos()
-#   20|   ...: 
+#   20|   : 
 #   20|   getEntryPoint(): [BlockStmt] { ... }
 #   21|     getStmt(0): [DeclStmt] declaration
 #   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of static_infos
@@ -10642,7 +10642,7 @@ struct_init.cpp:
 #   25|             ValueCategory = prvalue
 #   26|     getStmt(2): [ReturnStmt] return ...
 #   28| [TopLevelFunction] void declare_local_infos()
-#   28|   ...: 
+#   28|   : 
 #   28|   getEntryPoint(): [BlockStmt] { ... }
 #   29|     getStmt(0): [DeclStmt] declaration
 #   29|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of local_infos
@@ -10692,7 +10692,7 @@ struct_init.cpp:
 #   33|             ValueCategory = prvalue
 #   34|     getStmt(2): [ReturnStmt] return ...
 #   36| [TopLevelFunction] void declare_static_runtime_infos(char const*)
-#   36|   ...: 
+#   36|   : 
 #   36|     getParameter(0): [Parameter] name1
 #   36|         Type = [PointerType] const char *
 #   36|   getEntryPoint(): [BlockStmt] { ... }

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -1,10741 +1,10741 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long, std::align_val_t)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
-#-----|     2: [Parameter] (unnamed parameter 2)
+#-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long, std::align_val_t)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
-#-----|     2: [Parameter] (unnamed parameter 2)
+#-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long, std::align_val_t)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long, std::align_val_t)
-#-----|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#-----|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
-#-----|     1: [Parameter] (unnamed parameter 1)
+#-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 bad_asts.cpp:
 #    5| [CopyAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S const&)
-#    5|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    5|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    5| [MoveAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S&&)
-#    5|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    5|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    9| [FunctionTemplateInstantiation,MemberFunction] int Bad::S::MemberFunction<int 6>(int)
-#    9|   params: 
-#    9|     0: [Parameter] y
+#    9|   ...: 
+#    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
-#    9|   body: [BlockStmt] { ... }
-#   10|     0: [ReturnStmt] return ...
-#   10|       0: [AddExpr] ... + ...
+#    9|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [ReturnStmt] return ...
+#   10|       getExpr(): [AddExpr] ... + ...
 #   10|           Type = [IntType] int
 #   10|           ValueCategory = prvalue
-#   10|         0: [AddExpr] ... + ...
+#   10|         getLeftOperand(): [AddExpr] ... + ...
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue
-#   10|           0: [Literal] 6
+#   10|           getLeftOperand(): [Literal] 6
 #   10|               Type = [IntType] int
 #   10|               Value = [Literal] 6
 #   10|               ValueCategory = prvalue
-#   10|           1: [PointerFieldAccess] x
+#   10|           getRightOperand(): [PointerFieldAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|             -1: [ThisExpr] this
+#   10|             getQualifier(): [ThisExpr] this
 #   10|                 Type = [PointerType] S *
 #   10|                 ValueCategory = prvalue(load)
-#   10|         1: [VariableAccess] y
+#   10|         getRightOperand(): [VariableAccess] y
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #    9| [MemberFunction,TemplateFunction] int Bad::S::MemberFunction<int t>(int)
-#    9|   params: 
-#    9|     0: [Parameter] y
+#    9|   ...: 
+#    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
-#    9|   body: [BlockStmt] { ... }
-#   10|     0: [ReturnStmt] return ...
-#   10|       0: [AddExpr] ... + ...
+#    9|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [ReturnStmt] return ...
+#   10|       getExpr(): [AddExpr] ... + ...
 #   10|           Type = [IntType] int
 #   10|           ValueCategory = prvalue
-#   10|         0: [AddExpr] ... + ...
+#   10|         getLeftOperand(): [AddExpr] ... + ...
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue
-#   10|           0: [Literal] t
+#   10|           getLeftOperand(): [Literal] t
 #   10|               Type = [IntType] int
 #   10|               Value = [Literal] t
 #   10|               ValueCategory = prvalue
-#   10|           1: [PointerFieldAccess] x
+#   10|           getRightOperand(): [PointerFieldAccess] x
 #   10|               Type = [IntType] int
 #   10|               ValueCategory = prvalue(load)
-#   10|             -1: [ThisExpr] this
+#   10|             getQualifier(): [ThisExpr] this
 #   10|                 Type = [PointerType] S *
 #   10|                 ValueCategory = prvalue(load)
-#   10|         1: [VariableAccess] y
+#   10|         getRightOperand(): [VariableAccess] y
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #   14| [TopLevelFunction] void Bad::CallBadMemberFunction()
-#   14|   params: 
-#   14|   body: [BlockStmt] { ... }
-#   15|     0: [DeclStmt] declaration
-#   15|       0: [VariableDeclarationEntry] definition of s
+#   14|   ...: 
+#   14|   getEntryPoint(): [BlockStmt] { ... }
+#   15|     getStmt(0): [DeclStmt] declaration
+#   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 #   15|           Type = [Struct] S
-#   15|         init: [Initializer] initializer for s
-#   15|           expr: [ClassAggregateLiteral] {...}
+#   15|         getVariable().getInitializer(): [Initializer] initializer for s
+#   15|           getExpr(): [ClassAggregateLiteral] {...}
 #   15|               Type = [Struct] S
 #   15|               ValueCategory = prvalue
-#   16|     1: [ExprStmt] ExprStmt
-#   16|       0: [FunctionCall] call to MemberFunction
+#   16|     getStmt(1): [ExprStmt] ExprStmt
+#   16|       getExpr(): [FunctionCall] call to MemberFunction
 #   16|           Type = [IntType] int
 #   16|           ValueCategory = prvalue
-#   16|         -1: [VariableAccess] s
+#   16|         getQualifier(): [VariableAccess] s
 #   16|             Type = [Struct] S
 #   16|             ValueCategory = lvalue
-#   16|         0: [Literal] 1
+#   16|         getArgument(0): [Literal] 1
 #   16|             Type = [IntType] int
 #   16|             Value = [Literal] 1
 #   16|             ValueCategory = prvalue
-#   17|     2: [ReturnStmt] return ...
+#   17|     getStmt(2): [ReturnStmt] return ...
 #   19| [CopyAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point const&)
-#   19|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   19|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #   19| [MoveAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point&&)
-#   19|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   19|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   19| [CopyConstructor] void Bad::Point::Point(Bad::Point const&)
-#   19|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   19|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
-#   19|   initializations: 
-#   19|     0: [ConstructorFieldInit] constructor init of field x
+#   19|   ...: 
+#   19|     getInitializer(0): [ConstructorFieldInit] constructor init of field x
 #   19|         Type = [IntType] int
 #   19|         ValueCategory = prvalue
-#   19|       0: [Literal] Unknown literal
+#   19|       getExpr(): [Literal] Unknown literal
 #   19|           Type = [IntType] int
 #   19|           ValueCategory = prvalue
-#   19|     1: [ConstructorFieldInit] constructor init of field y
+#   19|     getInitializer(1): [ConstructorFieldInit] constructor init of field y
 #   19|         Type = [IntType] int
 #   19|         ValueCategory = prvalue
-#   19|       0: [Literal] Unknown literal
+#   19|       getExpr(): [Literal] Unknown literal
 #   19|           Type = [IntType] int
 #   19|           ValueCategory = prvalue
-#   19|   body: [BlockStmt] { ... }
-#   19|     0: [ReturnStmt] return ...
+#   19|   getEntryPoint(): [BlockStmt] { ... }
+#   19|     getStmt(0): [ReturnStmt] return ...
 #   19| [MoveConstructor] void Bad::Point::Point(Bad::Point&&)
-#   19|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#   19|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   22| [Constructor] void Bad::Point::Point()
-#   22|   params: 
-#   22|   initializations: 
-#   22|   body: [BlockStmt] { ... }
-#   23|     0: [ReturnStmt] return ...
+#   22|   ...: 
+#   22|   ...: 
+#   22|   getEntryPoint(): [BlockStmt] { ... }
+#   23|     getStmt(0): [ReturnStmt] return ...
 #   26| [TopLevelFunction] void Bad::CallCopyConstructor(Bad::Point const&)
-#   26|   params: 
-#   26|     0: [Parameter] a
+#   26|   ...: 
+#   26|     getParameter(0): [Parameter] a
 #   26|         Type = [LValueReferenceType] const Point &
-#   26|   body: [BlockStmt] { ... }
-#   27|     0: [DeclStmt] declaration
-#   27|       0: [VariableDeclarationEntry] definition of b
+#   26|   getEntryPoint(): [BlockStmt] { ... }
+#   27|     getStmt(0): [DeclStmt] declaration
+#   27|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #   27|           Type = [Struct] Point
-#   27|         init: [Initializer] initializer for b
-#   27|           expr: [VariableAccess] a
+#   27|         getVariable().getInitializer(): [Initializer] initializer for b
+#   27|           getExpr(): [VariableAccess] a
 #   27|               Type = [LValueReferenceType] const Point &
 #   27|               ValueCategory = prvalue(load)
-#   27|           expr converted: [CStyleCast] (Point)...
+#   27|           : [CStyleCast] (Point)...
 #   27|               Conversion = [GlvalueConversion] glvalue conversion
 #   27|               Type = [Struct] Point
 #   27|               ValueCategory = prvalue(load)
-#   27|             expr: [ReferenceDereferenceExpr] (reference dereference)
+#   27|             getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #   27|                 Type = [SpecifiedType] const Point
 #   27|                 ValueCategory = lvalue
-#   28|     1: [ReturnStmt] return ...
+#   28|     getStmt(1): [ReturnStmt] return ...
 #   30| [TopLevelFunction] void Bad::errorExpr()
-#   30|   params: 
-#   30|   body: [BlockStmt] { ... }
-#   31|     0: [DeclStmt] declaration
-#   31|       0: [VariableDeclarationEntry] definition of intref
+#   30|   ...: 
+#   30|   getEntryPoint(): [BlockStmt] { ... }
+#   31|     getStmt(0): [DeclStmt] declaration
+#   31|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of intref
 #   31|           Type = [LValueReferenceType] int &
-#   31|         init: [Initializer] initializer for intref
-#   31|           expr: [ErrorExpr] <error expr>
+#   31|         getVariable().getInitializer(): [Initializer] initializer for intref
+#   31|           getExpr(): [ErrorExpr] <error expr>
 #   31|               Type = [ErroneousType] error
 #   31|               ValueCategory = prvalue
-#   32|     1: [DeclStmt] declaration
-#   32|       0: [VariableDeclarationEntry] definition of x
+#   32|     getStmt(1): [DeclStmt] declaration
+#   32|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #   32|           Type = [IntType] int
-#   32|         init: [Initializer] initializer for x
-#   32|           expr: [ErrorExpr] <error expr>
+#   32|         getVariable().getInitializer(): [Initializer] initializer for x
+#   32|           getExpr(): [ErrorExpr] <error expr>
 #   32|               Type = [ErroneousType] error
 #   32|               ValueCategory = prvalue
-#   33|     2: [ExprStmt] ExprStmt
-#   33|       0: [AssignExpr] ... = ...
+#   33|     getStmt(2): [ExprStmt] ExprStmt
+#   33|       getExpr(): [AssignExpr] ... = ...
 #   33|           Type = [IntType] int
 #   33|           ValueCategory = lvalue
-#   33|         0: [VariableAccess] x
+#   33|         getLValue(): [VariableAccess] x
 #   33|             Type = [IntType] int
 #   33|             ValueCategory = lvalue
-#   33|         1: [ErrorExpr] <error expr>
+#   33|         getRValue(): [ErrorExpr] <error expr>
 #   33|             Type = [ErroneousType] error
 #   33|             ValueCategory = prvalue(load)
-#   34|     3: [ReturnStmt] return ...
+#   34|     getStmt(3): [ReturnStmt] return ...
 clang.cpp:
 #    5| [TopLevelFunction] int* globalIntAddress()
-#    5|   params: 
-#    5|   body: [BlockStmt] { ... }
-#    6|     0: [ReturnStmt] return ...
-#    6|       0: [BuiltInOperationBuiltInAddressOf] __builtin_addressof ...
+#    5|   ...: 
+#    5|   getEntryPoint(): [BlockStmt] { ... }
+#    6|     getStmt(0): [ReturnStmt] return ...
+#    6|       getExpr(): [BuiltInOperationBuiltInAddressOf] __builtin_addressof ...
 #    6|           Type = [IntPointerType] int *
 #    6|           ValueCategory = prvalue
-#    6|         0: [VariableAccess] globalInt
+#    6|         getOperand(): [VariableAccess] globalInt
 #    6|             Type = [IntType] int
 #    6|             ValueCategory = lvalue
 complex.c:
 #    1| [TopLevelFunction] void complex_literals()
-#    1|   params: 
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of cf
+#    1|   ...: 
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf
 #    2|           Type = [ArithmeticType] _Complex float
-#    2|         init: [Initializer] initializer for cf
-#    2|           expr: [Literal] 2.0
+#    2|         getVariable().getInitializer(): [Initializer] initializer for cf
+#    2|           getExpr(): [Literal] 2.0
 #    2|               Type = [DoubleType] double
 #    2|               Value = [Literal] 2.0
 #    2|               ValueCategory = prvalue
-#    2|           expr converted: [CStyleCast] (_Complex float)...
+#    2|           : [CStyleCast] (_Complex float)...
 #    2|               Conversion = [FloatingPointConversion] floating point conversion
 #    2|               Type = [ArithmeticType] _Complex float
 #    2|               ValueCategory = prvalue
-#    3|     1: [ExprStmt] ExprStmt
-#    3|       0: [AssignExpr] ... = ...
+#    3|     getStmt(1): [ExprStmt] ExprStmt
+#    3|       getExpr(): [AssignExpr] ... = ...
 #    3|           Type = [ArithmeticType] _Complex float
 #    3|           ValueCategory = prvalue
-#    3|         0: [VariableAccess] cf
+#    3|         getLValue(): [VariableAccess] cf
 #    3|             Type = [ArithmeticType] _Complex float
 #    3|             ValueCategory = lvalue
-#    3|         1: [Literal] 1.0i
+#    3|         getRValue(): [Literal] 1.0i
 #    3|             Type = [ArithmeticType] _Imaginary float
 #    3|             Value = [Literal] 1.0i
 #    3|             ValueCategory = prvalue
-#    3|         1 converted: [CStyleCast] (_Complex float)...
+#    3|         : [CStyleCast] (_Complex float)...
 #    3|             Conversion = [FloatingPointConversion] floating point conversion
 #    3|             Type = [ArithmeticType] _Complex float
 #    3|             ValueCategory = prvalue
-#    4|     2: [DeclStmt] declaration
-#    4|       0: [VariableDeclarationEntry] definition of cd
+#    4|     getStmt(2): [DeclStmt] declaration
+#    4|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cd
 #    4|           Type = [ArithmeticType] _Complex double
-#    4|         init: [Initializer] initializer for cd
-#    4|           expr: [Literal] 3.0
+#    4|         getVariable().getInitializer(): [Initializer] initializer for cd
+#    4|           getExpr(): [Literal] 3.0
 #    4|               Type = [DoubleType] double
 #    4|               Value = [Literal] 3.0
 #    4|               ValueCategory = prvalue
-#    4|           expr converted: [CStyleCast] (_Complex double)...
+#    4|           : [CStyleCast] (_Complex double)...
 #    4|               Conversion = [FloatingPointConversion] floating point conversion
 #    4|               Type = [ArithmeticType] _Complex double
 #    4|               ValueCategory = prvalue
-#    5|     3: [ExprStmt] ExprStmt
-#    5|       0: [AssignExpr] ... = ...
+#    5|     getStmt(3): [ExprStmt] ExprStmt
+#    5|       getExpr(): [AssignExpr] ... = ...
 #    5|           Type = [ArithmeticType] _Complex double
 #    5|           ValueCategory = prvalue
-#    5|         0: [VariableAccess] cd
+#    5|         getLValue(): [VariableAccess] cd
 #    5|             Type = [ArithmeticType] _Complex double
 #    5|             ValueCategory = lvalue
-#    5|         1: [Literal] 1.0i
+#    5|         getRValue(): [Literal] 1.0i
 #    5|             Type = [ArithmeticType] _Imaginary float
 #    5|             Value = [Literal] 1.0i
 #    5|             ValueCategory = prvalue
-#    5|         1 converted: [CStyleCast] (_Complex double)...
+#    5|         : [CStyleCast] (_Complex double)...
 #    5|             Conversion = [FloatingPointConversion] floating point conversion
 #    5|             Type = [ArithmeticType] _Complex double
 #    5|             ValueCategory = prvalue
-#    6|     4: [DeclStmt] declaration
-#    6|       0: [VariableDeclarationEntry] definition of cld
+#    6|     getStmt(4): [DeclStmt] declaration
+#    6|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cld
 #    6|           Type = [ArithmeticType] _Complex long double
-#    6|         init: [Initializer] initializer for cld
-#    6|           expr: [Literal] 5.0
+#    6|         getVariable().getInitializer(): [Initializer] initializer for cld
+#    6|           getExpr(): [Literal] 5.0
 #    6|               Type = [DoubleType] double
 #    6|               Value = [Literal] 5.0
 #    6|               ValueCategory = prvalue
-#    6|           expr converted: [CStyleCast] (_Complex long double)...
+#    6|           : [CStyleCast] (_Complex long double)...
 #    6|               Conversion = [FloatingPointConversion] floating point conversion
 #    6|               Type = [ArithmeticType] _Complex long double
 #    6|               ValueCategory = prvalue
-#    7|     5: [ExprStmt] ExprStmt
-#    7|       0: [AssignExpr] ... = ...
+#    7|     getStmt(5): [ExprStmt] ExprStmt
+#    7|       getExpr(): [AssignExpr] ... = ...
 #    7|           Type = [ArithmeticType] _Complex long double
 #    7|           ValueCategory = prvalue
-#    7|         0: [VariableAccess] cld
+#    7|         getLValue(): [VariableAccess] cld
 #    7|             Type = [ArithmeticType] _Complex long double
 #    7|             ValueCategory = lvalue
-#    7|         1: [Literal] 1.0i
+#    7|         getRValue(): [Literal] 1.0i
 #    7|             Type = [ArithmeticType] _Imaginary float
 #    7|             Value = [Literal] 1.0i
 #    7|             ValueCategory = prvalue
-#    7|         1 converted: [CStyleCast] (_Complex long double)...
+#    7|         : [CStyleCast] (_Complex long double)...
 #    7|             Conversion = [FloatingPointConversion] floating point conversion
 #    7|             Type = [ArithmeticType] _Complex long double
 #    7|             ValueCategory = prvalue
-#    9|     6: [DeclStmt] declaration
-#    9|       0: [VariableDeclarationEntry] definition of jf
+#    9|     getStmt(6): [DeclStmt] declaration
+#    9|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jf
 #    9|           Type = [ArithmeticType] _Imaginary float
-#    9|         init: [Initializer] initializer for jf
-#    9|           expr: [Literal] 1.0i
+#    9|         getVariable().getInitializer(): [Initializer] initializer for jf
+#    9|           getExpr(): [Literal] 1.0i
 #    9|               Type = [ArithmeticType] _Imaginary float
 #    9|               Value = [Literal] 1.0i
 #    9|               ValueCategory = prvalue
-#   10|     7: [DeclStmt] declaration
-#   10|       0: [VariableDeclarationEntry] definition of jd
+#   10|     getStmt(7): [DeclStmt] declaration
+#   10|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jd
 #   10|           Type = [ArithmeticType] _Imaginary double
-#   10|         init: [Initializer] initializer for jd
-#   10|           expr: [Literal] 1.0i
+#   10|         getVariable().getInitializer(): [Initializer] initializer for jd
+#   10|           getExpr(): [Literal] 1.0i
 #   10|               Type = [ArithmeticType] _Imaginary float
 #   10|               Value = [Literal] 1.0i
 #   10|               ValueCategory = prvalue
-#   10|           expr converted: [CStyleCast] (_Imaginary double)...
+#   10|           : [CStyleCast] (_Imaginary double)...
 #   10|               Conversion = [FloatingPointConversion] floating point conversion
 #   10|               Type = [ArithmeticType] _Imaginary double
 #   10|               ValueCategory = prvalue
-#   11|     8: [DeclStmt] declaration
-#   11|       0: [VariableDeclarationEntry] definition of jld
+#   11|     getStmt(8): [DeclStmt] declaration
+#   11|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jld
 #   11|           Type = [ArithmeticType] _Imaginary long double
-#   11|         init: [Initializer] initializer for jld
-#   11|           expr: [Literal] 1.0i
+#   11|         getVariable().getInitializer(): [Initializer] initializer for jld
+#   11|           getExpr(): [Literal] 1.0i
 #   11|               Type = [ArithmeticType] _Imaginary float
 #   11|               Value = [Literal] 1.0i
 #   11|               ValueCategory = prvalue
-#   11|           expr converted: [CStyleCast] (_Imaginary long double)...
+#   11|           : [CStyleCast] (_Imaginary long double)...
 #   11|               Conversion = [FloatingPointConversion] floating point conversion
 #   11|               Type = [ArithmeticType] _Imaginary long double
 #   11|               ValueCategory = prvalue
-#   12|     9: [ReturnStmt] return ...
+#   12|     getStmt(9): [ReturnStmt] return ...
 #   14| [TopLevelFunction] void complex_arithmetic()
-#   14|   params: 
-#   14|   body: [BlockStmt] { ... }
-#   15|     0: [DeclStmt] declaration
-#   15|       0: [VariableDeclarationEntry] definition of f1
+#   14|   ...: 
+#   14|   getEntryPoint(): [BlockStmt] { ... }
+#   15|     getStmt(0): [DeclStmt] declaration
+#   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f1
 #   15|           Type = [FloatType] float
-#   15|         init: [Initializer] initializer for f1
-#   15|           expr: [Literal] 5.0
+#   15|         getVariable().getInitializer(): [Initializer] initializer for f1
+#   15|           getExpr(): [Literal] 5.0
 #   15|               Type = [DoubleType] double
 #   15|               Value = [Literal] 5.0
 #   15|               ValueCategory = prvalue
-#   15|           expr converted: [CStyleCast] (float)...
+#   15|           : [CStyleCast] (float)...
 #   15|               Conversion = [FloatingPointConversion] floating point conversion
 #   15|               Type = [FloatType] float
 #   15|               Value = [CStyleCast] 5.0
 #   15|               ValueCategory = prvalue
-#   16|     1: [DeclStmt] declaration
-#   16|       0: [VariableDeclarationEntry] definition of f2
+#   16|     getStmt(1): [DeclStmt] declaration
+#   16|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f2
 #   16|           Type = [FloatType] float
-#   16|         init: [Initializer] initializer for f2
-#   16|           expr: [Literal] 7.0
+#   16|         getVariable().getInitializer(): [Initializer] initializer for f2
+#   16|           getExpr(): [Literal] 7.0
 #   16|               Type = [DoubleType] double
 #   16|               Value = [Literal] 7.0
 #   16|               ValueCategory = prvalue
-#   16|           expr converted: [CStyleCast] (float)...
+#   16|           : [CStyleCast] (float)...
 #   16|               Conversion = [FloatingPointConversion] floating point conversion
 #   16|               Type = [FloatType] float
 #   16|               Value = [CStyleCast] 7.0
 #   16|               ValueCategory = prvalue
-#   17|     2: [DeclStmt] declaration
-#   17|       0: [VariableDeclarationEntry] definition of f3
+#   17|     getStmt(2): [DeclStmt] declaration
+#   17|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f3
 #   17|           Type = [FloatType] float
-#   18|     3: [DeclStmt] declaration
-#   18|       0: [VariableDeclarationEntry] definition of cf1
+#   18|     getStmt(3): [DeclStmt] declaration
+#   18|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf1
 #   18|           Type = [ArithmeticType] _Complex float
-#   18|         init: [Initializer] initializer for cf1
-#   18|           expr: [Literal] 2.0
+#   18|         getVariable().getInitializer(): [Initializer] initializer for cf1
+#   18|           getExpr(): [Literal] 2.0
 #   18|               Type = [DoubleType] double
 #   18|               Value = [Literal] 2.0
 #   18|               ValueCategory = prvalue
-#   18|           expr converted: [CStyleCast] (_Complex float)...
+#   18|           : [CStyleCast] (_Complex float)...
 #   18|               Conversion = [FloatingPointConversion] floating point conversion
 #   18|               Type = [ArithmeticType] _Complex float
 #   18|               ValueCategory = prvalue
-#   19|     4: [DeclStmt] declaration
-#   19|       0: [VariableDeclarationEntry] definition of cf2
+#   19|     getStmt(4): [DeclStmt] declaration
+#   19|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf2
 #   19|           Type = [ArithmeticType] _Complex float
-#   19|         init: [Initializer] initializer for cf2
-#   19|           expr: [Literal] 1.0i
+#   19|         getVariable().getInitializer(): [Initializer] initializer for cf2
+#   19|           getExpr(): [Literal] 1.0i
 #   19|               Type = [ArithmeticType] _Imaginary float
 #   19|               Value = [Literal] 1.0i
 #   19|               ValueCategory = prvalue
-#   19|           expr converted: [CStyleCast] (_Complex float)...
+#   19|           : [CStyleCast] (_Complex float)...
 #   19|               Conversion = [FloatingPointConversion] floating point conversion
 #   19|               Type = [ArithmeticType] _Complex float
 #   19|               ValueCategory = prvalue
-#   20|     5: [DeclStmt] declaration
-#   20|       0: [VariableDeclarationEntry] definition of cf3
+#   20|     getStmt(5): [DeclStmt] declaration
+#   20|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf3
 #   20|           Type = [ArithmeticType] _Complex float
-#   21|     6: [DeclStmt] declaration
-#   21|       0: [VariableDeclarationEntry] definition of jf1
+#   21|     getStmt(6): [DeclStmt] declaration
+#   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jf1
 #   21|           Type = [ArithmeticType] _Imaginary float
-#   21|         init: [Initializer] initializer for jf1
-#   21|           expr: [Literal] 1.0i
+#   21|         getVariable().getInitializer(): [Initializer] initializer for jf1
+#   21|           getExpr(): [Literal] 1.0i
 #   21|               Type = [ArithmeticType] _Imaginary float
 #   21|               Value = [Literal] 1.0i
 #   21|               ValueCategory = prvalue
-#   22|     7: [DeclStmt] declaration
-#   22|       0: [VariableDeclarationEntry] definition of jf2
+#   22|     getStmt(7): [DeclStmt] declaration
+#   22|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jf2
 #   22|           Type = [ArithmeticType] _Imaginary float
-#   22|         init: [Initializer] initializer for jf2
-#   22|           expr: [Literal] 1.0i
+#   22|         getVariable().getInitializer(): [Initializer] initializer for jf2
+#   22|           getExpr(): [Literal] 1.0i
 #   22|               Type = [ArithmeticType] _Imaginary float
 #   22|               Value = [Literal] 1.0i
 #   22|               ValueCategory = prvalue
-#   23|     8: [DeclStmt] declaration
-#   23|       0: [VariableDeclarationEntry] definition of jf3
+#   23|     getStmt(8): [DeclStmt] declaration
+#   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jf3
 #   23|           Type = [ArithmeticType] _Imaginary float
-#   26|     9: [ExprStmt] ExprStmt
-#   26|       0: [AssignExpr] ... = ...
+#   26|     getStmt(9): [ExprStmt] ExprStmt
+#   26|       getExpr(): [AssignExpr] ... = ...
 #   26|           Type = [ArithmeticType] _Complex float
 #   26|           ValueCategory = prvalue
-#   26|         0: [VariableAccess] cf3
+#   26|         getLValue(): [VariableAccess] cf3
 #   26|             Type = [ArithmeticType] _Complex float
 #   26|             ValueCategory = lvalue
-#   26|         1: [UnaryPlusExpr] + ...
+#   26|         getRValue(): [UnaryPlusExpr] + ...
 #   26|             Type = [ArithmeticType] _Complex float
 #   26|             ValueCategory = prvalue
-#   26|           0: [VariableAccess] cf1
+#   26|           getOperand(): [VariableAccess] cf1
 #   26|               Type = [ArithmeticType] _Complex float
 #   26|               ValueCategory = prvalue(load)
-#   27|     10: [ExprStmt] ExprStmt
-#   27|       0: [AssignExpr] ... = ...
+#   27|     getStmt(10): [ExprStmt] ExprStmt
+#   27|       getExpr(): [AssignExpr] ... = ...
 #   27|           Type = [ArithmeticType] _Complex float
 #   27|           ValueCategory = prvalue
-#   27|         0: [VariableAccess] cf3
+#   27|         getLValue(): [VariableAccess] cf3
 #   27|             Type = [ArithmeticType] _Complex float
 #   27|             ValueCategory = lvalue
-#   27|         1: [UnaryMinusExpr] - ...
+#   27|         getRValue(): [UnaryMinusExpr] - ...
 #   27|             Type = [ArithmeticType] _Complex float
 #   27|             ValueCategory = prvalue
-#   27|           0: [VariableAccess] cf1
+#   27|           getOperand(): [VariableAccess] cf1
 #   27|               Type = [ArithmeticType] _Complex float
 #   27|               ValueCategory = prvalue(load)
-#   30|     11: [ExprStmt] ExprStmt
-#   30|       0: [AssignExpr] ... = ...
+#   30|     getStmt(11): [ExprStmt] ExprStmt
+#   30|       getExpr(): [AssignExpr] ... = ...
 #   30|           Type = [ArithmeticType] _Complex float
 #   30|           ValueCategory = prvalue
-#   30|         0: [VariableAccess] cf3
+#   30|         getLValue(): [VariableAccess] cf3
 #   30|             Type = [ArithmeticType] _Complex float
 #   30|             ValueCategory = lvalue
-#   30|         1: [AddExpr] ... + ...
+#   30|         getRValue(): [AddExpr] ... + ...
 #   30|             Type = [ArithmeticType] _Complex float
 #   30|             ValueCategory = prvalue
-#   30|           0: [VariableAccess] cf1
+#   30|           getLeftOperand(): [VariableAccess] cf1
 #   30|               Type = [ArithmeticType] _Complex float
 #   30|               ValueCategory = prvalue(load)
-#   30|           1: [VariableAccess] cf2
+#   30|           getRightOperand(): [VariableAccess] cf2
 #   30|               Type = [ArithmeticType] _Complex float
 #   30|               ValueCategory = prvalue(load)
-#   31|     12: [ExprStmt] ExprStmt
-#   31|       0: [AssignExpr] ... = ...
+#   31|     getStmt(12): [ExprStmt] ExprStmt
+#   31|       getExpr(): [AssignExpr] ... = ...
 #   31|           Type = [ArithmeticType] _Complex float
 #   31|           ValueCategory = prvalue
-#   31|         0: [VariableAccess] cf3
+#   31|         getLValue(): [VariableAccess] cf3
 #   31|             Type = [ArithmeticType] _Complex float
 #   31|             ValueCategory = lvalue
-#   31|         1: [SubExpr] ... - ...
+#   31|         getRValue(): [SubExpr] ... - ...
 #   31|             Type = [ArithmeticType] _Complex float
 #   31|             ValueCategory = prvalue
-#   31|           0: [VariableAccess] cf1
+#   31|           getLeftOperand(): [VariableAccess] cf1
 #   31|               Type = [ArithmeticType] _Complex float
 #   31|               ValueCategory = prvalue(load)
-#   31|           1: [VariableAccess] cf2
+#   31|           getRightOperand(): [VariableAccess] cf2
 #   31|               Type = [ArithmeticType] _Complex float
 #   31|               ValueCategory = prvalue(load)
-#   32|     13: [ExprStmt] ExprStmt
-#   32|       0: [AssignExpr] ... = ...
+#   32|     getStmt(13): [ExprStmt] ExprStmt
+#   32|       getExpr(): [AssignExpr] ... = ...
 #   32|           Type = [ArithmeticType] _Complex float
 #   32|           ValueCategory = prvalue
-#   32|         0: [VariableAccess] cf3
+#   32|         getLValue(): [VariableAccess] cf3
 #   32|             Type = [ArithmeticType] _Complex float
 #   32|             ValueCategory = lvalue
-#   32|         1: [MulExpr] ... * ...
+#   32|         getRValue(): [MulExpr] ... * ...
 #   32|             Type = [ArithmeticType] _Complex float
 #   32|             ValueCategory = prvalue
-#   32|           0: [VariableAccess] cf1
+#   32|           getLeftOperand(): [VariableAccess] cf1
 #   32|               Type = [ArithmeticType] _Complex float
 #   32|               ValueCategory = prvalue(load)
-#   32|           1: [VariableAccess] cf2
+#   32|           getRightOperand(): [VariableAccess] cf2
 #   32|               Type = [ArithmeticType] _Complex float
 #   32|               ValueCategory = prvalue(load)
-#   33|     14: [ExprStmt] ExprStmt
-#   33|       0: [AssignExpr] ... = ...
+#   33|     getStmt(14): [ExprStmt] ExprStmt
+#   33|       getExpr(): [AssignExpr] ... = ...
 #   33|           Type = [ArithmeticType] _Complex float
 #   33|           ValueCategory = prvalue
-#   33|         0: [VariableAccess] cf3
+#   33|         getLValue(): [VariableAccess] cf3
 #   33|             Type = [ArithmeticType] _Complex float
 #   33|             ValueCategory = lvalue
-#   33|         1: [DivExpr] ... / ...
+#   33|         getRValue(): [DivExpr] ... / ...
 #   33|             Type = [ArithmeticType] _Complex float
 #   33|             ValueCategory = prvalue
-#   33|           0: [VariableAccess] cf1
+#   33|           getLeftOperand(): [VariableAccess] cf1
 #   33|               Type = [ArithmeticType] _Complex float
 #   33|               ValueCategory = prvalue(load)
-#   33|           1: [VariableAccess] cf2
+#   33|           getRightOperand(): [VariableAccess] cf2
 #   33|               Type = [ArithmeticType] _Complex float
 #   33|               ValueCategory = prvalue(load)
-#   36|     15: [ExprStmt] ExprStmt
-#   36|       0: [AssignExpr] ... = ...
+#   36|     getStmt(15): [ExprStmt] ExprStmt
+#   36|       getExpr(): [AssignExpr] ... = ...
 #   36|           Type = [ArithmeticType] _Imaginary float
 #   36|           ValueCategory = prvalue
-#   36|         0: [VariableAccess] jf3
+#   36|         getLValue(): [VariableAccess] jf3
 #   36|             Type = [ArithmeticType] _Imaginary float
 #   36|             ValueCategory = lvalue
-#   36|         1: [UnaryPlusExpr] + ...
+#   36|         getRValue(): [UnaryPlusExpr] + ...
 #   36|             Type = [ArithmeticType] _Imaginary float
 #   36|             ValueCategory = prvalue
-#   36|           0: [VariableAccess] jf1
+#   36|           getOperand(): [VariableAccess] jf1
 #   36|               Type = [ArithmeticType] _Imaginary float
 #   36|               ValueCategory = prvalue(load)
-#   37|     16: [ExprStmt] ExprStmt
-#   37|       0: [AssignExpr] ... = ...
+#   37|     getStmt(16): [ExprStmt] ExprStmt
+#   37|       getExpr(): [AssignExpr] ... = ...
 #   37|           Type = [ArithmeticType] _Imaginary float
 #   37|           ValueCategory = prvalue
-#   37|         0: [VariableAccess] jf3
+#   37|         getLValue(): [VariableAccess] jf3
 #   37|             Type = [ArithmeticType] _Imaginary float
 #   37|             ValueCategory = lvalue
-#   37|         1: [UnaryMinusExpr] - ...
+#   37|         getRValue(): [UnaryMinusExpr] - ...
 #   37|             Type = [ArithmeticType] _Imaginary float
 #   37|             ValueCategory = prvalue
-#   37|           0: [VariableAccess] jf1
+#   37|           getOperand(): [VariableAccess] jf1
 #   37|               Type = [ArithmeticType] _Imaginary float
 #   37|               ValueCategory = prvalue(load)
-#   40|     17: [ExprStmt] ExprStmt
-#   40|       0: [AssignExpr] ... = ...
+#   40|     getStmt(17): [ExprStmt] ExprStmt
+#   40|       getExpr(): [AssignExpr] ... = ...
 #   40|           Type = [ArithmeticType] _Imaginary float
 #   40|           ValueCategory = prvalue
-#   40|         0: [VariableAccess] jf3
+#   40|         getLValue(): [VariableAccess] jf3
 #   40|             Type = [ArithmeticType] _Imaginary float
 #   40|             ValueCategory = lvalue
-#   40|         1: [AddExpr] ... + ...
+#   40|         getRValue(): [AddExpr] ... + ...
 #   40|             Type = [ArithmeticType] _Imaginary float
 #   40|             ValueCategory = prvalue
-#   40|           0: [VariableAccess] jf1
+#   40|           getLeftOperand(): [VariableAccess] jf1
 #   40|               Type = [ArithmeticType] _Imaginary float
 #   40|               ValueCategory = prvalue(load)
-#   40|           1: [VariableAccess] jf2
+#   40|           getRightOperand(): [VariableAccess] jf2
 #   40|               Type = [ArithmeticType] _Imaginary float
 #   40|               ValueCategory = prvalue(load)
-#   41|     18: [ExprStmt] ExprStmt
-#   41|       0: [AssignExpr] ... = ...
+#   41|     getStmt(18): [ExprStmt] ExprStmt
+#   41|       getExpr(): [AssignExpr] ... = ...
 #   41|           Type = [ArithmeticType] _Imaginary float
 #   41|           ValueCategory = prvalue
-#   41|         0: [VariableAccess] jf3
+#   41|         getLValue(): [VariableAccess] jf3
 #   41|             Type = [ArithmeticType] _Imaginary float
 #   41|             ValueCategory = lvalue
-#   41|         1: [SubExpr] ... - ...
+#   41|         getRValue(): [SubExpr] ... - ...
 #   41|             Type = [ArithmeticType] _Imaginary float
 #   41|             ValueCategory = prvalue
-#   41|           0: [VariableAccess] jf1
+#   41|           getLeftOperand(): [VariableAccess] jf1
 #   41|               Type = [ArithmeticType] _Imaginary float
 #   41|               ValueCategory = prvalue(load)
-#   41|           1: [VariableAccess] jf2
+#   41|           getRightOperand(): [VariableAccess] jf2
 #   41|               Type = [ArithmeticType] _Imaginary float
 #   41|               ValueCategory = prvalue(load)
-#   42|     19: [ExprStmt] ExprStmt
-#   42|       0: [AssignExpr] ... = ...
+#   42|     getStmt(19): [ExprStmt] ExprStmt
+#   42|       getExpr(): [AssignExpr] ... = ...
 #   42|           Type = [FloatType] float
 #   42|           ValueCategory = prvalue
-#   42|         0: [VariableAccess] f3
+#   42|         getLValue(): [VariableAccess] f3
 #   42|             Type = [FloatType] float
 #   42|             ValueCategory = lvalue
-#   42|         1: [ImaginaryMulExpr] ... * ...
+#   42|         getRValue(): [ImaginaryMulExpr] ... * ...
 #   42|             Type = [FloatType] float
 #   42|             ValueCategory = prvalue
-#   42|           0: [VariableAccess] jf1
+#   42|           getLeftOperand(): [VariableAccess] jf1
 #   42|               Type = [ArithmeticType] _Imaginary float
 #   42|               ValueCategory = prvalue(load)
-#   42|           1: [VariableAccess] jf2
+#   42|           getRightOperand(): [VariableAccess] jf2
 #   42|               Type = [ArithmeticType] _Imaginary float
 #   42|               ValueCategory = prvalue(load)
-#   43|     20: [ExprStmt] ExprStmt
-#   43|       0: [AssignExpr] ... = ...
+#   43|     getStmt(20): [ExprStmt] ExprStmt
+#   43|       getExpr(): [AssignExpr] ... = ...
 #   43|           Type = [FloatType] float
 #   43|           ValueCategory = prvalue
-#   43|         0: [VariableAccess] f3
+#   43|         getLValue(): [VariableAccess] f3
 #   43|             Type = [FloatType] float
 #   43|             ValueCategory = lvalue
-#   43|         1: [DivExpr] ... / ...
+#   43|         getRValue(): [DivExpr] ... / ...
 #   43|             Type = [FloatType] float
 #   43|             ValueCategory = prvalue
-#   43|           0: [VariableAccess] jf1
+#   43|           getLeftOperand(): [VariableAccess] jf1
 #   43|               Type = [ArithmeticType] _Imaginary float
 #   43|               ValueCategory = prvalue(load)
-#   43|           1: [VariableAccess] jf2
+#   43|           getRightOperand(): [VariableAccess] jf2
 #   43|               Type = [ArithmeticType] _Imaginary float
 #   43|               ValueCategory = prvalue(load)
-#   46|     21: [ExprStmt] ExprStmt
-#   46|       0: [AssignExpr] ... = ...
+#   46|     getStmt(21): [ExprStmt] ExprStmt
+#   46|       getExpr(): [AssignExpr] ... = ...
 #   46|           Type = [ArithmeticType] _Complex float
 #   46|           ValueCategory = prvalue
-#   46|         0: [VariableAccess] cf3
+#   46|         getLValue(): [VariableAccess] cf3
 #   46|             Type = [ArithmeticType] _Complex float
 #   46|             ValueCategory = lvalue
-#   46|         1: [ImaginaryRealAddExpr] ... + ...
+#   46|         getRValue(): [ImaginaryRealAddExpr] ... + ...
 #   46|             Type = [ArithmeticType] _Complex float
 #   46|             ValueCategory = prvalue
-#   46|           0: [VariableAccess] jf1
+#   46|           getLeftOperand(): [VariableAccess] jf1
 #   46|               Type = [ArithmeticType] _Imaginary float
 #   46|               ValueCategory = prvalue(load)
-#   46|           1: [VariableAccess] f2
+#   46|           getRightOperand(): [VariableAccess] f2
 #   46|               Type = [FloatType] float
 #   46|               ValueCategory = prvalue(load)
-#   47|     22: [ExprStmt] ExprStmt
-#   47|       0: [AssignExpr] ... = ...
+#   47|     getStmt(22): [ExprStmt] ExprStmt
+#   47|       getExpr(): [AssignExpr] ... = ...
 #   47|           Type = [ArithmeticType] _Complex float
 #   47|           ValueCategory = prvalue
-#   47|         0: [VariableAccess] cf3
+#   47|         getLValue(): [VariableAccess] cf3
 #   47|             Type = [ArithmeticType] _Complex float
 #   47|             ValueCategory = lvalue
-#   47|         1: [ImaginaryRealSubExpr] ... - ...
+#   47|         getRValue(): [ImaginaryRealSubExpr] ... - ...
 #   47|             Type = [ArithmeticType] _Complex float
 #   47|             ValueCategory = prvalue
-#   47|           0: [VariableAccess] jf1
+#   47|           getLeftOperand(): [VariableAccess] jf1
 #   47|               Type = [ArithmeticType] _Imaginary float
 #   47|               ValueCategory = prvalue(load)
-#   47|           1: [VariableAccess] f2
+#   47|           getRightOperand(): [VariableAccess] f2
 #   47|               Type = [FloatType] float
 #   47|               ValueCategory = prvalue(load)
-#   48|     23: [ExprStmt] ExprStmt
-#   48|       0: [AssignExpr] ... = ...
+#   48|     getStmt(23): [ExprStmt] ExprStmt
+#   48|       getExpr(): [AssignExpr] ... = ...
 #   48|           Type = [ArithmeticType] _Imaginary float
 #   48|           ValueCategory = prvalue
-#   48|         0: [VariableAccess] jf3
+#   48|         getLValue(): [VariableAccess] jf3
 #   48|             Type = [ArithmeticType] _Imaginary float
 #   48|             ValueCategory = lvalue
-#   48|         1: [MulExpr] ... * ...
+#   48|         getRValue(): [MulExpr] ... * ...
 #   48|             Type = [ArithmeticType] _Imaginary float
 #   48|             ValueCategory = prvalue
-#   48|           0: [VariableAccess] jf1
+#   48|           getLeftOperand(): [VariableAccess] jf1
 #   48|               Type = [ArithmeticType] _Imaginary float
 #   48|               ValueCategory = prvalue(load)
-#   48|           1: [VariableAccess] f2
+#   48|           getRightOperand(): [VariableAccess] f2
 #   48|               Type = [FloatType] float
 #   48|               ValueCategory = prvalue(load)
-#   49|     24: [ExprStmt] ExprStmt
-#   49|       0: [AssignExpr] ... = ...
+#   49|     getStmt(24): [ExprStmt] ExprStmt
+#   49|       getExpr(): [AssignExpr] ... = ...
 #   49|           Type = [ArithmeticType] _Imaginary float
 #   49|           ValueCategory = prvalue
-#   49|         0: [VariableAccess] jf3
+#   49|         getLValue(): [VariableAccess] jf3
 #   49|             Type = [ArithmeticType] _Imaginary float
 #   49|             ValueCategory = lvalue
-#   49|         1: [DivExpr] ... / ...
+#   49|         getRValue(): [DivExpr] ... / ...
 #   49|             Type = [ArithmeticType] _Imaginary float
 #   49|             ValueCategory = prvalue
-#   49|           0: [VariableAccess] jf1
+#   49|           getLeftOperand(): [VariableAccess] jf1
 #   49|               Type = [ArithmeticType] _Imaginary float
 #   49|               ValueCategory = prvalue(load)
-#   49|           1: [VariableAccess] f2
+#   49|           getRightOperand(): [VariableAccess] f2
 #   49|               Type = [FloatType] float
 #   49|               ValueCategory = prvalue(load)
-#   52|     25: [ExprStmt] ExprStmt
-#   52|       0: [AssignExpr] ... = ...
+#   52|     getStmt(25): [ExprStmt] ExprStmt
+#   52|       getExpr(): [AssignExpr] ... = ...
 #   52|           Type = [ArithmeticType] _Complex float
 #   52|           ValueCategory = prvalue
-#   52|         0: [VariableAccess] cf3
+#   52|         getLValue(): [VariableAccess] cf3
 #   52|             Type = [ArithmeticType] _Complex float
 #   52|             ValueCategory = lvalue
-#   52|         1: [RealImaginaryAddExpr] ... + ...
+#   52|         getRValue(): [RealImaginaryAddExpr] ... + ...
 #   52|             Type = [ArithmeticType] _Complex float
 #   52|             ValueCategory = prvalue
-#   52|           0: [VariableAccess] f1
+#   52|           getLeftOperand(): [VariableAccess] f1
 #   52|               Type = [FloatType] float
 #   52|               ValueCategory = prvalue(load)
-#   52|           1: [VariableAccess] jf2
+#   52|           getRightOperand(): [VariableAccess] jf2
 #   52|               Type = [ArithmeticType] _Imaginary float
 #   52|               ValueCategory = prvalue(load)
-#   53|     26: [ExprStmt] ExprStmt
-#   53|       0: [AssignExpr] ... = ...
+#   53|     getStmt(26): [ExprStmt] ExprStmt
+#   53|       getExpr(): [AssignExpr] ... = ...
 #   53|           Type = [ArithmeticType] _Complex float
 #   53|           ValueCategory = prvalue
-#   53|         0: [VariableAccess] cf3
+#   53|         getLValue(): [VariableAccess] cf3
 #   53|             Type = [ArithmeticType] _Complex float
 #   53|             ValueCategory = lvalue
-#   53|         1: [RealImaginarySubExpr] ... - ...
+#   53|         getRValue(): [RealImaginarySubExpr] ... - ...
 #   53|             Type = [ArithmeticType] _Complex float
 #   53|             ValueCategory = prvalue
-#   53|           0: [VariableAccess] f1
+#   53|           getLeftOperand(): [VariableAccess] f1
 #   53|               Type = [FloatType] float
 #   53|               ValueCategory = prvalue(load)
-#   53|           1: [VariableAccess] jf2
+#   53|           getRightOperand(): [VariableAccess] jf2
 #   53|               Type = [ArithmeticType] _Imaginary float
 #   53|               ValueCategory = prvalue(load)
-#   54|     27: [ExprStmt] ExprStmt
-#   54|       0: [AssignExpr] ... = ...
+#   54|     getStmt(27): [ExprStmt] ExprStmt
+#   54|       getExpr(): [AssignExpr] ... = ...
 #   54|           Type = [ArithmeticType] _Imaginary float
 #   54|           ValueCategory = prvalue
-#   54|         0: [VariableAccess] jf3
+#   54|         getLValue(): [VariableAccess] jf3
 #   54|             Type = [ArithmeticType] _Imaginary float
 #   54|             ValueCategory = lvalue
-#   54|         1: [MulExpr] ... * ...
+#   54|         getRValue(): [MulExpr] ... * ...
 #   54|             Type = [ArithmeticType] _Imaginary float
 #   54|             ValueCategory = prvalue
-#   54|           0: [VariableAccess] f1
+#   54|           getLeftOperand(): [VariableAccess] f1
 #   54|               Type = [FloatType] float
 #   54|               ValueCategory = prvalue(load)
-#   54|           1: [VariableAccess] jf2
+#   54|           getRightOperand(): [VariableAccess] jf2
 #   54|               Type = [ArithmeticType] _Imaginary float
 #   54|               ValueCategory = prvalue(load)
-#   55|     28: [ExprStmt] ExprStmt
-#   55|       0: [AssignExpr] ... = ...
+#   55|     getStmt(28): [ExprStmt] ExprStmt
+#   55|       getExpr(): [AssignExpr] ... = ...
 #   55|           Type = [ArithmeticType] _Imaginary float
 #   55|           ValueCategory = prvalue
-#   55|         0: [VariableAccess] jf3
+#   55|         getLValue(): [VariableAccess] jf3
 #   55|             Type = [ArithmeticType] _Imaginary float
 #   55|             ValueCategory = lvalue
-#   55|         1: [ImaginaryDivExpr] ... / ...
+#   55|         getRValue(): [ImaginaryDivExpr] ... / ...
 #   55|             Type = [ArithmeticType] _Imaginary float
 #   55|             ValueCategory = prvalue
-#   55|           0: [VariableAccess] f1
+#   55|           getLeftOperand(): [VariableAccess] f1
 #   55|               Type = [FloatType] float
 #   55|               ValueCategory = prvalue(load)
-#   55|           1: [VariableAccess] jf2
+#   55|           getRightOperand(): [VariableAccess] jf2
 #   55|               Type = [ArithmeticType] _Imaginary float
 #   55|               ValueCategory = prvalue(load)
-#   56|     29: [ReturnStmt] return ...
+#   56|     getStmt(29): [ReturnStmt] return ...
 #   58| [TopLevelFunction] void complex_conversions()
-#   58|   params: 
-#   58|   body: [BlockStmt] { ... }
-#   59|     0: [DeclStmt] declaration
-#   59|       0: [VariableDeclarationEntry] definition of f
+#   58|   ...: 
+#   58|   getEntryPoint(): [BlockStmt] { ... }
+#   59|     getStmt(0): [DeclStmt] declaration
+#   59|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
 #   59|           Type = [FloatType] float
-#   59|         init: [Initializer] initializer for f
-#   59|           expr: [Literal] 2.0
+#   59|         getVariable().getInitializer(): [Initializer] initializer for f
+#   59|           getExpr(): [Literal] 2.0
 #   59|               Type = [DoubleType] double
 #   59|               Value = [Literal] 2.0
 #   59|               ValueCategory = prvalue
-#   59|           expr converted: [CStyleCast] (float)...
+#   59|           : [CStyleCast] (float)...
 #   59|               Conversion = [FloatingPointConversion] floating point conversion
 #   59|               Type = [FloatType] float
 #   59|               Value = [CStyleCast] 2.0
 #   59|               ValueCategory = prvalue
-#   60|     1: [DeclStmt] declaration
-#   60|       0: [VariableDeclarationEntry] definition of d
+#   60|     getStmt(1): [DeclStmt] declaration
+#   60|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #   60|           Type = [DoubleType] double
-#   60|         init: [Initializer] initializer for d
-#   60|           expr: [Literal] 3.0
+#   60|         getVariable().getInitializer(): [Initializer] initializer for d
+#   60|           getExpr(): [Literal] 3.0
 #   60|               Type = [DoubleType] double
 #   60|               Value = [Literal] 3.0
 #   60|               ValueCategory = prvalue
-#   61|     2: [DeclStmt] declaration
-#   61|       0: [VariableDeclarationEntry] definition of ld
+#   61|     getStmt(2): [DeclStmt] declaration
+#   61|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ld
 #   61|           Type = [LongDoubleType] long double
-#   61|         init: [Initializer] initializer for ld
-#   61|           expr: [Literal] 5.0
+#   61|         getVariable().getInitializer(): [Initializer] initializer for ld
+#   61|           getExpr(): [Literal] 5.0
 #   61|               Type = [DoubleType] double
 #   61|               Value = [Literal] 5.0
 #   61|               ValueCategory = prvalue
-#   61|           expr converted: [CStyleCast] (long double)...
+#   61|           : [CStyleCast] (long double)...
 #   61|               Conversion = [FloatingPointConversion] floating point conversion
 #   61|               Type = [LongDoubleType] long double
 #   61|               Value = [CStyleCast] 5.0
 #   61|               ValueCategory = prvalue
-#   62|     3: [DeclStmt] declaration
-#   62|       0: [VariableDeclarationEntry] definition of cf
+#   62|     getStmt(3): [DeclStmt] declaration
+#   62|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf
 #   62|           Type = [ArithmeticType] _Complex float
-#   62|         init: [Initializer] initializer for cf
-#   62|           expr: [Literal] 7.0
+#   62|         getVariable().getInitializer(): [Initializer] initializer for cf
+#   62|           getExpr(): [Literal] 7.0
 #   62|               Type = [DoubleType] double
 #   62|               Value = [Literal] 7.0
 #   62|               ValueCategory = prvalue
-#   62|           expr converted: [CStyleCast] (_Complex float)...
+#   62|           : [CStyleCast] (_Complex float)...
 #   62|               Conversion = [FloatingPointConversion] floating point conversion
 #   62|               Type = [ArithmeticType] _Complex float
 #   62|               ValueCategory = prvalue
-#   63|     4: [DeclStmt] declaration
-#   63|       0: [VariableDeclarationEntry] definition of cd
+#   63|     getStmt(4): [DeclStmt] declaration
+#   63|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cd
 #   63|           Type = [ArithmeticType] _Complex double
-#   63|         init: [Initializer] initializer for cd
-#   63|           expr: [Literal] 11.0
+#   63|         getVariable().getInitializer(): [Initializer] initializer for cd
+#   63|           getExpr(): [Literal] 11.0
 #   63|               Type = [DoubleType] double
 #   63|               Value = [Literal] 11.0
 #   63|               ValueCategory = prvalue
-#   63|           expr converted: [CStyleCast] (_Complex double)...
+#   63|           : [CStyleCast] (_Complex double)...
 #   63|               Conversion = [FloatingPointConversion] floating point conversion
 #   63|               Type = [ArithmeticType] _Complex double
 #   63|               ValueCategory = prvalue
-#   64|     5: [DeclStmt] declaration
-#   64|       0: [VariableDeclarationEntry] definition of cld
+#   64|     getStmt(5): [DeclStmt] declaration
+#   64|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cld
 #   64|           Type = [ArithmeticType] _Complex long double
-#   64|         init: [Initializer] initializer for cld
-#   64|           expr: [Literal] 13.0
+#   64|         getVariable().getInitializer(): [Initializer] initializer for cld
+#   64|           getExpr(): [Literal] 13.0
 #   64|               Type = [DoubleType] double
 #   64|               Value = [Literal] 13.0
 #   64|               ValueCategory = prvalue
-#   64|           expr converted: [CStyleCast] (_Complex long double)...
+#   64|           : [CStyleCast] (_Complex long double)...
 #   64|               Conversion = [FloatingPointConversion] floating point conversion
 #   64|               Type = [ArithmeticType] _Complex long double
 #   64|               ValueCategory = prvalue
-#   65|     6: [DeclStmt] declaration
-#   65|       0: [VariableDeclarationEntry] definition of jf
+#   65|     getStmt(6): [DeclStmt] declaration
+#   65|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jf
 #   65|           Type = [ArithmeticType] _Imaginary float
-#   65|         init: [Initializer] initializer for jf
-#   65|           expr: [Literal] 1.0i
+#   65|         getVariable().getInitializer(): [Initializer] initializer for jf
+#   65|           getExpr(): [Literal] 1.0i
 #   65|               Type = [ArithmeticType] _Imaginary float
 #   65|               Value = [Literal] 1.0i
 #   65|               ValueCategory = prvalue
-#   66|     7: [DeclStmt] declaration
-#   66|       0: [VariableDeclarationEntry] definition of jd
+#   66|     getStmt(7): [DeclStmt] declaration
+#   66|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jd
 #   66|           Type = [ArithmeticType] _Imaginary double
-#   66|         init: [Initializer] initializer for jd
-#   66|           expr: [Literal] 1.0i
+#   66|         getVariable().getInitializer(): [Initializer] initializer for jd
+#   66|           getExpr(): [Literal] 1.0i
 #   66|               Type = [ArithmeticType] _Imaginary float
 #   66|               Value = [Literal] 1.0i
 #   66|               ValueCategory = prvalue
-#   66|           expr converted: [CStyleCast] (_Imaginary double)...
+#   66|           : [CStyleCast] (_Imaginary double)...
 #   66|               Conversion = [FloatingPointConversion] floating point conversion
 #   66|               Type = [ArithmeticType] _Imaginary double
 #   66|               ValueCategory = prvalue
-#   67|     8: [DeclStmt] declaration
-#   67|       0: [VariableDeclarationEntry] definition of jld
+#   67|     getStmt(8): [DeclStmt] declaration
+#   67|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of jld
 #   67|           Type = [ArithmeticType] _Imaginary long double
-#   67|         init: [Initializer] initializer for jld
-#   67|           expr: [Literal] 1.0i
+#   67|         getVariable().getInitializer(): [Initializer] initializer for jld
+#   67|           getExpr(): [Literal] 1.0i
 #   67|               Type = [ArithmeticType] _Imaginary float
 #   67|               Value = [Literal] 1.0i
 #   67|               ValueCategory = prvalue
-#   67|           expr converted: [CStyleCast] (_Imaginary long double)...
+#   67|           : [CStyleCast] (_Imaginary long double)...
 #   67|               Conversion = [FloatingPointConversion] floating point conversion
 #   67|               Type = [ArithmeticType] _Imaginary long double
 #   67|               ValueCategory = prvalue
-#   70|     9: [ExprStmt] ExprStmt
-#   70|       0: [AssignExpr] ... = ...
+#   70|     getStmt(9): [ExprStmt] ExprStmt
+#   70|       getExpr(): [AssignExpr] ... = ...
 #   70|           Type = [ArithmeticType] _Complex float
 #   70|           ValueCategory = prvalue
-#   70|         0: [VariableAccess] cf
+#   70|         getLValue(): [VariableAccess] cf
 #   70|             Type = [ArithmeticType] _Complex float
 #   70|             ValueCategory = lvalue
-#   70|         1: [VariableAccess] cf
+#   70|         getRValue(): [VariableAccess] cf
 #   70|             Type = [ArithmeticType] _Complex float
 #   70|             ValueCategory = prvalue(load)
-#   71|     10: [ExprStmt] ExprStmt
-#   71|       0: [AssignExpr] ... = ...
+#   71|     getStmt(10): [ExprStmt] ExprStmt
+#   71|       getExpr(): [AssignExpr] ... = ...
 #   71|           Type = [ArithmeticType] _Complex float
 #   71|           ValueCategory = prvalue
-#   71|         0: [VariableAccess] cf
+#   71|         getLValue(): [VariableAccess] cf
 #   71|             Type = [ArithmeticType] _Complex float
 #   71|             ValueCategory = lvalue
-#   71|         1: [VariableAccess] cd
+#   71|         getRValue(): [VariableAccess] cd
 #   71|             Type = [ArithmeticType] _Complex double
 #   71|             ValueCategory = prvalue(load)
-#   71|         1 converted: [CStyleCast] (_Complex float)...
+#   71|         : [CStyleCast] (_Complex float)...
 #   71|             Conversion = [FloatingPointConversion] floating point conversion
 #   71|             Type = [ArithmeticType] _Complex float
 #   71|             ValueCategory = prvalue
-#   72|     11: [ExprStmt] ExprStmt
-#   72|       0: [AssignExpr] ... = ...
+#   72|     getStmt(11): [ExprStmt] ExprStmt
+#   72|       getExpr(): [AssignExpr] ... = ...
 #   72|           Type = [ArithmeticType] _Complex float
 #   72|           ValueCategory = prvalue
-#   72|         0: [VariableAccess] cf
+#   72|         getLValue(): [VariableAccess] cf
 #   72|             Type = [ArithmeticType] _Complex float
 #   72|             ValueCategory = lvalue
-#   72|         1: [VariableAccess] cld
+#   72|         getRValue(): [VariableAccess] cld
 #   72|             Type = [ArithmeticType] _Complex long double
 #   72|             ValueCategory = prvalue(load)
-#   72|         1 converted: [CStyleCast] (_Complex float)...
+#   72|         : [CStyleCast] (_Complex float)...
 #   72|             Conversion = [FloatingPointConversion] floating point conversion
 #   72|             Type = [ArithmeticType] _Complex float
 #   72|             ValueCategory = prvalue
-#   73|     12: [ExprStmt] ExprStmt
-#   73|       0: [AssignExpr] ... = ...
+#   73|     getStmt(12): [ExprStmt] ExprStmt
+#   73|       getExpr(): [AssignExpr] ... = ...
 #   73|           Type = [ArithmeticType] _Complex double
 #   73|           ValueCategory = prvalue
-#   73|         0: [VariableAccess] cd
+#   73|         getLValue(): [VariableAccess] cd
 #   73|             Type = [ArithmeticType] _Complex double
 #   73|             ValueCategory = lvalue
-#   73|         1: [VariableAccess] cf
+#   73|         getRValue(): [VariableAccess] cf
 #   73|             Type = [ArithmeticType] _Complex float
 #   73|             ValueCategory = prvalue(load)
-#   73|         1 converted: [CStyleCast] (_Complex double)...
+#   73|         : [CStyleCast] (_Complex double)...
 #   73|             Conversion = [FloatingPointConversion] floating point conversion
 #   73|             Type = [ArithmeticType] _Complex double
 #   73|             ValueCategory = prvalue
-#   74|     13: [ExprStmt] ExprStmt
-#   74|       0: [AssignExpr] ... = ...
+#   74|     getStmt(13): [ExprStmt] ExprStmt
+#   74|       getExpr(): [AssignExpr] ... = ...
 #   74|           Type = [ArithmeticType] _Complex double
 #   74|           ValueCategory = prvalue
-#   74|         0: [VariableAccess] cd
+#   74|         getLValue(): [VariableAccess] cd
 #   74|             Type = [ArithmeticType] _Complex double
 #   74|             ValueCategory = lvalue
-#   74|         1: [VariableAccess] cd
+#   74|         getRValue(): [VariableAccess] cd
 #   74|             Type = [ArithmeticType] _Complex double
 #   74|             ValueCategory = prvalue(load)
-#   75|     14: [ExprStmt] ExprStmt
-#   75|       0: [AssignExpr] ... = ...
+#   75|     getStmt(14): [ExprStmt] ExprStmt
+#   75|       getExpr(): [AssignExpr] ... = ...
 #   75|           Type = [ArithmeticType] _Complex double
 #   75|           ValueCategory = prvalue
-#   75|         0: [VariableAccess] cd
+#   75|         getLValue(): [VariableAccess] cd
 #   75|             Type = [ArithmeticType] _Complex double
 #   75|             ValueCategory = lvalue
-#   75|         1: [VariableAccess] cld
+#   75|         getRValue(): [VariableAccess] cld
 #   75|             Type = [ArithmeticType] _Complex long double
 #   75|             ValueCategory = prvalue(load)
-#   75|         1 converted: [CStyleCast] (_Complex double)...
+#   75|         : [CStyleCast] (_Complex double)...
 #   75|             Conversion = [FloatingPointConversion] floating point conversion
 #   75|             Type = [ArithmeticType] _Complex double
 #   75|             ValueCategory = prvalue
-#   76|     15: [ExprStmt] ExprStmt
-#   76|       0: [AssignExpr] ... = ...
+#   76|     getStmt(15): [ExprStmt] ExprStmt
+#   76|       getExpr(): [AssignExpr] ... = ...
 #   76|           Type = [ArithmeticType] _Complex long double
 #   76|           ValueCategory = prvalue
-#   76|         0: [VariableAccess] cld
+#   76|         getLValue(): [VariableAccess] cld
 #   76|             Type = [ArithmeticType] _Complex long double
 #   76|             ValueCategory = lvalue
-#   76|         1: [VariableAccess] cf
+#   76|         getRValue(): [VariableAccess] cf
 #   76|             Type = [ArithmeticType] _Complex float
 #   76|             ValueCategory = prvalue(load)
-#   76|         1 converted: [CStyleCast] (_Complex long double)...
+#   76|         : [CStyleCast] (_Complex long double)...
 #   76|             Conversion = [FloatingPointConversion] floating point conversion
 #   76|             Type = [ArithmeticType] _Complex long double
 #   76|             ValueCategory = prvalue
-#   77|     16: [ExprStmt] ExprStmt
-#   77|       0: [AssignExpr] ... = ...
+#   77|     getStmt(16): [ExprStmt] ExprStmt
+#   77|       getExpr(): [AssignExpr] ... = ...
 #   77|           Type = [ArithmeticType] _Complex long double
 #   77|           ValueCategory = prvalue
-#   77|         0: [VariableAccess] cld
+#   77|         getLValue(): [VariableAccess] cld
 #   77|             Type = [ArithmeticType] _Complex long double
 #   77|             ValueCategory = lvalue
-#   77|         1: [VariableAccess] cd
+#   77|         getRValue(): [VariableAccess] cd
 #   77|             Type = [ArithmeticType] _Complex double
 #   77|             ValueCategory = prvalue(load)
-#   77|         1 converted: [CStyleCast] (_Complex long double)...
+#   77|         : [CStyleCast] (_Complex long double)...
 #   77|             Conversion = [FloatingPointConversion] floating point conversion
 #   77|             Type = [ArithmeticType] _Complex long double
 #   77|             ValueCategory = prvalue
-#   78|     17: [ExprStmt] ExprStmt
-#   78|       0: [AssignExpr] ... = ...
+#   78|     getStmt(17): [ExprStmt] ExprStmt
+#   78|       getExpr(): [AssignExpr] ... = ...
 #   78|           Type = [ArithmeticType] _Complex long double
 #   78|           ValueCategory = prvalue
-#   78|         0: [VariableAccess] cld
+#   78|         getLValue(): [VariableAccess] cld
 #   78|             Type = [ArithmeticType] _Complex long double
 #   78|             ValueCategory = lvalue
-#   78|         1: [VariableAccess] cld
+#   78|         getRValue(): [VariableAccess] cld
 #   78|             Type = [ArithmeticType] _Complex long double
 #   78|             ValueCategory = prvalue(load)
-#   81|     18: [ExprStmt] ExprStmt
-#   81|       0: [AssignExpr] ... = ...
+#   81|     getStmt(18): [ExprStmt] ExprStmt
+#   81|       getExpr(): [AssignExpr] ... = ...
 #   81|           Type = [ArithmeticType] _Complex float
 #   81|           ValueCategory = prvalue
-#   81|         0: [VariableAccess] cf
+#   81|         getLValue(): [VariableAccess] cf
 #   81|             Type = [ArithmeticType] _Complex float
 #   81|             ValueCategory = lvalue
-#   81|         1: [VariableAccess] f
+#   81|         getRValue(): [VariableAccess] f
 #   81|             Type = [FloatType] float
 #   81|             ValueCategory = prvalue(load)
-#   81|         1 converted: [CStyleCast] (_Complex float)...
+#   81|         : [CStyleCast] (_Complex float)...
 #   81|             Conversion = [FloatingPointConversion] floating point conversion
 #   81|             Type = [ArithmeticType] _Complex float
 #   81|             ValueCategory = prvalue
-#   82|     19: [ExprStmt] ExprStmt
-#   82|       0: [AssignExpr] ... = ...
+#   82|     getStmt(19): [ExprStmt] ExprStmt
+#   82|       getExpr(): [AssignExpr] ... = ...
 #   82|           Type = [ArithmeticType] _Complex float
 #   82|           ValueCategory = prvalue
-#   82|         0: [VariableAccess] cf
+#   82|         getLValue(): [VariableAccess] cf
 #   82|             Type = [ArithmeticType] _Complex float
 #   82|             ValueCategory = lvalue
-#   82|         1: [VariableAccess] d
+#   82|         getRValue(): [VariableAccess] d
 #   82|             Type = [DoubleType] double
 #   82|             ValueCategory = prvalue(load)
-#   82|         1 converted: [CStyleCast] (_Complex float)...
+#   82|         : [CStyleCast] (_Complex float)...
 #   82|             Conversion = [FloatingPointConversion] floating point conversion
 #   82|             Type = [ArithmeticType] _Complex float
 #   82|             ValueCategory = prvalue
-#   83|     20: [ExprStmt] ExprStmt
-#   83|       0: [AssignExpr] ... = ...
+#   83|     getStmt(20): [ExprStmt] ExprStmt
+#   83|       getExpr(): [AssignExpr] ... = ...
 #   83|           Type = [ArithmeticType] _Complex float
 #   83|           ValueCategory = prvalue
-#   83|         0: [VariableAccess] cf
+#   83|         getLValue(): [VariableAccess] cf
 #   83|             Type = [ArithmeticType] _Complex float
 #   83|             ValueCategory = lvalue
-#   83|         1: [VariableAccess] ld
+#   83|         getRValue(): [VariableAccess] ld
 #   83|             Type = [LongDoubleType] long double
 #   83|             ValueCategory = prvalue(load)
-#   83|         1 converted: [CStyleCast] (_Complex float)...
+#   83|         : [CStyleCast] (_Complex float)...
 #   83|             Conversion = [FloatingPointConversion] floating point conversion
 #   83|             Type = [ArithmeticType] _Complex float
 #   83|             ValueCategory = prvalue
-#   84|     21: [ExprStmt] ExprStmt
-#   84|       0: [AssignExpr] ... = ...
+#   84|     getStmt(21): [ExprStmt] ExprStmt
+#   84|       getExpr(): [AssignExpr] ... = ...
 #   84|           Type = [ArithmeticType] _Complex double
 #   84|           ValueCategory = prvalue
-#   84|         0: [VariableAccess] cd
+#   84|         getLValue(): [VariableAccess] cd
 #   84|             Type = [ArithmeticType] _Complex double
 #   84|             ValueCategory = lvalue
-#   84|         1: [VariableAccess] f
+#   84|         getRValue(): [VariableAccess] f
 #   84|             Type = [FloatType] float
 #   84|             ValueCategory = prvalue(load)
-#   84|         1 converted: [CStyleCast] (_Complex double)...
+#   84|         : [CStyleCast] (_Complex double)...
 #   84|             Conversion = [FloatingPointConversion] floating point conversion
 #   84|             Type = [ArithmeticType] _Complex double
 #   84|             ValueCategory = prvalue
-#   85|     22: [ExprStmt] ExprStmt
-#   85|       0: [AssignExpr] ... = ...
+#   85|     getStmt(22): [ExprStmt] ExprStmt
+#   85|       getExpr(): [AssignExpr] ... = ...
 #   85|           Type = [ArithmeticType] _Complex double
 #   85|           ValueCategory = prvalue
-#   85|         0: [VariableAccess] cd
+#   85|         getLValue(): [VariableAccess] cd
 #   85|             Type = [ArithmeticType] _Complex double
 #   85|             ValueCategory = lvalue
-#   85|         1: [VariableAccess] d
+#   85|         getRValue(): [VariableAccess] d
 #   85|             Type = [DoubleType] double
 #   85|             ValueCategory = prvalue(load)
-#   85|         1 converted: [CStyleCast] (_Complex double)...
+#   85|         : [CStyleCast] (_Complex double)...
 #   85|             Conversion = [FloatingPointConversion] floating point conversion
 #   85|             Type = [ArithmeticType] _Complex double
 #   85|             ValueCategory = prvalue
-#   86|     23: [ExprStmt] ExprStmt
-#   86|       0: [AssignExpr] ... = ...
+#   86|     getStmt(23): [ExprStmt] ExprStmt
+#   86|       getExpr(): [AssignExpr] ... = ...
 #   86|           Type = [ArithmeticType] _Complex double
 #   86|           ValueCategory = prvalue
-#   86|         0: [VariableAccess] cd
+#   86|         getLValue(): [VariableAccess] cd
 #   86|             Type = [ArithmeticType] _Complex double
 #   86|             ValueCategory = lvalue
-#   86|         1: [VariableAccess] ld
+#   86|         getRValue(): [VariableAccess] ld
 #   86|             Type = [LongDoubleType] long double
 #   86|             ValueCategory = prvalue(load)
-#   86|         1 converted: [CStyleCast] (_Complex double)...
+#   86|         : [CStyleCast] (_Complex double)...
 #   86|             Conversion = [FloatingPointConversion] floating point conversion
 #   86|             Type = [ArithmeticType] _Complex double
 #   86|             ValueCategory = prvalue
-#   87|     24: [ExprStmt] ExprStmt
-#   87|       0: [AssignExpr] ... = ...
+#   87|     getStmt(24): [ExprStmt] ExprStmt
+#   87|       getExpr(): [AssignExpr] ... = ...
 #   87|           Type = [ArithmeticType] _Complex long double
 #   87|           ValueCategory = prvalue
-#   87|         0: [VariableAccess] cld
+#   87|         getLValue(): [VariableAccess] cld
 #   87|             Type = [ArithmeticType] _Complex long double
 #   87|             ValueCategory = lvalue
-#   87|         1: [VariableAccess] f
+#   87|         getRValue(): [VariableAccess] f
 #   87|             Type = [FloatType] float
 #   87|             ValueCategory = prvalue(load)
-#   87|         1 converted: [CStyleCast] (_Complex long double)...
+#   87|         : [CStyleCast] (_Complex long double)...
 #   87|             Conversion = [FloatingPointConversion] floating point conversion
 #   87|             Type = [ArithmeticType] _Complex long double
 #   87|             ValueCategory = prvalue
-#   88|     25: [ExprStmt] ExprStmt
-#   88|       0: [AssignExpr] ... = ...
+#   88|     getStmt(25): [ExprStmt] ExprStmt
+#   88|       getExpr(): [AssignExpr] ... = ...
 #   88|           Type = [ArithmeticType] _Complex long double
 #   88|           ValueCategory = prvalue
-#   88|         0: [VariableAccess] cld
+#   88|         getLValue(): [VariableAccess] cld
 #   88|             Type = [ArithmeticType] _Complex long double
 #   88|             ValueCategory = lvalue
-#   88|         1: [VariableAccess] d
+#   88|         getRValue(): [VariableAccess] d
 #   88|             Type = [DoubleType] double
 #   88|             ValueCategory = prvalue(load)
-#   88|         1 converted: [CStyleCast] (_Complex long double)...
+#   88|         : [CStyleCast] (_Complex long double)...
 #   88|             Conversion = [FloatingPointConversion] floating point conversion
 #   88|             Type = [ArithmeticType] _Complex long double
 #   88|             ValueCategory = prvalue
-#   89|     26: [ExprStmt] ExprStmt
-#   89|       0: [AssignExpr] ... = ...
+#   89|     getStmt(26): [ExprStmt] ExprStmt
+#   89|       getExpr(): [AssignExpr] ... = ...
 #   89|           Type = [ArithmeticType] _Complex long double
 #   89|           ValueCategory = prvalue
-#   89|         0: [VariableAccess] cld
+#   89|         getLValue(): [VariableAccess] cld
 #   89|             Type = [ArithmeticType] _Complex long double
 #   89|             ValueCategory = lvalue
-#   89|         1: [VariableAccess] ld
+#   89|         getRValue(): [VariableAccess] ld
 #   89|             Type = [LongDoubleType] long double
 #   89|             ValueCategory = prvalue(load)
-#   89|         1 converted: [CStyleCast] (_Complex long double)...
+#   89|         : [CStyleCast] (_Complex long double)...
 #   89|             Conversion = [FloatingPointConversion] floating point conversion
 #   89|             Type = [ArithmeticType] _Complex long double
 #   89|             ValueCategory = prvalue
-#   92|     27: [ExprStmt] ExprStmt
-#   92|       0: [AssignExpr] ... = ...
+#   92|     getStmt(27): [ExprStmt] ExprStmt
+#   92|       getExpr(): [AssignExpr] ... = ...
 #   92|           Type = [FloatType] float
 #   92|           ValueCategory = prvalue
-#   92|         0: [VariableAccess] f
+#   92|         getLValue(): [VariableAccess] f
 #   92|             Type = [FloatType] float
 #   92|             ValueCategory = lvalue
-#   92|         1: [VariableAccess] cf
+#   92|         getRValue(): [VariableAccess] cf
 #   92|             Type = [ArithmeticType] _Complex float
 #   92|             ValueCategory = prvalue(load)
-#   92|         1 converted: [CStyleCast] (float)...
+#   92|         : [CStyleCast] (float)...
 #   92|             Conversion = [FloatingPointConversion] floating point conversion
 #   92|             Type = [FloatType] float
 #   92|             ValueCategory = prvalue
-#   93|     28: [ExprStmt] ExprStmt
-#   93|       0: [AssignExpr] ... = ...
+#   93|     getStmt(28): [ExprStmt] ExprStmt
+#   93|       getExpr(): [AssignExpr] ... = ...
 #   93|           Type = [FloatType] float
 #   93|           ValueCategory = prvalue
-#   93|         0: [VariableAccess] f
+#   93|         getLValue(): [VariableAccess] f
 #   93|             Type = [FloatType] float
 #   93|             ValueCategory = lvalue
-#   93|         1: [VariableAccess] cd
+#   93|         getRValue(): [VariableAccess] cd
 #   93|             Type = [ArithmeticType] _Complex double
 #   93|             ValueCategory = prvalue(load)
-#   93|         1 converted: [CStyleCast] (float)...
+#   93|         : [CStyleCast] (float)...
 #   93|             Conversion = [FloatingPointConversion] floating point conversion
 #   93|             Type = [FloatType] float
 #   93|             ValueCategory = prvalue
-#   94|     29: [ExprStmt] ExprStmt
-#   94|       0: [AssignExpr] ... = ...
+#   94|     getStmt(29): [ExprStmt] ExprStmt
+#   94|       getExpr(): [AssignExpr] ... = ...
 #   94|           Type = [FloatType] float
 #   94|           ValueCategory = prvalue
-#   94|         0: [VariableAccess] f
+#   94|         getLValue(): [VariableAccess] f
 #   94|             Type = [FloatType] float
 #   94|             ValueCategory = lvalue
-#   94|         1: [VariableAccess] cld
+#   94|         getRValue(): [VariableAccess] cld
 #   94|             Type = [ArithmeticType] _Complex long double
 #   94|             ValueCategory = prvalue(load)
-#   94|         1 converted: [CStyleCast] (float)...
+#   94|         : [CStyleCast] (float)...
 #   94|             Conversion = [FloatingPointConversion] floating point conversion
 #   94|             Type = [FloatType] float
 #   94|             ValueCategory = prvalue
-#   95|     30: [ExprStmt] ExprStmt
-#   95|       0: [AssignExpr] ... = ...
+#   95|     getStmt(30): [ExprStmt] ExprStmt
+#   95|       getExpr(): [AssignExpr] ... = ...
 #   95|           Type = [DoubleType] double
 #   95|           ValueCategory = prvalue
-#   95|         0: [VariableAccess] d
+#   95|         getLValue(): [VariableAccess] d
 #   95|             Type = [DoubleType] double
 #   95|             ValueCategory = lvalue
-#   95|         1: [VariableAccess] cf
+#   95|         getRValue(): [VariableAccess] cf
 #   95|             Type = [ArithmeticType] _Complex float
 #   95|             ValueCategory = prvalue(load)
-#   95|         1 converted: [CStyleCast] (double)...
+#   95|         : [CStyleCast] (double)...
 #   95|             Conversion = [FloatingPointConversion] floating point conversion
 #   95|             Type = [DoubleType] double
 #   95|             ValueCategory = prvalue
-#   96|     31: [ExprStmt] ExprStmt
-#   96|       0: [AssignExpr] ... = ...
+#   96|     getStmt(31): [ExprStmt] ExprStmt
+#   96|       getExpr(): [AssignExpr] ... = ...
 #   96|           Type = [DoubleType] double
 #   96|           ValueCategory = prvalue
-#   96|         0: [VariableAccess] d
+#   96|         getLValue(): [VariableAccess] d
 #   96|             Type = [DoubleType] double
 #   96|             ValueCategory = lvalue
-#   96|         1: [VariableAccess] cd
+#   96|         getRValue(): [VariableAccess] cd
 #   96|             Type = [ArithmeticType] _Complex double
 #   96|             ValueCategory = prvalue(load)
-#   96|         1 converted: [CStyleCast] (double)...
+#   96|         : [CStyleCast] (double)...
 #   96|             Conversion = [FloatingPointConversion] floating point conversion
 #   96|             Type = [DoubleType] double
 #   96|             ValueCategory = prvalue
-#   97|     32: [ExprStmt] ExprStmt
-#   97|       0: [AssignExpr] ... = ...
+#   97|     getStmt(32): [ExprStmt] ExprStmt
+#   97|       getExpr(): [AssignExpr] ... = ...
 #   97|           Type = [DoubleType] double
 #   97|           ValueCategory = prvalue
-#   97|         0: [VariableAccess] d
+#   97|         getLValue(): [VariableAccess] d
 #   97|             Type = [DoubleType] double
 #   97|             ValueCategory = lvalue
-#   97|         1: [VariableAccess] cld
+#   97|         getRValue(): [VariableAccess] cld
 #   97|             Type = [ArithmeticType] _Complex long double
 #   97|             ValueCategory = prvalue(load)
-#   97|         1 converted: [CStyleCast] (double)...
+#   97|         : [CStyleCast] (double)...
 #   97|             Conversion = [FloatingPointConversion] floating point conversion
 #   97|             Type = [DoubleType] double
 #   97|             ValueCategory = prvalue
-#   98|     33: [ExprStmt] ExprStmt
-#   98|       0: [AssignExpr] ... = ...
+#   98|     getStmt(33): [ExprStmt] ExprStmt
+#   98|       getExpr(): [AssignExpr] ... = ...
 #   98|           Type = [LongDoubleType] long double
 #   98|           ValueCategory = prvalue
-#   98|         0: [VariableAccess] ld
+#   98|         getLValue(): [VariableAccess] ld
 #   98|             Type = [LongDoubleType] long double
 #   98|             ValueCategory = lvalue
-#   98|         1: [VariableAccess] cf
+#   98|         getRValue(): [VariableAccess] cf
 #   98|             Type = [ArithmeticType] _Complex float
 #   98|             ValueCategory = prvalue(load)
-#   98|         1 converted: [CStyleCast] (long double)...
+#   98|         : [CStyleCast] (long double)...
 #   98|             Conversion = [FloatingPointConversion] floating point conversion
 #   98|             Type = [LongDoubleType] long double
 #   98|             ValueCategory = prvalue
-#   99|     34: [ExprStmt] ExprStmt
-#   99|       0: [AssignExpr] ... = ...
+#   99|     getStmt(34): [ExprStmt] ExprStmt
+#   99|       getExpr(): [AssignExpr] ... = ...
 #   99|           Type = [LongDoubleType] long double
 #   99|           ValueCategory = prvalue
-#   99|         0: [VariableAccess] ld
+#   99|         getLValue(): [VariableAccess] ld
 #   99|             Type = [LongDoubleType] long double
 #   99|             ValueCategory = lvalue
-#   99|         1: [VariableAccess] cd
+#   99|         getRValue(): [VariableAccess] cd
 #   99|             Type = [ArithmeticType] _Complex double
 #   99|             ValueCategory = prvalue(load)
-#   99|         1 converted: [CStyleCast] (long double)...
+#   99|         : [CStyleCast] (long double)...
 #   99|             Conversion = [FloatingPointConversion] floating point conversion
 #   99|             Type = [LongDoubleType] long double
 #   99|             ValueCategory = prvalue
-#  100|     35: [ExprStmt] ExprStmt
-#  100|       0: [AssignExpr] ... = ...
+#  100|     getStmt(35): [ExprStmt] ExprStmt
+#  100|       getExpr(): [AssignExpr] ... = ...
 #  100|           Type = [LongDoubleType] long double
 #  100|           ValueCategory = prvalue
-#  100|         0: [VariableAccess] ld
+#  100|         getLValue(): [VariableAccess] ld
 #  100|             Type = [LongDoubleType] long double
 #  100|             ValueCategory = lvalue
-#  100|         1: [VariableAccess] cld
+#  100|         getRValue(): [VariableAccess] cld
 #  100|             Type = [ArithmeticType] _Complex long double
 #  100|             ValueCategory = prvalue(load)
-#  100|         1 converted: [CStyleCast] (long double)...
+#  100|         : [CStyleCast] (long double)...
 #  100|             Conversion = [FloatingPointConversion] floating point conversion
 #  100|             Type = [LongDoubleType] long double
 #  100|             ValueCategory = prvalue
-#  103|     36: [ExprStmt] ExprStmt
-#  103|       0: [AssignExpr] ... = ...
+#  103|     getStmt(36): [ExprStmt] ExprStmt
+#  103|       getExpr(): [AssignExpr] ... = ...
 #  103|           Type = [ArithmeticType] _Complex float
 #  103|           ValueCategory = prvalue
-#  103|         0: [VariableAccess] cf
+#  103|         getLValue(): [VariableAccess] cf
 #  103|             Type = [ArithmeticType] _Complex float
 #  103|             ValueCategory = lvalue
-#  103|         1: [VariableAccess] jf
+#  103|         getRValue(): [VariableAccess] jf
 #  103|             Type = [ArithmeticType] _Imaginary float
 #  103|             ValueCategory = prvalue(load)
-#  103|         1 converted: [CStyleCast] (_Complex float)...
+#  103|         : [CStyleCast] (_Complex float)...
 #  103|             Conversion = [FloatingPointConversion] floating point conversion
 #  103|             Type = [ArithmeticType] _Complex float
 #  103|             ValueCategory = prvalue
-#  104|     37: [ExprStmt] ExprStmt
-#  104|       0: [AssignExpr] ... = ...
+#  104|     getStmt(37): [ExprStmt] ExprStmt
+#  104|       getExpr(): [AssignExpr] ... = ...
 #  104|           Type = [ArithmeticType] _Complex float
 #  104|           ValueCategory = prvalue
-#  104|         0: [VariableAccess] cf
+#  104|         getLValue(): [VariableAccess] cf
 #  104|             Type = [ArithmeticType] _Complex float
 #  104|             ValueCategory = lvalue
-#  104|         1: [VariableAccess] jd
+#  104|         getRValue(): [VariableAccess] jd
 #  104|             Type = [ArithmeticType] _Imaginary double
 #  104|             ValueCategory = prvalue(load)
-#  104|         1 converted: [CStyleCast] (_Complex float)...
+#  104|         : [CStyleCast] (_Complex float)...
 #  104|             Conversion = [FloatingPointConversion] floating point conversion
 #  104|             Type = [ArithmeticType] _Complex float
 #  104|             ValueCategory = prvalue
-#  105|     38: [ExprStmt] ExprStmt
-#  105|       0: [AssignExpr] ... = ...
+#  105|     getStmt(38): [ExprStmt] ExprStmt
+#  105|       getExpr(): [AssignExpr] ... = ...
 #  105|           Type = [ArithmeticType] _Complex float
 #  105|           ValueCategory = prvalue
-#  105|         0: [VariableAccess] cf
+#  105|         getLValue(): [VariableAccess] cf
 #  105|             Type = [ArithmeticType] _Complex float
 #  105|             ValueCategory = lvalue
-#  105|         1: [VariableAccess] jld
+#  105|         getRValue(): [VariableAccess] jld
 #  105|             Type = [ArithmeticType] _Imaginary long double
 #  105|             ValueCategory = prvalue(load)
-#  105|         1 converted: [CStyleCast] (_Complex float)...
+#  105|         : [CStyleCast] (_Complex float)...
 #  105|             Conversion = [FloatingPointConversion] floating point conversion
 #  105|             Type = [ArithmeticType] _Complex float
 #  105|             ValueCategory = prvalue
-#  106|     39: [ExprStmt] ExprStmt
-#  106|       0: [AssignExpr] ... = ...
+#  106|     getStmt(39): [ExprStmt] ExprStmt
+#  106|       getExpr(): [AssignExpr] ... = ...
 #  106|           Type = [ArithmeticType] _Complex double
 #  106|           ValueCategory = prvalue
-#  106|         0: [VariableAccess] cd
+#  106|         getLValue(): [VariableAccess] cd
 #  106|             Type = [ArithmeticType] _Complex double
 #  106|             ValueCategory = lvalue
-#  106|         1: [VariableAccess] jf
+#  106|         getRValue(): [VariableAccess] jf
 #  106|             Type = [ArithmeticType] _Imaginary float
 #  106|             ValueCategory = prvalue(load)
-#  106|         1 converted: [CStyleCast] (_Complex double)...
+#  106|         : [CStyleCast] (_Complex double)...
 #  106|             Conversion = [FloatingPointConversion] floating point conversion
 #  106|             Type = [ArithmeticType] _Complex double
 #  106|             ValueCategory = prvalue
-#  107|     40: [ExprStmt] ExprStmt
-#  107|       0: [AssignExpr] ... = ...
+#  107|     getStmt(40): [ExprStmt] ExprStmt
+#  107|       getExpr(): [AssignExpr] ... = ...
 #  107|           Type = [ArithmeticType] _Complex double
 #  107|           ValueCategory = prvalue
-#  107|         0: [VariableAccess] cd
+#  107|         getLValue(): [VariableAccess] cd
 #  107|             Type = [ArithmeticType] _Complex double
 #  107|             ValueCategory = lvalue
-#  107|         1: [VariableAccess] jd
+#  107|         getRValue(): [VariableAccess] jd
 #  107|             Type = [ArithmeticType] _Imaginary double
 #  107|             ValueCategory = prvalue(load)
-#  107|         1 converted: [CStyleCast] (_Complex double)...
+#  107|         : [CStyleCast] (_Complex double)...
 #  107|             Conversion = [FloatingPointConversion] floating point conversion
 #  107|             Type = [ArithmeticType] _Complex double
 #  107|             ValueCategory = prvalue
-#  108|     41: [ExprStmt] ExprStmt
-#  108|       0: [AssignExpr] ... = ...
+#  108|     getStmt(41): [ExprStmt] ExprStmt
+#  108|       getExpr(): [AssignExpr] ... = ...
 #  108|           Type = [ArithmeticType] _Complex double
 #  108|           ValueCategory = prvalue
-#  108|         0: [VariableAccess] cd
+#  108|         getLValue(): [VariableAccess] cd
 #  108|             Type = [ArithmeticType] _Complex double
 #  108|             ValueCategory = lvalue
-#  108|         1: [VariableAccess] jld
+#  108|         getRValue(): [VariableAccess] jld
 #  108|             Type = [ArithmeticType] _Imaginary long double
 #  108|             ValueCategory = prvalue(load)
-#  108|         1 converted: [CStyleCast] (_Complex double)...
+#  108|         : [CStyleCast] (_Complex double)...
 #  108|             Conversion = [FloatingPointConversion] floating point conversion
 #  108|             Type = [ArithmeticType] _Complex double
 #  108|             ValueCategory = prvalue
-#  109|     42: [ExprStmt] ExprStmt
-#  109|       0: [AssignExpr] ... = ...
+#  109|     getStmt(42): [ExprStmt] ExprStmt
+#  109|       getExpr(): [AssignExpr] ... = ...
 #  109|           Type = [ArithmeticType] _Complex long double
 #  109|           ValueCategory = prvalue
-#  109|         0: [VariableAccess] cld
+#  109|         getLValue(): [VariableAccess] cld
 #  109|             Type = [ArithmeticType] _Complex long double
 #  109|             ValueCategory = lvalue
-#  109|         1: [VariableAccess] jf
+#  109|         getRValue(): [VariableAccess] jf
 #  109|             Type = [ArithmeticType] _Imaginary float
 #  109|             ValueCategory = prvalue(load)
-#  109|         1 converted: [CStyleCast] (_Complex long double)...
+#  109|         : [CStyleCast] (_Complex long double)...
 #  109|             Conversion = [FloatingPointConversion] floating point conversion
 #  109|             Type = [ArithmeticType] _Complex long double
 #  109|             ValueCategory = prvalue
-#  110|     43: [ExprStmt] ExprStmt
-#  110|       0: [AssignExpr] ... = ...
+#  110|     getStmt(43): [ExprStmt] ExprStmt
+#  110|       getExpr(): [AssignExpr] ... = ...
 #  110|           Type = [ArithmeticType] _Complex long double
 #  110|           ValueCategory = prvalue
-#  110|         0: [VariableAccess] cld
+#  110|         getLValue(): [VariableAccess] cld
 #  110|             Type = [ArithmeticType] _Complex long double
 #  110|             ValueCategory = lvalue
-#  110|         1: [VariableAccess] jd
+#  110|         getRValue(): [VariableAccess] jd
 #  110|             Type = [ArithmeticType] _Imaginary double
 #  110|             ValueCategory = prvalue(load)
-#  110|         1 converted: [CStyleCast] (_Complex long double)...
+#  110|         : [CStyleCast] (_Complex long double)...
 #  110|             Conversion = [FloatingPointConversion] floating point conversion
 #  110|             Type = [ArithmeticType] _Complex long double
 #  110|             ValueCategory = prvalue
-#  111|     44: [ExprStmt] ExprStmt
-#  111|       0: [AssignExpr] ... = ...
+#  111|     getStmt(44): [ExprStmt] ExprStmt
+#  111|       getExpr(): [AssignExpr] ... = ...
 #  111|           Type = [ArithmeticType] _Complex long double
 #  111|           ValueCategory = prvalue
-#  111|         0: [VariableAccess] cld
+#  111|         getLValue(): [VariableAccess] cld
 #  111|             Type = [ArithmeticType] _Complex long double
 #  111|             ValueCategory = lvalue
-#  111|         1: [VariableAccess] jld
+#  111|         getRValue(): [VariableAccess] jld
 #  111|             Type = [ArithmeticType] _Imaginary long double
 #  111|             ValueCategory = prvalue(load)
-#  111|         1 converted: [CStyleCast] (_Complex long double)...
+#  111|         : [CStyleCast] (_Complex long double)...
 #  111|             Conversion = [FloatingPointConversion] floating point conversion
 #  111|             Type = [ArithmeticType] _Complex long double
 #  111|             ValueCategory = prvalue
-#  114|     45: [ExprStmt] ExprStmt
-#  114|       0: [AssignExpr] ... = ...
+#  114|     getStmt(45): [ExprStmt] ExprStmt
+#  114|       getExpr(): [AssignExpr] ... = ...
 #  114|           Type = [ArithmeticType] _Imaginary float
 #  114|           ValueCategory = prvalue
-#  114|         0: [VariableAccess] jf
+#  114|         getLValue(): [VariableAccess] jf
 #  114|             Type = [ArithmeticType] _Imaginary float
 #  114|             ValueCategory = lvalue
-#  114|         1: [VariableAccess] cf
+#  114|         getRValue(): [VariableAccess] cf
 #  114|             Type = [ArithmeticType] _Complex float
 #  114|             ValueCategory = prvalue(load)
-#  114|         1 converted: [CStyleCast] (_Imaginary float)...
+#  114|         : [CStyleCast] (_Imaginary float)...
 #  114|             Conversion = [FloatingPointConversion] floating point conversion
 #  114|             Type = [ArithmeticType] _Imaginary float
 #  114|             ValueCategory = prvalue
-#  115|     46: [ExprStmt] ExprStmt
-#  115|       0: [AssignExpr] ... = ...
+#  115|     getStmt(46): [ExprStmt] ExprStmt
+#  115|       getExpr(): [AssignExpr] ... = ...
 #  115|           Type = [ArithmeticType] _Imaginary float
 #  115|           ValueCategory = prvalue
-#  115|         0: [VariableAccess] jf
+#  115|         getLValue(): [VariableAccess] jf
 #  115|             Type = [ArithmeticType] _Imaginary float
 #  115|             ValueCategory = lvalue
-#  115|         1: [VariableAccess] cd
+#  115|         getRValue(): [VariableAccess] cd
 #  115|             Type = [ArithmeticType] _Complex double
 #  115|             ValueCategory = prvalue(load)
-#  115|         1 converted: [CStyleCast] (_Imaginary float)...
+#  115|         : [CStyleCast] (_Imaginary float)...
 #  115|             Conversion = [FloatingPointConversion] floating point conversion
 #  115|             Type = [ArithmeticType] _Imaginary float
 #  115|             ValueCategory = prvalue
-#  116|     47: [ExprStmt] ExprStmt
-#  116|       0: [AssignExpr] ... = ...
+#  116|     getStmt(47): [ExprStmt] ExprStmt
+#  116|       getExpr(): [AssignExpr] ... = ...
 #  116|           Type = [ArithmeticType] _Imaginary float
 #  116|           ValueCategory = prvalue
-#  116|         0: [VariableAccess] jf
+#  116|         getLValue(): [VariableAccess] jf
 #  116|             Type = [ArithmeticType] _Imaginary float
 #  116|             ValueCategory = lvalue
-#  116|         1: [VariableAccess] cld
+#  116|         getRValue(): [VariableAccess] cld
 #  116|             Type = [ArithmeticType] _Complex long double
 #  116|             ValueCategory = prvalue(load)
-#  116|         1 converted: [CStyleCast] (_Imaginary float)...
+#  116|         : [CStyleCast] (_Imaginary float)...
 #  116|             Conversion = [FloatingPointConversion] floating point conversion
 #  116|             Type = [ArithmeticType] _Imaginary float
 #  116|             ValueCategory = prvalue
-#  117|     48: [ExprStmt] ExprStmt
-#  117|       0: [AssignExpr] ... = ...
+#  117|     getStmt(48): [ExprStmt] ExprStmt
+#  117|       getExpr(): [AssignExpr] ... = ...
 #  117|           Type = [ArithmeticType] _Imaginary double
 #  117|           ValueCategory = prvalue
-#  117|         0: [VariableAccess] jd
+#  117|         getLValue(): [VariableAccess] jd
 #  117|             Type = [ArithmeticType] _Imaginary double
 #  117|             ValueCategory = lvalue
-#  117|         1: [VariableAccess] cf
+#  117|         getRValue(): [VariableAccess] cf
 #  117|             Type = [ArithmeticType] _Complex float
 #  117|             ValueCategory = prvalue(load)
-#  117|         1 converted: [CStyleCast] (_Imaginary double)...
+#  117|         : [CStyleCast] (_Imaginary double)...
 #  117|             Conversion = [FloatingPointConversion] floating point conversion
 #  117|             Type = [ArithmeticType] _Imaginary double
 #  117|             ValueCategory = prvalue
-#  118|     49: [ExprStmt] ExprStmt
-#  118|       0: [AssignExpr] ... = ...
+#  118|     getStmt(49): [ExprStmt] ExprStmt
+#  118|       getExpr(): [AssignExpr] ... = ...
 #  118|           Type = [ArithmeticType] _Imaginary double
 #  118|           ValueCategory = prvalue
-#  118|         0: [VariableAccess] jd
+#  118|         getLValue(): [VariableAccess] jd
 #  118|             Type = [ArithmeticType] _Imaginary double
 #  118|             ValueCategory = lvalue
-#  118|         1: [VariableAccess] cd
+#  118|         getRValue(): [VariableAccess] cd
 #  118|             Type = [ArithmeticType] _Complex double
 #  118|             ValueCategory = prvalue(load)
-#  118|         1 converted: [CStyleCast] (_Imaginary double)...
+#  118|         : [CStyleCast] (_Imaginary double)...
 #  118|             Conversion = [FloatingPointConversion] floating point conversion
 #  118|             Type = [ArithmeticType] _Imaginary double
 #  118|             ValueCategory = prvalue
-#  119|     50: [ExprStmt] ExprStmt
-#  119|       0: [AssignExpr] ... = ...
+#  119|     getStmt(50): [ExprStmt] ExprStmt
+#  119|       getExpr(): [AssignExpr] ... = ...
 #  119|           Type = [ArithmeticType] _Imaginary double
 #  119|           ValueCategory = prvalue
-#  119|         0: [VariableAccess] jd
+#  119|         getLValue(): [VariableAccess] jd
 #  119|             Type = [ArithmeticType] _Imaginary double
 #  119|             ValueCategory = lvalue
-#  119|         1: [VariableAccess] cld
+#  119|         getRValue(): [VariableAccess] cld
 #  119|             Type = [ArithmeticType] _Complex long double
 #  119|             ValueCategory = prvalue(load)
-#  119|         1 converted: [CStyleCast] (_Imaginary double)...
+#  119|         : [CStyleCast] (_Imaginary double)...
 #  119|             Conversion = [FloatingPointConversion] floating point conversion
 #  119|             Type = [ArithmeticType] _Imaginary double
 #  119|             ValueCategory = prvalue
-#  120|     51: [ExprStmt] ExprStmt
-#  120|       0: [AssignExpr] ... = ...
+#  120|     getStmt(51): [ExprStmt] ExprStmt
+#  120|       getExpr(): [AssignExpr] ... = ...
 #  120|           Type = [ArithmeticType] _Imaginary long double
 #  120|           ValueCategory = prvalue
-#  120|         0: [VariableAccess] jld
+#  120|         getLValue(): [VariableAccess] jld
 #  120|             Type = [ArithmeticType] _Imaginary long double
 #  120|             ValueCategory = lvalue
-#  120|         1: [VariableAccess] cf
+#  120|         getRValue(): [VariableAccess] cf
 #  120|             Type = [ArithmeticType] _Complex float
 #  120|             ValueCategory = prvalue(load)
-#  120|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  120|         : [CStyleCast] (_Imaginary long double)...
 #  120|             Conversion = [FloatingPointConversion] floating point conversion
 #  120|             Type = [ArithmeticType] _Imaginary long double
 #  120|             ValueCategory = prvalue
-#  121|     52: [ExprStmt] ExprStmt
-#  121|       0: [AssignExpr] ... = ...
+#  121|     getStmt(52): [ExprStmt] ExprStmt
+#  121|       getExpr(): [AssignExpr] ... = ...
 #  121|           Type = [ArithmeticType] _Imaginary long double
 #  121|           ValueCategory = prvalue
-#  121|         0: [VariableAccess] jld
+#  121|         getLValue(): [VariableAccess] jld
 #  121|             Type = [ArithmeticType] _Imaginary long double
 #  121|             ValueCategory = lvalue
-#  121|         1: [VariableAccess] cd
+#  121|         getRValue(): [VariableAccess] cd
 #  121|             Type = [ArithmeticType] _Complex double
 #  121|             ValueCategory = prvalue(load)
-#  121|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  121|         : [CStyleCast] (_Imaginary long double)...
 #  121|             Conversion = [FloatingPointConversion] floating point conversion
 #  121|             Type = [ArithmeticType] _Imaginary long double
 #  121|             ValueCategory = prvalue
-#  122|     53: [ExprStmt] ExprStmt
-#  122|       0: [AssignExpr] ... = ...
+#  122|     getStmt(53): [ExprStmt] ExprStmt
+#  122|       getExpr(): [AssignExpr] ... = ...
 #  122|           Type = [ArithmeticType] _Imaginary long double
 #  122|           ValueCategory = prvalue
-#  122|         0: [VariableAccess] jld
+#  122|         getLValue(): [VariableAccess] jld
 #  122|             Type = [ArithmeticType] _Imaginary long double
 #  122|             ValueCategory = lvalue
-#  122|         1: [VariableAccess] cld
+#  122|         getRValue(): [VariableAccess] cld
 #  122|             Type = [ArithmeticType] _Complex long double
 #  122|             ValueCategory = prvalue(load)
-#  122|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  122|         : [CStyleCast] (_Imaginary long double)...
 #  122|             Conversion = [FloatingPointConversion] floating point conversion
 #  122|             Type = [ArithmeticType] _Imaginary long double
 #  122|             ValueCategory = prvalue
-#  125|     54: [ExprStmt] ExprStmt
-#  125|       0: [AssignExpr] ... = ...
+#  125|     getStmt(54): [ExprStmt] ExprStmt
+#  125|       getExpr(): [AssignExpr] ... = ...
 #  125|           Type = [ArithmeticType] _Imaginary float
 #  125|           ValueCategory = prvalue
-#  125|         0: [VariableAccess] jf
+#  125|         getLValue(): [VariableAccess] jf
 #  125|             Type = [ArithmeticType] _Imaginary float
 #  125|             ValueCategory = lvalue
-#  125|         1: [VariableAccess] f
+#  125|         getRValue(): [VariableAccess] f
 #  125|             Type = [FloatType] float
 #  125|             ValueCategory = prvalue(load)
-#  125|         1 converted: [CStyleCast] (_Imaginary float)...
+#  125|         : [CStyleCast] (_Imaginary float)...
 #  125|             Conversion = [FloatingPointConversion] floating point conversion
 #  125|             Type = [ArithmeticType] _Imaginary float
 #  125|             ValueCategory = prvalue
-#  126|     55: [ExprStmt] ExprStmt
-#  126|       0: [AssignExpr] ... = ...
+#  126|     getStmt(55): [ExprStmt] ExprStmt
+#  126|       getExpr(): [AssignExpr] ... = ...
 #  126|           Type = [ArithmeticType] _Imaginary float
 #  126|           ValueCategory = prvalue
-#  126|         0: [VariableAccess] jf
+#  126|         getLValue(): [VariableAccess] jf
 #  126|             Type = [ArithmeticType] _Imaginary float
 #  126|             ValueCategory = lvalue
-#  126|         1: [VariableAccess] d
+#  126|         getRValue(): [VariableAccess] d
 #  126|             Type = [DoubleType] double
 #  126|             ValueCategory = prvalue(load)
-#  126|         1 converted: [CStyleCast] (_Imaginary float)...
+#  126|         : [CStyleCast] (_Imaginary float)...
 #  126|             Conversion = [FloatingPointConversion] floating point conversion
 #  126|             Type = [ArithmeticType] _Imaginary float
 #  126|             ValueCategory = prvalue
-#  127|     56: [ExprStmt] ExprStmt
-#  127|       0: [AssignExpr] ... = ...
+#  127|     getStmt(56): [ExprStmt] ExprStmt
+#  127|       getExpr(): [AssignExpr] ... = ...
 #  127|           Type = [ArithmeticType] _Imaginary float
 #  127|           ValueCategory = prvalue
-#  127|         0: [VariableAccess] jf
+#  127|         getLValue(): [VariableAccess] jf
 #  127|             Type = [ArithmeticType] _Imaginary float
 #  127|             ValueCategory = lvalue
-#  127|         1: [VariableAccess] ld
+#  127|         getRValue(): [VariableAccess] ld
 #  127|             Type = [LongDoubleType] long double
 #  127|             ValueCategory = prvalue(load)
-#  127|         1 converted: [CStyleCast] (_Imaginary float)...
+#  127|         : [CStyleCast] (_Imaginary float)...
 #  127|             Conversion = [FloatingPointConversion] floating point conversion
 #  127|             Type = [ArithmeticType] _Imaginary float
 #  127|             ValueCategory = prvalue
-#  128|     57: [ExprStmt] ExprStmt
-#  128|       0: [AssignExpr] ... = ...
+#  128|     getStmt(57): [ExprStmt] ExprStmt
+#  128|       getExpr(): [AssignExpr] ... = ...
 #  128|           Type = [ArithmeticType] _Imaginary double
 #  128|           ValueCategory = prvalue
-#  128|         0: [VariableAccess] jd
+#  128|         getLValue(): [VariableAccess] jd
 #  128|             Type = [ArithmeticType] _Imaginary double
 #  128|             ValueCategory = lvalue
-#  128|         1: [VariableAccess] f
+#  128|         getRValue(): [VariableAccess] f
 #  128|             Type = [FloatType] float
 #  128|             ValueCategory = prvalue(load)
-#  128|         1 converted: [CStyleCast] (_Imaginary double)...
+#  128|         : [CStyleCast] (_Imaginary double)...
 #  128|             Conversion = [FloatingPointConversion] floating point conversion
 #  128|             Type = [ArithmeticType] _Imaginary double
 #  128|             ValueCategory = prvalue
-#  129|     58: [ExprStmt] ExprStmt
-#  129|       0: [AssignExpr] ... = ...
+#  129|     getStmt(58): [ExprStmt] ExprStmt
+#  129|       getExpr(): [AssignExpr] ... = ...
 #  129|           Type = [ArithmeticType] _Imaginary double
 #  129|           ValueCategory = prvalue
-#  129|         0: [VariableAccess] jd
+#  129|         getLValue(): [VariableAccess] jd
 #  129|             Type = [ArithmeticType] _Imaginary double
 #  129|             ValueCategory = lvalue
-#  129|         1: [VariableAccess] d
+#  129|         getRValue(): [VariableAccess] d
 #  129|             Type = [DoubleType] double
 #  129|             ValueCategory = prvalue(load)
-#  129|         1 converted: [CStyleCast] (_Imaginary double)...
+#  129|         : [CStyleCast] (_Imaginary double)...
 #  129|             Conversion = [FloatingPointConversion] floating point conversion
 #  129|             Type = [ArithmeticType] _Imaginary double
 #  129|             ValueCategory = prvalue
-#  130|     59: [ExprStmt] ExprStmt
-#  130|       0: [AssignExpr] ... = ...
+#  130|     getStmt(59): [ExprStmt] ExprStmt
+#  130|       getExpr(): [AssignExpr] ... = ...
 #  130|           Type = [ArithmeticType] _Imaginary double
 #  130|           ValueCategory = prvalue
-#  130|         0: [VariableAccess] jd
+#  130|         getLValue(): [VariableAccess] jd
 #  130|             Type = [ArithmeticType] _Imaginary double
 #  130|             ValueCategory = lvalue
-#  130|         1: [VariableAccess] ld
+#  130|         getRValue(): [VariableAccess] ld
 #  130|             Type = [LongDoubleType] long double
 #  130|             ValueCategory = prvalue(load)
-#  130|         1 converted: [CStyleCast] (_Imaginary double)...
+#  130|         : [CStyleCast] (_Imaginary double)...
 #  130|             Conversion = [FloatingPointConversion] floating point conversion
 #  130|             Type = [ArithmeticType] _Imaginary double
 #  130|             ValueCategory = prvalue
-#  131|     60: [ExprStmt] ExprStmt
-#  131|       0: [AssignExpr] ... = ...
+#  131|     getStmt(60): [ExprStmt] ExprStmt
+#  131|       getExpr(): [AssignExpr] ... = ...
 #  131|           Type = [ArithmeticType] _Imaginary long double
 #  131|           ValueCategory = prvalue
-#  131|         0: [VariableAccess] jld
+#  131|         getLValue(): [VariableAccess] jld
 #  131|             Type = [ArithmeticType] _Imaginary long double
 #  131|             ValueCategory = lvalue
-#  131|         1: [VariableAccess] f
+#  131|         getRValue(): [VariableAccess] f
 #  131|             Type = [FloatType] float
 #  131|             ValueCategory = prvalue(load)
-#  131|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  131|         : [CStyleCast] (_Imaginary long double)...
 #  131|             Conversion = [FloatingPointConversion] floating point conversion
 #  131|             Type = [ArithmeticType] _Imaginary long double
 #  131|             ValueCategory = prvalue
-#  132|     61: [ExprStmt] ExprStmt
-#  132|       0: [AssignExpr] ... = ...
+#  132|     getStmt(61): [ExprStmt] ExprStmt
+#  132|       getExpr(): [AssignExpr] ... = ...
 #  132|           Type = [ArithmeticType] _Imaginary long double
 #  132|           ValueCategory = prvalue
-#  132|         0: [VariableAccess] jld
+#  132|         getLValue(): [VariableAccess] jld
 #  132|             Type = [ArithmeticType] _Imaginary long double
 #  132|             ValueCategory = lvalue
-#  132|         1: [VariableAccess] d
+#  132|         getRValue(): [VariableAccess] d
 #  132|             Type = [DoubleType] double
 #  132|             ValueCategory = prvalue(load)
-#  132|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  132|         : [CStyleCast] (_Imaginary long double)...
 #  132|             Conversion = [FloatingPointConversion] floating point conversion
 #  132|             Type = [ArithmeticType] _Imaginary long double
 #  132|             ValueCategory = prvalue
-#  133|     62: [ExprStmt] ExprStmt
-#  133|       0: [AssignExpr] ... = ...
+#  133|     getStmt(62): [ExprStmt] ExprStmt
+#  133|       getExpr(): [AssignExpr] ... = ...
 #  133|           Type = [ArithmeticType] _Imaginary long double
 #  133|           ValueCategory = prvalue
-#  133|         0: [VariableAccess] jld
+#  133|         getLValue(): [VariableAccess] jld
 #  133|             Type = [ArithmeticType] _Imaginary long double
 #  133|             ValueCategory = lvalue
-#  133|         1: [VariableAccess] ld
+#  133|         getRValue(): [VariableAccess] ld
 #  133|             Type = [LongDoubleType] long double
 #  133|             ValueCategory = prvalue(load)
-#  133|         1 converted: [CStyleCast] (_Imaginary long double)...
+#  133|         : [CStyleCast] (_Imaginary long double)...
 #  133|             Conversion = [FloatingPointConversion] floating point conversion
 #  133|             Type = [ArithmeticType] _Imaginary long double
 #  133|             ValueCategory = prvalue
-#  136|     63: [ExprStmt] ExprStmt
-#  136|       0: [AssignExpr] ... = ...
+#  136|     getStmt(63): [ExprStmt] ExprStmt
+#  136|       getExpr(): [AssignExpr] ... = ...
 #  136|           Type = [FloatType] float
 #  136|           ValueCategory = prvalue
-#  136|         0: [VariableAccess] f
+#  136|         getLValue(): [VariableAccess] f
 #  136|             Type = [FloatType] float
 #  136|             ValueCategory = lvalue
-#  136|         1: [VariableAccess] jf
+#  136|         getRValue(): [VariableAccess] jf
 #  136|             Type = [ArithmeticType] _Imaginary float
 #  136|             ValueCategory = prvalue(load)
-#  136|         1 converted: [CStyleCast] (float)...
+#  136|         : [CStyleCast] (float)...
 #  136|             Conversion = [FloatingPointConversion] floating point conversion
 #  136|             Type = [FloatType] float
 #  136|             ValueCategory = prvalue
-#  137|     64: [ExprStmt] ExprStmt
-#  137|       0: [AssignExpr] ... = ...
+#  137|     getStmt(64): [ExprStmt] ExprStmt
+#  137|       getExpr(): [AssignExpr] ... = ...
 #  137|           Type = [FloatType] float
 #  137|           ValueCategory = prvalue
-#  137|         0: [VariableAccess] f
+#  137|         getLValue(): [VariableAccess] f
 #  137|             Type = [FloatType] float
 #  137|             ValueCategory = lvalue
-#  137|         1: [VariableAccess] jd
+#  137|         getRValue(): [VariableAccess] jd
 #  137|             Type = [ArithmeticType] _Imaginary double
 #  137|             ValueCategory = prvalue(load)
-#  137|         1 converted: [CStyleCast] (float)...
+#  137|         : [CStyleCast] (float)...
 #  137|             Conversion = [FloatingPointConversion] floating point conversion
 #  137|             Type = [FloatType] float
 #  137|             ValueCategory = prvalue
-#  138|     65: [ExprStmt] ExprStmt
-#  138|       0: [AssignExpr] ... = ...
+#  138|     getStmt(65): [ExprStmt] ExprStmt
+#  138|       getExpr(): [AssignExpr] ... = ...
 #  138|           Type = [FloatType] float
 #  138|           ValueCategory = prvalue
-#  138|         0: [VariableAccess] f
+#  138|         getLValue(): [VariableAccess] f
 #  138|             Type = [FloatType] float
 #  138|             ValueCategory = lvalue
-#  138|         1: [VariableAccess] jld
+#  138|         getRValue(): [VariableAccess] jld
 #  138|             Type = [ArithmeticType] _Imaginary long double
 #  138|             ValueCategory = prvalue(load)
-#  138|         1 converted: [CStyleCast] (float)...
+#  138|         : [CStyleCast] (float)...
 #  138|             Conversion = [FloatingPointConversion] floating point conversion
 #  138|             Type = [FloatType] float
 #  138|             ValueCategory = prvalue
-#  139|     66: [ExprStmt] ExprStmt
-#  139|       0: [AssignExpr] ... = ...
+#  139|     getStmt(66): [ExprStmt] ExprStmt
+#  139|       getExpr(): [AssignExpr] ... = ...
 #  139|           Type = [DoubleType] double
 #  139|           ValueCategory = prvalue
-#  139|         0: [VariableAccess] d
+#  139|         getLValue(): [VariableAccess] d
 #  139|             Type = [DoubleType] double
 #  139|             ValueCategory = lvalue
-#  139|         1: [VariableAccess] jf
+#  139|         getRValue(): [VariableAccess] jf
 #  139|             Type = [ArithmeticType] _Imaginary float
 #  139|             ValueCategory = prvalue(load)
-#  139|         1 converted: [CStyleCast] (double)...
+#  139|         : [CStyleCast] (double)...
 #  139|             Conversion = [FloatingPointConversion] floating point conversion
 #  139|             Type = [DoubleType] double
 #  139|             ValueCategory = prvalue
-#  140|     67: [ExprStmt] ExprStmt
-#  140|       0: [AssignExpr] ... = ...
+#  140|     getStmt(67): [ExprStmt] ExprStmt
+#  140|       getExpr(): [AssignExpr] ... = ...
 #  140|           Type = [DoubleType] double
 #  140|           ValueCategory = prvalue
-#  140|         0: [VariableAccess] d
+#  140|         getLValue(): [VariableAccess] d
 #  140|             Type = [DoubleType] double
 #  140|             ValueCategory = lvalue
-#  140|         1: [VariableAccess] jd
+#  140|         getRValue(): [VariableAccess] jd
 #  140|             Type = [ArithmeticType] _Imaginary double
 #  140|             ValueCategory = prvalue(load)
-#  140|         1 converted: [CStyleCast] (double)...
+#  140|         : [CStyleCast] (double)...
 #  140|             Conversion = [FloatingPointConversion] floating point conversion
 #  140|             Type = [DoubleType] double
 #  140|             ValueCategory = prvalue
-#  141|     68: [ExprStmt] ExprStmt
-#  141|       0: [AssignExpr] ... = ...
+#  141|     getStmt(68): [ExprStmt] ExprStmt
+#  141|       getExpr(): [AssignExpr] ... = ...
 #  141|           Type = [DoubleType] double
 #  141|           ValueCategory = prvalue
-#  141|         0: [VariableAccess] d
+#  141|         getLValue(): [VariableAccess] d
 #  141|             Type = [DoubleType] double
 #  141|             ValueCategory = lvalue
-#  141|         1: [VariableAccess] jld
+#  141|         getRValue(): [VariableAccess] jld
 #  141|             Type = [ArithmeticType] _Imaginary long double
 #  141|             ValueCategory = prvalue(load)
-#  141|         1 converted: [CStyleCast] (double)...
+#  141|         : [CStyleCast] (double)...
 #  141|             Conversion = [FloatingPointConversion] floating point conversion
 #  141|             Type = [DoubleType] double
 #  141|             ValueCategory = prvalue
-#  142|     69: [ExprStmt] ExprStmt
-#  142|       0: [AssignExpr] ... = ...
+#  142|     getStmt(69): [ExprStmt] ExprStmt
+#  142|       getExpr(): [AssignExpr] ... = ...
 #  142|           Type = [LongDoubleType] long double
 #  142|           ValueCategory = prvalue
-#  142|         0: [VariableAccess] ld
+#  142|         getLValue(): [VariableAccess] ld
 #  142|             Type = [LongDoubleType] long double
 #  142|             ValueCategory = lvalue
-#  142|         1: [VariableAccess] jf
+#  142|         getRValue(): [VariableAccess] jf
 #  142|             Type = [ArithmeticType] _Imaginary float
 #  142|             ValueCategory = prvalue(load)
-#  142|         1 converted: [CStyleCast] (long double)...
+#  142|         : [CStyleCast] (long double)...
 #  142|             Conversion = [FloatingPointConversion] floating point conversion
 #  142|             Type = [LongDoubleType] long double
 #  142|             ValueCategory = prvalue
-#  143|     70: [ExprStmt] ExprStmt
-#  143|       0: [AssignExpr] ... = ...
+#  143|     getStmt(70): [ExprStmt] ExprStmt
+#  143|       getExpr(): [AssignExpr] ... = ...
 #  143|           Type = [LongDoubleType] long double
 #  143|           ValueCategory = prvalue
-#  143|         0: [VariableAccess] ld
+#  143|         getLValue(): [VariableAccess] ld
 #  143|             Type = [LongDoubleType] long double
 #  143|             ValueCategory = lvalue
-#  143|         1: [VariableAccess] jd
+#  143|         getRValue(): [VariableAccess] jd
 #  143|             Type = [ArithmeticType] _Imaginary double
 #  143|             ValueCategory = prvalue(load)
-#  143|         1 converted: [CStyleCast] (long double)...
+#  143|         : [CStyleCast] (long double)...
 #  143|             Conversion = [FloatingPointConversion] floating point conversion
 #  143|             Type = [LongDoubleType] long double
 #  143|             ValueCategory = prvalue
-#  144|     71: [ExprStmt] ExprStmt
-#  144|       0: [AssignExpr] ... = ...
+#  144|     getStmt(71): [ExprStmt] ExprStmt
+#  144|       getExpr(): [AssignExpr] ... = ...
 #  144|           Type = [LongDoubleType] long double
 #  144|           ValueCategory = prvalue
-#  144|         0: [VariableAccess] ld
+#  144|         getLValue(): [VariableAccess] ld
 #  144|             Type = [LongDoubleType] long double
 #  144|             ValueCategory = lvalue
-#  144|         1: [VariableAccess] jld
+#  144|         getRValue(): [VariableAccess] jld
 #  144|             Type = [ArithmeticType] _Imaginary long double
 #  144|             ValueCategory = prvalue(load)
-#  144|         1 converted: [CStyleCast] (long double)...
+#  144|         : [CStyleCast] (long double)...
 #  144|             Conversion = [FloatingPointConversion] floating point conversion
 #  144|             Type = [LongDoubleType] long double
 #  144|             ValueCategory = prvalue
-#  145|     72: [ReturnStmt] return ...
+#  145|     getStmt(72): [ReturnStmt] return ...
 ir.cpp:
 #    1| [TopLevelFunction] void Constants()
-#    1|   params: 
-#    1|   body: [BlockStmt] { ... }
-#    2|     0: [DeclStmt] declaration
-#    2|       0: [VariableDeclarationEntry] definition of c_i
+#    1|   ...: 
+#    1|   getEntryPoint(): [BlockStmt] { ... }
+#    2|     getStmt(0): [DeclStmt] declaration
+#    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c_i
 #    2|           Type = [PlainCharType] char
-#    2|         init: [Initializer] initializer for c_i
-#    2|           expr: [Literal] 1
+#    2|         getVariable().getInitializer(): [Initializer] initializer for c_i
+#    2|           getExpr(): [Literal] 1
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 1
 #    2|               ValueCategory = prvalue
-#    2|           expr converted: [CStyleCast] (char)...
+#    2|           : [CStyleCast] (char)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [PlainCharType] char
 #    2|               Value = [CStyleCast] 1
 #    2|               ValueCategory = prvalue
-#    3|     1: [DeclStmt] declaration
-#    3|       0: [VariableDeclarationEntry] definition of c_c
+#    3|     getStmt(1): [DeclStmt] declaration
+#    3|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c_c
 #    3|           Type = [PlainCharType] char
-#    3|         init: [Initializer] initializer for c_c
-#    3|           expr: [CharLiteral] 65
+#    3|         getVariable().getInitializer(): [Initializer] initializer for c_c
+#    3|           getExpr(): [CharLiteral] 65
 #    3|               Type = [PlainCharType] char
 #    3|               Value = [CharLiteral] 65
 #    3|               ValueCategory = prvalue
-#    5|     2: [DeclStmt] declaration
-#    5|       0: [VariableDeclarationEntry] definition of sc_i
+#    5|     getStmt(2): [DeclStmt] declaration
+#    5|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of sc_i
 #    5|           Type = [SignedCharType] signed char
-#    5|         init: [Initializer] initializer for sc_i
-#    5|           expr: [UnaryMinusExpr] - ...
+#    5|         getVariable().getInitializer(): [Initializer] initializer for sc_i
+#    5|           getExpr(): [UnaryMinusExpr] - ...
 #    5|               Type = [IntType] int
 #    5|               Value = [UnaryMinusExpr] -1
 #    5|               ValueCategory = prvalue
-#    5|             0: [Literal] 1
+#    5|             getOperand(): [Literal] 1
 #    5|                 Type = [IntType] int
 #    5|                 Value = [Literal] 1
 #    5|                 ValueCategory = prvalue
-#    5|           expr converted: [CStyleCast] (signed char)...
+#    5|           : [CStyleCast] (signed char)...
 #    5|               Conversion = [IntegralConversion] integral conversion
 #    5|               Type = [SignedCharType] signed char
 #    5|               Value = [CStyleCast] -1
 #    5|               ValueCategory = prvalue
-#    6|     3: [DeclStmt] declaration
-#    6|       0: [VariableDeclarationEntry] definition of sc_c
+#    6|     getStmt(3): [DeclStmt] declaration
+#    6|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of sc_c
 #    6|           Type = [SignedCharType] signed char
-#    6|         init: [Initializer] initializer for sc_c
-#    6|           expr: [CharLiteral] 65
+#    6|         getVariable().getInitializer(): [Initializer] initializer for sc_c
+#    6|           getExpr(): [CharLiteral] 65
 #    6|               Type = [PlainCharType] char
 #    6|               Value = [CharLiteral] 65
 #    6|               ValueCategory = prvalue
-#    6|           expr converted: [CStyleCast] (signed char)...
+#    6|           : [CStyleCast] (signed char)...
 #    6|               Conversion = [IntegralConversion] integral conversion
 #    6|               Type = [SignedCharType] signed char
 #    6|               Value = [CStyleCast] 65
 #    6|               ValueCategory = prvalue
-#    8|     4: [DeclStmt] declaration
-#    8|       0: [VariableDeclarationEntry] definition of uc_i
+#    8|     getStmt(4): [DeclStmt] declaration
+#    8|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of uc_i
 #    8|           Type = [UnsignedCharType] unsigned char
-#    8|         init: [Initializer] initializer for uc_i
-#    8|           expr: [Literal] 5
+#    8|         getVariable().getInitializer(): [Initializer] initializer for uc_i
+#    8|           getExpr(): [Literal] 5
 #    8|               Type = [IntType] int
 #    8|               Value = [Literal] 5
 #    8|               ValueCategory = prvalue
-#    8|           expr converted: [CStyleCast] (unsigned char)...
+#    8|           : [CStyleCast] (unsigned char)...
 #    8|               Conversion = [IntegralConversion] integral conversion
 #    8|               Type = [UnsignedCharType] unsigned char
 #    8|               Value = [CStyleCast] 5
 #    8|               ValueCategory = prvalue
-#    9|     5: [DeclStmt] declaration
-#    9|       0: [VariableDeclarationEntry] definition of uc_c
+#    9|     getStmt(5): [DeclStmt] declaration
+#    9|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of uc_c
 #    9|           Type = [UnsignedCharType] unsigned char
-#    9|         init: [Initializer] initializer for uc_c
-#    9|           expr: [CharLiteral] 65
+#    9|         getVariable().getInitializer(): [Initializer] initializer for uc_c
+#    9|           getExpr(): [CharLiteral] 65
 #    9|               Type = [PlainCharType] char
 #    9|               Value = [CharLiteral] 65
 #    9|               ValueCategory = prvalue
-#    9|           expr converted: [CStyleCast] (unsigned char)...
+#    9|           : [CStyleCast] (unsigned char)...
 #    9|               Conversion = [IntegralConversion] integral conversion
 #    9|               Type = [UnsignedCharType] unsigned char
 #    9|               Value = [CStyleCast] 65
 #    9|               ValueCategory = prvalue
-#   11|     6: [DeclStmt] declaration
-#   11|       0: [VariableDeclarationEntry] definition of s
+#   11|     getStmt(6): [DeclStmt] declaration
+#   11|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 #   11|           Type = [ShortType] short
-#   11|         init: [Initializer] initializer for s
-#   11|           expr: [Literal] 5
+#   11|         getVariable().getInitializer(): [Initializer] initializer for s
+#   11|           getExpr(): [Literal] 5
 #   11|               Type = [IntType] int
 #   11|               Value = [Literal] 5
 #   11|               ValueCategory = prvalue
-#   11|           expr converted: [CStyleCast] (short)...
+#   11|           : [CStyleCast] (short)...
 #   11|               Conversion = [IntegralConversion] integral conversion
 #   11|               Type = [ShortType] short
 #   11|               Value = [CStyleCast] 5
 #   11|               ValueCategory = prvalue
-#   12|     7: [DeclStmt] declaration
-#   12|       0: [VariableDeclarationEntry] definition of us
+#   12|     getStmt(7): [DeclStmt] declaration
+#   12|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of us
 #   12|           Type = [ShortType] unsigned short
-#   12|         init: [Initializer] initializer for us
-#   12|           expr: [Literal] 5
+#   12|         getVariable().getInitializer(): [Initializer] initializer for us
+#   12|           getExpr(): [Literal] 5
 #   12|               Type = [IntType] int
 #   12|               Value = [Literal] 5
 #   12|               ValueCategory = prvalue
-#   12|           expr converted: [CStyleCast] (unsigned short)...
+#   12|           : [CStyleCast] (unsigned short)...
 #   12|               Conversion = [IntegralConversion] integral conversion
 #   12|               Type = [ShortType] unsigned short
 #   12|               Value = [CStyleCast] 5
 #   12|               ValueCategory = prvalue
-#   14|     8: [DeclStmt] declaration
-#   14|       0: [VariableDeclarationEntry] definition of i
+#   14|     getStmt(8): [DeclStmt] declaration
+#   14|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #   14|           Type = [IntType] int
-#   14|         init: [Initializer] initializer for i
-#   14|           expr: [Literal] 5
+#   14|         getVariable().getInitializer(): [Initializer] initializer for i
+#   14|           getExpr(): [Literal] 5
 #   14|               Type = [IntType] int
 #   14|               Value = [Literal] 5
 #   14|               ValueCategory = prvalue
-#   15|     9: [DeclStmt] declaration
-#   15|       0: [VariableDeclarationEntry] definition of ui
+#   15|     getStmt(9): [DeclStmt] declaration
+#   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ui
 #   15|           Type = [IntType] unsigned int
-#   15|         init: [Initializer] initializer for ui
-#   15|           expr: [Literal] 5
+#   15|         getVariable().getInitializer(): [Initializer] initializer for ui
+#   15|           getExpr(): [Literal] 5
 #   15|               Type = [IntType] int
 #   15|               Value = [Literal] 5
 #   15|               ValueCategory = prvalue
-#   15|           expr converted: [CStyleCast] (unsigned int)...
+#   15|           : [CStyleCast] (unsigned int)...
 #   15|               Conversion = [IntegralConversion] integral conversion
 #   15|               Type = [IntType] unsigned int
 #   15|               Value = [CStyleCast] 5
 #   15|               ValueCategory = prvalue
-#   17|     10: [DeclStmt] declaration
-#   17|       0: [VariableDeclarationEntry] definition of l
+#   17|     getStmt(10): [DeclStmt] declaration
+#   17|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of l
 #   17|           Type = [LongType] long
-#   17|         init: [Initializer] initializer for l
-#   17|           expr: [Literal] 5
+#   17|         getVariable().getInitializer(): [Initializer] initializer for l
+#   17|           getExpr(): [Literal] 5
 #   17|               Type = [IntType] int
 #   17|               Value = [Literal] 5
 #   17|               ValueCategory = prvalue
-#   17|           expr converted: [CStyleCast] (long)...
+#   17|           : [CStyleCast] (long)...
 #   17|               Conversion = [IntegralConversion] integral conversion
 #   17|               Type = [LongType] long
 #   17|               Value = [CStyleCast] 5
 #   17|               ValueCategory = prvalue
-#   18|     11: [DeclStmt] declaration
-#   18|       0: [VariableDeclarationEntry] definition of ul
+#   18|     getStmt(11): [DeclStmt] declaration
+#   18|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ul
 #   18|           Type = [LongType] unsigned long
-#   18|         init: [Initializer] initializer for ul
-#   18|           expr: [Literal] 5
+#   18|         getVariable().getInitializer(): [Initializer] initializer for ul
+#   18|           getExpr(): [Literal] 5
 #   18|               Type = [IntType] int
 #   18|               Value = [Literal] 5
 #   18|               ValueCategory = prvalue
-#   18|           expr converted: [CStyleCast] (unsigned long)...
+#   18|           : [CStyleCast] (unsigned long)...
 #   18|               Conversion = [IntegralConversion] integral conversion
 #   18|               Type = [LongType] unsigned long
 #   18|               Value = [CStyleCast] 5
 #   18|               ValueCategory = prvalue
-#   20|     12: [DeclStmt] declaration
-#   20|       0: [VariableDeclarationEntry] definition of ll_i
+#   20|     getStmt(12): [DeclStmt] declaration
+#   20|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ll_i
 #   20|           Type = [LongLongType] long long
-#   20|         init: [Initializer] initializer for ll_i
-#   20|           expr: [Literal] 5
+#   20|         getVariable().getInitializer(): [Initializer] initializer for ll_i
+#   20|           getExpr(): [Literal] 5
 #   20|               Type = [IntType] int
 #   20|               Value = [Literal] 5
 #   20|               ValueCategory = prvalue
-#   20|           expr converted: [CStyleCast] (long long)...
+#   20|           : [CStyleCast] (long long)...
 #   20|               Conversion = [IntegralConversion] integral conversion
 #   20|               Type = [LongLongType] long long
 #   20|               Value = [CStyleCast] 5
 #   20|               ValueCategory = prvalue
-#   21|     13: [DeclStmt] declaration
-#   21|       0: [VariableDeclarationEntry] definition of ll_ll
+#   21|     getStmt(13): [DeclStmt] declaration
+#   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ll_ll
 #   21|           Type = [LongLongType] long long
-#   21|         init: [Initializer] initializer for ll_ll
-#   21|           expr: [Literal] 5
+#   21|         getVariable().getInitializer(): [Initializer] initializer for ll_ll
+#   21|           getExpr(): [Literal] 5
 #   21|               Type = [LongLongType] long long
 #   21|               Value = [Literal] 5
 #   21|               ValueCategory = prvalue
-#   22|     14: [DeclStmt] declaration
-#   22|       0: [VariableDeclarationEntry] definition of ull_i
+#   22|     getStmt(14): [DeclStmt] declaration
+#   22|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ull_i
 #   22|           Type = [LongLongType] unsigned long long
-#   22|         init: [Initializer] initializer for ull_i
-#   22|           expr: [Literal] 5
+#   22|         getVariable().getInitializer(): [Initializer] initializer for ull_i
+#   22|           getExpr(): [Literal] 5
 #   22|               Type = [IntType] int
 #   22|               Value = [Literal] 5
 #   22|               ValueCategory = prvalue
-#   22|           expr converted: [CStyleCast] (unsigned long long)...
+#   22|           : [CStyleCast] (unsigned long long)...
 #   22|               Conversion = [IntegralConversion] integral conversion
 #   22|               Type = [LongLongType] unsigned long long
 #   22|               Value = [CStyleCast] 5
 #   22|               ValueCategory = prvalue
-#   23|     15: [DeclStmt] declaration
-#   23|       0: [VariableDeclarationEntry] definition of ull_ull
+#   23|     getStmt(15): [DeclStmt] declaration
+#   23|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ull_ull
 #   23|           Type = [LongLongType] unsigned long long
-#   23|         init: [Initializer] initializer for ull_ull
-#   23|           expr: [Literal] 5
+#   23|         getVariable().getInitializer(): [Initializer] initializer for ull_ull
+#   23|           getExpr(): [Literal] 5
 #   23|               Type = [LongLongType] unsigned long long
 #   23|               Value = [Literal] 5
 #   23|               ValueCategory = prvalue
-#   25|     16: [DeclStmt] declaration
-#   25|       0: [VariableDeclarationEntry] definition of b_t
+#   25|     getStmt(16): [DeclStmt] declaration
+#   25|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b_t
 #   25|           Type = [BoolType] bool
-#   25|         init: [Initializer] initializer for b_t
-#   25|           expr: [Literal] 1
+#   25|         getVariable().getInitializer(): [Initializer] initializer for b_t
+#   25|           getExpr(): [Literal] 1
 #   25|               Type = [BoolType] bool
 #   25|               Value = [Literal] 1
 #   25|               ValueCategory = prvalue
-#   26|     17: [DeclStmt] declaration
-#   26|       0: [VariableDeclarationEntry] definition of b_f
+#   26|     getStmt(17): [DeclStmt] declaration
+#   26|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b_f
 #   26|           Type = [BoolType] bool
-#   26|         init: [Initializer] initializer for b_f
-#   26|           expr: [Literal] 0
+#   26|         getVariable().getInitializer(): [Initializer] initializer for b_f
+#   26|           getExpr(): [Literal] 0
 #   26|               Type = [BoolType] bool
 #   26|               Value = [Literal] 0
 #   26|               ValueCategory = prvalue
-#   28|     18: [DeclStmt] declaration
-#   28|       0: [VariableDeclarationEntry] definition of wc_i
+#   28|     getStmt(18): [DeclStmt] declaration
+#   28|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of wc_i
 #   28|           Type = [Wchar_t,WideCharType] wchar_t
-#   28|         init: [Initializer] initializer for wc_i
-#   28|           expr: [Literal] 5
+#   28|         getVariable().getInitializer(): [Initializer] initializer for wc_i
+#   28|           getExpr(): [Literal] 5
 #   28|               Type = [IntType] int
 #   28|               Value = [Literal] 5
 #   28|               ValueCategory = prvalue
-#   28|           expr converted: [CStyleCast] (wchar_t)...
+#   28|           : [CStyleCast] (wchar_t)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [Wchar_t,WideCharType] wchar_t
 #   28|               Value = [CStyleCast] 5
 #   28|               ValueCategory = prvalue
-#   29|     19: [DeclStmt] declaration
-#   29|       0: [VariableDeclarationEntry] definition of wc_c
+#   29|     getStmt(19): [DeclStmt] declaration
+#   29|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of wc_c
 #   29|           Type = [Wchar_t,WideCharType] wchar_t
-#   29|         init: [Initializer] initializer for wc_c
-#   29|           expr: [CharLiteral] 65
+#   29|         getVariable().getInitializer(): [Initializer] initializer for wc_c
+#   29|           getExpr(): [CharLiteral] 65
 #   29|               Type = [Wchar_t,WideCharType] wchar_t
 #   29|               Value = [CharLiteral] 65
 #   29|               ValueCategory = prvalue
-#   31|     20: [DeclStmt] declaration
-#   31|       0: [VariableDeclarationEntry] definition of c16
+#   31|     getStmt(20): [DeclStmt] declaration
+#   31|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c16
 #   31|           Type = [Char16Type] char16_t
-#   31|         init: [Initializer] initializer for c16
-#   31|           expr: [Literal] 65
+#   31|         getVariable().getInitializer(): [Initializer] initializer for c16
+#   31|           getExpr(): [Literal] 65
 #   31|               Type = [Char16Type] char16_t
 #   31|               Value = [Literal] 65
 #   31|               ValueCategory = prvalue
-#   32|     21: [DeclStmt] declaration
-#   32|       0: [VariableDeclarationEntry] definition of c32
+#   32|     getStmt(21): [DeclStmt] declaration
+#   32|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c32
 #   32|           Type = [Char32Type] char32_t
-#   32|         init: [Initializer] initializer for c32
-#   32|           expr: [Literal] 65
+#   32|         getVariable().getInitializer(): [Initializer] initializer for c32
+#   32|           getExpr(): [Literal] 65
 #   32|               Type = [Char32Type] char32_t
 #   32|               Value = [Literal] 65
 #   32|               ValueCategory = prvalue
-#   34|     22: [DeclStmt] declaration
-#   34|       0: [VariableDeclarationEntry] definition of f_i
+#   34|     getStmt(22): [DeclStmt] declaration
+#   34|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f_i
 #   34|           Type = [FloatType] float
-#   34|         init: [Initializer] initializer for f_i
-#   34|           expr: [Literal] 1
+#   34|         getVariable().getInitializer(): [Initializer] initializer for f_i
+#   34|           getExpr(): [Literal] 1
 #   34|               Type = [IntType] int
 #   34|               Value = [Literal] 1
 #   34|               ValueCategory = prvalue
-#   34|           expr converted: [CStyleCast] (float)...
+#   34|           : [CStyleCast] (float)...
 #   34|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   34|               Type = [FloatType] float
 #   34|               Value = [CStyleCast] 1.0
 #   34|               ValueCategory = prvalue
-#   35|     23: [DeclStmt] declaration
-#   35|       0: [VariableDeclarationEntry] definition of f_f
+#   35|     getStmt(23): [DeclStmt] declaration
+#   35|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f_f
 #   35|           Type = [FloatType] float
-#   35|         init: [Initializer] initializer for f_f
-#   35|           expr: [Literal] 1.0
+#   35|         getVariable().getInitializer(): [Initializer] initializer for f_f
+#   35|           getExpr(): [Literal] 1.0
 #   35|               Type = [FloatType] float
 #   35|               Value = [Literal] 1.0
 #   35|               ValueCategory = prvalue
-#   36|     24: [DeclStmt] declaration
-#   36|       0: [VariableDeclarationEntry] definition of f_d
+#   36|     getStmt(24): [DeclStmt] declaration
+#   36|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f_d
 #   36|           Type = [FloatType] float
-#   36|         init: [Initializer] initializer for f_d
-#   36|           expr: [Literal] 1.0
+#   36|         getVariable().getInitializer(): [Initializer] initializer for f_d
+#   36|           getExpr(): [Literal] 1.0
 #   36|               Type = [DoubleType] double
 #   36|               Value = [Literal] 1.0
 #   36|               ValueCategory = prvalue
-#   36|           expr converted: [CStyleCast] (float)...
+#   36|           : [CStyleCast] (float)...
 #   36|               Conversion = [FloatingPointConversion] floating point conversion
 #   36|               Type = [FloatType] float
 #   36|               Value = [CStyleCast] 1.0
 #   36|               ValueCategory = prvalue
-#   38|     25: [DeclStmt] declaration
-#   38|       0: [VariableDeclarationEntry] definition of d_i
+#   38|     getStmt(25): [DeclStmt] declaration
+#   38|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d_i
 #   38|           Type = [DoubleType] double
-#   38|         init: [Initializer] initializer for d_i
-#   38|           expr: [Literal] 1
+#   38|         getVariable().getInitializer(): [Initializer] initializer for d_i
+#   38|           getExpr(): [Literal] 1
 #   38|               Type = [IntType] int
 #   38|               Value = [Literal] 1
 #   38|               ValueCategory = prvalue
-#   38|           expr converted: [CStyleCast] (double)...
+#   38|           : [CStyleCast] (double)...
 #   38|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   38|               Type = [DoubleType] double
 #   38|               Value = [CStyleCast] 1.0
 #   38|               ValueCategory = prvalue
-#   39|     26: [DeclStmt] declaration
-#   39|       0: [VariableDeclarationEntry] definition of d_f
+#   39|     getStmt(26): [DeclStmt] declaration
+#   39|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d_f
 #   39|           Type = [DoubleType] double
-#   39|         init: [Initializer] initializer for d_f
-#   39|           expr: [Literal] 1.0
+#   39|         getVariable().getInitializer(): [Initializer] initializer for d_f
+#   39|           getExpr(): [Literal] 1.0
 #   39|               Type = [FloatType] float
 #   39|               Value = [Literal] 1.0
 #   39|               ValueCategory = prvalue
-#   39|           expr converted: [CStyleCast] (double)...
+#   39|           : [CStyleCast] (double)...
 #   39|               Conversion = [FloatingPointConversion] floating point conversion
 #   39|               Type = [DoubleType] double
 #   39|               Value = [CStyleCast] 1.0
 #   39|               ValueCategory = prvalue
-#   40|     27: [DeclStmt] declaration
-#   40|       0: [VariableDeclarationEntry] definition of d_d
+#   40|     getStmt(27): [DeclStmt] declaration
+#   40|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d_d
 #   40|           Type = [DoubleType] double
-#   40|         init: [Initializer] initializer for d_d
-#   40|           expr: [Literal] 1.0
+#   40|         getVariable().getInitializer(): [Initializer] initializer for d_d
+#   40|           getExpr(): [Literal] 1.0
 #   40|               Type = [DoubleType] double
 #   40|               Value = [Literal] 1.0
 #   40|               ValueCategory = prvalue
-#   41|     28: [ReturnStmt] return ...
+#   41|     getStmt(28): [ReturnStmt] return ...
 #   43| [TopLevelFunction] void Foo()
-#   43|   params: 
-#   43|   body: [BlockStmt] { ... }
-#   44|     0: [DeclStmt] declaration
-#   44|       0: [VariableDeclarationEntry] definition of x
+#   43|   ...: 
+#   43|   getEntryPoint(): [BlockStmt] { ... }
+#   44|     getStmt(0): [DeclStmt] declaration
+#   44|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #   44|           Type = [IntType] int
-#   44|         init: [Initializer] initializer for x
-#   44|           expr: [AddExpr] ... + ...
+#   44|         getVariable().getInitializer(): [Initializer] initializer for x
+#   44|           getExpr(): [AddExpr] ... + ...
 #   44|               Type = [IntType] int
 #   44|               Value = [AddExpr] 17
 #   44|               ValueCategory = prvalue
-#   44|             0: [Literal] 5
+#   44|             getLeftOperand(): [Literal] 5
 #   44|                 Type = [IntType] int
 #   44|                 Value = [Literal] 5
 #   44|                 ValueCategory = prvalue
-#   44|             1: [Literal] 12
+#   44|             getRightOperand(): [Literal] 12
 #   44|                 Type = [IntType] int
 #   44|                 Value = [Literal] 12
 #   44|                 ValueCategory = prvalue
-#   45|     1: [DeclStmt] declaration
-#   45|       0: [VariableDeclarationEntry] definition of y
+#   45|     getStmt(1): [DeclStmt] declaration
+#   45|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #   45|           Type = [ShortType] short
-#   45|         init: [Initializer] initializer for y
-#   45|           expr: [Literal] 7
+#   45|         getVariable().getInitializer(): [Initializer] initializer for y
+#   45|           getExpr(): [Literal] 7
 #   45|               Type = [IntType] int
 #   45|               Value = [Literal] 7
 #   45|               ValueCategory = prvalue
-#   45|           expr converted: [CStyleCast] (short)...
+#   45|           : [CStyleCast] (short)...
 #   45|               Conversion = [IntegralConversion] integral conversion
 #   45|               Type = [ShortType] short
 #   45|               Value = [CStyleCast] 7
 #   45|               ValueCategory = prvalue
-#   46|     2: [ExprStmt] ExprStmt
-#   46|       0: [AssignExpr] ... = ...
+#   46|     getStmt(2): [ExprStmt] ExprStmt
+#   46|       getExpr(): [AssignExpr] ... = ...
 #   46|           Type = [ShortType] short
 #   46|           ValueCategory = lvalue
-#   46|         0: [VariableAccess] y
+#   46|         getLValue(): [VariableAccess] y
 #   46|             Type = [ShortType] short
 #   46|             ValueCategory = lvalue
-#   46|         1: [AddExpr] ... + ...
+#   46|         getRValue(): [AddExpr] ... + ...
 #   46|             Type = [IntType] int
 #   46|             ValueCategory = prvalue
-#   46|           0: [VariableAccess] x
+#   46|           getLeftOperand(): [VariableAccess] x
 #   46|               Type = [IntType] int
 #   46|               ValueCategory = prvalue(load)
-#   46|           1: [VariableAccess] y
+#   46|           getRightOperand(): [VariableAccess] y
 #   46|               Type = [ShortType] short
 #   46|               ValueCategory = prvalue(load)
-#   46|           1 converted: [CStyleCast] (int)...
+#   46|           : [CStyleCast] (int)...
 #   46|               Conversion = [IntegralConversion] integral conversion
 #   46|               Type = [IntType] int
 #   46|               ValueCategory = prvalue
-#   46|         1 converted: [CStyleCast] (short)...
+#   46|         : [CStyleCast] (short)...
 #   46|             Conversion = [IntegralConversion] integral conversion
 #   46|             Type = [ShortType] short
 #   46|             ValueCategory = prvalue
-#   47|     3: [ExprStmt] ExprStmt
-#   47|       0: [AssignExpr] ... = ...
+#   47|     getStmt(3): [ExprStmt] ExprStmt
+#   47|       getExpr(): [AssignExpr] ... = ...
 #   47|           Type = [IntType] int
 #   47|           ValueCategory = lvalue
-#   47|         0: [VariableAccess] x
+#   47|         getLValue(): [VariableAccess] x
 #   47|             Type = [IntType] int
 #   47|             ValueCategory = lvalue
-#   47|         1: [MulExpr] ... * ...
+#   47|         getRValue(): [MulExpr] ... * ...
 #   47|             Type = [IntType] int
 #   47|             ValueCategory = prvalue
-#   47|           0: [VariableAccess] x
+#   47|           getLeftOperand(): [VariableAccess] x
 #   47|               Type = [IntType] int
 #   47|               ValueCategory = prvalue(load)
-#   47|           1: [VariableAccess] y
+#   47|           getRightOperand(): [VariableAccess] y
 #   47|               Type = [ShortType] short
 #   47|               ValueCategory = prvalue(load)
-#   47|           1 converted: [CStyleCast] (int)...
+#   47|           : [CStyleCast] (int)...
 #   47|               Conversion = [IntegralConversion] integral conversion
 #   47|               Type = [IntType] int
 #   47|               ValueCategory = prvalue
-#   48|     4: [ReturnStmt] return ...
+#   48|     getStmt(4): [ReturnStmt] return ...
 #   50| [TopLevelFunction] void IntegerOps(int, int)
-#   50|   params: 
-#   50|     0: [Parameter] x
+#   50|   ...: 
+#   50|     getParameter(0): [Parameter] x
 #   50|         Type = [IntType] int
-#   50|     1: [Parameter] y
+#   50|     getParameter(1): [Parameter] y
 #   50|         Type = [IntType] int
-#   50|   body: [BlockStmt] { ... }
-#   51|     0: [DeclStmt] declaration
-#   51|       0: [VariableDeclarationEntry] definition of z
+#   50|   getEntryPoint(): [BlockStmt] { ... }
+#   51|     getStmt(0): [DeclStmt] declaration
+#   51|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 #   51|           Type = [IntType] int
-#   53|     1: [ExprStmt] ExprStmt
-#   53|       0: [AssignExpr] ... = ...
+#   53|     getStmt(1): [ExprStmt] ExprStmt
+#   53|       getExpr(): [AssignExpr] ... = ...
 #   53|           Type = [IntType] int
 #   53|           ValueCategory = lvalue
-#   53|         0: [VariableAccess] z
+#   53|         getLValue(): [VariableAccess] z
 #   53|             Type = [IntType] int
 #   53|             ValueCategory = lvalue
-#   53|         1: [AddExpr] ... + ...
+#   53|         getRValue(): [AddExpr] ... + ...
 #   53|             Type = [IntType] int
 #   53|             ValueCategory = prvalue
-#   53|           0: [VariableAccess] x
+#   53|           getLeftOperand(): [VariableAccess] x
 #   53|               Type = [IntType] int
 #   53|               ValueCategory = prvalue(load)
-#   53|           1: [VariableAccess] y
+#   53|           getRightOperand(): [VariableAccess] y
 #   53|               Type = [IntType] int
 #   53|               ValueCategory = prvalue(load)
-#   54|     2: [ExprStmt] ExprStmt
-#   54|       0: [AssignExpr] ... = ...
+#   54|     getStmt(2): [ExprStmt] ExprStmt
+#   54|       getExpr(): [AssignExpr] ... = ...
 #   54|           Type = [IntType] int
 #   54|           ValueCategory = lvalue
-#   54|         0: [VariableAccess] z
+#   54|         getLValue(): [VariableAccess] z
 #   54|             Type = [IntType] int
 #   54|             ValueCategory = lvalue
-#   54|         1: [SubExpr] ... - ...
+#   54|         getRValue(): [SubExpr] ... - ...
 #   54|             Type = [IntType] int
 #   54|             ValueCategory = prvalue
-#   54|           0: [VariableAccess] x
+#   54|           getLeftOperand(): [VariableAccess] x
 #   54|               Type = [IntType] int
 #   54|               ValueCategory = prvalue(load)
-#   54|           1: [VariableAccess] y
+#   54|           getRightOperand(): [VariableAccess] y
 #   54|               Type = [IntType] int
 #   54|               ValueCategory = prvalue(load)
-#   55|     3: [ExprStmt] ExprStmt
-#   55|       0: [AssignExpr] ... = ...
+#   55|     getStmt(3): [ExprStmt] ExprStmt
+#   55|       getExpr(): [AssignExpr] ... = ...
 #   55|           Type = [IntType] int
 #   55|           ValueCategory = lvalue
-#   55|         0: [VariableAccess] z
+#   55|         getLValue(): [VariableAccess] z
 #   55|             Type = [IntType] int
 #   55|             ValueCategory = lvalue
-#   55|         1: [MulExpr] ... * ...
+#   55|         getRValue(): [MulExpr] ... * ...
 #   55|             Type = [IntType] int
 #   55|             ValueCategory = prvalue
-#   55|           0: [VariableAccess] x
+#   55|           getLeftOperand(): [VariableAccess] x
 #   55|               Type = [IntType] int
 #   55|               ValueCategory = prvalue(load)
-#   55|           1: [VariableAccess] y
+#   55|           getRightOperand(): [VariableAccess] y
 #   55|               Type = [IntType] int
 #   55|               ValueCategory = prvalue(load)
-#   56|     4: [ExprStmt] ExprStmt
-#   56|       0: [AssignExpr] ... = ...
+#   56|     getStmt(4): [ExprStmt] ExprStmt
+#   56|       getExpr(): [AssignExpr] ... = ...
 #   56|           Type = [IntType] int
 #   56|           ValueCategory = lvalue
-#   56|         0: [VariableAccess] z
+#   56|         getLValue(): [VariableAccess] z
 #   56|             Type = [IntType] int
 #   56|             ValueCategory = lvalue
-#   56|         1: [DivExpr] ... / ...
+#   56|         getRValue(): [DivExpr] ... / ...
 #   56|             Type = [IntType] int
 #   56|             ValueCategory = prvalue
-#   56|           0: [VariableAccess] x
+#   56|           getLeftOperand(): [VariableAccess] x
 #   56|               Type = [IntType] int
 #   56|               ValueCategory = prvalue(load)
-#   56|           1: [VariableAccess] y
+#   56|           getRightOperand(): [VariableAccess] y
 #   56|               Type = [IntType] int
 #   56|               ValueCategory = prvalue(load)
-#   57|     5: [ExprStmt] ExprStmt
-#   57|       0: [AssignExpr] ... = ...
+#   57|     getStmt(5): [ExprStmt] ExprStmt
+#   57|       getExpr(): [AssignExpr] ... = ...
 #   57|           Type = [IntType] int
 #   57|           ValueCategory = lvalue
-#   57|         0: [VariableAccess] z
+#   57|         getLValue(): [VariableAccess] z
 #   57|             Type = [IntType] int
 #   57|             ValueCategory = lvalue
-#   57|         1: [RemExpr] ... % ...
+#   57|         getRValue(): [RemExpr] ... % ...
 #   57|             Type = [IntType] int
 #   57|             ValueCategory = prvalue
-#   57|           0: [VariableAccess] x
+#   57|           getLeftOperand(): [VariableAccess] x
 #   57|               Type = [IntType] int
 #   57|               ValueCategory = prvalue(load)
-#   57|           1: [VariableAccess] y
+#   57|           getRightOperand(): [VariableAccess] y
 #   57|               Type = [IntType] int
 #   57|               ValueCategory = prvalue(load)
-#   59|     6: [ExprStmt] ExprStmt
-#   59|       0: [AssignExpr] ... = ...
+#   59|     getStmt(6): [ExprStmt] ExprStmt
+#   59|       getExpr(): [AssignExpr] ... = ...
 #   59|           Type = [IntType] int
 #   59|           ValueCategory = lvalue
-#   59|         0: [VariableAccess] z
+#   59|         getLValue(): [VariableAccess] z
 #   59|             Type = [IntType] int
 #   59|             ValueCategory = lvalue
-#   59|         1: [BitwiseAndExpr] ... & ...
+#   59|         getRValue(): [BitwiseAndExpr] ... & ...
 #   59|             Type = [IntType] int
 #   59|             ValueCategory = prvalue
-#   59|           0: [VariableAccess] x
+#   59|           getLeftOperand(): [VariableAccess] x
 #   59|               Type = [IntType] int
 #   59|               ValueCategory = prvalue(load)
-#   59|           1: [VariableAccess] y
+#   59|           getRightOperand(): [VariableAccess] y
 #   59|               Type = [IntType] int
 #   59|               ValueCategory = prvalue(load)
-#   60|     7: [ExprStmt] ExprStmt
-#   60|       0: [AssignExpr] ... = ...
+#   60|     getStmt(7): [ExprStmt] ExprStmt
+#   60|       getExpr(): [AssignExpr] ... = ...
 #   60|           Type = [IntType] int
 #   60|           ValueCategory = lvalue
-#   60|         0: [VariableAccess] z
+#   60|         getLValue(): [VariableAccess] z
 #   60|             Type = [IntType] int
 #   60|             ValueCategory = lvalue
-#   60|         1: [BitwiseOrExpr] ... | ...
+#   60|         getRValue(): [BitwiseOrExpr] ... | ...
 #   60|             Type = [IntType] int
 #   60|             ValueCategory = prvalue
-#   60|           0: [VariableAccess] x
+#   60|           getLeftOperand(): [VariableAccess] x
 #   60|               Type = [IntType] int
 #   60|               ValueCategory = prvalue(load)
-#   60|           1: [VariableAccess] y
+#   60|           getRightOperand(): [VariableAccess] y
 #   60|               Type = [IntType] int
 #   60|               ValueCategory = prvalue(load)
-#   61|     8: [ExprStmt] ExprStmt
-#   61|       0: [AssignExpr] ... = ...
+#   61|     getStmt(8): [ExprStmt] ExprStmt
+#   61|       getExpr(): [AssignExpr] ... = ...
 #   61|           Type = [IntType] int
 #   61|           ValueCategory = lvalue
-#   61|         0: [VariableAccess] z
+#   61|         getLValue(): [VariableAccess] z
 #   61|             Type = [IntType] int
 #   61|             ValueCategory = lvalue
-#   61|         1: [BitwiseXorExpr] ... ^ ...
+#   61|         getRValue(): [BitwiseXorExpr] ... ^ ...
 #   61|             Type = [IntType] int
 #   61|             ValueCategory = prvalue
-#   61|           0: [VariableAccess] x
+#   61|           getLeftOperand(): [VariableAccess] x
 #   61|               Type = [IntType] int
 #   61|               ValueCategory = prvalue(load)
-#   61|           1: [VariableAccess] y
+#   61|           getRightOperand(): [VariableAccess] y
 #   61|               Type = [IntType] int
 #   61|               ValueCategory = prvalue(load)
-#   63|     9: [ExprStmt] ExprStmt
-#   63|       0: [AssignExpr] ... = ...
+#   63|     getStmt(9): [ExprStmt] ExprStmt
+#   63|       getExpr(): [AssignExpr] ... = ...
 #   63|           Type = [IntType] int
 #   63|           ValueCategory = lvalue
-#   63|         0: [VariableAccess] z
+#   63|         getLValue(): [VariableAccess] z
 #   63|             Type = [IntType] int
 #   63|             ValueCategory = lvalue
-#   63|         1: [LShiftExpr] ... << ...
+#   63|         getRValue(): [LShiftExpr] ... << ...
 #   63|             Type = [IntType] int
 #   63|             ValueCategory = prvalue
-#   63|           0: [VariableAccess] x
+#   63|           getLeftOperand(): [VariableAccess] x
 #   63|               Type = [IntType] int
 #   63|               ValueCategory = prvalue(load)
-#   63|           1: [VariableAccess] y
+#   63|           getRightOperand(): [VariableAccess] y
 #   63|               Type = [IntType] int
 #   63|               ValueCategory = prvalue(load)
-#   64|     10: [ExprStmt] ExprStmt
-#   64|       0: [AssignExpr] ... = ...
+#   64|     getStmt(10): [ExprStmt] ExprStmt
+#   64|       getExpr(): [AssignExpr] ... = ...
 #   64|           Type = [IntType] int
 #   64|           ValueCategory = lvalue
-#   64|         0: [VariableAccess] z
+#   64|         getLValue(): [VariableAccess] z
 #   64|             Type = [IntType] int
 #   64|             ValueCategory = lvalue
-#   64|         1: [RShiftExpr] ... >> ...
+#   64|         getRValue(): [RShiftExpr] ... >> ...
 #   64|             Type = [IntType] int
 #   64|             ValueCategory = prvalue
-#   64|           0: [VariableAccess] x
+#   64|           getLeftOperand(): [VariableAccess] x
 #   64|               Type = [IntType] int
 #   64|               ValueCategory = prvalue(load)
-#   64|           1: [VariableAccess] y
+#   64|           getRightOperand(): [VariableAccess] y
 #   64|               Type = [IntType] int
 #   64|               ValueCategory = prvalue(load)
-#   66|     11: [ExprStmt] ExprStmt
-#   66|       0: [AssignExpr] ... = ...
+#   66|     getStmt(11): [ExprStmt] ExprStmt
+#   66|       getExpr(): [AssignExpr] ... = ...
 #   66|           Type = [IntType] int
 #   66|           ValueCategory = lvalue
-#   66|         0: [VariableAccess] z
+#   66|         getLValue(): [VariableAccess] z
 #   66|             Type = [IntType] int
 #   66|             ValueCategory = lvalue
-#   66|         1: [VariableAccess] x
+#   66|         getRValue(): [VariableAccess] x
 #   66|             Type = [IntType] int
 #   66|             ValueCategory = prvalue(load)
-#   68|     12: [ExprStmt] ExprStmt
-#   68|       0: [AssignAddExpr] ... += ...
+#   68|     getStmt(12): [ExprStmt] ExprStmt
+#   68|       getExpr(): [AssignAddExpr] ... += ...
 #   68|           Type = [IntType] int
 #   68|           ValueCategory = lvalue
-#   68|         0: [VariableAccess] z
+#   68|         getLValue(): [VariableAccess] z
 #   68|             Type = [IntType] int
 #   68|             ValueCategory = lvalue
-#   68|         1: [VariableAccess] x
+#   68|         getRValue(): [VariableAccess] x
 #   68|             Type = [IntType] int
 #   68|             ValueCategory = prvalue(load)
-#   69|     13: [ExprStmt] ExprStmt
-#   69|       0: [AssignSubExpr] ... -= ...
+#   69|     getStmt(13): [ExprStmt] ExprStmt
+#   69|       getExpr(): [AssignSubExpr] ... -= ...
 #   69|           Type = [IntType] int
 #   69|           ValueCategory = lvalue
-#   69|         0: [VariableAccess] z
+#   69|         getLValue(): [VariableAccess] z
 #   69|             Type = [IntType] int
 #   69|             ValueCategory = lvalue
-#   69|         1: [VariableAccess] x
+#   69|         getRValue(): [VariableAccess] x
 #   69|             Type = [IntType] int
 #   69|             ValueCategory = prvalue(load)
-#   70|     14: [ExprStmt] ExprStmt
-#   70|       0: [AssignMulExpr] ... *= ...
+#   70|     getStmt(14): [ExprStmt] ExprStmt
+#   70|       getExpr(): [AssignMulExpr] ... *= ...
 #   70|           Type = [IntType] int
 #   70|           ValueCategory = lvalue
-#   70|         0: [VariableAccess] z
+#   70|         getLValue(): [VariableAccess] z
 #   70|             Type = [IntType] int
 #   70|             ValueCategory = lvalue
-#   70|         1: [VariableAccess] x
+#   70|         getRValue(): [VariableAccess] x
 #   70|             Type = [IntType] int
 #   70|             ValueCategory = prvalue(load)
-#   71|     15: [ExprStmt] ExprStmt
-#   71|       0: [AssignDivExpr] ... /= ...
+#   71|     getStmt(15): [ExprStmt] ExprStmt
+#   71|       getExpr(): [AssignDivExpr] ... /= ...
 #   71|           Type = [IntType] int
 #   71|           ValueCategory = lvalue
-#   71|         0: [VariableAccess] z
+#   71|         getLValue(): [VariableAccess] z
 #   71|             Type = [IntType] int
 #   71|             ValueCategory = lvalue
-#   71|         1: [VariableAccess] x
+#   71|         getRValue(): [VariableAccess] x
 #   71|             Type = [IntType] int
 #   71|             ValueCategory = prvalue(load)
-#   72|     16: [ExprStmt] ExprStmt
-#   72|       0: [AssignRemExpr] ... %= ...
+#   72|     getStmt(16): [ExprStmt] ExprStmt
+#   72|       getExpr(): [AssignRemExpr] ... %= ...
 #   72|           Type = [IntType] int
 #   72|           ValueCategory = lvalue
-#   72|         0: [VariableAccess] z
+#   72|         getLValue(): [VariableAccess] z
 #   72|             Type = [IntType] int
 #   72|             ValueCategory = lvalue
-#   72|         1: [VariableAccess] x
+#   72|         getRValue(): [VariableAccess] x
 #   72|             Type = [IntType] int
 #   72|             ValueCategory = prvalue(load)
-#   74|     17: [ExprStmt] ExprStmt
-#   74|       0: [AssignAndExpr] ... &= ...
+#   74|     getStmt(17): [ExprStmt] ExprStmt
+#   74|       getExpr(): [AssignAndExpr] ... &= ...
 #   74|           Type = [IntType] int
 #   74|           ValueCategory = lvalue
-#   74|         0: [VariableAccess] z
+#   74|         getLValue(): [VariableAccess] z
 #   74|             Type = [IntType] int
 #   74|             ValueCategory = lvalue
-#   74|         1: [VariableAccess] x
+#   74|         getRValue(): [VariableAccess] x
 #   74|             Type = [IntType] int
 #   74|             ValueCategory = prvalue(load)
-#   75|     18: [ExprStmt] ExprStmt
-#   75|       0: [AssignOrExpr] ... |= ...
+#   75|     getStmt(18): [ExprStmt] ExprStmt
+#   75|       getExpr(): [AssignOrExpr] ... |= ...
 #   75|           Type = [IntType] int
 #   75|           ValueCategory = lvalue
-#   75|         0: [VariableAccess] z
+#   75|         getLValue(): [VariableAccess] z
 #   75|             Type = [IntType] int
 #   75|             ValueCategory = lvalue
-#   75|         1: [VariableAccess] x
+#   75|         getRValue(): [VariableAccess] x
 #   75|             Type = [IntType] int
 #   75|             ValueCategory = prvalue(load)
-#   76|     19: [ExprStmt] ExprStmt
-#   76|       0: [AssignXorExpr] ... ^= ...
+#   76|     getStmt(19): [ExprStmt] ExprStmt
+#   76|       getExpr(): [AssignXorExpr] ... ^= ...
 #   76|           Type = [IntType] int
 #   76|           ValueCategory = lvalue
-#   76|         0: [VariableAccess] z
+#   76|         getLValue(): [VariableAccess] z
 #   76|             Type = [IntType] int
 #   76|             ValueCategory = lvalue
-#   76|         1: [VariableAccess] x
+#   76|         getRValue(): [VariableAccess] x
 #   76|             Type = [IntType] int
 #   76|             ValueCategory = prvalue(load)
-#   78|     20: [ExprStmt] ExprStmt
-#   78|       0: [AssignLShiftExpr] ... <<= ...
+#   78|     getStmt(20): [ExprStmt] ExprStmt
+#   78|       getExpr(): [AssignLShiftExpr] ... <<= ...
 #   78|           Type = [IntType] int
 #   78|           ValueCategory = lvalue
-#   78|         0: [VariableAccess] z
+#   78|         getLValue(): [VariableAccess] z
 #   78|             Type = [IntType] int
 #   78|             ValueCategory = lvalue
-#   78|         1: [VariableAccess] x
+#   78|         getRValue(): [VariableAccess] x
 #   78|             Type = [IntType] int
 #   78|             ValueCategory = prvalue(load)
-#   79|     21: [ExprStmt] ExprStmt
-#   79|       0: [AssignRShiftExpr] ... >>= ...
+#   79|     getStmt(21): [ExprStmt] ExprStmt
+#   79|       getExpr(): [AssignRShiftExpr] ... >>= ...
 #   79|           Type = [IntType] int
 #   79|           ValueCategory = lvalue
-#   79|         0: [VariableAccess] z
+#   79|         getLValue(): [VariableAccess] z
 #   79|             Type = [IntType] int
 #   79|             ValueCategory = lvalue
-#   79|         1: [VariableAccess] x
+#   79|         getRValue(): [VariableAccess] x
 #   79|             Type = [IntType] int
 #   79|             ValueCategory = prvalue(load)
-#   81|     22: [ExprStmt] ExprStmt
-#   81|       0: [AssignExpr] ... = ...
+#   81|     getStmt(22): [ExprStmt] ExprStmt
+#   81|       getExpr(): [AssignExpr] ... = ...
 #   81|           Type = [IntType] int
 #   81|           ValueCategory = lvalue
-#   81|         0: [VariableAccess] z
+#   81|         getLValue(): [VariableAccess] z
 #   81|             Type = [IntType] int
 #   81|             ValueCategory = lvalue
-#   81|         1: [UnaryPlusExpr] + ...
+#   81|         getRValue(): [UnaryPlusExpr] + ...
 #   81|             Type = [IntType] int
 #   81|             ValueCategory = prvalue
-#   81|           0: [VariableAccess] x
+#   81|           getOperand(): [VariableAccess] x
 #   81|               Type = [IntType] int
 #   81|               ValueCategory = prvalue(load)
-#   82|     23: [ExprStmt] ExprStmt
-#   82|       0: [AssignExpr] ... = ...
+#   82|     getStmt(23): [ExprStmt] ExprStmt
+#   82|       getExpr(): [AssignExpr] ... = ...
 #   82|           Type = [IntType] int
 #   82|           ValueCategory = lvalue
-#   82|         0: [VariableAccess] z
+#   82|         getLValue(): [VariableAccess] z
 #   82|             Type = [IntType] int
 #   82|             ValueCategory = lvalue
-#   82|         1: [UnaryMinusExpr] - ...
+#   82|         getRValue(): [UnaryMinusExpr] - ...
 #   82|             Type = [IntType] int
 #   82|             ValueCategory = prvalue
-#   82|           0: [VariableAccess] x
+#   82|           getOperand(): [VariableAccess] x
 #   82|               Type = [IntType] int
 #   82|               ValueCategory = prvalue(load)
-#   83|     24: [ExprStmt] ExprStmt
-#   83|       0: [AssignExpr] ... = ...
+#   83|     getStmt(24): [ExprStmt] ExprStmt
+#   83|       getExpr(): [AssignExpr] ... = ...
 #   83|           Type = [IntType] int
 #   83|           ValueCategory = lvalue
-#   83|         0: [VariableAccess] z
+#   83|         getLValue(): [VariableAccess] z
 #   83|             Type = [IntType] int
 #   83|             ValueCategory = lvalue
-#   83|         1: [ComplementExpr] ~ ...
+#   83|         getRValue(): [ComplementExpr] ~ ...
 #   83|             Type = [IntType] int
 #   83|             ValueCategory = prvalue
-#   83|           0: [VariableAccess] x
+#   83|           getOperand(): [VariableAccess] x
 #   83|               Type = [IntType] int
 #   83|               ValueCategory = prvalue(load)
-#   84|     25: [ExprStmt] ExprStmt
-#   84|       0: [AssignExpr] ... = ...
+#   84|     getStmt(25): [ExprStmt] ExprStmt
+#   84|       getExpr(): [AssignExpr] ... = ...
 #   84|           Type = [IntType] int
 #   84|           ValueCategory = lvalue
-#   84|         0: [VariableAccess] z
+#   84|         getLValue(): [VariableAccess] z
 #   84|             Type = [IntType] int
 #   84|             ValueCategory = lvalue
-#   84|         1: [NotExpr] ! ...
+#   84|         getRValue(): [NotExpr] ! ...
 #   84|             Type = [BoolType] bool
 #   84|             ValueCategory = prvalue
-#   84|           0: [VariableAccess] x
+#   84|           getOperand(): [VariableAccess] x
 #   84|               Type = [IntType] int
 #   84|               ValueCategory = prvalue(load)
-#   84|           0 converted: [CStyleCast] (bool)...
+#   84|           : [CStyleCast] (bool)...
 #   84|               Conversion = [BoolConversion] conversion to bool
 #   84|               Type = [BoolType] bool
 #   84|               ValueCategory = prvalue
-#   84|         1 converted: [CStyleCast] (int)...
+#   84|         : [CStyleCast] (int)...
 #   84|             Conversion = [IntegralConversion] integral conversion
 #   84|             Type = [IntType] int
 #   84|             ValueCategory = prvalue
-#   85|     26: [ReturnStmt] return ...
+#   85|     getStmt(26): [ReturnStmt] return ...
 #   87| [TopLevelFunction] void IntegerCompare(int, int)
-#   87|   params: 
-#   87|     0: [Parameter] x
+#   87|   ...: 
+#   87|     getParameter(0): [Parameter] x
 #   87|         Type = [IntType] int
-#   87|     1: [Parameter] y
+#   87|     getParameter(1): [Parameter] y
 #   87|         Type = [IntType] int
-#   87|   body: [BlockStmt] { ... }
-#   88|     0: [DeclStmt] declaration
-#   88|       0: [VariableDeclarationEntry] definition of b
+#   87|   getEntryPoint(): [BlockStmt] { ... }
+#   88|     getStmt(0): [DeclStmt] declaration
+#   88|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #   88|           Type = [BoolType] bool
-#   90|     1: [ExprStmt] ExprStmt
-#   90|       0: [AssignExpr] ... = ...
+#   90|     getStmt(1): [ExprStmt] ExprStmt
+#   90|       getExpr(): [AssignExpr] ... = ...
 #   90|           Type = [BoolType] bool
 #   90|           ValueCategory = lvalue
-#   90|         0: [VariableAccess] b
+#   90|         getLValue(): [VariableAccess] b
 #   90|             Type = [BoolType] bool
 #   90|             ValueCategory = lvalue
-#   90|         1: [EQExpr] ... == ...
+#   90|         getRValue(): [EQExpr] ... == ...
 #   90|             Type = [BoolType] bool
 #   90|             ValueCategory = prvalue
-#   90|           0: [VariableAccess] x
+#   90|           getLeftOperand(): [VariableAccess] x
 #   90|               Type = [IntType] int
 #   90|               ValueCategory = prvalue(load)
-#   90|           1: [VariableAccess] y
+#   90|           getRightOperand(): [VariableAccess] y
 #   90|               Type = [IntType] int
 #   90|               ValueCategory = prvalue(load)
-#   91|     2: [ExprStmt] ExprStmt
-#   91|       0: [AssignExpr] ... = ...
+#   91|     getStmt(2): [ExprStmt] ExprStmt
+#   91|       getExpr(): [AssignExpr] ... = ...
 #   91|           Type = [BoolType] bool
 #   91|           ValueCategory = lvalue
-#   91|         0: [VariableAccess] b
+#   91|         getLValue(): [VariableAccess] b
 #   91|             Type = [BoolType] bool
 #   91|             ValueCategory = lvalue
-#   91|         1: [NEExpr] ... != ...
+#   91|         getRValue(): [NEExpr] ... != ...
 #   91|             Type = [BoolType] bool
 #   91|             ValueCategory = prvalue
-#   91|           0: [VariableAccess] x
+#   91|           getLeftOperand(): [VariableAccess] x
 #   91|               Type = [IntType] int
 #   91|               ValueCategory = prvalue(load)
-#   91|           1: [VariableAccess] y
+#   91|           getRightOperand(): [VariableAccess] y
 #   91|               Type = [IntType] int
 #   91|               ValueCategory = prvalue(load)
-#   92|     3: [ExprStmt] ExprStmt
-#   92|       0: [AssignExpr] ... = ...
+#   92|     getStmt(3): [ExprStmt] ExprStmt
+#   92|       getExpr(): [AssignExpr] ... = ...
 #   92|           Type = [BoolType] bool
 #   92|           ValueCategory = lvalue
-#   92|         0: [VariableAccess] b
+#   92|         getLValue(): [VariableAccess] b
 #   92|             Type = [BoolType] bool
 #   92|             ValueCategory = lvalue
-#   92|         1: [LTExpr] ... < ...
+#   92|         getRValue(): [LTExpr] ... < ...
 #   92|             Type = [BoolType] bool
 #   92|             ValueCategory = prvalue
-#   92|           0: [VariableAccess] x
+#   92|           getLesserOperand(): [VariableAccess] x
 #   92|               Type = [IntType] int
 #   92|               ValueCategory = prvalue(load)
-#   92|           1: [VariableAccess] y
+#   92|           getGreaterOperand(): [VariableAccess] y
 #   92|               Type = [IntType] int
 #   92|               ValueCategory = prvalue(load)
-#   93|     4: [ExprStmt] ExprStmt
-#   93|       0: [AssignExpr] ... = ...
+#   93|     getStmt(4): [ExprStmt] ExprStmt
+#   93|       getExpr(): [AssignExpr] ... = ...
 #   93|           Type = [BoolType] bool
 #   93|           ValueCategory = lvalue
-#   93|         0: [VariableAccess] b
+#   93|         getLValue(): [VariableAccess] b
 #   93|             Type = [BoolType] bool
 #   93|             ValueCategory = lvalue
-#   93|         1: [GTExpr] ... > ...
+#   93|         getRValue(): [GTExpr] ... > ...
 #   93|             Type = [BoolType] bool
 #   93|             ValueCategory = prvalue
-#   93|           0: [VariableAccess] x
+#   93|           getGreaterOperand(): [VariableAccess] x
 #   93|               Type = [IntType] int
 #   93|               ValueCategory = prvalue(load)
-#   93|           1: [VariableAccess] y
+#   93|           getLesserOperand(): [VariableAccess] y
 #   93|               Type = [IntType] int
 #   93|               ValueCategory = prvalue(load)
-#   94|     5: [ExprStmt] ExprStmt
-#   94|       0: [AssignExpr] ... = ...
+#   94|     getStmt(5): [ExprStmt] ExprStmt
+#   94|       getExpr(): [AssignExpr] ... = ...
 #   94|           Type = [BoolType] bool
 #   94|           ValueCategory = lvalue
-#   94|         0: [VariableAccess] b
+#   94|         getLValue(): [VariableAccess] b
 #   94|             Type = [BoolType] bool
 #   94|             ValueCategory = lvalue
-#   94|         1: [LEExpr] ... <= ...
+#   94|         getRValue(): [LEExpr] ... <= ...
 #   94|             Type = [BoolType] bool
 #   94|             ValueCategory = prvalue
-#   94|           0: [VariableAccess] x
+#   94|           getLesserOperand(): [VariableAccess] x
 #   94|               Type = [IntType] int
 #   94|               ValueCategory = prvalue(load)
-#   94|           1: [VariableAccess] y
+#   94|           getGreaterOperand(): [VariableAccess] y
 #   94|               Type = [IntType] int
 #   94|               ValueCategory = prvalue(load)
-#   95|     6: [ExprStmt] ExprStmt
-#   95|       0: [AssignExpr] ... = ...
+#   95|     getStmt(6): [ExprStmt] ExprStmt
+#   95|       getExpr(): [AssignExpr] ... = ...
 #   95|           Type = [BoolType] bool
 #   95|           ValueCategory = lvalue
-#   95|         0: [VariableAccess] b
+#   95|         getLValue(): [VariableAccess] b
 #   95|             Type = [BoolType] bool
 #   95|             ValueCategory = lvalue
-#   95|         1: [GEExpr] ... >= ...
+#   95|         getRValue(): [GEExpr] ... >= ...
 #   95|             Type = [BoolType] bool
 #   95|             ValueCategory = prvalue
-#   95|           0: [VariableAccess] x
+#   95|           getGreaterOperand(): [VariableAccess] x
 #   95|               Type = [IntType] int
 #   95|               ValueCategory = prvalue(load)
-#   95|           1: [VariableAccess] y
+#   95|           getLesserOperand(): [VariableAccess] y
 #   95|               Type = [IntType] int
 #   95|               ValueCategory = prvalue(load)
-#   96|     7: [ReturnStmt] return ...
+#   96|     getStmt(7): [ReturnStmt] return ...
 #   98| [TopLevelFunction] void IntegerCrement(int)
-#   98|   params: 
-#   98|     0: [Parameter] x
+#   98|   ...: 
+#   98|     getParameter(0): [Parameter] x
 #   98|         Type = [IntType] int
-#   98|   body: [BlockStmt] { ... }
-#   99|     0: [DeclStmt] declaration
-#   99|       0: [VariableDeclarationEntry] definition of y
+#   98|   getEntryPoint(): [BlockStmt] { ... }
+#   99|     getStmt(0): [DeclStmt] declaration
+#   99|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #   99|           Type = [IntType] int
-#  101|     1: [ExprStmt] ExprStmt
-#  101|       0: [AssignExpr] ... = ...
+#  101|     getStmt(1): [ExprStmt] ExprStmt
+#  101|       getExpr(): [AssignExpr] ... = ...
 #  101|           Type = [IntType] int
 #  101|           ValueCategory = lvalue
-#  101|         0: [VariableAccess] y
+#  101|         getLValue(): [VariableAccess] y
 #  101|             Type = [IntType] int
 #  101|             ValueCategory = lvalue
-#  101|         1: [PrefixIncrExpr] ++ ...
+#  101|         getRValue(): [PrefixIncrExpr] ++ ...
 #  101|             Type = [IntType] int
 #  101|             ValueCategory = prvalue
-#  101|           0: [VariableAccess] x
+#  101|           getOperand(): [VariableAccess] x
 #  101|               Type = [IntType] int
 #  101|               ValueCategory = lvalue
-#  102|     2: [ExprStmt] ExprStmt
-#  102|       0: [AssignExpr] ... = ...
+#  102|     getStmt(2): [ExprStmt] ExprStmt
+#  102|       getExpr(): [AssignExpr] ... = ...
 #  102|           Type = [IntType] int
 #  102|           ValueCategory = lvalue
-#  102|         0: [VariableAccess] y
+#  102|         getLValue(): [VariableAccess] y
 #  102|             Type = [IntType] int
 #  102|             ValueCategory = lvalue
-#  102|         1: [PrefixDecrExpr] -- ...
+#  102|         getRValue(): [PrefixDecrExpr] -- ...
 #  102|             Type = [IntType] int
 #  102|             ValueCategory = prvalue
-#  102|           0: [VariableAccess] x
+#  102|           getOperand(): [VariableAccess] x
 #  102|               Type = [IntType] int
 #  102|               ValueCategory = lvalue
-#  103|     3: [ExprStmt] ExprStmt
-#  103|       0: [AssignExpr] ... = ...
+#  103|     getStmt(3): [ExprStmt] ExprStmt
+#  103|       getExpr(): [AssignExpr] ... = ...
 #  103|           Type = [IntType] int
 #  103|           ValueCategory = lvalue
-#  103|         0: [VariableAccess] y
+#  103|         getLValue(): [VariableAccess] y
 #  103|             Type = [IntType] int
 #  103|             ValueCategory = lvalue
-#  103|         1: [PostfixIncrExpr] ... ++
+#  103|         getRValue(): [PostfixIncrExpr] ... ++
 #  103|             Type = [IntType] int
 #  103|             ValueCategory = prvalue
-#  103|           0: [VariableAccess] x
+#  103|           getOperand(): [VariableAccess] x
 #  103|               Type = [IntType] int
 #  103|               ValueCategory = lvalue
-#  104|     4: [ExprStmt] ExprStmt
-#  104|       0: [AssignExpr] ... = ...
+#  104|     getStmt(4): [ExprStmt] ExprStmt
+#  104|       getExpr(): [AssignExpr] ... = ...
 #  104|           Type = [IntType] int
 #  104|           ValueCategory = lvalue
-#  104|         0: [VariableAccess] y
+#  104|         getLValue(): [VariableAccess] y
 #  104|             Type = [IntType] int
 #  104|             ValueCategory = lvalue
-#  104|         1: [PostfixDecrExpr] ... --
+#  104|         getRValue(): [PostfixDecrExpr] ... --
 #  104|             Type = [IntType] int
 #  104|             ValueCategory = prvalue
-#  104|           0: [VariableAccess] x
+#  104|           getOperand(): [VariableAccess] x
 #  104|               Type = [IntType] int
 #  104|               ValueCategory = lvalue
-#  105|     5: [ReturnStmt] return ...
+#  105|     getStmt(5): [ReturnStmt] return ...
 #  107| [TopLevelFunction] void IntegerCrement_LValue(int)
-#  107|   params: 
-#  107|     0: [Parameter] x
+#  107|   ...: 
+#  107|     getParameter(0): [Parameter] x
 #  107|         Type = [IntType] int
-#  107|   body: [BlockStmt] { ... }
-#  108|     0: [DeclStmt] declaration
-#  108|       0: [VariableDeclarationEntry] definition of p
+#  107|   getEntryPoint(): [BlockStmt] { ... }
+#  108|     getStmt(0): [DeclStmt] declaration
+#  108|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
 #  108|           Type = [IntPointerType] int *
-#  110|     1: [ExprStmt] ExprStmt
-#  110|       0: [AssignExpr] ... = ...
+#  110|     getStmt(1): [ExprStmt] ExprStmt
+#  110|       getExpr(): [AssignExpr] ... = ...
 #  110|           Type = [IntPointerType] int *
 #  110|           ValueCategory = lvalue
-#  110|         0: [VariableAccess] p
+#  110|         getLValue(): [VariableAccess] p
 #  110|             Type = [IntPointerType] int *
 #  110|             ValueCategory = lvalue
-#  110|         1: [AddressOfExpr] & ...
+#  110|         getRValue(): [AddressOfExpr] & ...
 #  110|             Type = [IntPointerType] int *
 #  110|             ValueCategory = prvalue
-#  110|           0: [PrefixIncrExpr] ++ ...
+#  110|           getOperand(): [PrefixIncrExpr] ++ ...
 #  110|               Type = [IntType] int
 #  110|               ValueCategory = lvalue
-#  110|             0: [VariableAccess] x
+#  110|             getOperand(): [VariableAccess] x
 #  110|                 Type = [IntType] int
 #  110|                 ValueCategory = lvalue
-#  110|           0 converted: [ParenthesisExpr] (...)
+#  110|           : [ParenthesisExpr] (...)
 #  110|               Type = [IntType] int
 #  110|               ValueCategory = lvalue
-#  111|     2: [ExprStmt] ExprStmt
-#  111|       0: [AssignExpr] ... = ...
+#  111|     getStmt(2): [ExprStmt] ExprStmt
+#  111|       getExpr(): [AssignExpr] ... = ...
 #  111|           Type = [IntPointerType] int *
 #  111|           ValueCategory = lvalue
-#  111|         0: [VariableAccess] p
+#  111|         getLValue(): [VariableAccess] p
 #  111|             Type = [IntPointerType] int *
 #  111|             ValueCategory = lvalue
-#  111|         1: [AddressOfExpr] & ...
+#  111|         getRValue(): [AddressOfExpr] & ...
 #  111|             Type = [IntPointerType] int *
 #  111|             ValueCategory = prvalue
-#  111|           0: [PrefixDecrExpr] -- ...
+#  111|           getOperand(): [PrefixDecrExpr] -- ...
 #  111|               Type = [IntType] int
 #  111|               ValueCategory = lvalue
-#  111|             0: [VariableAccess] x
+#  111|             getOperand(): [VariableAccess] x
 #  111|                 Type = [IntType] int
 #  111|                 ValueCategory = lvalue
-#  111|           0 converted: [ParenthesisExpr] (...)
+#  111|           : [ParenthesisExpr] (...)
 #  111|               Type = [IntType] int
 #  111|               ValueCategory = lvalue
-#  112|     3: [ReturnStmt] return ...
+#  112|     getStmt(3): [ReturnStmt] return ...
 #  114| [TopLevelFunction] void FloatOps(double, double)
-#  114|   params: 
-#  114|     0: [Parameter] x
+#  114|   ...: 
+#  114|     getParameter(0): [Parameter] x
 #  114|         Type = [DoubleType] double
-#  114|     1: [Parameter] y
+#  114|     getParameter(1): [Parameter] y
 #  114|         Type = [DoubleType] double
-#  114|   body: [BlockStmt] { ... }
-#  115|     0: [DeclStmt] declaration
-#  115|       0: [VariableDeclarationEntry] definition of z
+#  114|   getEntryPoint(): [BlockStmt] { ... }
+#  115|     getStmt(0): [DeclStmt] declaration
+#  115|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 #  115|           Type = [DoubleType] double
-#  117|     1: [ExprStmt] ExprStmt
-#  117|       0: [AssignExpr] ... = ...
+#  117|     getStmt(1): [ExprStmt] ExprStmt
+#  117|       getExpr(): [AssignExpr] ... = ...
 #  117|           Type = [DoubleType] double
 #  117|           ValueCategory = lvalue
-#  117|         0: [VariableAccess] z
+#  117|         getLValue(): [VariableAccess] z
 #  117|             Type = [DoubleType] double
 #  117|             ValueCategory = lvalue
-#  117|         1: [AddExpr] ... + ...
+#  117|         getRValue(): [AddExpr] ... + ...
 #  117|             Type = [DoubleType] double
 #  117|             ValueCategory = prvalue
-#  117|           0: [VariableAccess] x
+#  117|           getLeftOperand(): [VariableAccess] x
 #  117|               Type = [DoubleType] double
 #  117|               ValueCategory = prvalue(load)
-#  117|           1: [VariableAccess] y
+#  117|           getRightOperand(): [VariableAccess] y
 #  117|               Type = [DoubleType] double
 #  117|               ValueCategory = prvalue(load)
-#  118|     2: [ExprStmt] ExprStmt
-#  118|       0: [AssignExpr] ... = ...
+#  118|     getStmt(2): [ExprStmt] ExprStmt
+#  118|       getExpr(): [AssignExpr] ... = ...
 #  118|           Type = [DoubleType] double
 #  118|           ValueCategory = lvalue
-#  118|         0: [VariableAccess] z
+#  118|         getLValue(): [VariableAccess] z
 #  118|             Type = [DoubleType] double
 #  118|             ValueCategory = lvalue
-#  118|         1: [SubExpr] ... - ...
+#  118|         getRValue(): [SubExpr] ... - ...
 #  118|             Type = [DoubleType] double
 #  118|             ValueCategory = prvalue
-#  118|           0: [VariableAccess] x
+#  118|           getLeftOperand(): [VariableAccess] x
 #  118|               Type = [DoubleType] double
 #  118|               ValueCategory = prvalue(load)
-#  118|           1: [VariableAccess] y
+#  118|           getRightOperand(): [VariableAccess] y
 #  118|               Type = [DoubleType] double
 #  118|               ValueCategory = prvalue(load)
-#  119|     3: [ExprStmt] ExprStmt
-#  119|       0: [AssignExpr] ... = ...
+#  119|     getStmt(3): [ExprStmt] ExprStmt
+#  119|       getExpr(): [AssignExpr] ... = ...
 #  119|           Type = [DoubleType] double
 #  119|           ValueCategory = lvalue
-#  119|         0: [VariableAccess] z
+#  119|         getLValue(): [VariableAccess] z
 #  119|             Type = [DoubleType] double
 #  119|             ValueCategory = lvalue
-#  119|         1: [MulExpr] ... * ...
+#  119|         getRValue(): [MulExpr] ... * ...
 #  119|             Type = [DoubleType] double
 #  119|             ValueCategory = prvalue
-#  119|           0: [VariableAccess] x
+#  119|           getLeftOperand(): [VariableAccess] x
 #  119|               Type = [DoubleType] double
 #  119|               ValueCategory = prvalue(load)
-#  119|           1: [VariableAccess] y
+#  119|           getRightOperand(): [VariableAccess] y
 #  119|               Type = [DoubleType] double
 #  119|               ValueCategory = prvalue(load)
-#  120|     4: [ExprStmt] ExprStmt
-#  120|       0: [AssignExpr] ... = ...
+#  120|     getStmt(4): [ExprStmt] ExprStmt
+#  120|       getExpr(): [AssignExpr] ... = ...
 #  120|           Type = [DoubleType] double
 #  120|           ValueCategory = lvalue
-#  120|         0: [VariableAccess] z
+#  120|         getLValue(): [VariableAccess] z
 #  120|             Type = [DoubleType] double
 #  120|             ValueCategory = lvalue
-#  120|         1: [DivExpr] ... / ...
+#  120|         getRValue(): [DivExpr] ... / ...
 #  120|             Type = [DoubleType] double
 #  120|             ValueCategory = prvalue
-#  120|           0: [VariableAccess] x
+#  120|           getLeftOperand(): [VariableAccess] x
 #  120|               Type = [DoubleType] double
 #  120|               ValueCategory = prvalue(load)
-#  120|           1: [VariableAccess] y
+#  120|           getRightOperand(): [VariableAccess] y
 #  120|               Type = [DoubleType] double
 #  120|               ValueCategory = prvalue(load)
-#  122|     5: [ExprStmt] ExprStmt
-#  122|       0: [AssignExpr] ... = ...
+#  122|     getStmt(5): [ExprStmt] ExprStmt
+#  122|       getExpr(): [AssignExpr] ... = ...
 #  122|           Type = [DoubleType] double
 #  122|           ValueCategory = lvalue
-#  122|         0: [VariableAccess] z
+#  122|         getLValue(): [VariableAccess] z
 #  122|             Type = [DoubleType] double
 #  122|             ValueCategory = lvalue
-#  122|         1: [VariableAccess] x
+#  122|         getRValue(): [VariableAccess] x
 #  122|             Type = [DoubleType] double
 #  122|             ValueCategory = prvalue(load)
-#  124|     6: [ExprStmt] ExprStmt
-#  124|       0: [AssignAddExpr] ... += ...
+#  124|     getStmt(6): [ExprStmt] ExprStmt
+#  124|       getExpr(): [AssignAddExpr] ... += ...
 #  124|           Type = [DoubleType] double
 #  124|           ValueCategory = lvalue
-#  124|         0: [VariableAccess] z
+#  124|         getLValue(): [VariableAccess] z
 #  124|             Type = [DoubleType] double
 #  124|             ValueCategory = lvalue
-#  124|         1: [VariableAccess] x
+#  124|         getRValue(): [VariableAccess] x
 #  124|             Type = [DoubleType] double
 #  124|             ValueCategory = prvalue(load)
-#  125|     7: [ExprStmt] ExprStmt
-#  125|       0: [AssignSubExpr] ... -= ...
+#  125|     getStmt(7): [ExprStmt] ExprStmt
+#  125|       getExpr(): [AssignSubExpr] ... -= ...
 #  125|           Type = [DoubleType] double
 #  125|           ValueCategory = lvalue
-#  125|         0: [VariableAccess] z
+#  125|         getLValue(): [VariableAccess] z
 #  125|             Type = [DoubleType] double
 #  125|             ValueCategory = lvalue
-#  125|         1: [VariableAccess] x
+#  125|         getRValue(): [VariableAccess] x
 #  125|             Type = [DoubleType] double
 #  125|             ValueCategory = prvalue(load)
-#  126|     8: [ExprStmt] ExprStmt
-#  126|       0: [AssignMulExpr] ... *= ...
+#  126|     getStmt(8): [ExprStmt] ExprStmt
+#  126|       getExpr(): [AssignMulExpr] ... *= ...
 #  126|           Type = [DoubleType] double
 #  126|           ValueCategory = lvalue
-#  126|         0: [VariableAccess] z
+#  126|         getLValue(): [VariableAccess] z
 #  126|             Type = [DoubleType] double
 #  126|             ValueCategory = lvalue
-#  126|         1: [VariableAccess] x
+#  126|         getRValue(): [VariableAccess] x
 #  126|             Type = [DoubleType] double
 #  126|             ValueCategory = prvalue(load)
-#  127|     9: [ExprStmt] ExprStmt
-#  127|       0: [AssignDivExpr] ... /= ...
+#  127|     getStmt(9): [ExprStmt] ExprStmt
+#  127|       getExpr(): [AssignDivExpr] ... /= ...
 #  127|           Type = [DoubleType] double
 #  127|           ValueCategory = lvalue
-#  127|         0: [VariableAccess] z
+#  127|         getLValue(): [VariableAccess] z
 #  127|             Type = [DoubleType] double
 #  127|             ValueCategory = lvalue
-#  127|         1: [VariableAccess] x
+#  127|         getRValue(): [VariableAccess] x
 #  127|             Type = [DoubleType] double
 #  127|             ValueCategory = prvalue(load)
-#  129|     10: [ExprStmt] ExprStmt
-#  129|       0: [AssignExpr] ... = ...
+#  129|     getStmt(10): [ExprStmt] ExprStmt
+#  129|       getExpr(): [AssignExpr] ... = ...
 #  129|           Type = [DoubleType] double
 #  129|           ValueCategory = lvalue
-#  129|         0: [VariableAccess] z
+#  129|         getLValue(): [VariableAccess] z
 #  129|             Type = [DoubleType] double
 #  129|             ValueCategory = lvalue
-#  129|         1: [UnaryPlusExpr] + ...
+#  129|         getRValue(): [UnaryPlusExpr] + ...
 #  129|             Type = [DoubleType] double
 #  129|             ValueCategory = prvalue
-#  129|           0: [VariableAccess] x
+#  129|           getOperand(): [VariableAccess] x
 #  129|               Type = [DoubleType] double
 #  129|               ValueCategory = prvalue(load)
-#  130|     11: [ExprStmt] ExprStmt
-#  130|       0: [AssignExpr] ... = ...
+#  130|     getStmt(11): [ExprStmt] ExprStmt
+#  130|       getExpr(): [AssignExpr] ... = ...
 #  130|           Type = [DoubleType] double
 #  130|           ValueCategory = lvalue
-#  130|         0: [VariableAccess] z
+#  130|         getLValue(): [VariableAccess] z
 #  130|             Type = [DoubleType] double
 #  130|             ValueCategory = lvalue
-#  130|         1: [UnaryMinusExpr] - ...
+#  130|         getRValue(): [UnaryMinusExpr] - ...
 #  130|             Type = [DoubleType] double
 #  130|             ValueCategory = prvalue
-#  130|           0: [VariableAccess] x
+#  130|           getOperand(): [VariableAccess] x
 #  130|               Type = [DoubleType] double
 #  130|               ValueCategory = prvalue(load)
-#  131|     12: [ReturnStmt] return ...
+#  131|     getStmt(12): [ReturnStmt] return ...
 #  133| [TopLevelFunction] void FloatCompare(double, double)
-#  133|   params: 
-#  133|     0: [Parameter] x
+#  133|   ...: 
+#  133|     getParameter(0): [Parameter] x
 #  133|         Type = [DoubleType] double
-#  133|     1: [Parameter] y
+#  133|     getParameter(1): [Parameter] y
 #  133|         Type = [DoubleType] double
-#  133|   body: [BlockStmt] { ... }
-#  134|     0: [DeclStmt] declaration
-#  134|       0: [VariableDeclarationEntry] definition of b
+#  133|   getEntryPoint(): [BlockStmt] { ... }
+#  134|     getStmt(0): [DeclStmt] declaration
+#  134|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  134|           Type = [BoolType] bool
-#  136|     1: [ExprStmt] ExprStmt
-#  136|       0: [AssignExpr] ... = ...
+#  136|     getStmt(1): [ExprStmt] ExprStmt
+#  136|       getExpr(): [AssignExpr] ... = ...
 #  136|           Type = [BoolType] bool
 #  136|           ValueCategory = lvalue
-#  136|         0: [VariableAccess] b
+#  136|         getLValue(): [VariableAccess] b
 #  136|             Type = [BoolType] bool
 #  136|             ValueCategory = lvalue
-#  136|         1: [EQExpr] ... == ...
+#  136|         getRValue(): [EQExpr] ... == ...
 #  136|             Type = [BoolType] bool
 #  136|             ValueCategory = prvalue
-#  136|           0: [VariableAccess] x
+#  136|           getLeftOperand(): [VariableAccess] x
 #  136|               Type = [DoubleType] double
 #  136|               ValueCategory = prvalue(load)
-#  136|           1: [VariableAccess] y
+#  136|           getRightOperand(): [VariableAccess] y
 #  136|               Type = [DoubleType] double
 #  136|               ValueCategory = prvalue(load)
-#  137|     2: [ExprStmt] ExprStmt
-#  137|       0: [AssignExpr] ... = ...
+#  137|     getStmt(2): [ExprStmt] ExprStmt
+#  137|       getExpr(): [AssignExpr] ... = ...
 #  137|           Type = [BoolType] bool
 #  137|           ValueCategory = lvalue
-#  137|         0: [VariableAccess] b
+#  137|         getLValue(): [VariableAccess] b
 #  137|             Type = [BoolType] bool
 #  137|             ValueCategory = lvalue
-#  137|         1: [NEExpr] ... != ...
+#  137|         getRValue(): [NEExpr] ... != ...
 #  137|             Type = [BoolType] bool
 #  137|             ValueCategory = prvalue
-#  137|           0: [VariableAccess] x
+#  137|           getLeftOperand(): [VariableAccess] x
 #  137|               Type = [DoubleType] double
 #  137|               ValueCategory = prvalue(load)
-#  137|           1: [VariableAccess] y
+#  137|           getRightOperand(): [VariableAccess] y
 #  137|               Type = [DoubleType] double
 #  137|               ValueCategory = prvalue(load)
-#  138|     3: [ExprStmt] ExprStmt
-#  138|       0: [AssignExpr] ... = ...
+#  138|     getStmt(3): [ExprStmt] ExprStmt
+#  138|       getExpr(): [AssignExpr] ... = ...
 #  138|           Type = [BoolType] bool
 #  138|           ValueCategory = lvalue
-#  138|         0: [VariableAccess] b
+#  138|         getLValue(): [VariableAccess] b
 #  138|             Type = [BoolType] bool
 #  138|             ValueCategory = lvalue
-#  138|         1: [LTExpr] ... < ...
+#  138|         getRValue(): [LTExpr] ... < ...
 #  138|             Type = [BoolType] bool
 #  138|             ValueCategory = prvalue
-#  138|           0: [VariableAccess] x
+#  138|           getLesserOperand(): [VariableAccess] x
 #  138|               Type = [DoubleType] double
 #  138|               ValueCategory = prvalue(load)
-#  138|           1: [VariableAccess] y
+#  138|           getGreaterOperand(): [VariableAccess] y
 #  138|               Type = [DoubleType] double
 #  138|               ValueCategory = prvalue(load)
-#  139|     4: [ExprStmt] ExprStmt
-#  139|       0: [AssignExpr] ... = ...
+#  139|     getStmt(4): [ExprStmt] ExprStmt
+#  139|       getExpr(): [AssignExpr] ... = ...
 #  139|           Type = [BoolType] bool
 #  139|           ValueCategory = lvalue
-#  139|         0: [VariableAccess] b
+#  139|         getLValue(): [VariableAccess] b
 #  139|             Type = [BoolType] bool
 #  139|             ValueCategory = lvalue
-#  139|         1: [GTExpr] ... > ...
+#  139|         getRValue(): [GTExpr] ... > ...
 #  139|             Type = [BoolType] bool
 #  139|             ValueCategory = prvalue
-#  139|           0: [VariableAccess] x
+#  139|           getGreaterOperand(): [VariableAccess] x
 #  139|               Type = [DoubleType] double
 #  139|               ValueCategory = prvalue(load)
-#  139|           1: [VariableAccess] y
+#  139|           getLesserOperand(): [VariableAccess] y
 #  139|               Type = [DoubleType] double
 #  139|               ValueCategory = prvalue(load)
-#  140|     5: [ExprStmt] ExprStmt
-#  140|       0: [AssignExpr] ... = ...
+#  140|     getStmt(5): [ExprStmt] ExprStmt
+#  140|       getExpr(): [AssignExpr] ... = ...
 #  140|           Type = [BoolType] bool
 #  140|           ValueCategory = lvalue
-#  140|         0: [VariableAccess] b
+#  140|         getLValue(): [VariableAccess] b
 #  140|             Type = [BoolType] bool
 #  140|             ValueCategory = lvalue
-#  140|         1: [LEExpr] ... <= ...
+#  140|         getRValue(): [LEExpr] ... <= ...
 #  140|             Type = [BoolType] bool
 #  140|             ValueCategory = prvalue
-#  140|           0: [VariableAccess] x
+#  140|           getLesserOperand(): [VariableAccess] x
 #  140|               Type = [DoubleType] double
 #  140|               ValueCategory = prvalue(load)
-#  140|           1: [VariableAccess] y
+#  140|           getGreaterOperand(): [VariableAccess] y
 #  140|               Type = [DoubleType] double
 #  140|               ValueCategory = prvalue(load)
-#  141|     6: [ExprStmt] ExprStmt
-#  141|       0: [AssignExpr] ... = ...
+#  141|     getStmt(6): [ExprStmt] ExprStmt
+#  141|       getExpr(): [AssignExpr] ... = ...
 #  141|           Type = [BoolType] bool
 #  141|           ValueCategory = lvalue
-#  141|         0: [VariableAccess] b
+#  141|         getLValue(): [VariableAccess] b
 #  141|             Type = [BoolType] bool
 #  141|             ValueCategory = lvalue
-#  141|         1: [GEExpr] ... >= ...
+#  141|         getRValue(): [GEExpr] ... >= ...
 #  141|             Type = [BoolType] bool
 #  141|             ValueCategory = prvalue
-#  141|           0: [VariableAccess] x
+#  141|           getGreaterOperand(): [VariableAccess] x
 #  141|               Type = [DoubleType] double
 #  141|               ValueCategory = prvalue(load)
-#  141|           1: [VariableAccess] y
+#  141|           getLesserOperand(): [VariableAccess] y
 #  141|               Type = [DoubleType] double
 #  141|               ValueCategory = prvalue(load)
-#  142|     7: [ReturnStmt] return ...
+#  142|     getStmt(7): [ReturnStmt] return ...
 #  144| [TopLevelFunction] void FloatCrement(float)
-#  144|   params: 
-#  144|     0: [Parameter] x
+#  144|   ...: 
+#  144|     getParameter(0): [Parameter] x
 #  144|         Type = [FloatType] float
-#  144|   body: [BlockStmt] { ... }
-#  145|     0: [DeclStmt] declaration
-#  145|       0: [VariableDeclarationEntry] definition of y
+#  144|   getEntryPoint(): [BlockStmt] { ... }
+#  145|     getStmt(0): [DeclStmt] declaration
+#  145|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #  145|           Type = [FloatType] float
-#  147|     1: [ExprStmt] ExprStmt
-#  147|       0: [AssignExpr] ... = ...
+#  147|     getStmt(1): [ExprStmt] ExprStmt
+#  147|       getExpr(): [AssignExpr] ... = ...
 #  147|           Type = [FloatType] float
 #  147|           ValueCategory = lvalue
-#  147|         0: [VariableAccess] y
+#  147|         getLValue(): [VariableAccess] y
 #  147|             Type = [FloatType] float
 #  147|             ValueCategory = lvalue
-#  147|         1: [PrefixIncrExpr] ++ ...
+#  147|         getRValue(): [PrefixIncrExpr] ++ ...
 #  147|             Type = [FloatType] float
 #  147|             ValueCategory = prvalue
-#  147|           0: [VariableAccess] x
+#  147|           getOperand(): [VariableAccess] x
 #  147|               Type = [FloatType] float
 #  147|               ValueCategory = lvalue
-#  148|     2: [ExprStmt] ExprStmt
-#  148|       0: [AssignExpr] ... = ...
+#  148|     getStmt(2): [ExprStmt] ExprStmt
+#  148|       getExpr(): [AssignExpr] ... = ...
 #  148|           Type = [FloatType] float
 #  148|           ValueCategory = lvalue
-#  148|         0: [VariableAccess] y
+#  148|         getLValue(): [VariableAccess] y
 #  148|             Type = [FloatType] float
 #  148|             ValueCategory = lvalue
-#  148|         1: [PrefixDecrExpr] -- ...
+#  148|         getRValue(): [PrefixDecrExpr] -- ...
 #  148|             Type = [FloatType] float
 #  148|             ValueCategory = prvalue
-#  148|           0: [VariableAccess] x
+#  148|           getOperand(): [VariableAccess] x
 #  148|               Type = [FloatType] float
 #  148|               ValueCategory = lvalue
-#  149|     3: [ExprStmt] ExprStmt
-#  149|       0: [AssignExpr] ... = ...
+#  149|     getStmt(3): [ExprStmt] ExprStmt
+#  149|       getExpr(): [AssignExpr] ... = ...
 #  149|           Type = [FloatType] float
 #  149|           ValueCategory = lvalue
-#  149|         0: [VariableAccess] y
+#  149|         getLValue(): [VariableAccess] y
 #  149|             Type = [FloatType] float
 #  149|             ValueCategory = lvalue
-#  149|         1: [PostfixIncrExpr] ... ++
+#  149|         getRValue(): [PostfixIncrExpr] ... ++
 #  149|             Type = [FloatType] float
 #  149|             ValueCategory = prvalue
-#  149|           0: [VariableAccess] x
+#  149|           getOperand(): [VariableAccess] x
 #  149|               Type = [FloatType] float
 #  149|               ValueCategory = lvalue
-#  150|     4: [ExprStmt] ExprStmt
-#  150|       0: [AssignExpr] ... = ...
+#  150|     getStmt(4): [ExprStmt] ExprStmt
+#  150|       getExpr(): [AssignExpr] ... = ...
 #  150|           Type = [FloatType] float
 #  150|           ValueCategory = lvalue
-#  150|         0: [VariableAccess] y
+#  150|         getLValue(): [VariableAccess] y
 #  150|             Type = [FloatType] float
 #  150|             ValueCategory = lvalue
-#  150|         1: [PostfixDecrExpr] ... --
+#  150|         getRValue(): [PostfixDecrExpr] ... --
 #  150|             Type = [FloatType] float
 #  150|             ValueCategory = prvalue
-#  150|           0: [VariableAccess] x
+#  150|           getOperand(): [VariableAccess] x
 #  150|               Type = [FloatType] float
 #  150|               ValueCategory = lvalue
-#  151|     5: [ReturnStmt] return ...
+#  151|     getStmt(5): [ReturnStmt] return ...
 #  153| [TopLevelFunction] void PointerOps(int*, int)
-#  153|   params: 
-#  153|     0: [Parameter] p
+#  153|   ...: 
+#  153|     getParameter(0): [Parameter] p
 #  153|         Type = [IntPointerType] int *
-#  153|     1: [Parameter] i
+#  153|     getParameter(1): [Parameter] i
 #  153|         Type = [IntType] int
-#  153|   body: [BlockStmt] { ... }
-#  154|     0: [DeclStmt] declaration
-#  154|       0: [VariableDeclarationEntry] definition of q
+#  153|   getEntryPoint(): [BlockStmt] { ... }
+#  154|     getStmt(0): [DeclStmt] declaration
+#  154|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of q
 #  154|           Type = [IntPointerType] int *
-#  155|     1: [DeclStmt] declaration
-#  155|       0: [VariableDeclarationEntry] definition of b
+#  155|     getStmt(1): [DeclStmt] declaration
+#  155|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  155|           Type = [BoolType] bool
-#  157|     2: [ExprStmt] ExprStmt
-#  157|       0: [AssignExpr] ... = ...
+#  157|     getStmt(2): [ExprStmt] ExprStmt
+#  157|       getExpr(): [AssignExpr] ... = ...
 #  157|           Type = [IntPointerType] int *
 #  157|           ValueCategory = lvalue
-#  157|         0: [VariableAccess] q
+#  157|         getLValue(): [VariableAccess] q
 #  157|             Type = [IntPointerType] int *
 #  157|             ValueCategory = lvalue
-#  157|         1: [PointerAddExpr] ... + ...
+#  157|         getRValue(): [PointerAddExpr] ... + ...
 #  157|             Type = [IntPointerType] int *
 #  157|             ValueCategory = prvalue
-#  157|           0: [VariableAccess] p
+#  157|           getLeftOperand(): [VariableAccess] p
 #  157|               Type = [IntPointerType] int *
 #  157|               ValueCategory = prvalue(load)
-#  157|           1: [VariableAccess] i
+#  157|           getRightOperand(): [VariableAccess] i
 #  157|               Type = [IntType] int
 #  157|               ValueCategory = prvalue(load)
-#  158|     3: [ExprStmt] ExprStmt
-#  158|       0: [AssignExpr] ... = ...
+#  158|     getStmt(3): [ExprStmt] ExprStmt
+#  158|       getExpr(): [AssignExpr] ... = ...
 #  158|           Type = [IntPointerType] int *
 #  158|           ValueCategory = lvalue
-#  158|         0: [VariableAccess] q
+#  158|         getLValue(): [VariableAccess] q
 #  158|             Type = [IntPointerType] int *
 #  158|             ValueCategory = lvalue
-#  158|         1: [PointerAddExpr] ... + ...
+#  158|         getRValue(): [PointerAddExpr] ... + ...
 #  158|             Type = [IntPointerType] int *
 #  158|             ValueCategory = prvalue
-#  158|           0: [VariableAccess] i
+#  158|           getLeftOperand(): [VariableAccess] i
 #  158|               Type = [IntType] int
 #  158|               ValueCategory = prvalue(load)
-#  158|           1: [VariableAccess] p
+#  158|           getRightOperand(): [VariableAccess] p
 #  158|               Type = [IntPointerType] int *
 #  158|               ValueCategory = prvalue(load)
-#  159|     4: [ExprStmt] ExprStmt
-#  159|       0: [AssignExpr] ... = ...
+#  159|     getStmt(4): [ExprStmt] ExprStmt
+#  159|       getExpr(): [AssignExpr] ... = ...
 #  159|           Type = [IntPointerType] int *
 #  159|           ValueCategory = lvalue
-#  159|         0: [VariableAccess] q
+#  159|         getLValue(): [VariableAccess] q
 #  159|             Type = [IntPointerType] int *
 #  159|             ValueCategory = lvalue
-#  159|         1: [PointerSubExpr] ... - ...
+#  159|         getRValue(): [PointerSubExpr] ... - ...
 #  159|             Type = [IntPointerType] int *
 #  159|             ValueCategory = prvalue
-#  159|           0: [VariableAccess] p
+#  159|           getLeftOperand(): [VariableAccess] p
 #  159|               Type = [IntPointerType] int *
 #  159|               ValueCategory = prvalue(load)
-#  159|           1: [VariableAccess] i
+#  159|           getRightOperand(): [VariableAccess] i
 #  159|               Type = [IntType] int
 #  159|               ValueCategory = prvalue(load)
-#  160|     5: [ExprStmt] ExprStmt
-#  160|       0: [AssignExpr] ... = ...
+#  160|     getStmt(5): [ExprStmt] ExprStmt
+#  160|       getExpr(): [AssignExpr] ... = ...
 #  160|           Type = [IntType] int
 #  160|           ValueCategory = lvalue
-#  160|         0: [VariableAccess] i
+#  160|         getLValue(): [VariableAccess] i
 #  160|             Type = [IntType] int
 #  160|             ValueCategory = lvalue
-#  160|         1: [PointerDiffExpr] ... - ...
+#  160|         getRValue(): [PointerDiffExpr] ... - ...
 #  160|             Type = [LongType] long
 #  160|             ValueCategory = prvalue
-#  160|           0: [VariableAccess] p
+#  160|           getLeftOperand(): [VariableAccess] p
 #  160|               Type = [IntPointerType] int *
 #  160|               ValueCategory = prvalue(load)
-#  160|           1: [VariableAccess] q
+#  160|           getRightOperand(): [VariableAccess] q
 #  160|               Type = [IntPointerType] int *
 #  160|               ValueCategory = prvalue(load)
-#  160|         1 converted: [CStyleCast] (int)...
+#  160|         : [CStyleCast] (int)...
 #  160|             Conversion = [IntegralConversion] integral conversion
 #  160|             Type = [IntType] int
 #  160|             ValueCategory = prvalue
-#  162|     6: [ExprStmt] ExprStmt
-#  162|       0: [AssignExpr] ... = ...
+#  162|     getStmt(6): [ExprStmt] ExprStmt
+#  162|       getExpr(): [AssignExpr] ... = ...
 #  162|           Type = [IntPointerType] int *
 #  162|           ValueCategory = lvalue
-#  162|         0: [VariableAccess] q
+#  162|         getLValue(): [VariableAccess] q
 #  162|             Type = [IntPointerType] int *
 #  162|             ValueCategory = lvalue
-#  162|         1: [VariableAccess] p
+#  162|         getRValue(): [VariableAccess] p
 #  162|             Type = [IntPointerType] int *
 #  162|             ValueCategory = prvalue(load)
-#  164|     7: [ExprStmt] ExprStmt
-#  164|       0: [AssignPointerAddExpr] ... += ...
+#  164|     getStmt(7): [ExprStmt] ExprStmt
+#  164|       getExpr(): [AssignPointerAddExpr] ... += ...
 #  164|           Type = [IntPointerType] int *
 #  164|           ValueCategory = lvalue
-#  164|         0: [VariableAccess] q
+#  164|         getLValue(): [VariableAccess] q
 #  164|             Type = [IntPointerType] int *
 #  164|             ValueCategory = lvalue
-#  164|         1: [VariableAccess] i
+#  164|         getRValue(): [VariableAccess] i
 #  164|             Type = [IntType] int
 #  164|             ValueCategory = prvalue(load)
-#  165|     8: [ExprStmt] ExprStmt
-#  165|       0: [AssignPointerSubExpr] ... -= ...
+#  165|     getStmt(8): [ExprStmt] ExprStmt
+#  165|       getExpr(): [AssignPointerSubExpr] ... -= ...
 #  165|           Type = [IntPointerType] int *
 #  165|           ValueCategory = lvalue
-#  165|         0: [VariableAccess] q
+#  165|         getLValue(): [VariableAccess] q
 #  165|             Type = [IntPointerType] int *
 #  165|             ValueCategory = lvalue
-#  165|         1: [VariableAccess] i
+#  165|         getRValue(): [VariableAccess] i
 #  165|             Type = [IntType] int
 #  165|             ValueCategory = prvalue(load)
-#  167|     9: [ExprStmt] ExprStmt
-#  167|       0: [AssignExpr] ... = ...
+#  167|     getStmt(9): [ExprStmt] ExprStmt
+#  167|       getExpr(): [AssignExpr] ... = ...
 #  167|           Type = [BoolType] bool
 #  167|           ValueCategory = lvalue
-#  167|         0: [VariableAccess] b
+#  167|         getLValue(): [VariableAccess] b
 #  167|             Type = [BoolType] bool
 #  167|             ValueCategory = lvalue
-#  167|         1: [VariableAccess] p
+#  167|         getRValue(): [VariableAccess] p
 #  167|             Type = [IntPointerType] int *
 #  167|             ValueCategory = prvalue(load)
-#  167|         1 converted: [CStyleCast] (bool)...
+#  167|         : [CStyleCast] (bool)...
 #  167|             Conversion = [BoolConversion] conversion to bool
 #  167|             Type = [BoolType] bool
 #  167|             ValueCategory = prvalue
-#  168|     10: [ExprStmt] ExprStmt
-#  168|       0: [AssignExpr] ... = ...
+#  168|     getStmt(10): [ExprStmt] ExprStmt
+#  168|       getExpr(): [AssignExpr] ... = ...
 #  168|           Type = [BoolType] bool
 #  168|           ValueCategory = lvalue
-#  168|         0: [VariableAccess] b
+#  168|         getLValue(): [VariableAccess] b
 #  168|             Type = [BoolType] bool
 #  168|             ValueCategory = lvalue
-#  168|         1: [NotExpr] ! ...
+#  168|         getRValue(): [NotExpr] ! ...
 #  168|             Type = [BoolType] bool
 #  168|             ValueCategory = prvalue
-#  168|           0: [VariableAccess] p
+#  168|           getOperand(): [VariableAccess] p
 #  168|               Type = [IntPointerType] int *
 #  168|               ValueCategory = prvalue(load)
-#  168|           0 converted: [CStyleCast] (bool)...
+#  168|           : [CStyleCast] (bool)...
 #  168|               Conversion = [BoolConversion] conversion to bool
 #  168|               Type = [BoolType] bool
 #  168|               ValueCategory = prvalue
-#  169|     11: [ReturnStmt] return ...
+#  169|     getStmt(11): [ReturnStmt] return ...
 #  171| [TopLevelFunction] void ArrayAccess(int*, int)
-#  171|   params: 
-#  171|     0: [Parameter] p
+#  171|   ...: 
+#  171|     getParameter(0): [Parameter] p
 #  171|         Type = [IntPointerType] int *
-#  171|     1: [Parameter] i
+#  171|     getParameter(1): [Parameter] i
 #  171|         Type = [IntType] int
-#  171|   body: [BlockStmt] { ... }
-#  172|     0: [DeclStmt] declaration
-#  172|       0: [VariableDeclarationEntry] definition of x
+#  171|   getEntryPoint(): [BlockStmt] { ... }
+#  172|     getStmt(0): [DeclStmt] declaration
+#  172|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  172|           Type = [IntType] int
-#  174|     1: [ExprStmt] ExprStmt
-#  174|       0: [AssignExpr] ... = ...
+#  174|     getStmt(1): [ExprStmt] ExprStmt
+#  174|       getExpr(): [AssignExpr] ... = ...
 #  174|           Type = [IntType] int
 #  174|           ValueCategory = lvalue
-#  174|         0: [VariableAccess] x
+#  174|         getLValue(): [VariableAccess] x
 #  174|             Type = [IntType] int
 #  174|             ValueCategory = lvalue
-#  174|         1: [ArrayExpr] access to array
+#  174|         getRValue(): [ArrayExpr] access to array
 #  174|             Type = [IntType] int
 #  174|             ValueCategory = prvalue(load)
-#  174|           0: [VariableAccess] p
+#  174|           getArrayBase(): [VariableAccess] p
 #  174|               Type = [IntPointerType] int *
 #  174|               ValueCategory = prvalue(load)
-#  174|           1: [VariableAccess] i
+#  174|           getArrayOffset(): [VariableAccess] i
 #  174|               Type = [IntType] int
 #  174|               ValueCategory = prvalue(load)
-#  175|     2: [ExprStmt] ExprStmt
-#  175|       0: [AssignExpr] ... = ...
+#  175|     getStmt(2): [ExprStmt] ExprStmt
+#  175|       getExpr(): [AssignExpr] ... = ...
 #  175|           Type = [IntType] int
 #  175|           ValueCategory = lvalue
-#  175|         0: [VariableAccess] x
+#  175|         getLValue(): [VariableAccess] x
 #  175|             Type = [IntType] int
 #  175|             ValueCategory = lvalue
-#  175|         1: [ArrayExpr] access to array
+#  175|         getRValue(): [ArrayExpr] access to array
 #  175|             Type = [IntType] int
 #  175|             ValueCategory = prvalue(load)
-#  175|           0: [VariableAccess] p
+#  175|           getArrayBase(): [VariableAccess] p
 #  175|               Type = [IntPointerType] int *
 #  175|               ValueCategory = prvalue(load)
-#  175|           1: [VariableAccess] i
+#  175|           getArrayOffset(): [VariableAccess] i
 #  175|               Type = [IntType] int
 #  175|               ValueCategory = prvalue(load)
-#  177|     3: [ExprStmt] ExprStmt
-#  177|       0: [AssignExpr] ... = ...
+#  177|     getStmt(3): [ExprStmt] ExprStmt
+#  177|       getExpr(): [AssignExpr] ... = ...
 #  177|           Type = [IntType] int
 #  177|           ValueCategory = lvalue
-#  177|         0: [ArrayExpr] access to array
+#  177|         getLValue(): [ArrayExpr] access to array
 #  177|             Type = [IntType] int
 #  177|             ValueCategory = lvalue
-#  177|           0: [VariableAccess] p
+#  177|           getArrayBase(): [VariableAccess] p
 #  177|               Type = [IntPointerType] int *
 #  177|               ValueCategory = prvalue(load)
-#  177|           1: [VariableAccess] i
+#  177|           getArrayOffset(): [VariableAccess] i
 #  177|               Type = [IntType] int
 #  177|               ValueCategory = prvalue(load)
-#  177|         1: [VariableAccess] x
+#  177|         getRValue(): [VariableAccess] x
 #  177|             Type = [IntType] int
 #  177|             ValueCategory = prvalue(load)
-#  178|     4: [ExprStmt] ExprStmt
-#  178|       0: [AssignExpr] ... = ...
+#  178|     getStmt(4): [ExprStmt] ExprStmt
+#  178|       getExpr(): [AssignExpr] ... = ...
 #  178|           Type = [IntType] int
 #  178|           ValueCategory = lvalue
-#  178|         0: [ArrayExpr] access to array
+#  178|         getLValue(): [ArrayExpr] access to array
 #  178|             Type = [IntType] int
 #  178|             ValueCategory = lvalue
-#  178|           0: [VariableAccess] p
+#  178|           getArrayBase(): [VariableAccess] p
 #  178|               Type = [IntPointerType] int *
 #  178|               ValueCategory = prvalue(load)
-#  178|           1: [VariableAccess] i
+#  178|           getArrayOffset(): [VariableAccess] i
 #  178|               Type = [IntType] int
 #  178|               ValueCategory = prvalue(load)
-#  178|         1: [VariableAccess] x
+#  178|         getRValue(): [VariableAccess] x
 #  178|             Type = [IntType] int
 #  178|             ValueCategory = prvalue(load)
-#  180|     5: [DeclStmt] declaration
-#  180|       0: [VariableDeclarationEntry] definition of a
+#  180|     getStmt(5): [DeclStmt] declaration
+#  180|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 #  180|           Type = [ArrayType] int[10]
-#  181|     6: [ExprStmt] ExprStmt
-#  181|       0: [AssignExpr] ... = ...
+#  181|     getStmt(6): [ExprStmt] ExprStmt
+#  181|       getExpr(): [AssignExpr] ... = ...
 #  181|           Type = [IntType] int
 #  181|           ValueCategory = lvalue
-#  181|         0: [VariableAccess] x
+#  181|         getLValue(): [VariableAccess] x
 #  181|             Type = [IntType] int
 #  181|             ValueCategory = lvalue
-#  181|         1: [ArrayExpr] access to array
+#  181|         getRValue(): [ArrayExpr] access to array
 #  181|             Type = [IntType] int
 #  181|             ValueCategory = prvalue(load)
-#  181|           0: [VariableAccess] a
+#  181|           getArrayBase(): [VariableAccess] a
 #  181|               Type = [ArrayType] int[10]
 #  181|               ValueCategory = lvalue
-#  181|           1: [VariableAccess] i
+#  181|           getArrayOffset(): [VariableAccess] i
 #  181|               Type = [IntType] int
 #  181|               ValueCategory = prvalue(load)
-#  181|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  181|           : [ArrayToPointerConversion] array to pointer conversion
 #  181|               Type = [IntPointerType] int *
 #  181|               ValueCategory = prvalue
-#  182|     7: [ExprStmt] ExprStmt
-#  182|       0: [AssignExpr] ... = ...
+#  182|     getStmt(7): [ExprStmt] ExprStmt
+#  182|       getExpr(): [AssignExpr] ... = ...
 #  182|           Type = [IntType] int
 #  182|           ValueCategory = lvalue
-#  182|         0: [VariableAccess] x
+#  182|         getLValue(): [VariableAccess] x
 #  182|             Type = [IntType] int
 #  182|             ValueCategory = lvalue
-#  182|         1: [ArrayExpr] access to array
+#  182|         getRValue(): [ArrayExpr] access to array
 #  182|             Type = [IntType] int
 #  182|             ValueCategory = prvalue(load)
-#  182|           0: [VariableAccess] a
+#  182|           getArrayBase(): [VariableAccess] a
 #  182|               Type = [ArrayType] int[10]
 #  182|               ValueCategory = lvalue
-#  182|           1: [VariableAccess] i
+#  182|           getArrayOffset(): [VariableAccess] i
 #  182|               Type = [IntType] int
 #  182|               ValueCategory = prvalue(load)
-#  182|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  182|           : [ArrayToPointerConversion] array to pointer conversion
 #  182|               Type = [IntPointerType] int *
 #  182|               ValueCategory = prvalue
-#  183|     8: [ExprStmt] ExprStmt
-#  183|       0: [AssignExpr] ... = ...
+#  183|     getStmt(8): [ExprStmt] ExprStmt
+#  183|       getExpr(): [AssignExpr] ... = ...
 #  183|           Type = [IntType] int
 #  183|           ValueCategory = lvalue
-#  183|         0: [ArrayExpr] access to array
+#  183|         getLValue(): [ArrayExpr] access to array
 #  183|             Type = [IntType] int
 #  183|             ValueCategory = lvalue
-#  183|           0: [VariableAccess] a
+#  183|           getArrayBase(): [VariableAccess] a
 #  183|               Type = [ArrayType] int[10]
 #  183|               ValueCategory = lvalue
-#  183|           1: [VariableAccess] i
+#  183|           getArrayOffset(): [VariableAccess] i
 #  183|               Type = [IntType] int
 #  183|               ValueCategory = prvalue(load)
-#  183|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  183|           : [ArrayToPointerConversion] array to pointer conversion
 #  183|               Type = [IntPointerType] int *
 #  183|               ValueCategory = prvalue
-#  183|         1: [VariableAccess] x
+#  183|         getRValue(): [VariableAccess] x
 #  183|             Type = [IntType] int
 #  183|             ValueCategory = prvalue(load)
-#  184|     9: [ExprStmt] ExprStmt
-#  184|       0: [AssignExpr] ... = ...
+#  184|     getStmt(9): [ExprStmt] ExprStmt
+#  184|       getExpr(): [AssignExpr] ... = ...
 #  184|           Type = [IntType] int
 #  184|           ValueCategory = lvalue
-#  184|         0: [ArrayExpr] access to array
+#  184|         getLValue(): [ArrayExpr] access to array
 #  184|             Type = [IntType] int
 #  184|             ValueCategory = lvalue
-#  184|           0: [VariableAccess] a
+#  184|           getArrayBase(): [VariableAccess] a
 #  184|               Type = [ArrayType] int[10]
 #  184|               ValueCategory = lvalue
-#  184|           1: [VariableAccess] i
+#  184|           getArrayOffset(): [VariableAccess] i
 #  184|               Type = [IntType] int
 #  184|               ValueCategory = prvalue(load)
-#  184|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  184|           : [ArrayToPointerConversion] array to pointer conversion
 #  184|               Type = [IntPointerType] int *
 #  184|               ValueCategory = prvalue
-#  184|         1: [VariableAccess] x
+#  184|         getRValue(): [VariableAccess] x
 #  184|             Type = [IntType] int
 #  184|             ValueCategory = prvalue(load)
-#  185|     10: [ReturnStmt] return ...
+#  185|     getStmt(10): [ReturnStmt] return ...
 #  187| [TopLevelFunction] void StringLiteral(int)
-#  187|   params: 
-#  187|     0: [Parameter] i
+#  187|   ...: 
+#  187|     getParameter(0): [Parameter] i
 #  187|         Type = [IntType] int
-#  187|   body: [BlockStmt] { ... }
-#  188|     0: [DeclStmt] declaration
-#  188|       0: [VariableDeclarationEntry] definition of c
+#  187|   getEntryPoint(): [BlockStmt] { ... }
+#  188|     getStmt(0): [DeclStmt] declaration
+#  188|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 #  188|           Type = [PlainCharType] char
-#  188|         init: [Initializer] initializer for c
-#  188|           expr: [ArrayExpr] access to array
+#  188|         getVariable().getInitializer(): [Initializer] initializer for c
+#  188|           getExpr(): [ArrayExpr] access to array
 #  188|               Type = [PlainCharType] char
 #  188|               ValueCategory = prvalue(load)
-#  188|             0: Foo
+#  188|             getArrayBase(): Foo
 #  188|                 Type = [ArrayType] const char[4]
 #  188|                 Value = [StringLiteral] "Foo"
 #  188|                 ValueCategory = lvalue
-#  188|             1: [VariableAccess] i
+#  188|             getArrayOffset(): [VariableAccess] i
 #  188|                 Type = [IntType] int
 #  188|                 ValueCategory = prvalue(load)
-#  188|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  188|             : [ArrayToPointerConversion] array to pointer conversion
 #  188|                 Type = [PointerType] const char *
 #  188|                 ValueCategory = prvalue
-#  189|     1: [DeclStmt] declaration
-#  189|       0: [VariableDeclarationEntry] definition of pwc
+#  189|     getStmt(1): [DeclStmt] declaration
+#  189|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pwc
 #  189|           Type = [PointerType] wchar_t *
-#  189|         init: [Initializer] initializer for pwc
-#  189|           expr: Bar
+#  189|         getVariable().getInitializer(): [Initializer] initializer for pwc
+#  189|           getExpr(): Bar
 #  189|               Type = [ArrayType] const wchar_t[4]
 #  189|               Value = [StringLiteral] "Bar"
 #  189|               ValueCategory = lvalue
-#  189|           expr converted: [CStyleCast] (wchar_t *)...
+#  189|           : [CStyleCast] (wchar_t *)...
 #  189|               Conversion = [PointerConversion] pointer conversion
 #  189|               Type = [PointerType] wchar_t *
 #  189|               ValueCategory = prvalue
-#  189|             expr: [ArrayToPointerConversion] array to pointer conversion
+#  189|             getExpr(): [ArrayToPointerConversion] array to pointer conversion
 #  189|                 Type = [PointerType] const wchar_t *
 #  189|                 ValueCategory = prvalue
-#  190|     2: [DeclStmt] declaration
-#  190|       0: [VariableDeclarationEntry] definition of wc
+#  190|     getStmt(2): [DeclStmt] declaration
+#  190|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of wc
 #  190|           Type = [Wchar_t,WideCharType] wchar_t
-#  190|         init: [Initializer] initializer for wc
-#  190|           expr: [ArrayExpr] access to array
+#  190|         getVariable().getInitializer(): [Initializer] initializer for wc
+#  190|           getExpr(): [ArrayExpr] access to array
 #  190|               Type = [Wchar_t,WideCharType] wchar_t
 #  190|               ValueCategory = prvalue(load)
-#  190|             0: [VariableAccess] pwc
+#  190|             getArrayBase(): [VariableAccess] pwc
 #  190|                 Type = [PointerType] wchar_t *
 #  190|                 ValueCategory = prvalue(load)
-#  190|             1: [VariableAccess] i
+#  190|             getArrayOffset(): [VariableAccess] i
 #  190|                 Type = [IntType] int
 #  190|                 ValueCategory = prvalue(load)
-#  191|     3: [ReturnStmt] return ...
+#  191|     getStmt(3): [ReturnStmt] return ...
 #  193| [TopLevelFunction] void PointerCompare(int*, int*)
-#  193|   params: 
-#  193|     0: [Parameter] p
+#  193|   ...: 
+#  193|     getParameter(0): [Parameter] p
 #  193|         Type = [IntPointerType] int *
-#  193|     1: [Parameter] q
+#  193|     getParameter(1): [Parameter] q
 #  193|         Type = [IntPointerType] int *
-#  193|   body: [BlockStmt] { ... }
-#  194|     0: [DeclStmt] declaration
-#  194|       0: [VariableDeclarationEntry] definition of b
+#  193|   getEntryPoint(): [BlockStmt] { ... }
+#  194|     getStmt(0): [DeclStmt] declaration
+#  194|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  194|           Type = [BoolType] bool
-#  196|     1: [ExprStmt] ExprStmt
-#  196|       0: [AssignExpr] ... = ...
+#  196|     getStmt(1): [ExprStmt] ExprStmt
+#  196|       getExpr(): [AssignExpr] ... = ...
 #  196|           Type = [BoolType] bool
 #  196|           ValueCategory = lvalue
-#  196|         0: [VariableAccess] b
+#  196|         getLValue(): [VariableAccess] b
 #  196|             Type = [BoolType] bool
 #  196|             ValueCategory = lvalue
-#  196|         1: [EQExpr] ... == ...
+#  196|         getRValue(): [EQExpr] ... == ...
 #  196|             Type = [BoolType] bool
 #  196|             ValueCategory = prvalue
-#  196|           0: [VariableAccess] p
+#  196|           getLeftOperand(): [VariableAccess] p
 #  196|               Type = [IntPointerType] int *
 #  196|               ValueCategory = prvalue(load)
-#  196|           1: [VariableAccess] q
+#  196|           getRightOperand(): [VariableAccess] q
 #  196|               Type = [IntPointerType] int *
 #  196|               ValueCategory = prvalue(load)
-#  197|     2: [ExprStmt] ExprStmt
-#  197|       0: [AssignExpr] ... = ...
+#  197|     getStmt(2): [ExprStmt] ExprStmt
+#  197|       getExpr(): [AssignExpr] ... = ...
 #  197|           Type = [BoolType] bool
 #  197|           ValueCategory = lvalue
-#  197|         0: [VariableAccess] b
+#  197|         getLValue(): [VariableAccess] b
 #  197|             Type = [BoolType] bool
 #  197|             ValueCategory = lvalue
-#  197|         1: [NEExpr] ... != ...
+#  197|         getRValue(): [NEExpr] ... != ...
 #  197|             Type = [BoolType] bool
 #  197|             ValueCategory = prvalue
-#  197|           0: [VariableAccess] p
+#  197|           getLeftOperand(): [VariableAccess] p
 #  197|               Type = [IntPointerType] int *
 #  197|               ValueCategory = prvalue(load)
-#  197|           1: [VariableAccess] q
+#  197|           getRightOperand(): [VariableAccess] q
 #  197|               Type = [IntPointerType] int *
 #  197|               ValueCategory = prvalue(load)
-#  198|     3: [ExprStmt] ExprStmt
-#  198|       0: [AssignExpr] ... = ...
+#  198|     getStmt(3): [ExprStmt] ExprStmt
+#  198|       getExpr(): [AssignExpr] ... = ...
 #  198|           Type = [BoolType] bool
 #  198|           ValueCategory = lvalue
-#  198|         0: [VariableAccess] b
+#  198|         getLValue(): [VariableAccess] b
 #  198|             Type = [BoolType] bool
 #  198|             ValueCategory = lvalue
-#  198|         1: [LTExpr] ... < ...
+#  198|         getRValue(): [LTExpr] ... < ...
 #  198|             Type = [BoolType] bool
 #  198|             ValueCategory = prvalue
-#  198|           0: [VariableAccess] p
+#  198|           getLesserOperand(): [VariableAccess] p
 #  198|               Type = [IntPointerType] int *
 #  198|               ValueCategory = prvalue(load)
-#  198|           1: [VariableAccess] q
+#  198|           getGreaterOperand(): [VariableAccess] q
 #  198|               Type = [IntPointerType] int *
 #  198|               ValueCategory = prvalue(load)
-#  199|     4: [ExprStmt] ExprStmt
-#  199|       0: [AssignExpr] ... = ...
+#  199|     getStmt(4): [ExprStmt] ExprStmt
+#  199|       getExpr(): [AssignExpr] ... = ...
 #  199|           Type = [BoolType] bool
 #  199|           ValueCategory = lvalue
-#  199|         0: [VariableAccess] b
+#  199|         getLValue(): [VariableAccess] b
 #  199|             Type = [BoolType] bool
 #  199|             ValueCategory = lvalue
-#  199|         1: [GTExpr] ... > ...
+#  199|         getRValue(): [GTExpr] ... > ...
 #  199|             Type = [BoolType] bool
 #  199|             ValueCategory = prvalue
-#  199|           0: [VariableAccess] p
+#  199|           getGreaterOperand(): [VariableAccess] p
 #  199|               Type = [IntPointerType] int *
 #  199|               ValueCategory = prvalue(load)
-#  199|           1: [VariableAccess] q
+#  199|           getLesserOperand(): [VariableAccess] q
 #  199|               Type = [IntPointerType] int *
 #  199|               ValueCategory = prvalue(load)
-#  200|     5: [ExprStmt] ExprStmt
-#  200|       0: [AssignExpr] ... = ...
+#  200|     getStmt(5): [ExprStmt] ExprStmt
+#  200|       getExpr(): [AssignExpr] ... = ...
 #  200|           Type = [BoolType] bool
 #  200|           ValueCategory = lvalue
-#  200|         0: [VariableAccess] b
+#  200|         getLValue(): [VariableAccess] b
 #  200|             Type = [BoolType] bool
 #  200|             ValueCategory = lvalue
-#  200|         1: [LEExpr] ... <= ...
+#  200|         getRValue(): [LEExpr] ... <= ...
 #  200|             Type = [BoolType] bool
 #  200|             ValueCategory = prvalue
-#  200|           0: [VariableAccess] p
+#  200|           getLesserOperand(): [VariableAccess] p
 #  200|               Type = [IntPointerType] int *
 #  200|               ValueCategory = prvalue(load)
-#  200|           1: [VariableAccess] q
+#  200|           getGreaterOperand(): [VariableAccess] q
 #  200|               Type = [IntPointerType] int *
 #  200|               ValueCategory = prvalue(load)
-#  201|     6: [ExprStmt] ExprStmt
-#  201|       0: [AssignExpr] ... = ...
+#  201|     getStmt(6): [ExprStmt] ExprStmt
+#  201|       getExpr(): [AssignExpr] ... = ...
 #  201|           Type = [BoolType] bool
 #  201|           ValueCategory = lvalue
-#  201|         0: [VariableAccess] b
+#  201|         getLValue(): [VariableAccess] b
 #  201|             Type = [BoolType] bool
 #  201|             ValueCategory = lvalue
-#  201|         1: [GEExpr] ... >= ...
+#  201|         getRValue(): [GEExpr] ... >= ...
 #  201|             Type = [BoolType] bool
 #  201|             ValueCategory = prvalue
-#  201|           0: [VariableAccess] p
+#  201|           getGreaterOperand(): [VariableAccess] p
 #  201|               Type = [IntPointerType] int *
 #  201|               ValueCategory = prvalue(load)
-#  201|           1: [VariableAccess] q
+#  201|           getLesserOperand(): [VariableAccess] q
 #  201|               Type = [IntPointerType] int *
 #  201|               ValueCategory = prvalue(load)
-#  202|     7: [ReturnStmt] return ...
+#  202|     getStmt(7): [ReturnStmt] return ...
 #  204| [TopLevelFunction] void PointerCrement(int*)
-#  204|   params: 
-#  204|     0: [Parameter] p
+#  204|   ...: 
+#  204|     getParameter(0): [Parameter] p
 #  204|         Type = [IntPointerType] int *
-#  204|   body: [BlockStmt] { ... }
-#  205|     0: [DeclStmt] declaration
-#  205|       0: [VariableDeclarationEntry] definition of q
+#  204|   getEntryPoint(): [BlockStmt] { ... }
+#  205|     getStmt(0): [DeclStmt] declaration
+#  205|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of q
 #  205|           Type = [IntPointerType] int *
-#  207|     1: [ExprStmt] ExprStmt
-#  207|       0: [AssignExpr] ... = ...
+#  207|     getStmt(1): [ExprStmt] ExprStmt
+#  207|       getExpr(): [AssignExpr] ... = ...
 #  207|           Type = [IntPointerType] int *
 #  207|           ValueCategory = lvalue
-#  207|         0: [VariableAccess] q
+#  207|         getLValue(): [VariableAccess] q
 #  207|             Type = [IntPointerType] int *
 #  207|             ValueCategory = lvalue
-#  207|         1: [PrefixIncrExpr] ++ ...
+#  207|         getRValue(): [PrefixIncrExpr] ++ ...
 #  207|             Type = [IntPointerType] int *
 #  207|             ValueCategory = prvalue
-#  207|           0: [VariableAccess] p
+#  207|           getOperand(): [VariableAccess] p
 #  207|               Type = [IntPointerType] int *
 #  207|               ValueCategory = lvalue
-#  208|     2: [ExprStmt] ExprStmt
-#  208|       0: [AssignExpr] ... = ...
+#  208|     getStmt(2): [ExprStmt] ExprStmt
+#  208|       getExpr(): [AssignExpr] ... = ...
 #  208|           Type = [IntPointerType] int *
 #  208|           ValueCategory = lvalue
-#  208|         0: [VariableAccess] q
+#  208|         getLValue(): [VariableAccess] q
 #  208|             Type = [IntPointerType] int *
 #  208|             ValueCategory = lvalue
-#  208|         1: [PrefixDecrExpr] -- ...
+#  208|         getRValue(): [PrefixDecrExpr] -- ...
 #  208|             Type = [IntPointerType] int *
 #  208|             ValueCategory = prvalue
-#  208|           0: [VariableAccess] p
+#  208|           getOperand(): [VariableAccess] p
 #  208|               Type = [IntPointerType] int *
 #  208|               ValueCategory = lvalue
-#  209|     3: [ExprStmt] ExprStmt
-#  209|       0: [AssignExpr] ... = ...
+#  209|     getStmt(3): [ExprStmt] ExprStmt
+#  209|       getExpr(): [AssignExpr] ... = ...
 #  209|           Type = [IntPointerType] int *
 #  209|           ValueCategory = lvalue
-#  209|         0: [VariableAccess] q
+#  209|         getLValue(): [VariableAccess] q
 #  209|             Type = [IntPointerType] int *
 #  209|             ValueCategory = lvalue
-#  209|         1: [PostfixIncrExpr] ... ++
+#  209|         getRValue(): [PostfixIncrExpr] ... ++
 #  209|             Type = [IntPointerType] int *
 #  209|             ValueCategory = prvalue
-#  209|           0: [VariableAccess] p
+#  209|           getOperand(): [VariableAccess] p
 #  209|               Type = [IntPointerType] int *
 #  209|               ValueCategory = lvalue
-#  210|     4: [ExprStmt] ExprStmt
-#  210|       0: [AssignExpr] ... = ...
+#  210|     getStmt(4): [ExprStmt] ExprStmt
+#  210|       getExpr(): [AssignExpr] ... = ...
 #  210|           Type = [IntPointerType] int *
 #  210|           ValueCategory = lvalue
-#  210|         0: [VariableAccess] q
+#  210|         getLValue(): [VariableAccess] q
 #  210|             Type = [IntPointerType] int *
 #  210|             ValueCategory = lvalue
-#  210|         1: [PostfixDecrExpr] ... --
+#  210|         getRValue(): [PostfixDecrExpr] ... --
 #  210|             Type = [IntPointerType] int *
 #  210|             ValueCategory = prvalue
-#  210|           0: [VariableAccess] p
+#  210|           getOperand(): [VariableAccess] p
 #  210|               Type = [IntPointerType] int *
 #  210|               ValueCategory = lvalue
-#  211|     5: [ReturnStmt] return ...
+#  211|     getStmt(5): [ReturnStmt] return ...
 #  213| [TopLevelFunction] void CompoundAssignment()
-#  213|   params: 
-#  213|   body: [BlockStmt] { ... }
-#  215|     0: [DeclStmt] declaration
-#  215|       0: [VariableDeclarationEntry] definition of x
+#  213|   ...: 
+#  213|   getEntryPoint(): [BlockStmt] { ... }
+#  215|     getStmt(0): [DeclStmt] declaration
+#  215|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  215|           Type = [IntType] int
-#  215|         init: [Initializer] initializer for x
-#  215|           expr: [Literal] 5
+#  215|         getVariable().getInitializer(): [Initializer] initializer for x
+#  215|           getExpr(): [Literal] 5
 #  215|               Type = [IntType] int
 #  215|               Value = [Literal] 5
 #  215|               ValueCategory = prvalue
-#  216|     1: [ExprStmt] ExprStmt
-#  216|       0: [AssignAddExpr] ... += ...
+#  216|     getStmt(1): [ExprStmt] ExprStmt
+#  216|       getExpr(): [AssignAddExpr] ... += ...
 #  216|           Type = [IntType] int
 #  216|           ValueCategory = lvalue
-#  216|         0: [VariableAccess] x
+#  216|         getLValue(): [VariableAccess] x
 #  216|             Type = [IntType] int
 #  216|             ValueCategory = lvalue
-#  216|         1: [Literal] 7
+#  216|         getRValue(): [Literal] 7
 #  216|             Type = [IntType] int
 #  216|             Value = [Literal] 7
 #  216|             ValueCategory = prvalue
-#  219|     2: [DeclStmt] declaration
-#  219|       0: [VariableDeclarationEntry] definition of y
+#  219|     getStmt(2): [DeclStmt] declaration
+#  219|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #  219|           Type = [ShortType] short
-#  219|         init: [Initializer] initializer for y
-#  219|           expr: [Literal] 5
+#  219|         getVariable().getInitializer(): [Initializer] initializer for y
+#  219|           getExpr(): [Literal] 5
 #  219|               Type = [IntType] int
 #  219|               Value = [Literal] 5
 #  219|               ValueCategory = prvalue
-#  219|           expr converted: [CStyleCast] (short)...
+#  219|           : [CStyleCast] (short)...
 #  219|               Conversion = [IntegralConversion] integral conversion
 #  219|               Type = [ShortType] short
 #  219|               Value = [CStyleCast] 5
 #  219|               ValueCategory = prvalue
-#  220|     3: [ExprStmt] ExprStmt
-#  220|       0: [AssignAddExpr] ... += ...
+#  220|     getStmt(3): [ExprStmt] ExprStmt
+#  220|       getExpr(): [AssignAddExpr] ... += ...
 #  220|           Type = [ShortType] short
 #  220|           ValueCategory = lvalue
-#  220|         0: [VariableAccess] y
+#  220|         getLValue(): [VariableAccess] y
 #  220|             Type = [ShortType] short
 #  220|             ValueCategory = lvalue
-#  220|         1: [VariableAccess] x
+#  220|         getRValue(): [VariableAccess] x
 #  220|             Type = [IntType] int
 #  220|             ValueCategory = prvalue(load)
-#  223|     4: [ExprStmt] ExprStmt
-#  223|       0: [AssignLShiftExpr] ... <<= ...
+#  223|     getStmt(4): [ExprStmt] ExprStmt
+#  223|       getExpr(): [AssignLShiftExpr] ... <<= ...
 #  223|           Type = [ShortType] short
 #  223|           ValueCategory = lvalue
-#  223|         0: [VariableAccess] y
+#  223|         getLValue(): [VariableAccess] y
 #  223|             Type = [ShortType] short
 #  223|             ValueCategory = lvalue
-#  223|         1: [Literal] 1
+#  223|         getRValue(): [Literal] 1
 #  223|             Type = [IntType] int
 #  223|             Value = [Literal] 1
 #  223|             ValueCategory = prvalue
-#  226|     5: [DeclStmt] declaration
-#  226|       0: [VariableDeclarationEntry] definition of z
+#  226|     getStmt(5): [DeclStmt] declaration
+#  226|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 #  226|           Type = [LongType] long
-#  226|         init: [Initializer] initializer for z
-#  226|           expr: [Literal] 7
+#  226|         getVariable().getInitializer(): [Initializer] initializer for z
+#  226|           getExpr(): [Literal] 7
 #  226|               Type = [IntType] int
 #  226|               Value = [Literal] 7
 #  226|               ValueCategory = prvalue
-#  226|           expr converted: [CStyleCast] (long)...
+#  226|           : [CStyleCast] (long)...
 #  226|               Conversion = [IntegralConversion] integral conversion
 #  226|               Type = [LongType] long
 #  226|               Value = [CStyleCast] 7
 #  226|               ValueCategory = prvalue
-#  227|     6: [ExprStmt] ExprStmt
-#  227|       0: [AssignAddExpr] ... += ...
+#  227|     getStmt(6): [ExprStmt] ExprStmt
+#  227|       getExpr(): [AssignAddExpr] ... += ...
 #  227|           Type = [LongType] long
 #  227|           ValueCategory = lvalue
-#  227|         0: [VariableAccess] z
+#  227|         getLValue(): [VariableAccess] z
 #  227|             Type = [LongType] long
 #  227|             ValueCategory = lvalue
-#  227|         1: [Literal] 2.0
+#  227|         getRValue(): [Literal] 2.0
 #  227|             Type = [FloatType] float
 #  227|             Value = [Literal] 2.0
 #  227|             ValueCategory = prvalue
-#  228|     7: [ReturnStmt] return ...
+#  228|     getStmt(7): [ReturnStmt] return ...
 #  230| [TopLevelFunction] void UninitializedVariables()
-#  230|   params: 
-#  230|   body: [BlockStmt] { ... }
-#  231|     0: [DeclStmt] declaration
-#  231|       0: [VariableDeclarationEntry] definition of x
+#  230|   ...: 
+#  230|   getEntryPoint(): [BlockStmt] { ... }
+#  231|     getStmt(0): [DeclStmt] declaration
+#  231|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  231|           Type = [IntType] int
-#  232|     1: [DeclStmt] declaration
-#  232|       0: [VariableDeclarationEntry] definition of y
+#  232|     getStmt(1): [DeclStmt] declaration
+#  232|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #  232|           Type = [IntType] int
-#  232|         init: [Initializer] initializer for y
-#  232|           expr: [VariableAccess] x
+#  232|         getVariable().getInitializer(): [Initializer] initializer for y
+#  232|           getExpr(): [VariableAccess] x
 #  232|               Type = [IntType] int
 #  232|               ValueCategory = prvalue(load)
-#  233|     2: [ReturnStmt] return ...
+#  233|     getStmt(2): [ReturnStmt] return ...
 #  235| [TopLevelFunction] int Parameters(int, int)
-#  235|   params: 
-#  235|     0: [Parameter] x
+#  235|   ...: 
+#  235|     getParameter(0): [Parameter] x
 #  235|         Type = [IntType] int
-#  235|     1: [Parameter] y
+#  235|     getParameter(1): [Parameter] y
 #  235|         Type = [IntType] int
-#  235|   body: [BlockStmt] { ... }
-#  236|     0: [ReturnStmt] return ...
-#  236|       0: [RemExpr] ... % ...
+#  235|   getEntryPoint(): [BlockStmt] { ... }
+#  236|     getStmt(0): [ReturnStmt] return ...
+#  236|       getExpr(): [RemExpr] ... % ...
 #  236|           Type = [IntType] int
 #  236|           ValueCategory = prvalue
-#  236|         0: [VariableAccess] x
+#  236|         getLeftOperand(): [VariableAccess] x
 #  236|             Type = [IntType] int
 #  236|             ValueCategory = prvalue(load)
-#  236|         1: [VariableAccess] y
+#  236|         getRightOperand(): [VariableAccess] y
 #  236|             Type = [IntType] int
 #  236|             ValueCategory = prvalue(load)
 #  239| [TopLevelFunction] void IfStatements(bool, int, int)
-#  239|   params: 
-#  239|     0: [Parameter] b
+#  239|   ...: 
+#  239|     getParameter(0): [Parameter] b
 #  239|         Type = [BoolType] bool
-#  239|     1: [Parameter] x
+#  239|     getParameter(1): [Parameter] x
 #  239|         Type = [IntType] int
-#  239|     2: [Parameter] y
+#  239|     getParameter(2): [Parameter] y
 #  239|         Type = [IntType] int
-#  239|   body: [BlockStmt] { ... }
-#  240|     0: [IfStmt] if (...) ... 
-#  240|       0: [VariableAccess] b
+#  239|   getEntryPoint(): [BlockStmt] { ... }
+#  240|     getStmt(0): [IfStmt] if (...) ... 
+#  240|       getCondition(): [VariableAccess] b
 #  240|           Type = [BoolType] bool
 #  240|           ValueCategory = prvalue(load)
-#  240|       1: [BlockStmt] { ... }
-#  243|     1: [IfStmt] if (...) ... 
-#  243|       0: [VariableAccess] b
+#  240|       getThen(): [BlockStmt] { ... }
+#  243|     getStmt(1): [IfStmt] if (...) ... 
+#  243|       getCondition(): [VariableAccess] b
 #  243|           Type = [BoolType] bool
 #  243|           ValueCategory = prvalue(load)
-#  243|       1: [BlockStmt] { ... }
-#  244|         0: [ExprStmt] ExprStmt
-#  244|           0: [AssignExpr] ... = ...
+#  243|       getThen(): [BlockStmt] { ... }
+#  244|         getStmt(0): [ExprStmt] ExprStmt
+#  244|           getExpr(): [AssignExpr] ... = ...
 #  244|               Type = [IntType] int
 #  244|               ValueCategory = lvalue
-#  244|             0: [VariableAccess] x
+#  244|             getLValue(): [VariableAccess] x
 #  244|                 Type = [IntType] int
 #  244|                 ValueCategory = lvalue
-#  244|             1: [VariableAccess] y
+#  244|             getRValue(): [VariableAccess] y
 #  244|                 Type = [IntType] int
 #  244|                 ValueCategory = prvalue(load)
-#  247|     2: [IfStmt] if (...) ... 
-#  247|       0: [LTExpr] ... < ...
+#  247|     getStmt(2): [IfStmt] if (...) ... 
+#  247|       getCondition(): [LTExpr] ... < ...
 #  247|           Type = [BoolType] bool
 #  247|           ValueCategory = prvalue
-#  247|         0: [VariableAccess] x
+#  247|         getLesserOperand(): [VariableAccess] x
 #  247|             Type = [IntType] int
 #  247|             ValueCategory = prvalue(load)
-#  247|         1: [Literal] 7
+#  247|         getGreaterOperand(): [Literal] 7
 #  247|             Type = [IntType] int
 #  247|             Value = [Literal] 7
 #  247|             ValueCategory = prvalue
-#  248|       1: [ExprStmt] ExprStmt
-#  248|         0: [AssignExpr] ... = ...
+#  248|       getThen(): [ExprStmt] ExprStmt
+#  248|         getExpr(): [AssignExpr] ... = ...
 #  248|             Type = [IntType] int
 #  248|             ValueCategory = lvalue
-#  248|           0: [VariableAccess] x
+#  248|           getLValue(): [VariableAccess] x
 #  248|               Type = [IntType] int
 #  248|               ValueCategory = lvalue
-#  248|           1: [Literal] 2
+#  248|           getRValue(): [Literal] 2
 #  248|               Type = [IntType] int
 #  248|               Value = [Literal] 2
 #  248|               ValueCategory = prvalue
-#  250|       2: [ExprStmt] ExprStmt
-#  250|         0: [AssignExpr] ... = ...
+#  250|       getElse(): [ExprStmt] ExprStmt
+#  250|         getExpr(): [AssignExpr] ... = ...
 #  250|             Type = [IntType] int
 #  250|             ValueCategory = lvalue
-#  250|           0: [VariableAccess] x
+#  250|           getLValue(): [VariableAccess] x
 #  250|               Type = [IntType] int
 #  250|               ValueCategory = lvalue
-#  250|           1: [Literal] 7
+#  250|           getRValue(): [Literal] 7
 #  250|               Type = [IntType] int
 #  250|               Value = [Literal] 7
 #  250|               ValueCategory = prvalue
-#  251|     3: [ReturnStmt] return ...
+#  251|     getStmt(3): [ReturnStmt] return ...
 #  253| [TopLevelFunction] void WhileStatements(int)
-#  253|   params: 
-#  253|     0: [Parameter] n
+#  253|   ...: 
+#  253|     getParameter(0): [Parameter] n
 #  253|         Type = [IntType] int
-#  253|   body: [BlockStmt] { ... }
-#  254|     0: [WhileStmt] while (...) ...
-#  254|       0: [GTExpr] ... > ...
+#  253|   getEntryPoint(): [BlockStmt] { ... }
+#  254|     getStmt(0): [WhileStmt] while (...) ...
+#  254|       getCondition(): [GTExpr] ... > ...
 #  254|           Type = [BoolType] bool
 #  254|           ValueCategory = prvalue
-#  254|         0: [VariableAccess] n
+#  254|         getGreaterOperand(): [VariableAccess] n
 #  254|             Type = [IntType] int
 #  254|             ValueCategory = prvalue(load)
-#  254|         1: [Literal] 0
+#  254|         getLesserOperand(): [Literal] 0
 #  254|             Type = [IntType] int
 #  254|             Value = [Literal] 0
 #  254|             ValueCategory = prvalue
-#  254|       1: [BlockStmt] { ... }
-#  255|         0: [ExprStmt] ExprStmt
-#  255|           0: [AssignSubExpr] ... -= ...
+#  254|       getStmt(): [BlockStmt] { ... }
+#  255|         getStmt(0): [ExprStmt] ExprStmt
+#  255|           getExpr(): [AssignSubExpr] ... -= ...
 #  255|               Type = [IntType] int
 #  255|               ValueCategory = lvalue
-#  255|             0: [VariableAccess] n
+#  255|             getLValue(): [VariableAccess] n
 #  255|                 Type = [IntType] int
 #  255|                 ValueCategory = lvalue
-#  255|             1: [Literal] 1
+#  255|             getRValue(): [Literal] 1
 #  255|                 Type = [IntType] int
 #  255|                 Value = [Literal] 1
 #  255|                 ValueCategory = prvalue
-#  257|     1: [ReturnStmt] return ...
+#  257|     getStmt(1): [ReturnStmt] return ...
 #  259| [TopLevelFunction] void DoStatements(int)
-#  259|   params: 
-#  259|     0: [Parameter] n
+#  259|   ...: 
+#  259|     getParameter(0): [Parameter] n
 #  259|         Type = [IntType] int
-#  259|   body: [BlockStmt] { ... }
-#  260|     0: [DoStmt] do (...) ...
-#  262|       0: [GTExpr] ... > ...
+#  259|   getEntryPoint(): [BlockStmt] { ... }
+#  260|     getStmt(0): [DoStmt] do (...) ...
+#  262|       getCondition(): [GTExpr] ... > ...
 #  262|           Type = [BoolType] bool
 #  262|           ValueCategory = prvalue
-#  262|         0: [VariableAccess] n
+#  262|         getGreaterOperand(): [VariableAccess] n
 #  262|             Type = [IntType] int
 #  262|             ValueCategory = prvalue(load)
-#  262|         1: [Literal] 0
+#  262|         getLesserOperand(): [Literal] 0
 #  262|             Type = [IntType] int
 #  262|             Value = [Literal] 0
 #  262|             ValueCategory = prvalue
-#  260|       1: [BlockStmt] { ... }
-#  261|         0: [ExprStmt] ExprStmt
-#  261|           0: [AssignSubExpr] ... -= ...
+#  260|       getStmt(): [BlockStmt] { ... }
+#  261|         getStmt(0): [ExprStmt] ExprStmt
+#  261|           getExpr(): [AssignSubExpr] ... -= ...
 #  261|               Type = [IntType] int
 #  261|               ValueCategory = lvalue
-#  261|             0: [VariableAccess] n
+#  261|             getLValue(): [VariableAccess] n
 #  261|                 Type = [IntType] int
 #  261|                 ValueCategory = lvalue
-#  261|             1: [Literal] 1
+#  261|             getRValue(): [Literal] 1
 #  261|                 Type = [IntType] int
 #  261|                 Value = [Literal] 1
 #  261|                 ValueCategory = prvalue
-#  263|     1: [ReturnStmt] return ...
+#  263|     getStmt(1): [ReturnStmt] return ...
 #  265| [TopLevelFunction] void For_Empty()
-#  265|   params: 
-#  265|   body: [BlockStmt] { ... }
-#  266|     0: [DeclStmt] declaration
-#  266|       0: [VariableDeclarationEntry] definition of j
+#  265|   ...: 
+#  265|   getEntryPoint(): [BlockStmt] { ... }
+#  266|     getStmt(0): [DeclStmt] declaration
+#  266|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
 #  266|           Type = [IntType] int
-#  267|     1: [ForStmt] for(...;...;...) ...
-#  267|       3: [BlockStmt] { ... }
-#  268|         0: [EmptyStmt] ;
+#  267|     getStmt(1): [ForStmt] for(...;...;...) ...
+#  267|       getStmt(): [BlockStmt] { ... }
+#  268|         getStmt(0): [EmptyStmt] ;
 #  272| [TopLevelFunction] void For_Init()
-#  272|   params: 
-#  272|   body: [BlockStmt] { ... }
-#  273|     0: [ForStmt] for(...;...;...) ...
-#  273|       0: [DeclStmt] declaration
-#  273|         0: [VariableDeclarationEntry] definition of i
+#  272|   ...: 
+#  272|   getEntryPoint(): [BlockStmt] { ... }
+#  273|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  273|       getInitialization(): [DeclStmt] declaration
+#  273|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  273|             Type = [IntType] int
-#  273|           init: [Initializer] initializer for i
-#  273|             expr: [Literal] 0
+#  273|           getVariable().getInitializer(): [Initializer] initializer for i
+#  273|             getExpr(): [Literal] 0
 #  273|                 Type = [IntType] int
 #  273|                 Value = [Literal] 0
 #  273|                 ValueCategory = prvalue
-#  273|       3: [BlockStmt] { ... }
-#  274|         0: [EmptyStmt] ;
+#  273|       getStmt(): [BlockStmt] { ... }
+#  274|         getStmt(0): [EmptyStmt] ;
 #  278| [TopLevelFunction] void For_Condition()
-#  278|   params: 
-#  278|   body: [BlockStmt] { ... }
-#  279|     0: [DeclStmt] declaration
-#  279|       0: [VariableDeclarationEntry] definition of i
+#  278|   ...: 
+#  278|   getEntryPoint(): [BlockStmt] { ... }
+#  279|     getStmt(0): [DeclStmt] declaration
+#  279|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  279|           Type = [IntType] int
-#  279|         init: [Initializer] initializer for i
-#  279|           expr: [Literal] 0
+#  279|         getVariable().getInitializer(): [Initializer] initializer for i
+#  279|           getExpr(): [Literal] 0
 #  279|               Type = [IntType] int
 #  279|               Value = [Literal] 0
 #  279|               ValueCategory = prvalue
-#  280|     1: [ForStmt] for(...;...;...) ...
-#  280|       1: [LTExpr] ... < ...
+#  280|     getStmt(1): [ForStmt] for(...;...;...) ...
+#  280|       getCondition(): [LTExpr] ... < ...
 #  280|           Type = [BoolType] bool
 #  280|           ValueCategory = prvalue
-#  280|         0: [VariableAccess] i
+#  280|         getLesserOperand(): [VariableAccess] i
 #  280|             Type = [IntType] int
 #  280|             ValueCategory = prvalue(load)
-#  280|         1: [Literal] 10
+#  280|         getGreaterOperand(): [Literal] 10
 #  280|             Type = [IntType] int
 #  280|             Value = [Literal] 10
 #  280|             ValueCategory = prvalue
-#  280|       3: [BlockStmt] { ... }
-#  281|         0: [EmptyStmt] ;
-#  283|     2: [ReturnStmt] return ...
+#  280|       getStmt(): [BlockStmt] { ... }
+#  281|         getStmt(0): [EmptyStmt] ;
+#  283|     getStmt(2): [ReturnStmt] return ...
 #  285| [TopLevelFunction] void For_Update()
-#  285|   params: 
-#  285|   body: [BlockStmt] { ... }
-#  286|     0: [DeclStmt] declaration
-#  286|       0: [VariableDeclarationEntry] definition of i
+#  285|   ...: 
+#  285|   getEntryPoint(): [BlockStmt] { ... }
+#  286|     getStmt(0): [DeclStmt] declaration
+#  286|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  286|           Type = [IntType] int
-#  286|         init: [Initializer] initializer for i
-#  286|           expr: [Literal] 0
+#  286|         getVariable().getInitializer(): [Initializer] initializer for i
+#  286|           getExpr(): [Literal] 0
 #  286|               Type = [IntType] int
 #  286|               Value = [Literal] 0
 #  286|               ValueCategory = prvalue
-#  287|     1: [ForStmt] for(...;...;...) ...
-#  287|       2: [AssignAddExpr] ... += ...
+#  287|     getStmt(1): [ForStmt] for(...;...;...) ...
+#  287|       getUpdate(): [AssignAddExpr] ... += ...
 #  287|           Type = [IntType] int
 #  287|           ValueCategory = lvalue
-#  287|         0: [VariableAccess] i
+#  287|         getLValue(): [VariableAccess] i
 #  287|             Type = [IntType] int
 #  287|             ValueCategory = lvalue
-#  287|         1: [Literal] 1
+#  287|         getRValue(): [Literal] 1
 #  287|             Type = [IntType] int
 #  287|             Value = [Literal] 1
 #  287|             ValueCategory = prvalue
-#  287|       3: [BlockStmt] { ... }
-#  288|         0: [EmptyStmt] ;
+#  287|       getStmt(): [BlockStmt] { ... }
+#  288|         getStmt(0): [EmptyStmt] ;
 #  292| [TopLevelFunction] void For_InitCondition()
-#  292|   params: 
-#  292|   body: [BlockStmt] { ... }
-#  293|     0: [ForStmt] for(...;...;...) ...
-#  293|       0: [DeclStmt] declaration
-#  293|         0: [VariableDeclarationEntry] definition of i
+#  292|   ...: 
+#  292|   getEntryPoint(): [BlockStmt] { ... }
+#  293|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  293|       getInitialization(): [DeclStmt] declaration
+#  293|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  293|             Type = [IntType] int
-#  293|           init: [Initializer] initializer for i
-#  293|             expr: [Literal] 0
+#  293|           getVariable().getInitializer(): [Initializer] initializer for i
+#  293|             getExpr(): [Literal] 0
 #  293|                 Type = [IntType] int
 #  293|                 Value = [Literal] 0
 #  293|                 ValueCategory = prvalue
-#  293|       1: [LTExpr] ... < ...
+#  293|       getCondition(): [LTExpr] ... < ...
 #  293|           Type = [BoolType] bool
 #  293|           ValueCategory = prvalue
-#  293|         0: [VariableAccess] i
+#  293|         getLesserOperand(): [VariableAccess] i
 #  293|             Type = [IntType] int
 #  293|             ValueCategory = prvalue(load)
-#  293|         1: [Literal] 10
+#  293|         getGreaterOperand(): [Literal] 10
 #  293|             Type = [IntType] int
 #  293|             Value = [Literal] 10
 #  293|             ValueCategory = prvalue
-#  293|       3: [BlockStmt] { ... }
-#  294|         0: [EmptyStmt] ;
-#  296|     1: [ReturnStmt] return ...
+#  293|       getStmt(): [BlockStmt] { ... }
+#  294|         getStmt(0): [EmptyStmt] ;
+#  296|     getStmt(1): [ReturnStmt] return ...
 #  298| [TopLevelFunction] void For_InitUpdate()
-#  298|   params: 
-#  298|   body: [BlockStmt] { ... }
-#  299|     0: [ForStmt] for(...;...;...) ...
-#  299|       0: [DeclStmt] declaration
-#  299|         0: [VariableDeclarationEntry] definition of i
+#  298|   ...: 
+#  298|   getEntryPoint(): [BlockStmt] { ... }
+#  299|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  299|       getInitialization(): [DeclStmt] declaration
+#  299|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  299|             Type = [IntType] int
-#  299|           init: [Initializer] initializer for i
-#  299|             expr: [Literal] 0
+#  299|           getVariable().getInitializer(): [Initializer] initializer for i
+#  299|             getExpr(): [Literal] 0
 #  299|                 Type = [IntType] int
 #  299|                 Value = [Literal] 0
 #  299|                 ValueCategory = prvalue
-#  299|       2: [AssignAddExpr] ... += ...
+#  299|       getUpdate(): [AssignAddExpr] ... += ...
 #  299|           Type = [IntType] int
 #  299|           ValueCategory = lvalue
-#  299|         0: [VariableAccess] i
+#  299|         getLValue(): [VariableAccess] i
 #  299|             Type = [IntType] int
 #  299|             ValueCategory = lvalue
-#  299|         1: [Literal] 1
+#  299|         getRValue(): [Literal] 1
 #  299|             Type = [IntType] int
 #  299|             Value = [Literal] 1
 #  299|             ValueCategory = prvalue
-#  299|       3: [BlockStmt] { ... }
-#  300|         0: [EmptyStmt] ;
+#  299|       getStmt(): [BlockStmt] { ... }
+#  300|         getStmt(0): [EmptyStmt] ;
 #  304| [TopLevelFunction] void For_ConditionUpdate()
-#  304|   params: 
-#  304|   body: [BlockStmt] { ... }
-#  305|     0: [DeclStmt] declaration
-#  305|       0: [VariableDeclarationEntry] definition of i
+#  304|   ...: 
+#  304|   getEntryPoint(): [BlockStmt] { ... }
+#  305|     getStmt(0): [DeclStmt] declaration
+#  305|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  305|           Type = [IntType] int
-#  305|         init: [Initializer] initializer for i
-#  305|           expr: [Literal] 0
+#  305|         getVariable().getInitializer(): [Initializer] initializer for i
+#  305|           getExpr(): [Literal] 0
 #  305|               Type = [IntType] int
 #  305|               Value = [Literal] 0
 #  305|               ValueCategory = prvalue
-#  306|     1: [ForStmt] for(...;...;...) ...
-#  306|       1: [LTExpr] ... < ...
+#  306|     getStmt(1): [ForStmt] for(...;...;...) ...
+#  306|       getCondition(): [LTExpr] ... < ...
 #  306|           Type = [BoolType] bool
 #  306|           ValueCategory = prvalue
-#  306|         0: [VariableAccess] i
+#  306|         getLesserOperand(): [VariableAccess] i
 #  306|             Type = [IntType] int
 #  306|             ValueCategory = prvalue(load)
-#  306|         1: [Literal] 10
+#  306|         getGreaterOperand(): [Literal] 10
 #  306|             Type = [IntType] int
 #  306|             Value = [Literal] 10
 #  306|             ValueCategory = prvalue
-#  306|       2: [AssignAddExpr] ... += ...
+#  306|       getUpdate(): [AssignAddExpr] ... += ...
 #  306|           Type = [IntType] int
 #  306|           ValueCategory = lvalue
-#  306|         0: [VariableAccess] i
+#  306|         getLValue(): [VariableAccess] i
 #  306|             Type = [IntType] int
 #  306|             ValueCategory = lvalue
-#  306|         1: [Literal] 1
+#  306|         getRValue(): [Literal] 1
 #  306|             Type = [IntType] int
 #  306|             Value = [Literal] 1
 #  306|             ValueCategory = prvalue
-#  306|       3: [BlockStmt] { ... }
-#  307|         0: [EmptyStmt] ;
-#  309|     2: [ReturnStmt] return ...
+#  306|       getStmt(): [BlockStmt] { ... }
+#  307|         getStmt(0): [EmptyStmt] ;
+#  309|     getStmt(2): [ReturnStmt] return ...
 #  311| [TopLevelFunction] void For_InitConditionUpdate()
-#  311|   params: 
-#  311|   body: [BlockStmt] { ... }
-#  312|     0: [ForStmt] for(...;...;...) ...
-#  312|       0: [DeclStmt] declaration
-#  312|         0: [VariableDeclarationEntry] definition of i
+#  311|   ...: 
+#  311|   getEntryPoint(): [BlockStmt] { ... }
+#  312|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  312|       getInitialization(): [DeclStmt] declaration
+#  312|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  312|             Type = [IntType] int
-#  312|           init: [Initializer] initializer for i
-#  312|             expr: [Literal] 0
+#  312|           getVariable().getInitializer(): [Initializer] initializer for i
+#  312|             getExpr(): [Literal] 0
 #  312|                 Type = [IntType] int
 #  312|                 Value = [Literal] 0
 #  312|                 ValueCategory = prvalue
-#  312|       1: [LTExpr] ... < ...
+#  312|       getCondition(): [LTExpr] ... < ...
 #  312|           Type = [BoolType] bool
 #  312|           ValueCategory = prvalue
-#  312|         0: [VariableAccess] i
+#  312|         getLesserOperand(): [VariableAccess] i
 #  312|             Type = [IntType] int
 #  312|             ValueCategory = prvalue(load)
-#  312|         1: [Literal] 10
+#  312|         getGreaterOperand(): [Literal] 10
 #  312|             Type = [IntType] int
 #  312|             Value = [Literal] 10
 #  312|             ValueCategory = prvalue
-#  312|       2: [AssignAddExpr] ... += ...
+#  312|       getUpdate(): [AssignAddExpr] ... += ...
 #  312|           Type = [IntType] int
 #  312|           ValueCategory = lvalue
-#  312|         0: [VariableAccess] i
+#  312|         getLValue(): [VariableAccess] i
 #  312|             Type = [IntType] int
 #  312|             ValueCategory = lvalue
-#  312|         1: [Literal] 1
+#  312|         getRValue(): [Literal] 1
 #  312|             Type = [IntType] int
 #  312|             Value = [Literal] 1
 #  312|             ValueCategory = prvalue
-#  312|       3: [BlockStmt] { ... }
-#  313|         0: [EmptyStmt] ;
-#  315|     1: [ReturnStmt] return ...
+#  312|       getStmt(): [BlockStmt] { ... }
+#  313|         getStmt(0): [EmptyStmt] ;
+#  315|     getStmt(1): [ReturnStmt] return ...
 #  317| [TopLevelFunction] void For_Break()
-#  317|   params: 
-#  317|   body: [BlockStmt] { ... }
-#  318|     0: [ForStmt] for(...;...;...) ...
-#  318|       0: [DeclStmt] declaration
-#  318|         0: [VariableDeclarationEntry] definition of i
+#  317|   ...: 
+#  317|   getEntryPoint(): [BlockStmt] { ... }
+#  318|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  318|       getInitialization(): [DeclStmt] declaration
+#  318|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  318|             Type = [IntType] int
-#  318|           init: [Initializer] initializer for i
-#  318|             expr: [Literal] 0
+#  318|           getVariable().getInitializer(): [Initializer] initializer for i
+#  318|             getExpr(): [Literal] 0
 #  318|                 Type = [IntType] int
 #  318|                 Value = [Literal] 0
 #  318|                 ValueCategory = prvalue
-#  318|       1: [LTExpr] ... < ...
+#  318|       getCondition(): [LTExpr] ... < ...
 #  318|           Type = [BoolType] bool
 #  318|           ValueCategory = prvalue
-#  318|         0: [VariableAccess] i
+#  318|         getLesserOperand(): [VariableAccess] i
 #  318|             Type = [IntType] int
 #  318|             ValueCategory = prvalue(load)
-#  318|         1: [Literal] 10
+#  318|         getGreaterOperand(): [Literal] 10
 #  318|             Type = [IntType] int
 #  318|             Value = [Literal] 10
 #  318|             ValueCategory = prvalue
-#  318|       2: [AssignAddExpr] ... += ...
+#  318|       getUpdate(): [AssignAddExpr] ... += ...
 #  318|           Type = [IntType] int
 #  318|           ValueCategory = lvalue
-#  318|         0: [VariableAccess] i
+#  318|         getLValue(): [VariableAccess] i
 #  318|             Type = [IntType] int
 #  318|             ValueCategory = lvalue
-#  318|         1: [Literal] 1
+#  318|         getRValue(): [Literal] 1
 #  318|             Type = [IntType] int
 #  318|             Value = [Literal] 1
 #  318|             ValueCategory = prvalue
-#  318|       3: [BlockStmt] { ... }
-#  319|         0: [IfStmt] if (...) ... 
-#  319|           0: [EQExpr] ... == ...
+#  318|       getStmt(): [BlockStmt] { ... }
+#  319|         getStmt(0): [IfStmt] if (...) ... 
+#  319|           getCondition(): [EQExpr] ... == ...
 #  319|               Type = [BoolType] bool
 #  319|               ValueCategory = prvalue
-#  319|             0: [VariableAccess] i
+#  319|             getLeftOperand(): [VariableAccess] i
 #  319|                 Type = [IntType] int
 #  319|                 ValueCategory = prvalue(load)
-#  319|             1: [Literal] 5
+#  319|             getRightOperand(): [Literal] 5
 #  319|                 Type = [IntType] int
 #  319|                 Value = [Literal] 5
 #  319|                 ValueCategory = prvalue
-#  319|           1: [BlockStmt] { ... }
-#  320|             0: [BreakStmt] break;
-#  322|     1: [LabelStmt] label ...:
-#  323|     2: [ReturnStmt] return ...
+#  319|           getThen(): [BlockStmt] { ... }
+#  320|             getStmt(0): [BreakStmt] break;
+#  322|     getStmt(1): [LabelStmt] label ...:
+#  323|     getStmt(2): [ReturnStmt] return ...
 #  325| [TopLevelFunction] void For_Continue_Update()
-#  325|   params: 
-#  325|   body: [BlockStmt] { ... }
-#  326|     0: [ForStmt] for(...;...;...) ...
-#  326|       0: [DeclStmt] declaration
-#  326|         0: [VariableDeclarationEntry] definition of i
+#  325|   ...: 
+#  325|   getEntryPoint(): [BlockStmt] { ... }
+#  326|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  326|       getInitialization(): [DeclStmt] declaration
+#  326|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  326|             Type = [IntType] int
-#  326|           init: [Initializer] initializer for i
-#  326|             expr: [Literal] 0
+#  326|           getVariable().getInitializer(): [Initializer] initializer for i
+#  326|             getExpr(): [Literal] 0
 #  326|                 Type = [IntType] int
 #  326|                 Value = [Literal] 0
 #  326|                 ValueCategory = prvalue
-#  326|       1: [LTExpr] ... < ...
+#  326|       getCondition(): [LTExpr] ... < ...
 #  326|           Type = [BoolType] bool
 #  326|           ValueCategory = prvalue
-#  326|         0: [VariableAccess] i
+#  326|         getLesserOperand(): [VariableAccess] i
 #  326|             Type = [IntType] int
 #  326|             ValueCategory = prvalue(load)
-#  326|         1: [Literal] 10
+#  326|         getGreaterOperand(): [Literal] 10
 #  326|             Type = [IntType] int
 #  326|             Value = [Literal] 10
 #  326|             ValueCategory = prvalue
-#  326|       2: [AssignAddExpr] ... += ...
+#  326|       getUpdate(): [AssignAddExpr] ... += ...
 #  326|           Type = [IntType] int
 #  326|           ValueCategory = lvalue
-#  326|         0: [VariableAccess] i
+#  326|         getLValue(): [VariableAccess] i
 #  326|             Type = [IntType] int
 #  326|             ValueCategory = lvalue
-#  326|         1: [Literal] 1
+#  326|         getRValue(): [Literal] 1
 #  326|             Type = [IntType] int
 #  326|             Value = [Literal] 1
 #  326|             ValueCategory = prvalue
-#  326|       3: [BlockStmt] { ... }
-#  327|         0: [IfStmt] if (...) ... 
-#  327|           0: [EQExpr] ... == ...
+#  326|       getStmt(): [BlockStmt] { ... }
+#  327|         getStmt(0): [IfStmt] if (...) ... 
+#  327|           getCondition(): [EQExpr] ... == ...
 #  327|               Type = [BoolType] bool
 #  327|               ValueCategory = prvalue
-#  327|             0: [VariableAccess] i
+#  327|             getLeftOperand(): [VariableAccess] i
 #  327|                 Type = [IntType] int
 #  327|                 ValueCategory = prvalue(load)
-#  327|             1: [Literal] 5
+#  327|             getRightOperand(): [Literal] 5
 #  327|                 Type = [IntType] int
 #  327|                 Value = [Literal] 5
 #  327|                 ValueCategory = prvalue
-#  327|           1: [BlockStmt] { ... }
-#  328|             0: [ContinueStmt] continue;
-#  326|         1: [LabelStmt] label ...:
-#  331|     1: [ReturnStmt] return ...
+#  327|           getThen(): [BlockStmt] { ... }
+#  328|             getStmt(0): [ContinueStmt] continue;
+#  326|         getStmt(1): [LabelStmt] label ...:
+#  331|     getStmt(1): [ReturnStmt] return ...
 #  333| [TopLevelFunction] void For_Continue_NoUpdate()
-#  333|   params: 
-#  333|   body: [BlockStmt] { ... }
-#  334|     0: [ForStmt] for(...;...;...) ...
-#  334|       0: [DeclStmt] declaration
-#  334|         0: [VariableDeclarationEntry] definition of i
+#  333|   ...: 
+#  333|   getEntryPoint(): [BlockStmt] { ... }
+#  334|     getStmt(0): [ForStmt] for(...;...;...) ...
+#  334|       getInitialization(): [DeclStmt] declaration
+#  334|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 #  334|             Type = [IntType] int
-#  334|           init: [Initializer] initializer for i
-#  334|             expr: [Literal] 0
+#  334|           getVariable().getInitializer(): [Initializer] initializer for i
+#  334|             getExpr(): [Literal] 0
 #  334|                 Type = [IntType] int
 #  334|                 Value = [Literal] 0
 #  334|                 ValueCategory = prvalue
-#  334|       1: [LTExpr] ... < ...
+#  334|       getCondition(): [LTExpr] ... < ...
 #  334|           Type = [BoolType] bool
 #  334|           ValueCategory = prvalue
-#  334|         0: [VariableAccess] i
+#  334|         getLesserOperand(): [VariableAccess] i
 #  334|             Type = [IntType] int
 #  334|             ValueCategory = prvalue(load)
-#  334|         1: [Literal] 10
+#  334|         getGreaterOperand(): [Literal] 10
 #  334|             Type = [IntType] int
 #  334|             Value = [Literal] 10
 #  334|             ValueCategory = prvalue
-#  334|       3: [BlockStmt] { ... }
-#  335|         0: [IfStmt] if (...) ... 
-#  335|           0: [EQExpr] ... == ...
+#  334|       getStmt(): [BlockStmt] { ... }
+#  335|         getStmt(0): [IfStmt] if (...) ... 
+#  335|           getCondition(): [EQExpr] ... == ...
 #  335|               Type = [BoolType] bool
 #  335|               ValueCategory = prvalue
-#  335|             0: [VariableAccess] i
+#  335|             getLeftOperand(): [VariableAccess] i
 #  335|                 Type = [IntType] int
 #  335|                 ValueCategory = prvalue(load)
-#  335|             1: [Literal] 5
+#  335|             getRightOperand(): [Literal] 5
 #  335|                 Type = [IntType] int
 #  335|                 Value = [Literal] 5
 #  335|                 ValueCategory = prvalue
-#  335|           1: [BlockStmt] { ... }
-#  336|             0: [ContinueStmt] continue;
-#  334|         1: [LabelStmt] label ...:
-#  339|     1: [ReturnStmt] return ...
+#  335|           getThen(): [BlockStmt] { ... }
+#  336|             getStmt(0): [ContinueStmt] continue;
+#  334|         getStmt(1): [LabelStmt] label ...:
+#  339|     getStmt(1): [ReturnStmt] return ...
 #  341| [TopLevelFunction] int Dereference(int*)
-#  341|   params: 
-#  341|     0: [Parameter] p
+#  341|   ...: 
+#  341|     getParameter(0): [Parameter] p
 #  341|         Type = [IntPointerType] int *
-#  341|   body: [BlockStmt] { ... }
-#  342|     0: [ExprStmt] ExprStmt
-#  342|       0: [AssignExpr] ... = ...
+#  341|   getEntryPoint(): [BlockStmt] { ... }
+#  342|     getStmt(0): [ExprStmt] ExprStmt
+#  342|       getExpr(): [AssignExpr] ... = ...
 #  342|           Type = [IntType] int
 #  342|           ValueCategory = lvalue
-#  342|         0: [PointerDereferenceExpr] * ...
+#  342|         getLValue(): [PointerDereferenceExpr] * ...
 #  342|             Type = [IntType] int
 #  342|             ValueCategory = lvalue
-#  342|           0: [VariableAccess] p
+#  342|           getOperand(): [VariableAccess] p
 #  342|               Type = [IntPointerType] int *
 #  342|               ValueCategory = prvalue(load)
-#  342|         1: [Literal] 1
+#  342|         getRValue(): [Literal] 1
 #  342|             Type = [IntType] int
 #  342|             Value = [Literal] 1
 #  342|             ValueCategory = prvalue
-#  343|     1: [ReturnStmt] return ...
-#  343|       0: [PointerDereferenceExpr] * ...
+#  343|     getStmt(1): [ReturnStmt] return ...
+#  343|       getExpr(): [PointerDereferenceExpr] * ...
 #  343|           Type = [IntType] int
 #  343|           ValueCategory = prvalue(load)
-#  343|         0: [VariableAccess] p
+#  343|         getOperand(): [VariableAccess] p
 #  343|             Type = [IntPointerType] int *
 #  343|             ValueCategory = prvalue(load)
 #  348| [TopLevelFunction] int* AddressOf()
-#  348|   params: 
-#  348|   body: [BlockStmt] { ... }
-#  349|     0: [ReturnStmt] return ...
-#  349|       0: [AddressOfExpr] & ...
+#  348|   ...: 
+#  348|   getEntryPoint(): [BlockStmt] { ... }
+#  349|     getStmt(0): [ReturnStmt] return ...
+#  349|       getExpr(): [AddressOfExpr] & ...
 #  349|           Type = [IntPointerType] int *
 #  349|           ValueCategory = prvalue
-#  349|         0: [VariableAccess] g
+#  349|         getOperand(): [VariableAccess] g
 #  349|             Type = [IntType] int
 #  349|             ValueCategory = lvalue
 #  352| [TopLevelFunction] void Break(int)
-#  352|   params: 
-#  352|     0: [Parameter] n
+#  352|   ...: 
+#  352|     getParameter(0): [Parameter] n
 #  352|         Type = [IntType] int
-#  352|   body: [BlockStmt] { ... }
-#  353|     0: [WhileStmt] while (...) ...
-#  353|       0: [GTExpr] ... > ...
+#  352|   getEntryPoint(): [BlockStmt] { ... }
+#  353|     getStmt(0): [WhileStmt] while (...) ...
+#  353|       getCondition(): [GTExpr] ... > ...
 #  353|           Type = [BoolType] bool
 #  353|           ValueCategory = prvalue
-#  353|         0: [VariableAccess] n
+#  353|         getGreaterOperand(): [VariableAccess] n
 #  353|             Type = [IntType] int
 #  353|             ValueCategory = prvalue(load)
-#  353|         1: [Literal] 0
+#  353|         getLesserOperand(): [Literal] 0
 #  353|             Type = [IntType] int
 #  353|             Value = [Literal] 0
 #  353|             ValueCategory = prvalue
-#  353|       1: [BlockStmt] { ... }
-#  354|         0: [IfStmt] if (...) ... 
-#  354|           0: [EQExpr] ... == ...
+#  353|       getStmt(): [BlockStmt] { ... }
+#  354|         getStmt(0): [IfStmt] if (...) ... 
+#  354|           getCondition(): [EQExpr] ... == ...
 #  354|               Type = [BoolType] bool
 #  354|               ValueCategory = prvalue
-#  354|             0: [VariableAccess] n
+#  354|             getLeftOperand(): [VariableAccess] n
 #  354|                 Type = [IntType] int
 #  354|                 ValueCategory = prvalue(load)
-#  354|             1: [Literal] 1
+#  354|             getRightOperand(): [Literal] 1
 #  354|                 Type = [IntType] int
 #  354|                 Value = [Literal] 1
 #  354|                 ValueCategory = prvalue
-#  355|           1: [BreakStmt] break;
-#  356|         1: [ExprStmt] ExprStmt
-#  356|           0: [AssignSubExpr] ... -= ...
+#  355|           getThen(): [BreakStmt] break;
+#  356|         getStmt(1): [ExprStmt] ExprStmt
+#  356|           getExpr(): [AssignSubExpr] ... -= ...
 #  356|               Type = [IntType] int
 #  356|               ValueCategory = lvalue
-#  356|             0: [VariableAccess] n
+#  356|             getLValue(): [VariableAccess] n
 #  356|                 Type = [IntType] int
 #  356|                 ValueCategory = lvalue
-#  356|             1: [Literal] 1
+#  356|             getRValue(): [Literal] 1
 #  356|                 Type = [IntType] int
 #  356|                 Value = [Literal] 1
 #  356|                 ValueCategory = prvalue
-#  357|     1: [LabelStmt] label ...:
-#  358|     2: [ReturnStmt] return ...
+#  357|     getStmt(1): [LabelStmt] label ...:
+#  358|     getStmt(2): [ReturnStmt] return ...
 #  360| [TopLevelFunction] void Continue(int)
-#  360|   params: 
-#  360|     0: [Parameter] n
+#  360|   ...: 
+#  360|     getParameter(0): [Parameter] n
 #  360|         Type = [IntType] int
-#  360|   body: [BlockStmt] { ... }
-#  361|     0: [DoStmt] do (...) ...
-#  366|       0: [GTExpr] ... > ...
+#  360|   getEntryPoint(): [BlockStmt] { ... }
+#  361|     getStmt(0): [DoStmt] do (...) ...
+#  366|       getCondition(): [GTExpr] ... > ...
 #  366|           Type = [BoolType] bool
 #  366|           ValueCategory = prvalue
-#  366|         0: [VariableAccess] n
+#  366|         getGreaterOperand(): [VariableAccess] n
 #  366|             Type = [IntType] int
 #  366|             ValueCategory = prvalue(load)
-#  366|         1: [Literal] 0
+#  366|         getLesserOperand(): [Literal] 0
 #  366|             Type = [IntType] int
 #  366|             Value = [Literal] 0
 #  366|             ValueCategory = prvalue
-#  361|       1: [BlockStmt] { ... }
-#  362|         0: [IfStmt] if (...) ... 
-#  362|           0: [EQExpr] ... == ...
+#  361|       getStmt(): [BlockStmt] { ... }
+#  362|         getStmt(0): [IfStmt] if (...) ... 
+#  362|           getCondition(): [EQExpr] ... == ...
 #  362|               Type = [BoolType] bool
 #  362|               ValueCategory = prvalue
-#  362|             0: [VariableAccess] n
+#  362|             getLeftOperand(): [VariableAccess] n
 #  362|                 Type = [IntType] int
 #  362|                 ValueCategory = prvalue(load)
-#  362|             1: [Literal] 1
+#  362|             getRightOperand(): [Literal] 1
 #  362|                 Type = [IntType] int
 #  362|                 Value = [Literal] 1
 #  362|                 ValueCategory = prvalue
-#  362|           1: [BlockStmt] { ... }
-#  363|             0: [ContinueStmt] continue;
-#  365|         1: [ExprStmt] ExprStmt
-#  365|           0: [AssignSubExpr] ... -= ...
+#  362|           getThen(): [BlockStmt] { ... }
+#  363|             getStmt(0): [ContinueStmt] continue;
+#  365|         getStmt(1): [ExprStmt] ExprStmt
+#  365|           getExpr(): [AssignSubExpr] ... -= ...
 #  365|               Type = [IntType] int
 #  365|               ValueCategory = lvalue
-#  365|             0: [VariableAccess] n
+#  365|             getLValue(): [VariableAccess] n
 #  365|                 Type = [IntType] int
 #  365|                 ValueCategory = lvalue
-#  365|             1: [Literal] 1
+#  365|             getRValue(): [Literal] 1
 #  365|                 Type = [IntType] int
 #  365|                 Value = [Literal] 1
 #  365|                 ValueCategory = prvalue
-#  361|         2: [LabelStmt] label ...:
-#  367|     1: [ReturnStmt] return ...
+#  361|         getStmt(2): [LabelStmt] label ...:
+#  367|     getStmt(1): [ReturnStmt] return ...
 #  369| [TopLevelFunction] void VoidFunc()
-#  369|   params: 
+#  369|   ...: 
 #  370| [TopLevelFunction] int Add(int, int)
-#  370|   params: 
-#  370|     0: [Parameter] x
+#  370|   ...: 
+#  370|     getParameter(0): [Parameter] x
 #  370|         Type = [IntType] int
-#  370|     1: [Parameter] y
+#  370|     getParameter(1): [Parameter] y
 #  370|         Type = [IntType] int
 #  372| [TopLevelFunction] void Call()
-#  372|   params: 
-#  372|   body: [BlockStmt] { ... }
-#  373|     0: [ExprStmt] ExprStmt
-#  373|       0: [FunctionCall] call to VoidFunc
+#  372|   ...: 
+#  372|   getEntryPoint(): [BlockStmt] { ... }
+#  373|     getStmt(0): [ExprStmt] ExprStmt
+#  373|       getExpr(): [FunctionCall] call to VoidFunc
 #  373|           Type = [VoidType] void
 #  373|           ValueCategory = prvalue
-#  374|     1: [ReturnStmt] return ...
+#  374|     getStmt(1): [ReturnStmt] return ...
 #  376| [TopLevelFunction] int CallAdd(int, int)
-#  376|   params: 
-#  376|     0: [Parameter] x
+#  376|   ...: 
+#  376|     getParameter(0): [Parameter] x
 #  376|         Type = [IntType] int
-#  376|     1: [Parameter] y
+#  376|     getParameter(1): [Parameter] y
 #  376|         Type = [IntType] int
-#  376|   body: [BlockStmt] { ... }
-#  377|     0: [ReturnStmt] return ...
-#  377|       0: [FunctionCall] call to Add
+#  376|   getEntryPoint(): [BlockStmt] { ... }
+#  377|     getStmt(0): [ReturnStmt] return ...
+#  377|       getExpr(): [FunctionCall] call to Add
 #  377|           Type = [IntType] int
 #  377|           ValueCategory = prvalue
-#  377|         0: [VariableAccess] x
+#  377|         getArgument(0): [VariableAccess] x
 #  377|             Type = [IntType] int
 #  377|             ValueCategory = prvalue(load)
-#  377|         1: [VariableAccess] y
+#  377|         getArgument(1): [VariableAccess] y
 #  377|             Type = [IntType] int
 #  377|             ValueCategory = prvalue(load)
 #  380| [TopLevelFunction] int Comma(int, int)
-#  380|   params: 
-#  380|     0: [Parameter] x
+#  380|   ...: 
+#  380|     getParameter(0): [Parameter] x
 #  380|         Type = [IntType] int
-#  380|     1: [Parameter] y
+#  380|     getParameter(1): [Parameter] y
 #  380|         Type = [IntType] int
-#  380|   body: [BlockStmt] { ... }
-#  381|     0: [ReturnStmt] return ...
-#  381|       0: [CommaExpr] ... , ...
+#  380|   getEntryPoint(): [BlockStmt] { ... }
+#  381|     getStmt(0): [ReturnStmt] return ...
+#  381|       getExpr(): [CommaExpr] ... , ...
 #  381|           Type = [IntType] int
 #  381|           ValueCategory = prvalue
-#  381|         0: [FunctionCall] call to VoidFunc
+#  381|         getLeftOperand(): [FunctionCall] call to VoidFunc
 #  381|             Type = [VoidType] void
 #  381|             ValueCategory = prvalue
-#  381|         1: [FunctionCall] call to CallAdd
+#  381|         getRightOperand(): [FunctionCall] call to CallAdd
 #  381|             Type = [IntType] int
 #  381|             ValueCategory = prvalue
-#  381|           0: [VariableAccess] x
+#  381|           getArgument(0): [VariableAccess] x
 #  381|               Type = [IntType] int
 #  381|               ValueCategory = prvalue(load)
-#  381|           1: [VariableAccess] y
+#  381|           getArgument(1): [VariableAccess] y
 #  381|               Type = [IntType] int
 #  381|               ValueCategory = prvalue(load)
 #  384| [TopLevelFunction] void Switch(int)
-#  384|   params: 
-#  384|     0: [Parameter] x
+#  384|   ...: 
+#  384|     getParameter(0): [Parameter] x
 #  384|         Type = [IntType] int
-#  384|   body: [BlockStmt] { ... }
-#  385|     0: [DeclStmt] declaration
-#  385|       0: [VariableDeclarationEntry] definition of y
+#  384|   getEntryPoint(): [BlockStmt] { ... }
+#  385|     getStmt(0): [DeclStmt] declaration
+#  385|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #  385|           Type = [IntType] int
-#  386|     1: [SwitchStmt] switch (...) ... 
-#  386|       0: [VariableAccess] x
+#  386|     getStmt(1): [SwitchStmt] switch (...) ... 
+#  386|       getExpr(): [VariableAccess] x
 #  386|           Type = [IntType] int
 #  386|           ValueCategory = prvalue(load)
-#  386|       1: [BlockStmt] { ... }
-#  387|         0: [ExprStmt] ExprStmt
-#  387|           0: [AssignExpr] ... = ...
+#  386|       getStmt(): [BlockStmt] { ... }
+#  387|         getStmt(0): [ExprStmt] ExprStmt
+#  387|           getExpr(): [AssignExpr] ... = ...
 #  387|               Type = [IntType] int
 #  387|               ValueCategory = lvalue
-#  387|             0: [VariableAccess] y
+#  387|             getLValue(): [VariableAccess] y
 #  387|                 Type = [IntType] int
 #  387|                 ValueCategory = lvalue
-#  387|             1: [Literal] 1234
+#  387|             getRValue(): [Literal] 1234
 #  387|                 Type = [IntType] int
 #  387|                 Value = [Literal] 1234
 #  387|                 ValueCategory = prvalue
-#  389|         1: [SwitchCase] case ...:
-#  389|           0: [UnaryMinusExpr] - ...
+#  389|         getStmt(1): [SwitchCase] case ...:
+#  389|           getExpr(): [UnaryMinusExpr] - ...
 #  389|               Type = [IntType] int
 #  389|               Value = [UnaryMinusExpr] -1
 #  389|               ValueCategory = prvalue
-#  389|             0: [Literal] 1
+#  389|             getOperand(): [Literal] 1
 #  389|                 Type = [IntType] int
 #  389|                 Value = [Literal] 1
 #  389|                 ValueCategory = prvalue
-#  390|         2: [ExprStmt] ExprStmt
-#  390|           0: [AssignExpr] ... = ...
+#  390|         getStmt(2): [ExprStmt] ExprStmt
+#  390|           getExpr(): [AssignExpr] ... = ...
 #  390|               Type = [IntType] int
 #  390|               ValueCategory = lvalue
-#  390|             0: [VariableAccess] y
+#  390|             getLValue(): [VariableAccess] y
 #  390|                 Type = [IntType] int
 #  390|                 ValueCategory = lvalue
-#  390|             1: [UnaryMinusExpr] - ...
+#  390|             getRValue(): [UnaryMinusExpr] - ...
 #  390|                 Type = [IntType] int
 #  390|                 Value = [UnaryMinusExpr] -1
 #  390|                 ValueCategory = prvalue
-#  390|               0: [Literal] 1
+#  390|               getOperand(): [Literal] 1
 #  390|                   Type = [IntType] int
 #  390|                   Value = [Literal] 1
 #  390|                   ValueCategory = prvalue
-#  391|         3: [BreakStmt] break;
-#  393|         4: [SwitchCase] case ...:
-#  393|           0: [Literal] 1
+#  391|         getStmt(3): [BreakStmt] break;
+#  393|         getStmt(4): [SwitchCase] case ...:
+#  393|           getExpr(): [Literal] 1
 #  393|               Type = [IntType] int
 #  393|               Value = [Literal] 1
 #  393|               ValueCategory = prvalue
-#  394|         5: [SwitchCase] case ...:
-#  394|           0: [Literal] 2
+#  394|         getStmt(5): [SwitchCase] case ...:
+#  394|           getExpr(): [Literal] 2
 #  394|               Type = [IntType] int
 #  394|               Value = [Literal] 2
 #  394|               ValueCategory = prvalue
-#  395|         6: [ExprStmt] ExprStmt
-#  395|           0: [AssignExpr] ... = ...
+#  395|         getStmt(6): [ExprStmt] ExprStmt
+#  395|           getExpr(): [AssignExpr] ... = ...
 #  395|               Type = [IntType] int
 #  395|               ValueCategory = lvalue
-#  395|             0: [VariableAccess] y
+#  395|             getLValue(): [VariableAccess] y
 #  395|                 Type = [IntType] int
 #  395|                 ValueCategory = lvalue
-#  395|             1: [Literal] 1
+#  395|             getRValue(): [Literal] 1
 #  395|                 Type = [IntType] int
 #  395|                 Value = [Literal] 1
 #  395|                 ValueCategory = prvalue
-#  396|         7: [BreakStmt] break;
-#  398|         8: [SwitchCase] case ...:
-#  398|           0: [Literal] 3
+#  396|         getStmt(7): [BreakStmt] break;
+#  398|         getStmt(8): [SwitchCase] case ...:
+#  398|           getExpr(): [Literal] 3
 #  398|               Type = [IntType] int
 #  398|               Value = [Literal] 3
 #  398|               ValueCategory = prvalue
-#  399|         9: [ExprStmt] ExprStmt
-#  399|           0: [AssignExpr] ... = ...
+#  399|         getStmt(9): [ExprStmt] ExprStmt
+#  399|           getExpr(): [AssignExpr] ... = ...
 #  399|               Type = [IntType] int
 #  399|               ValueCategory = lvalue
-#  399|             0: [VariableAccess] y
+#  399|             getLValue(): [VariableAccess] y
 #  399|                 Type = [IntType] int
 #  399|                 ValueCategory = lvalue
-#  399|             1: [Literal] 3
+#  399|             getRValue(): [Literal] 3
 #  399|                 Type = [IntType] int
 #  399|                 Value = [Literal] 3
 #  399|                 ValueCategory = prvalue
-#  400|         10: [SwitchCase] case ...:
-#  400|           0: [Literal] 4
+#  400|         getStmt(10): [SwitchCase] case ...:
+#  400|           getExpr(): [Literal] 4
 #  400|               Type = [IntType] int
 #  400|               Value = [Literal] 4
 #  400|               ValueCategory = prvalue
-#  401|         11: [ExprStmt] ExprStmt
-#  401|           0: [AssignExpr] ... = ...
+#  401|         getStmt(11): [ExprStmt] ExprStmt
+#  401|           getExpr(): [AssignExpr] ... = ...
 #  401|               Type = [IntType] int
 #  401|               ValueCategory = lvalue
-#  401|             0: [VariableAccess] y
+#  401|             getLValue(): [VariableAccess] y
 #  401|                 Type = [IntType] int
 #  401|                 ValueCategory = lvalue
-#  401|             1: [Literal] 4
+#  401|             getRValue(): [Literal] 4
 #  401|                 Type = [IntType] int
 #  401|                 Value = [Literal] 4
 #  401|                 ValueCategory = prvalue
-#  402|         12: [BreakStmt] break;
-#  404|         13: [SwitchCase] default: 
-#  405|         14: [ExprStmt] ExprStmt
-#  405|           0: [AssignExpr] ... = ...
+#  402|         getStmt(12): [BreakStmt] break;
+#  404|         getStmt(13): [SwitchCase] default: 
+#  405|         getStmt(14): [ExprStmt] ExprStmt
+#  405|           getExpr(): [AssignExpr] ... = ...
 #  405|               Type = [IntType] int
 #  405|               ValueCategory = lvalue
-#  405|             0: [VariableAccess] y
+#  405|             getLValue(): [VariableAccess] y
 #  405|                 Type = [IntType] int
 #  405|                 ValueCategory = lvalue
-#  405|             1: [Literal] 0
+#  405|             getRValue(): [Literal] 0
 #  405|                 Type = [IntType] int
 #  405|                 Value = [Literal] 0
 #  405|                 ValueCategory = prvalue
-#  406|         15: [BreakStmt] break;
-#  408|         16: [ExprStmt] ExprStmt
-#  408|           0: [AssignExpr] ... = ...
+#  406|         getStmt(15): [BreakStmt] break;
+#  408|         getStmt(16): [ExprStmt] ExprStmt
+#  408|           getExpr(): [AssignExpr] ... = ...
 #  408|               Type = [IntType] int
 #  408|               ValueCategory = lvalue
-#  408|             0: [VariableAccess] y
+#  408|             getLValue(): [VariableAccess] y
 #  408|                 Type = [IntType] int
 #  408|                 ValueCategory = lvalue
-#  408|             1: [Literal] 5678
+#  408|             getRValue(): [Literal] 5678
 #  408|                 Type = [IntType] int
 #  408|                 Value = [Literal] 5678
 #  408|                 ValueCategory = prvalue
-#  409|     2: [LabelStmt] label ...:
-#  410|     3: [ReturnStmt] return ...
+#  409|     getStmt(2): [LabelStmt] label ...:
+#  410|     getStmt(3): [ReturnStmt] return ...
 #  412| [CopyAssignmentOperator] Point& Point::operator=(Point const&)
-#  412|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  412|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #  412| [MoveAssignmentOperator] Point& Point::operator=(Point&&)
-#  412|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  412|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #  417| [CopyAssignmentOperator] Rect& Rect::operator=(Rect const&)
-#  417|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  417|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Rect &
 #  417| [MoveAssignmentOperator] Rect& Rect::operator=(Rect&&)
-#  417|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  417|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Rect &&
 #  422| [TopLevelFunction] Point ReturnStruct(Point)
-#  422|   params: 
-#  422|     0: [Parameter] pt
+#  422|   ...: 
+#  422|     getParameter(0): [Parameter] pt
 #  422|         Type = [Struct] Point
-#  422|   body: [BlockStmt] { ... }
-#  423|     0: [ReturnStmt] return ...
-#  423|       0: [VariableAccess] pt
+#  422|   getEntryPoint(): [BlockStmt] { ... }
+#  423|     getStmt(0): [ReturnStmt] return ...
+#  423|       getExpr(): [VariableAccess] pt
 #  423|           Type = [Struct] Point
 #  423|           ValueCategory = prvalue(load)
 #  426| [TopLevelFunction] void FieldAccess()
-#  426|   params: 
-#  426|   body: [BlockStmt] { ... }
-#  427|     0: [DeclStmt] declaration
-#  427|       0: [VariableDeclarationEntry] definition of pt
+#  426|   ...: 
+#  426|   getEntryPoint(): [BlockStmt] { ... }
+#  427|     getStmt(0): [DeclStmt] declaration
+#  427|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt
 #  427|           Type = [Struct] Point
-#  428|     1: [ExprStmt] ExprStmt
-#  428|       0: [AssignExpr] ... = ...
+#  428|     getStmt(1): [ExprStmt] ExprStmt
+#  428|       getExpr(): [AssignExpr] ... = ...
 #  428|           Type = [IntType] int
 #  428|           ValueCategory = lvalue
-#  428|         0: [ValueFieldAccess] x
+#  428|         getLValue(): [ValueFieldAccess] x
 #  428|             Type = [IntType] int
 #  428|             ValueCategory = lvalue
-#  428|           -1: [VariableAccess] pt
+#  428|           getQualifier(): [VariableAccess] pt
 #  428|               Type = [Struct] Point
 #  428|               ValueCategory = lvalue
-#  428|         1: [Literal] 5
+#  428|         getRValue(): [Literal] 5
 #  428|             Type = [IntType] int
 #  428|             Value = [Literal] 5
 #  428|             ValueCategory = prvalue
-#  429|     2: [ExprStmt] ExprStmt
-#  429|       0: [AssignExpr] ... = ...
+#  429|     getStmt(2): [ExprStmt] ExprStmt
+#  429|       getExpr(): [AssignExpr] ... = ...
 #  429|           Type = [IntType] int
 #  429|           ValueCategory = lvalue
-#  429|         0: [ValueFieldAccess] y
+#  429|         getLValue(): [ValueFieldAccess] y
 #  429|             Type = [IntType] int
 #  429|             ValueCategory = lvalue
-#  429|           -1: [VariableAccess] pt
+#  429|           getQualifier(): [VariableAccess] pt
 #  429|               Type = [Struct] Point
 #  429|               ValueCategory = lvalue
-#  429|         1: [ValueFieldAccess] x
+#  429|         getRValue(): [ValueFieldAccess] x
 #  429|             Type = [IntType] int
 #  429|             ValueCategory = prvalue(load)
-#  429|           -1: [VariableAccess] pt
+#  429|           getQualifier(): [VariableAccess] pt
 #  429|               Type = [Struct] Point
 #  429|               ValueCategory = lvalue
-#  430|     3: [DeclStmt] declaration
-#  430|       0: [VariableDeclarationEntry] definition of p
+#  430|     getStmt(3): [DeclStmt] declaration
+#  430|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
 #  430|           Type = [IntPointerType] int *
-#  430|         init: [Initializer] initializer for p
-#  430|           expr: [AddressOfExpr] & ...
+#  430|         getVariable().getInitializer(): [Initializer] initializer for p
+#  430|           getExpr(): [AddressOfExpr] & ...
 #  430|               Type = [IntPointerType] int *
 #  430|               ValueCategory = prvalue
-#  430|             0: [ValueFieldAccess] y
+#  430|             getOperand(): [ValueFieldAccess] y
 #  430|                 Type = [IntType] int
 #  430|                 ValueCategory = lvalue
-#  430|               -1: [VariableAccess] pt
+#  430|               getQualifier(): [VariableAccess] pt
 #  430|                   Type = [Struct] Point
 #  430|                   ValueCategory = lvalue
-#  431|     4: [ReturnStmt] return ...
+#  431|     getStmt(4): [ReturnStmt] return ...
 #  433| [TopLevelFunction] void LogicalOr(bool, bool)
-#  433|   params: 
-#  433|     0: [Parameter] a
+#  433|   ...: 
+#  433|     getParameter(0): [Parameter] a
 #  433|         Type = [BoolType] bool
-#  433|     1: [Parameter] b
+#  433|     getParameter(1): [Parameter] b
 #  433|         Type = [BoolType] bool
-#  433|   body: [BlockStmt] { ... }
-#  434|     0: [DeclStmt] declaration
-#  434|       0: [VariableDeclarationEntry] definition of x
+#  433|   getEntryPoint(): [BlockStmt] { ... }
+#  434|     getStmt(0): [DeclStmt] declaration
+#  434|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  434|           Type = [IntType] int
-#  435|     1: [IfStmt] if (...) ... 
-#  435|       0: [LogicalOrExpr] ... || ...
+#  435|     getStmt(1): [IfStmt] if (...) ... 
+#  435|       getCondition(): [LogicalOrExpr] ... || ...
 #  435|           Type = [BoolType] bool
 #  435|           ValueCategory = prvalue
-#  435|         0: [VariableAccess] a
+#  435|         getLeftOperand(): [VariableAccess] a
 #  435|             Type = [BoolType] bool
 #  435|             ValueCategory = prvalue(load)
-#  435|         1: [VariableAccess] b
+#  435|         getRightOperand(): [VariableAccess] b
 #  435|             Type = [BoolType] bool
 #  435|             ValueCategory = prvalue(load)
-#  435|       1: [BlockStmt] { ... }
-#  436|         0: [ExprStmt] ExprStmt
-#  436|           0: [AssignExpr] ... = ...
+#  435|       getThen(): [BlockStmt] { ... }
+#  436|         getStmt(0): [ExprStmt] ExprStmt
+#  436|           getExpr(): [AssignExpr] ... = ...
 #  436|               Type = [IntType] int
 #  436|               ValueCategory = lvalue
-#  436|             0: [VariableAccess] x
+#  436|             getLValue(): [VariableAccess] x
 #  436|                 Type = [IntType] int
 #  436|                 ValueCategory = lvalue
-#  436|             1: [Literal] 7
+#  436|             getRValue(): [Literal] 7
 #  436|                 Type = [IntType] int
 #  436|                 Value = [Literal] 7
 #  436|                 ValueCategory = prvalue
-#  439|     2: [IfStmt] if (...) ... 
-#  439|       0: [LogicalOrExpr] ... || ...
+#  439|     getStmt(2): [IfStmt] if (...) ... 
+#  439|       getCondition(): [LogicalOrExpr] ... || ...
 #  439|           Type = [BoolType] bool
 #  439|           ValueCategory = prvalue
-#  439|         0: [VariableAccess] a
+#  439|         getLeftOperand(): [VariableAccess] a
 #  439|             Type = [BoolType] bool
 #  439|             ValueCategory = prvalue(load)
-#  439|         1: [VariableAccess] b
+#  439|         getRightOperand(): [VariableAccess] b
 #  439|             Type = [BoolType] bool
 #  439|             ValueCategory = prvalue(load)
-#  439|       1: [BlockStmt] { ... }
-#  440|         0: [ExprStmt] ExprStmt
-#  440|           0: [AssignExpr] ... = ...
+#  439|       getThen(): [BlockStmt] { ... }
+#  440|         getStmt(0): [ExprStmt] ExprStmt
+#  440|           getExpr(): [AssignExpr] ... = ...
 #  440|               Type = [IntType] int
 #  440|               ValueCategory = lvalue
-#  440|             0: [VariableAccess] x
+#  440|             getLValue(): [VariableAccess] x
 #  440|                 Type = [IntType] int
 #  440|                 ValueCategory = lvalue
-#  440|             1: [Literal] 1
+#  440|             getRValue(): [Literal] 1
 #  440|                 Type = [IntType] int
 #  440|                 Value = [Literal] 1
 #  440|                 ValueCategory = prvalue
-#  442|       2: [BlockStmt] { ... }
-#  443|         0: [ExprStmt] ExprStmt
-#  443|           0: [AssignExpr] ... = ...
+#  442|       getElse(): [BlockStmt] { ... }
+#  443|         getStmt(0): [ExprStmt] ExprStmt
+#  443|           getExpr(): [AssignExpr] ... = ...
 #  443|               Type = [IntType] int
 #  443|               ValueCategory = lvalue
-#  443|             0: [VariableAccess] x
+#  443|             getLValue(): [VariableAccess] x
 #  443|                 Type = [IntType] int
 #  443|                 ValueCategory = lvalue
-#  443|             1: [Literal] 5
+#  443|             getRValue(): [Literal] 5
 #  443|                 Type = [IntType] int
 #  443|                 Value = [Literal] 5
 #  443|                 ValueCategory = prvalue
-#  445|     3: [ReturnStmt] return ...
+#  445|     getStmt(3): [ReturnStmt] return ...
 #  447| [TopLevelFunction] void LogicalAnd(bool, bool)
-#  447|   params: 
-#  447|     0: [Parameter] a
+#  447|   ...: 
+#  447|     getParameter(0): [Parameter] a
 #  447|         Type = [BoolType] bool
-#  447|     1: [Parameter] b
+#  447|     getParameter(1): [Parameter] b
 #  447|         Type = [BoolType] bool
-#  447|   body: [BlockStmt] { ... }
-#  448|     0: [DeclStmt] declaration
-#  448|       0: [VariableDeclarationEntry] definition of x
+#  447|   getEntryPoint(): [BlockStmt] { ... }
+#  448|     getStmt(0): [DeclStmt] declaration
+#  448|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  448|           Type = [IntType] int
-#  449|     1: [IfStmt] if (...) ... 
-#  449|       0: [LogicalAndExpr] ... && ...
+#  449|     getStmt(1): [IfStmt] if (...) ... 
+#  449|       getCondition(): [LogicalAndExpr] ... && ...
 #  449|           Type = [BoolType] bool
 #  449|           ValueCategory = prvalue
-#  449|         0: [VariableAccess] a
+#  449|         getLeftOperand(): [VariableAccess] a
 #  449|             Type = [BoolType] bool
 #  449|             ValueCategory = prvalue(load)
-#  449|         1: [VariableAccess] b
+#  449|         getRightOperand(): [VariableAccess] b
 #  449|             Type = [BoolType] bool
 #  449|             ValueCategory = prvalue(load)
-#  449|       1: [BlockStmt] { ... }
-#  450|         0: [ExprStmt] ExprStmt
-#  450|           0: [AssignExpr] ... = ...
+#  449|       getThen(): [BlockStmt] { ... }
+#  450|         getStmt(0): [ExprStmt] ExprStmt
+#  450|           getExpr(): [AssignExpr] ... = ...
 #  450|               Type = [IntType] int
 #  450|               ValueCategory = lvalue
-#  450|             0: [VariableAccess] x
+#  450|             getLValue(): [VariableAccess] x
 #  450|                 Type = [IntType] int
 #  450|                 ValueCategory = lvalue
-#  450|             1: [Literal] 7
+#  450|             getRValue(): [Literal] 7
 #  450|                 Type = [IntType] int
 #  450|                 Value = [Literal] 7
 #  450|                 ValueCategory = prvalue
-#  453|     2: [IfStmt] if (...) ... 
-#  453|       0: [LogicalAndExpr] ... && ...
+#  453|     getStmt(2): [IfStmt] if (...) ... 
+#  453|       getCondition(): [LogicalAndExpr] ... && ...
 #  453|           Type = [BoolType] bool
 #  453|           ValueCategory = prvalue
-#  453|         0: [VariableAccess] a
+#  453|         getLeftOperand(): [VariableAccess] a
 #  453|             Type = [BoolType] bool
 #  453|             ValueCategory = prvalue(load)
-#  453|         1: [VariableAccess] b
+#  453|         getRightOperand(): [VariableAccess] b
 #  453|             Type = [BoolType] bool
 #  453|             ValueCategory = prvalue(load)
-#  453|       1: [BlockStmt] { ... }
-#  454|         0: [ExprStmt] ExprStmt
-#  454|           0: [AssignExpr] ... = ...
+#  453|       getThen(): [BlockStmt] { ... }
+#  454|         getStmt(0): [ExprStmt] ExprStmt
+#  454|           getExpr(): [AssignExpr] ... = ...
 #  454|               Type = [IntType] int
 #  454|               ValueCategory = lvalue
-#  454|             0: [VariableAccess] x
+#  454|             getLValue(): [VariableAccess] x
 #  454|                 Type = [IntType] int
 #  454|                 ValueCategory = lvalue
-#  454|             1: [Literal] 1
+#  454|             getRValue(): [Literal] 1
 #  454|                 Type = [IntType] int
 #  454|                 Value = [Literal] 1
 #  454|                 ValueCategory = prvalue
-#  456|       2: [BlockStmt] { ... }
-#  457|         0: [ExprStmt] ExprStmt
-#  457|           0: [AssignExpr] ... = ...
+#  456|       getElse(): [BlockStmt] { ... }
+#  457|         getStmt(0): [ExprStmt] ExprStmt
+#  457|           getExpr(): [AssignExpr] ... = ...
 #  457|               Type = [IntType] int
 #  457|               ValueCategory = lvalue
-#  457|             0: [VariableAccess] x
+#  457|             getLValue(): [VariableAccess] x
 #  457|                 Type = [IntType] int
 #  457|                 ValueCategory = lvalue
-#  457|             1: [Literal] 5
+#  457|             getRValue(): [Literal] 5
 #  457|                 Type = [IntType] int
 #  457|                 Value = [Literal] 5
 #  457|                 ValueCategory = prvalue
-#  459|     3: [ReturnStmt] return ...
+#  459|     getStmt(3): [ReturnStmt] return ...
 #  461| [TopLevelFunction] void LogicalNot(bool, bool)
-#  461|   params: 
-#  461|     0: [Parameter] a
+#  461|   ...: 
+#  461|     getParameter(0): [Parameter] a
 #  461|         Type = [BoolType] bool
-#  461|     1: [Parameter] b
+#  461|     getParameter(1): [Parameter] b
 #  461|         Type = [BoolType] bool
-#  461|   body: [BlockStmt] { ... }
-#  462|     0: [DeclStmt] declaration
-#  462|       0: [VariableDeclarationEntry] definition of x
+#  461|   getEntryPoint(): [BlockStmt] { ... }
+#  462|     getStmt(0): [DeclStmt] declaration
+#  462|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  462|           Type = [IntType] int
-#  463|     1: [IfStmt] if (...) ... 
-#  463|       0: [NotExpr] ! ...
+#  463|     getStmt(1): [IfStmt] if (...) ... 
+#  463|       getCondition(): [NotExpr] ! ...
 #  463|           Type = [BoolType] bool
 #  463|           ValueCategory = prvalue
-#  463|         0: [VariableAccess] a
+#  463|         getOperand(): [VariableAccess] a
 #  463|             Type = [BoolType] bool
 #  463|             ValueCategory = prvalue(load)
-#  463|       1: [BlockStmt] { ... }
-#  464|         0: [ExprStmt] ExprStmt
-#  464|           0: [AssignExpr] ... = ...
+#  463|       getThen(): [BlockStmt] { ... }
+#  464|         getStmt(0): [ExprStmt] ExprStmt
+#  464|           getExpr(): [AssignExpr] ... = ...
 #  464|               Type = [IntType] int
 #  464|               ValueCategory = lvalue
-#  464|             0: [VariableAccess] x
+#  464|             getLValue(): [VariableAccess] x
 #  464|                 Type = [IntType] int
 #  464|                 ValueCategory = lvalue
-#  464|             1: [Literal] 1
+#  464|             getRValue(): [Literal] 1
 #  464|                 Type = [IntType] int
 #  464|                 Value = [Literal] 1
 #  464|                 ValueCategory = prvalue
-#  467|     2: [IfStmt] if (...) ... 
-#  467|       0: [NotExpr] ! ...
+#  467|     getStmt(2): [IfStmt] if (...) ... 
+#  467|       getCondition(): [NotExpr] ! ...
 #  467|           Type = [BoolType] bool
 #  467|           ValueCategory = prvalue
-#  467|         0: [LogicalAndExpr] ... && ...
+#  467|         getOperand(): [LogicalAndExpr] ... && ...
 #  467|             Type = [BoolType] bool
 #  467|             ValueCategory = prvalue
-#  467|           0: [VariableAccess] a
+#  467|           getLeftOperand(): [VariableAccess] a
 #  467|               Type = [BoolType] bool
 #  467|               ValueCategory = prvalue(load)
-#  467|           1: [VariableAccess] b
+#  467|           getRightOperand(): [VariableAccess] b
 #  467|               Type = [BoolType] bool
 #  467|               ValueCategory = prvalue(load)
-#  467|         0 converted: [ParenthesisExpr] (...)
+#  467|         : [ParenthesisExpr] (...)
 #  467|             Type = [BoolType] bool
 #  467|             ValueCategory = prvalue
-#  467|       1: [BlockStmt] { ... }
-#  468|         0: [ExprStmt] ExprStmt
-#  468|           0: [AssignExpr] ... = ...
+#  467|       getThen(): [BlockStmt] { ... }
+#  468|         getStmt(0): [ExprStmt] ExprStmt
+#  468|           getExpr(): [AssignExpr] ... = ...
 #  468|               Type = [IntType] int
 #  468|               ValueCategory = lvalue
-#  468|             0: [VariableAccess] x
+#  468|             getLValue(): [VariableAccess] x
 #  468|                 Type = [IntType] int
 #  468|                 ValueCategory = lvalue
-#  468|             1: [Literal] 2
+#  468|             getRValue(): [Literal] 2
 #  468|                 Type = [IntType] int
 #  468|                 Value = [Literal] 2
 #  468|                 ValueCategory = prvalue
-#  470|       2: [BlockStmt] { ... }
-#  471|         0: [ExprStmt] ExprStmt
-#  471|           0: [AssignExpr] ... = ...
+#  470|       getElse(): [BlockStmt] { ... }
+#  471|         getStmt(0): [ExprStmt] ExprStmt
+#  471|           getExpr(): [AssignExpr] ... = ...
 #  471|               Type = [IntType] int
 #  471|               ValueCategory = lvalue
-#  471|             0: [VariableAccess] x
+#  471|             getLValue(): [VariableAccess] x
 #  471|                 Type = [IntType] int
 #  471|                 ValueCategory = lvalue
-#  471|             1: [Literal] 3
+#  471|             getRValue(): [Literal] 3
 #  471|                 Type = [IntType] int
 #  471|                 Value = [Literal] 3
 #  471|                 ValueCategory = prvalue
-#  473|     3: [ReturnStmt] return ...
+#  473|     getStmt(3): [ReturnStmt] return ...
 #  475| [TopLevelFunction] void ConditionValues(bool, bool)
-#  475|   params: 
-#  475|     0: [Parameter] a
+#  475|   ...: 
+#  475|     getParameter(0): [Parameter] a
 #  475|         Type = [BoolType] bool
-#  475|     1: [Parameter] b
+#  475|     getParameter(1): [Parameter] b
 #  475|         Type = [BoolType] bool
-#  475|   body: [BlockStmt] { ... }
-#  476|     0: [DeclStmt] declaration
-#  476|       0: [VariableDeclarationEntry] definition of x
+#  475|   getEntryPoint(): [BlockStmt] { ... }
+#  476|     getStmt(0): [DeclStmt] declaration
+#  476|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  476|           Type = [BoolType] bool
-#  477|     1: [ExprStmt] ExprStmt
-#  477|       0: [AssignExpr] ... = ...
+#  477|     getStmt(1): [ExprStmt] ExprStmt
+#  477|       getExpr(): [AssignExpr] ... = ...
 #  477|           Type = [BoolType] bool
 #  477|           ValueCategory = lvalue
-#  477|         0: [VariableAccess] x
+#  477|         getLValue(): [VariableAccess] x
 #  477|             Type = [BoolType] bool
 #  477|             ValueCategory = lvalue
-#  477|         1: [LogicalAndExpr] ... && ...
+#  477|         getRValue(): [LogicalAndExpr] ... && ...
 #  477|             Type = [BoolType] bool
 #  477|             ValueCategory = prvalue
-#  477|           0: [VariableAccess] a
+#  477|           getLeftOperand(): [VariableAccess] a
 #  477|               Type = [BoolType] bool
 #  477|               ValueCategory = prvalue(load)
-#  477|           1: [VariableAccess] b
+#  477|           getRightOperand(): [VariableAccess] b
 #  477|               Type = [BoolType] bool
 #  477|               ValueCategory = prvalue(load)
-#  478|     2: [ExprStmt] ExprStmt
-#  478|       0: [AssignExpr] ... = ...
+#  478|     getStmt(2): [ExprStmt] ExprStmt
+#  478|       getExpr(): [AssignExpr] ... = ...
 #  478|           Type = [BoolType] bool
 #  478|           ValueCategory = lvalue
-#  478|         0: [VariableAccess] x
+#  478|         getLValue(): [VariableAccess] x
 #  478|             Type = [BoolType] bool
 #  478|             ValueCategory = lvalue
-#  478|         1: [LogicalOrExpr] ... || ...
+#  478|         getRValue(): [LogicalOrExpr] ... || ...
 #  478|             Type = [BoolType] bool
 #  478|             ValueCategory = prvalue
-#  478|           0: [VariableAccess] a
+#  478|           getLeftOperand(): [VariableAccess] a
 #  478|               Type = [BoolType] bool
 #  478|               ValueCategory = prvalue(load)
-#  478|           1: [VariableAccess] b
+#  478|           getRightOperand(): [VariableAccess] b
 #  478|               Type = [BoolType] bool
 #  478|               ValueCategory = prvalue(load)
-#  479|     3: [ExprStmt] ExprStmt
-#  479|       0: [AssignExpr] ... = ...
+#  479|     getStmt(3): [ExprStmt] ExprStmt
+#  479|       getExpr(): [AssignExpr] ... = ...
 #  479|           Type = [BoolType] bool
 #  479|           ValueCategory = lvalue
-#  479|         0: [VariableAccess] x
+#  479|         getLValue(): [VariableAccess] x
 #  479|             Type = [BoolType] bool
 #  479|             ValueCategory = lvalue
-#  479|         1: [NotExpr] ! ...
+#  479|         getRValue(): [NotExpr] ! ...
 #  479|             Type = [BoolType] bool
 #  479|             ValueCategory = prvalue
-#  479|           0: [LogicalOrExpr] ... || ...
+#  479|           getOperand(): [LogicalOrExpr] ... || ...
 #  479|               Type = [BoolType] bool
 #  479|               ValueCategory = prvalue
-#  479|             0: [VariableAccess] a
+#  479|             getLeftOperand(): [VariableAccess] a
 #  479|                 Type = [BoolType] bool
 #  479|                 ValueCategory = prvalue(load)
-#  479|             1: [VariableAccess] b
+#  479|             getRightOperand(): [VariableAccess] b
 #  479|                 Type = [BoolType] bool
 #  479|                 ValueCategory = prvalue(load)
-#  479|           0 converted: [ParenthesisExpr] (...)
+#  479|           : [ParenthesisExpr] (...)
 #  479|               Type = [BoolType] bool
 #  479|               ValueCategory = prvalue
-#  480|     4: [ReturnStmt] return ...
+#  480|     getStmt(4): [ReturnStmt] return ...
 #  482| [TopLevelFunction] void Conditional(bool, int, int)
-#  482|   params: 
-#  482|     0: [Parameter] a
+#  482|   ...: 
+#  482|     getParameter(0): [Parameter] a
 #  482|         Type = [BoolType] bool
-#  482|     1: [Parameter] x
+#  482|     getParameter(1): [Parameter] x
 #  482|         Type = [IntType] int
-#  482|     2: [Parameter] y
+#  482|     getParameter(2): [Parameter] y
 #  482|         Type = [IntType] int
-#  482|   body: [BlockStmt] { ... }
-#  483|     0: [DeclStmt] declaration
-#  483|       0: [VariableDeclarationEntry] definition of z
+#  482|   getEntryPoint(): [BlockStmt] { ... }
+#  483|     getStmt(0): [DeclStmt] declaration
+#  483|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 #  483|           Type = [IntType] int
-#  483|         init: [Initializer] initializer for z
-#  483|           expr: [ConditionalExpr] ... ? ... : ...
+#  483|         getVariable().getInitializer(): [Initializer] initializer for z
+#  483|           getExpr(): [ConditionalExpr] ... ? ... : ...
 #  483|               Type = [IntType] int
 #  483|               ValueCategory = prvalue
-#  483|             0: [VariableAccess] a
+#  483|             getCondition(): [VariableAccess] a
 #  483|                 Type = [BoolType] bool
 #  483|                 ValueCategory = prvalue(load)
-#  483|             1: [VariableAccess] x
+#  483|             getThen(): [VariableAccess] x
 #  483|                 Type = [IntType] int
 #  483|                 ValueCategory = prvalue(load)
-#  483|             2: [VariableAccess] y
+#  483|             getElse(): [VariableAccess] y
 #  483|                 Type = [IntType] int
 #  483|                 ValueCategory = prvalue(load)
-#  484|     1: [ReturnStmt] return ...
+#  484|     getStmt(1): [ReturnStmt] return ...
 #  486| [TopLevelFunction] void Conditional_LValue(bool)
-#  486|   params: 
-#  486|     0: [Parameter] a
+#  486|   ...: 
+#  486|     getParameter(0): [Parameter] a
 #  486|         Type = [BoolType] bool
-#  486|   body: [BlockStmt] { ... }
-#  487|     0: [DeclStmt] declaration
-#  487|       0: [VariableDeclarationEntry] definition of x
+#  486|   getEntryPoint(): [BlockStmt] { ... }
+#  487|     getStmt(0): [DeclStmt] declaration
+#  487|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  487|           Type = [IntType] int
-#  488|     1: [DeclStmt] declaration
-#  488|       0: [VariableDeclarationEntry] definition of y
+#  488|     getStmt(1): [DeclStmt] declaration
+#  488|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 #  488|           Type = [IntType] int
-#  489|     2: [ExprStmt] ExprStmt
-#  489|       0: [AssignExpr] ... = ...
+#  489|     getStmt(2): [ExprStmt] ExprStmt
+#  489|       getExpr(): [AssignExpr] ... = ...
 #  489|           Type = [IntType] int
 #  489|           ValueCategory = lvalue
-#  489|         0: [ConditionalExpr] ... ? ... : ...
+#  489|         getLValue(): [ConditionalExpr] ... ? ... : ...
 #  489|             Type = [IntType] int
 #  489|             ValueCategory = lvalue
-#  489|           0: [VariableAccess] a
+#  489|           getCondition(): [VariableAccess] a
 #  489|               Type = [BoolType] bool
 #  489|               ValueCategory = prvalue(load)
-#  489|           1: [VariableAccess] x
+#  489|           getThen(): [VariableAccess] x
 #  489|               Type = [IntType] int
 #  489|               ValueCategory = lvalue
-#  489|           2: [VariableAccess] y
+#  489|           getElse(): [VariableAccess] y
 #  489|               Type = [IntType] int
 #  489|               ValueCategory = lvalue
-#  489|         1: [Literal] 5
+#  489|         getRValue(): [Literal] 5
 #  489|             Type = [IntType] int
 #  489|             Value = [Literal] 5
 #  489|             ValueCategory = prvalue
-#  489|         0 converted: [ParenthesisExpr] (...)
+#  489|         : [ParenthesisExpr] (...)
 #  489|             Type = [IntType] int
 #  489|             ValueCategory = lvalue
-#  490|     3: [ReturnStmt] return ...
+#  490|     getStmt(3): [ReturnStmt] return ...
 #  492| [TopLevelFunction] void Conditional_Void(bool)
-#  492|   params: 
-#  492|     0: [Parameter] a
+#  492|   ...: 
+#  492|     getParameter(0): [Parameter] a
 #  492|         Type = [BoolType] bool
-#  492|   body: [BlockStmt] { ... }
-#  493|     0: [ExprStmt] ExprStmt
-#  493|       0: [ConditionalExpr] ... ? ... : ...
+#  492|   getEntryPoint(): [BlockStmt] { ... }
+#  493|     getStmt(0): [ExprStmt] ExprStmt
+#  493|       getExpr(): [ConditionalExpr] ... ? ... : ...
 #  493|           Type = [VoidType] void
 #  493|           ValueCategory = prvalue
-#  493|         0: [VariableAccess] a
+#  493|         getCondition(): [VariableAccess] a
 #  493|             Type = [BoolType] bool
 #  493|             ValueCategory = prvalue(load)
-#  493|         1: [FunctionCall] call to VoidFunc
+#  493|         getThen(): [FunctionCall] call to VoidFunc
 #  493|             Type = [VoidType] void
 #  493|             ValueCategory = prvalue
-#  493|         2: [FunctionCall] call to VoidFunc
+#  493|         getElse(): [FunctionCall] call to VoidFunc
 #  493|             Type = [VoidType] void
 #  493|             ValueCategory = prvalue
-#  494|     1: [ReturnStmt] return ...
+#  494|     getStmt(1): [ReturnStmt] return ...
 #  496| [TopLevelFunction] void Nullptr()
-#  496|   params: 
-#  496|   body: [BlockStmt] { ... }
-#  497|     0: [DeclStmt] declaration
-#  497|       0: [VariableDeclarationEntry] definition of p
+#  496|   ...: 
+#  496|   getEntryPoint(): [BlockStmt] { ... }
+#  497|     getStmt(0): [DeclStmt] declaration
+#  497|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
 #  497|           Type = [IntPointerType] int *
-#  497|         init: [Initializer] initializer for p
-#  497|           expr: [Literal] 0
+#  497|         getVariable().getInitializer(): [Initializer] initializer for p
+#  497|           getExpr(): [Literal] 0
 #  497|               Type = [NullPointerType] decltype(nullptr)
 #  497|               Value = [Literal] 0
 #  497|               ValueCategory = prvalue
-#  497|           expr converted: [CStyleCast] (int *)...
+#  497|           : [CStyleCast] (int *)...
 #  497|               Conversion = [PointerConversion] pointer conversion
 #  497|               Type = [IntPointerType] int *
 #  497|               Value = [CStyleCast] 0
 #  497|               ValueCategory = prvalue
-#  498|     1: [DeclStmt] declaration
-#  498|       0: [VariableDeclarationEntry] definition of q
+#  498|     getStmt(1): [DeclStmt] declaration
+#  498|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of q
 #  498|           Type = [IntPointerType] int *
-#  498|         init: [Initializer] initializer for q
-#  498|           expr: [Literal] 0
+#  498|         getVariable().getInitializer(): [Initializer] initializer for q
+#  498|           getExpr(): [Literal] 0
 #  498|               Type = [IntType] int
 #  498|               Value = [Literal] 0
 #  498|               ValueCategory = prvalue
-#  498|           expr converted: [CStyleCast] (int *)...
+#  498|           : [CStyleCast] (int *)...
 #  498|               Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  498|               Type = [IntPointerType] int *
 #  498|               Value = [CStyleCast] 0
 #  498|               ValueCategory = prvalue
-#  499|     2: [ExprStmt] ExprStmt
-#  499|       0: [AssignExpr] ... = ...
+#  499|     getStmt(2): [ExprStmt] ExprStmt
+#  499|       getExpr(): [AssignExpr] ... = ...
 #  499|           Type = [IntPointerType] int *
 #  499|           ValueCategory = lvalue
-#  499|         0: [VariableAccess] p
+#  499|         getLValue(): [VariableAccess] p
 #  499|             Type = [IntPointerType] int *
 #  499|             ValueCategory = lvalue
-#  499|         1: [Literal] 0
+#  499|         getRValue(): [Literal] 0
 #  499|             Type = [NullPointerType] decltype(nullptr)
 #  499|             Value = [Literal] 0
 #  499|             ValueCategory = prvalue
-#  499|         1 converted: [CStyleCast] (int *)...
+#  499|         : [CStyleCast] (int *)...
 #  499|             Conversion = [PointerConversion] pointer conversion
 #  499|             Type = [IntPointerType] int *
 #  499|             Value = [CStyleCast] 0
 #  499|             ValueCategory = prvalue
-#  500|     3: [ExprStmt] ExprStmt
-#  500|       0: [AssignExpr] ... = ...
+#  500|     getStmt(3): [ExprStmt] ExprStmt
+#  500|       getExpr(): [AssignExpr] ... = ...
 #  500|           Type = [IntPointerType] int *
 #  500|           ValueCategory = lvalue
-#  500|         0: [VariableAccess] q
+#  500|         getLValue(): [VariableAccess] q
 #  500|             Type = [IntPointerType] int *
 #  500|             ValueCategory = lvalue
-#  500|         1: [Literal] 0
+#  500|         getRValue(): [Literal] 0
 #  500|             Type = [IntType] int
 #  500|             Value = [Literal] 0
 #  500|             ValueCategory = prvalue
-#  500|         1 converted: [CStyleCast] (int *)...
+#  500|         : [CStyleCast] (int *)...
 #  500|             Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  500|             Type = [IntPointerType] int *
 #  500|             Value = [CStyleCast] 0
 #  500|             ValueCategory = prvalue
-#  501|     4: [ReturnStmt] return ...
+#  501|     getStmt(4): [ReturnStmt] return ...
 #  503| [TopLevelFunction] void InitList(int, float)
-#  503|   params: 
-#  503|     0: [Parameter] x
+#  503|   ...: 
+#  503|     getParameter(0): [Parameter] x
 #  503|         Type = [IntType] int
-#  503|     1: [Parameter] f
+#  503|     getParameter(1): [Parameter] f
 #  503|         Type = [FloatType] float
-#  503|   body: [BlockStmt] { ... }
-#  504|     0: [DeclStmt] declaration
-#  504|       0: [VariableDeclarationEntry] definition of pt1
+#  503|   getEntryPoint(): [BlockStmt] { ... }
+#  504|     getStmt(0): [DeclStmt] declaration
+#  504|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt1
 #  504|           Type = [Struct] Point
-#  504|         init: [Initializer] initializer for pt1
-#  504|           expr: [ClassAggregateLiteral] {...}
+#  504|         getVariable().getInitializer(): [Initializer] initializer for pt1
+#  504|           getExpr(): [ClassAggregateLiteral] {...}
 #  504|               Type = [Struct] Point
 #  504|               ValueCategory = prvalue
-#  504|             .x: [VariableAccess] x
+#  504|             getFieldExpr(x): [VariableAccess] x
 #  504|                 Type = [IntType] int
 #  504|                 ValueCategory = prvalue(load)
-#  504|             .y: [VariableAccess] f
+#  504|             getFieldExpr(y): [VariableAccess] f
 #  504|                 Type = [FloatType] float
 #  504|                 ValueCategory = prvalue(load)
-#  504|             .y converted: [CStyleCast] (int)...
+#  504|             : [CStyleCast] (int)...
 #  504|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  504|                 Type = [IntType] int
 #  504|                 ValueCategory = prvalue
-#  505|     1: [DeclStmt] declaration
-#  505|       0: [VariableDeclarationEntry] definition of pt2
+#  505|     getStmt(1): [DeclStmt] declaration
+#  505|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt2
 #  505|           Type = [Struct] Point
-#  505|         init: [Initializer] initializer for pt2
-#  505|           expr: [ClassAggregateLiteral] {...}
+#  505|         getVariable().getInitializer(): [Initializer] initializer for pt2
+#  505|           getExpr(): [ClassAggregateLiteral] {...}
 #  505|               Type = [Struct] Point
 #  505|               ValueCategory = prvalue
-#  505|             .x: [VariableAccess] x
+#  505|             getFieldExpr(x): [VariableAccess] x
 #  505|                 Type = [IntType] int
 #  505|                 ValueCategory = prvalue(load)
-#  506|     2: [DeclStmt] declaration
-#  506|       0: [VariableDeclarationEntry] definition of pt3
+#  506|     getStmt(2): [DeclStmt] declaration
+#  506|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt3
 #  506|           Type = [Struct] Point
-#  506|         init: [Initializer] initializer for pt3
-#  506|           expr: [ClassAggregateLiteral] {...}
+#  506|         getVariable().getInitializer(): [Initializer] initializer for pt3
+#  506|           getExpr(): [ClassAggregateLiteral] {...}
 #  506|               Type = [Struct] Point
 #  506|               ValueCategory = prvalue
-#  508|     3: [DeclStmt] declaration
-#  508|       0: [VariableDeclarationEntry] definition of x1
+#  508|     getStmt(3): [DeclStmt] declaration
+#  508|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x1
 #  508|           Type = [IntType] int
-#  508|         init: [Initializer] initializer for x1
-#  508|           expr: [Literal] 1
+#  508|         getVariable().getInitializer(): [Initializer] initializer for x1
+#  508|           getExpr(): [Literal] 1
 #  508|               Type = [IntType] int
 #  508|               Value = [Literal] 1
 #  508|               ValueCategory = prvalue
-#  509|     4: [DeclStmt] declaration
-#  509|       0: [VariableDeclarationEntry] definition of x2
+#  509|     getStmt(4): [DeclStmt] declaration
+#  509|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x2
 #  509|           Type = [IntType] int
-#  509|         init: [Initializer] initializer for x2
-#  509|           expr: [Literal] 0
+#  509|         getVariable().getInitializer(): [Initializer] initializer for x2
+#  509|           getExpr(): [Literal] 0
 #  509|               Type = [IntType] int
 #  509|               Value = [Literal] 0
 #  509|               ValueCategory = prvalue
-#  510|     5: [ReturnStmt] return ...
+#  510|     getStmt(5): [ReturnStmt] return ...
 #  512| [TopLevelFunction] void NestedInitList(int, float)
-#  512|   params: 
-#  512|     0: [Parameter] x
+#  512|   ...: 
+#  512|     getParameter(0): [Parameter] x
 #  512|         Type = [IntType] int
-#  512|     1: [Parameter] f
+#  512|     getParameter(1): [Parameter] f
 #  512|         Type = [FloatType] float
-#  512|   body: [BlockStmt] { ... }
-#  513|     0: [DeclStmt] declaration
-#  513|       0: [VariableDeclarationEntry] definition of r1
+#  512|   getEntryPoint(): [BlockStmt] { ... }
+#  513|     getStmt(0): [DeclStmt] declaration
+#  513|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r1
 #  513|           Type = [Struct] Rect
-#  513|         init: [Initializer] initializer for r1
-#  513|           expr: [ClassAggregateLiteral] {...}
+#  513|         getVariable().getInitializer(): [Initializer] initializer for r1
+#  513|           getExpr(): [ClassAggregateLiteral] {...}
 #  513|               Type = [Struct] Rect
 #  513|               ValueCategory = prvalue
-#  514|     1: [DeclStmt] declaration
-#  514|       0: [VariableDeclarationEntry] definition of r2
+#  514|     getStmt(1): [DeclStmt] declaration
+#  514|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r2
 #  514|           Type = [Struct] Rect
-#  514|         init: [Initializer] initializer for r2
-#  514|           expr: [ClassAggregateLiteral] {...}
+#  514|         getVariable().getInitializer(): [Initializer] initializer for r2
+#  514|           getExpr(): [ClassAggregateLiteral] {...}
 #  514|               Type = [Struct] Rect
 #  514|               ValueCategory = prvalue
-#  514|             .topLeft: [ClassAggregateLiteral] {...}
+#  514|             getFieldExpr(topLeft): [ClassAggregateLiteral] {...}
 #  514|                 Type = [Struct] Point
 #  514|                 ValueCategory = prvalue
-#  514|               .x: [VariableAccess] x
+#  514|               getFieldExpr(x): [VariableAccess] x
 #  514|                   Type = [IntType] int
 #  514|                   ValueCategory = prvalue(load)
-#  514|               .y: [VariableAccess] f
+#  514|               getFieldExpr(y): [VariableAccess] f
 #  514|                   Type = [FloatType] float
 #  514|                   ValueCategory = prvalue(load)
-#  514|               .y converted: [CStyleCast] (int)...
+#  514|               : [CStyleCast] (int)...
 #  514|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  514|                   Type = [IntType] int
 #  514|                   ValueCategory = prvalue
-#  515|     2: [DeclStmt] declaration
-#  515|       0: [VariableDeclarationEntry] definition of r3
+#  515|     getStmt(2): [DeclStmt] declaration
+#  515|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r3
 #  515|           Type = [Struct] Rect
-#  515|         init: [Initializer] initializer for r3
-#  515|           expr: [ClassAggregateLiteral] {...}
+#  515|         getVariable().getInitializer(): [Initializer] initializer for r3
+#  515|           getExpr(): [ClassAggregateLiteral] {...}
 #  515|               Type = [Struct] Rect
 #  515|               ValueCategory = prvalue
-#  515|             .topLeft: [ClassAggregateLiteral] {...}
+#  515|             getFieldExpr(topLeft): [ClassAggregateLiteral] {...}
 #  515|                 Type = [Struct] Point
 #  515|                 ValueCategory = prvalue
-#  515|               .x: [VariableAccess] x
+#  515|               getFieldExpr(x): [VariableAccess] x
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y: [VariableAccess] f
+#  515|               getFieldExpr(y): [VariableAccess] f
 #  515|                   Type = [FloatType] float
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y converted: [CStyleCast] (int)...
+#  515|               : [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
-#  515|             .bottomRight: [ClassAggregateLiteral] {...}
+#  515|             getFieldExpr(bottomRight): [ClassAggregateLiteral] {...}
 #  515|                 Type = [Struct] Point
 #  515|                 ValueCategory = prvalue
-#  515|               .x: [VariableAccess] x
+#  515|               getFieldExpr(x): [VariableAccess] x
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y: [VariableAccess] f
+#  515|               getFieldExpr(y): [VariableAccess] f
 #  515|                   Type = [FloatType] float
 #  515|                   ValueCategory = prvalue(load)
-#  515|               .y converted: [CStyleCast] (int)...
+#  515|               : [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
-#  516|     3: [DeclStmt] declaration
-#  516|       0: [VariableDeclarationEntry] definition of r4
+#  516|     getStmt(3): [DeclStmt] declaration
+#  516|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r4
 #  516|           Type = [Struct] Rect
-#  516|         init: [Initializer] initializer for r4
-#  516|           expr: [ClassAggregateLiteral] {...}
+#  516|         getVariable().getInitializer(): [Initializer] initializer for r4
+#  516|           getExpr(): [ClassAggregateLiteral] {...}
 #  516|               Type = [Struct] Rect
 #  516|               ValueCategory = prvalue
-#  516|             .topLeft: [ClassAggregateLiteral] {...}
+#  516|             getFieldExpr(topLeft): [ClassAggregateLiteral] {...}
 #  516|                 Type = [Struct] Point
 #  516|                 ValueCategory = prvalue
-#  516|               .x: [VariableAccess] x
+#  516|               getFieldExpr(x): [VariableAccess] x
 #  516|                   Type = [IntType] int
 #  516|                   ValueCategory = prvalue(load)
-#  516|             .bottomRight: [ClassAggregateLiteral] {...}
+#  516|             getFieldExpr(bottomRight): [ClassAggregateLiteral] {...}
 #  516|                 Type = [Struct] Point
 #  516|                 ValueCategory = prvalue
-#  516|               .x: [VariableAccess] x
+#  516|               getFieldExpr(x): [VariableAccess] x
 #  516|                   Type = [IntType] int
 #  516|                   ValueCategory = prvalue(load)
-#  517|     4: [ReturnStmt] return ...
+#  517|     getStmt(4): [ReturnStmt] return ...
 #  519| [TopLevelFunction] void ArrayInit(int, float)
-#  519|   params: 
-#  519|     0: [Parameter] x
+#  519|   ...: 
+#  519|     getParameter(0): [Parameter] x
 #  519|         Type = [IntType] int
-#  519|     1: [Parameter] f
+#  519|     getParameter(1): [Parameter] f
 #  519|         Type = [FloatType] float
-#  519|   body: [BlockStmt] { ... }
-#  520|     0: [DeclStmt] declaration
-#  520|       0: [VariableDeclarationEntry] definition of a1
+#  519|   getEntryPoint(): [BlockStmt] { ... }
+#  520|     getStmt(0): [DeclStmt] declaration
+#  520|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a1
 #  520|           Type = [ArrayType] int[3]
-#  520|         init: [Initializer] initializer for a1
-#  520|           expr: [ArrayAggregateLiteral] {...}
+#  520|         getVariable().getInitializer(): [Initializer] initializer for a1
+#  520|           getExpr(): [ArrayAggregateLiteral] {...}
 #  520|               Type = [ArrayType] int[3]
 #  520|               ValueCategory = prvalue
-#  521|     1: [DeclStmt] declaration
-#  521|       0: [VariableDeclarationEntry] definition of a2
+#  521|     getStmt(1): [DeclStmt] declaration
+#  521|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a2
 #  521|           Type = [ArrayType] int[3]
-#  521|         init: [Initializer] initializer for a2
-#  521|           expr: [ArrayAggregateLiteral] {...}
+#  521|         getVariable().getInitializer(): [Initializer] initializer for a2
+#  521|           getExpr(): [ArrayAggregateLiteral] {...}
 #  521|               Type = [ArrayType] int[3]
 #  521|               ValueCategory = prvalue
-#  521|             [0]: [VariableAccess] x
+#  521|             getElementExpr(0): [VariableAccess] x
 #  521|                 Type = [IntType] int
 #  521|                 ValueCategory = prvalue(load)
-#  521|             [1]: [VariableAccess] f
+#  521|             getElementExpr(1): [VariableAccess] f
 #  521|                 Type = [FloatType] float
 #  521|                 ValueCategory = prvalue(load)
-#  521|             [2]: [Literal] 0
+#  521|             getElementExpr(2): [Literal] 0
 #  521|                 Type = [IntType] int
 #  521|                 Value = [Literal] 0
 #  521|                 ValueCategory = prvalue
-#  521|             [1] converted: [CStyleCast] (int)...
+#  521|             : [CStyleCast] (int)...
 #  521|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  521|                 Type = [IntType] int
 #  521|                 ValueCategory = prvalue
-#  522|     2: [DeclStmt] declaration
-#  522|       0: [VariableDeclarationEntry] definition of a3
+#  522|     getStmt(2): [DeclStmt] declaration
+#  522|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a3
 #  522|           Type = [ArrayType] int[3]
-#  522|         init: [Initializer] initializer for a3
-#  522|           expr: [ArrayAggregateLiteral] {...}
+#  522|         getVariable().getInitializer(): [Initializer] initializer for a3
+#  522|           getExpr(): [ArrayAggregateLiteral] {...}
 #  522|               Type = [ArrayType] int[3]
 #  522|               ValueCategory = prvalue
-#  522|             [0]: [VariableAccess] x
+#  522|             getElementExpr(0): [VariableAccess] x
 #  522|                 Type = [IntType] int
 #  522|                 ValueCategory = prvalue(load)
-#  523|     3: [ReturnStmt] return ...
+#  523|     getStmt(3): [ReturnStmt] return ...
 #  525| [CopyAssignmentOperator] U& U::operator=(U const&)
-#  525|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  525|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #  525| [MoveAssignmentOperator] U& U::operator=(U&&)
-#  525|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  525|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #  530| [TopLevelFunction] void UnionInit(int, float)
-#  530|   params: 
-#  530|     0: [Parameter] x
+#  530|   ...: 
+#  530|     getParameter(0): [Parameter] x
 #  530|         Type = [IntType] int
-#  530|     1: [Parameter] f
+#  530|     getParameter(1): [Parameter] f
 #  530|         Type = [FloatType] float
-#  530|   body: [BlockStmt] { ... }
-#  531|     0: [DeclStmt] declaration
-#  531|       0: [VariableDeclarationEntry] definition of u1
+#  530|   getEntryPoint(): [BlockStmt] { ... }
+#  531|     getStmt(0): [DeclStmt] declaration
+#  531|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of u1
 #  531|           Type = [Union] U
-#  531|         init: [Initializer] initializer for u1
-#  531|           expr: [ClassAggregateLiteral] {...}
+#  531|         getVariable().getInitializer(): [Initializer] initializer for u1
+#  531|           getExpr(): [ClassAggregateLiteral] {...}
 #  531|               Type = [Union] U
 #  531|               ValueCategory = prvalue
-#  531|             .d: [VariableAccess] f
+#  531|             getFieldExpr(d): [VariableAccess] f
 #  531|                 Type = [FloatType] float
 #  531|                 ValueCategory = prvalue(load)
-#  531|             .d converted: [CStyleCast] (double)...
+#  531|             : [CStyleCast] (double)...
 #  531|                 Conversion = [FloatingPointConversion] floating point conversion
 #  531|                 Type = [DoubleType] double
 #  531|                 ValueCategory = prvalue
-#  533|     1: [ReturnStmt] return ...
+#  533|     getStmt(1): [ReturnStmt] return ...
 #  535| [TopLevelFunction] void EarlyReturn(int, int)
-#  535|   params: 
-#  535|     0: [Parameter] x
+#  535|   ...: 
+#  535|     getParameter(0): [Parameter] x
 #  535|         Type = [IntType] int
-#  535|     1: [Parameter] y
+#  535|     getParameter(1): [Parameter] y
 #  535|         Type = [IntType] int
-#  535|   body: [BlockStmt] { ... }
-#  536|     0: [IfStmt] if (...) ... 
-#  536|       0: [LTExpr] ... < ...
+#  535|   getEntryPoint(): [BlockStmt] { ... }
+#  536|     getStmt(0): [IfStmt] if (...) ... 
+#  536|       getCondition(): [LTExpr] ... < ...
 #  536|           Type = [BoolType] bool
 #  536|           ValueCategory = prvalue
-#  536|         0: [VariableAccess] x
+#  536|         getLesserOperand(): [VariableAccess] x
 #  536|             Type = [IntType] int
 #  536|             ValueCategory = prvalue(load)
-#  536|         1: [VariableAccess] y
+#  536|         getGreaterOperand(): [VariableAccess] y
 #  536|             Type = [IntType] int
 #  536|             ValueCategory = prvalue(load)
-#  536|       1: [BlockStmt] { ... }
-#  537|         0: [ReturnStmt] return ...
-#  540|     1: [ExprStmt] ExprStmt
-#  540|       0: [AssignExpr] ... = ...
+#  536|       getThen(): [BlockStmt] { ... }
+#  537|         getStmt(0): [ReturnStmt] return ...
+#  540|     getStmt(1): [ExprStmt] ExprStmt
+#  540|       getExpr(): [AssignExpr] ... = ...
 #  540|           Type = [IntType] int
 #  540|           ValueCategory = lvalue
-#  540|         0: [VariableAccess] y
+#  540|         getLValue(): [VariableAccess] y
 #  540|             Type = [IntType] int
 #  540|             ValueCategory = lvalue
-#  540|         1: [VariableAccess] x
+#  540|         getRValue(): [VariableAccess] x
 #  540|             Type = [IntType] int
 #  540|             ValueCategory = prvalue(load)
-#  541|     2: [ReturnStmt] return ...
+#  541|     getStmt(2): [ReturnStmt] return ...
 #  543| [TopLevelFunction] int EarlyReturnValue(int, int)
-#  543|   params: 
-#  543|     0: [Parameter] x
+#  543|   ...: 
+#  543|     getParameter(0): [Parameter] x
 #  543|         Type = [IntType] int
-#  543|     1: [Parameter] y
+#  543|     getParameter(1): [Parameter] y
 #  543|         Type = [IntType] int
-#  543|   body: [BlockStmt] { ... }
-#  544|     0: [IfStmt] if (...) ... 
-#  544|       0: [LTExpr] ... < ...
+#  543|   getEntryPoint(): [BlockStmt] { ... }
+#  544|     getStmt(0): [IfStmt] if (...) ... 
+#  544|       getCondition(): [LTExpr] ... < ...
 #  544|           Type = [BoolType] bool
 #  544|           ValueCategory = prvalue
-#  544|         0: [VariableAccess] x
+#  544|         getLesserOperand(): [VariableAccess] x
 #  544|             Type = [IntType] int
 #  544|             ValueCategory = prvalue(load)
-#  544|         1: [VariableAccess] y
+#  544|         getGreaterOperand(): [VariableAccess] y
 #  544|             Type = [IntType] int
 #  544|             ValueCategory = prvalue(load)
-#  544|       1: [BlockStmt] { ... }
-#  545|         0: [ReturnStmt] return ...
-#  545|           0: [VariableAccess] x
+#  544|       getThen(): [BlockStmt] { ... }
+#  545|         getStmt(0): [ReturnStmt] return ...
+#  545|           getExpr(): [VariableAccess] x
 #  545|               Type = [IntType] int
 #  545|               ValueCategory = prvalue(load)
-#  548|     1: [ReturnStmt] return ...
-#  548|       0: [AddExpr] ... + ...
+#  548|     getStmt(1): [ReturnStmt] return ...
+#  548|       getExpr(): [AddExpr] ... + ...
 #  548|           Type = [IntType] int
 #  548|           ValueCategory = prvalue
-#  548|         0: [VariableAccess] x
+#  548|         getLeftOperand(): [VariableAccess] x
 #  548|             Type = [IntType] int
 #  548|             ValueCategory = prvalue(load)
-#  548|         1: [VariableAccess] y
+#  548|         getRightOperand(): [VariableAccess] y
 #  548|             Type = [IntType] int
 #  548|             ValueCategory = prvalue(load)
 #  551| [TopLevelFunction] int CallViaFuncPtr(int(*)(int))
-#  551|   params: 
-#  551|     0: [Parameter] pfn
+#  551|   ...: 
+#  551|     getParameter(0): [Parameter] pfn
 #  551|         Type = [FunctionPointerType] ..(*)(..)
-#  551|   body: [BlockStmt] { ... }
-#  552|     0: [ReturnStmt] return ...
-#  552|       0: [VariableCall] call to expression
+#  551|   getEntryPoint(): [BlockStmt] { ... }
+#  552|     getStmt(0): [ReturnStmt] return ...
+#  552|       getExpr(): [VariableCall] call to expression
 #  552|           Type = [IntType] int
 #  552|           ValueCategory = prvalue
-#  552|         0: [VariableAccess] pfn
+#  552|         getExpr(): [VariableAccess] pfn
 #  552|             Type = [FunctionPointerType] ..(*)(..)
 #  552|             ValueCategory = prvalue(load)
-#  552|         1: [Literal] 5
+#  552|         getArgument(0): [Literal] 5
 #  552|             Type = [IntType] int
 #  552|             Value = [Literal] 5
 #  552|             ValueCategory = prvalue
 #  560| [TopLevelFunction] int EnumSwitch(E)
-#  560|   params: 
-#  560|     0: [Parameter] e
+#  560|   ...: 
+#  560|     getParameter(0): [Parameter] e
 #  560|         Type = [CTypedefType] E
-#  560|   body: [BlockStmt] { ... }
-#  561|     0: [SwitchStmt] switch (...) ... 
-#  561|       0: [VariableAccess] e
+#  560|   getEntryPoint(): [BlockStmt] { ... }
+#  561|     getStmt(0): [SwitchStmt] switch (...) ... 
+#  561|       getExpr(): [VariableAccess] e
 #  561|           Type = [CTypedefType] E
 #  561|           ValueCategory = prvalue(load)
-#  561|       1: [BlockStmt] { ... }
-#  562|         0: [SwitchCase] case ...:
-#  562|           0: [EnumConstantAccess] E_0
+#  561|       getStmt(): [BlockStmt] { ... }
+#  562|         getStmt(0): [SwitchCase] case ...:
+#  562|           getExpr(): [EnumConstantAccess] E_0
 #  562|               Type = [Enum] E
 #  562|               Value = [EnumConstantAccess] 0
 #  562|               ValueCategory = prvalue
-#  562|           0 converted: [CStyleCast] (int)...
+#  562|           : [CStyleCast] (int)...
 #  562|               Conversion = [IntegralConversion] integral conversion
 #  562|               Type = [IntType] int
 #  562|               Value = [CStyleCast] 0
 #  562|               ValueCategory = prvalue
-#  563|         1: [ReturnStmt] return ...
-#  563|           0: [Literal] 0
+#  563|         getStmt(1): [ReturnStmt] return ...
+#  563|           getExpr(): [Literal] 0
 #  563|               Type = [IntType] int
 #  563|               Value = [Literal] 0
 #  563|               ValueCategory = prvalue
-#  564|         2: [SwitchCase] case ...:
-#  564|           0: [EnumConstantAccess] E_1
+#  564|         getStmt(2): [SwitchCase] case ...:
+#  564|           getExpr(): [EnumConstantAccess] E_1
 #  564|               Type = [Enum] E
 #  564|               Value = [EnumConstantAccess] 1
 #  564|               ValueCategory = prvalue
-#  564|           0 converted: [CStyleCast] (int)...
+#  564|           : [CStyleCast] (int)...
 #  564|               Conversion = [IntegralConversion] integral conversion
 #  564|               Type = [IntType] int
 #  564|               Value = [CStyleCast] 1
 #  564|               ValueCategory = prvalue
-#  565|         3: [ReturnStmt] return ...
-#  565|           0: [Literal] 1
+#  565|         getStmt(3): [ReturnStmt] return ...
+#  565|           getExpr(): [Literal] 1
 #  565|               Type = [IntType] int
 #  565|               Value = [Literal] 1
 #  565|               ValueCategory = prvalue
-#  566|         4: [SwitchCase] default: 
-#  567|         5: [ReturnStmt] return ...
-#  567|           0: [UnaryMinusExpr] - ...
+#  566|         getStmt(4): [SwitchCase] default: 
+#  567|         getStmt(5): [ReturnStmt] return ...
+#  567|           getExpr(): [UnaryMinusExpr] - ...
 #  567|               Type = [IntType] int
 #  567|               Value = [UnaryMinusExpr] -1
 #  567|               ValueCategory = prvalue
-#  567|             0: [Literal] 1
+#  567|             getOperand(): [Literal] 1
 #  567|                 Type = [IntType] int
 #  567|                 Value = [Literal] 1
 #  567|                 ValueCategory = prvalue
-#  561|       0 converted: [CStyleCast] (int)...
+#  561|       : [CStyleCast] (int)...
 #  561|           Conversion = [IntegralConversion] integral conversion
 #  561|           Type = [IntType] int
 #  561|           ValueCategory = prvalue
 #  571| [TopLevelFunction] void InitArray()
-#  571|   params: 
-#  571|   body: [BlockStmt] { ... }
-#  572|     0: [DeclStmt] declaration
-#  572|       0: [VariableDeclarationEntry] definition of a_pad
+#  571|   ...: 
+#  571|   getEntryPoint(): [BlockStmt] { ... }
+#  572|     getStmt(0): [DeclStmt] declaration
+#  572|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a_pad
 #  572|           Type = [ArrayType] char[32]
-#  572|         init: [Initializer] initializer for a_pad
-#  572|           expr: 
+#  572|         getVariable().getInitializer(): [Initializer] initializer for a_pad
+#  572|           getExpr(): 
 #  572|               Type = [ArrayType] const char[32]
 #  572|               Value = [StringLiteral] ""
 #  572|               ValueCategory = lvalue
-#  573|     1: [DeclStmt] declaration
-#  573|       0: [VariableDeclarationEntry] definition of a_nopad
+#  573|     getStmt(1): [DeclStmt] declaration
+#  573|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a_nopad
 #  573|           Type = [ArrayType] char[4]
-#  573|         init: [Initializer] initializer for a_nopad
-#  573|           expr: foo
+#  573|         getVariable().getInitializer(): [Initializer] initializer for a_nopad
+#  573|           getExpr(): foo
 #  573|               Type = [ArrayType] const char[4]
 #  573|               Value = [StringLiteral] "foo"
 #  573|               ValueCategory = lvalue
-#  574|     2: [DeclStmt] declaration
-#  574|       0: [VariableDeclarationEntry] definition of a_infer
+#  574|     getStmt(2): [DeclStmt] declaration
+#  574|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a_infer
 #  574|           Type = [ArrayType] char[]
-#  574|         init: [Initializer] initializer for a_infer
-#  574|           expr: blah
+#  574|         getVariable().getInitializer(): [Initializer] initializer for a_infer
+#  574|           getExpr(): blah
 #  574|               Type = [ArrayType] const char[5]
 #  574|               Value = [StringLiteral] "blah"
 #  574|               ValueCategory = lvalue
-#  575|     3: [DeclStmt] declaration
-#  575|       0: [VariableDeclarationEntry] definition of b
+#  575|     getStmt(3): [DeclStmt] declaration
+#  575|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  575|           Type = [ArrayType] char[2]
-#  576|     4: [DeclStmt] declaration
-#  576|       0: [VariableDeclarationEntry] definition of c
+#  576|     getStmt(4): [DeclStmt] declaration
+#  576|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 #  576|           Type = [ArrayType] char[2]
-#  576|         init: [Initializer] initializer for c
-#  576|           expr: [ArrayAggregateLiteral] {...}
+#  576|         getVariable().getInitializer(): [Initializer] initializer for c
+#  576|           getExpr(): [ArrayAggregateLiteral] {...}
 #  576|               Type = [ArrayType] char[2]
 #  576|               ValueCategory = prvalue
-#  577|     5: [DeclStmt] declaration
-#  577|       0: [VariableDeclarationEntry] definition of d
+#  577|     getStmt(5): [DeclStmt] declaration
+#  577|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #  577|           Type = [ArrayType] char[2]
-#  577|         init: [Initializer] initializer for d
-#  577|           expr: [ArrayAggregateLiteral] {...}
+#  577|         getVariable().getInitializer(): [Initializer] initializer for d
+#  577|           getExpr(): [ArrayAggregateLiteral] {...}
 #  577|               Type = [ArrayType] char[2]
 #  577|               ValueCategory = prvalue
-#  577|             [0]: [Literal] 0
+#  577|             getElementExpr(0): [Literal] 0
 #  577|                 Type = [IntType] int
 #  577|                 Value = [Literal] 0
 #  577|                 ValueCategory = prvalue
-#  577|             [0] converted: [CStyleCast] (char)...
+#  577|             : [CStyleCast] (char)...
 #  577|                 Conversion = [IntegralConversion] integral conversion
 #  577|                 Type = [PlainCharType] char
 #  577|                 Value = [CStyleCast] 0
 #  577|                 ValueCategory = prvalue
-#  578|     6: [DeclStmt] declaration
-#  578|       0: [VariableDeclarationEntry] definition of e
+#  578|     getStmt(6): [DeclStmt] declaration
+#  578|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of e
 #  578|           Type = [ArrayType] char[2]
-#  578|         init: [Initializer] initializer for e
-#  578|           expr: [ArrayAggregateLiteral] {...}
+#  578|         getVariable().getInitializer(): [Initializer] initializer for e
+#  578|           getExpr(): [ArrayAggregateLiteral] {...}
 #  578|               Type = [ArrayType] char[2]
 #  578|               ValueCategory = prvalue
-#  578|             [0]: [Literal] 0
+#  578|             getElementExpr(0): [Literal] 0
 #  578|                 Type = [IntType] int
 #  578|                 Value = [Literal] 0
 #  578|                 ValueCategory = prvalue
-#  578|             [1]: [Literal] 1
+#  578|             getElementExpr(1): [Literal] 1
 #  578|                 Type = [IntType] int
 #  578|                 Value = [Literal] 1
 #  578|                 ValueCategory = prvalue
-#  578|             [0] converted: [CStyleCast] (char)...
+#  578|             : [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 0
 #  578|                 ValueCategory = prvalue
-#  578|             [1] converted: [CStyleCast] (char)...
+#  578|             : [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 1
 #  578|                 ValueCategory = prvalue
-#  579|     7: [DeclStmt] declaration
-#  579|       0: [VariableDeclarationEntry] definition of f
+#  579|     getStmt(7): [DeclStmt] declaration
+#  579|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
 #  579|           Type = [ArrayType] char[3]
-#  579|         init: [Initializer] initializer for f
-#  579|           expr: [ArrayAggregateLiteral] {...}
+#  579|         getVariable().getInitializer(): [Initializer] initializer for f
+#  579|           getExpr(): [ArrayAggregateLiteral] {...}
 #  579|               Type = [ArrayType] char[3]
 #  579|               ValueCategory = prvalue
-#  579|             [0]: [Literal] 0
+#  579|             getElementExpr(0): [Literal] 0
 #  579|                 Type = [IntType] int
 #  579|                 Value = [Literal] 0
 #  579|                 ValueCategory = prvalue
-#  579|             [0] converted: [CStyleCast] (char)...
+#  579|             : [CStyleCast] (char)...
 #  579|                 Conversion = [IntegralConversion] integral conversion
 #  579|                 Type = [PlainCharType] char
 #  579|                 Value = [CStyleCast] 0
 #  579|                 ValueCategory = prvalue
-#  580|     8: [ReturnStmt] return ...
+#  580|     getStmt(8): [ReturnStmt] return ...
 #  582| [TopLevelFunction] void VarArgFunction(char const*)
-#  582|   params: 
-#  582|     0: [Parameter] s
+#  582|   ...: 
+#  582|     getParameter(0): [Parameter] s
 #  582|         Type = [PointerType] const char *
 #  584| [TopLevelFunction] void VarArgs()
-#  584|   params: 
-#  584|   body: [BlockStmt] { ... }
-#  585|     0: [ExprStmt] ExprStmt
-#  585|       0: [FunctionCall] call to VarArgFunction
+#  584|   ...: 
+#  584|   getEntryPoint(): [BlockStmt] { ... }
+#  585|     getStmt(0): [ExprStmt] ExprStmt
+#  585|       getExpr(): [FunctionCall] call to VarArgFunction
 #  585|           Type = [VoidType] void
 #  585|           ValueCategory = prvalue
-#  585|         0: %d %s
+#  585|         getArgument(0): %d %s
 #  585|             Type = [ArrayType] const char[6]
 #  585|             Value = [StringLiteral] "%d %s"
 #  585|             ValueCategory = lvalue
-#  585|         1: [Literal] 1
+#  585|         getArgument(1): [Literal] 1
 #  585|             Type = [IntType] int
 #  585|             Value = [Literal] 1
 #  585|             ValueCategory = prvalue
-#  585|         2: string
+#  585|         getArgument(2): string
 #  585|             Type = [ArrayType] const char[7]
 #  585|             Value = [StringLiteral] "string"
 #  585|             ValueCategory = lvalue
-#  585|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  585|         : [ArrayToPointerConversion] array to pointer conversion
 #  585|             Type = [PointerType] const char *
 #  585|             ValueCategory = prvalue
-#  585|         2 converted: [ArrayToPointerConversion] array to pointer conversion
+#  585|         : [ArrayToPointerConversion] array to pointer conversion
 #  585|             Type = [PointerType] const char *
 #  585|             ValueCategory = prvalue
-#  586|     1: [ReturnStmt] return ...
+#  586|     getStmt(1): [ReturnStmt] return ...
 #  588| [TopLevelFunction] int FuncPtrTarget(int)
-#  588|   params: 
-#  588|     0: [Parameter] (unnamed parameter 0)
+#  588|   ...: 
+#  588|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  588|         Type = [IntType] int
 #  590| [TopLevelFunction] void SetFuncPtr()
-#  590|   params: 
-#  590|   body: [BlockStmt] { ... }
-#  591|     0: [DeclStmt] declaration
-#  591|       0: [VariableDeclarationEntry] definition of pfn
+#  590|   ...: 
+#  590|   getEntryPoint(): [BlockStmt] { ... }
+#  591|     getStmt(0): [DeclStmt] declaration
+#  591|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pfn
 #  591|           Type = [FunctionPointerType] ..(*)(..)
-#  591|         init: [Initializer] initializer for pfn
-#  591|           expr: [FunctionAccess] FuncPtrTarget
+#  591|         getVariable().getInitializer(): [Initializer] initializer for pfn
+#  591|           getExpr(): [FunctionAccess] FuncPtrTarget
 #  591|               Type = [FunctionPointerType] ..(*)(..)
 #  591|               ValueCategory = prvalue(load)
-#  592|     1: [ExprStmt] ExprStmt
-#  592|       0: [AssignExpr] ... = ...
+#  592|     getStmt(1): [ExprStmt] ExprStmt
+#  592|       getExpr(): [AssignExpr] ... = ...
 #  592|           Type = [FunctionPointerType] ..(*)(..)
 #  592|           ValueCategory = lvalue
-#  592|         0: [VariableAccess] pfn
+#  592|         getLValue(): [VariableAccess] pfn
 #  592|             Type = [FunctionPointerType] ..(*)(..)
 #  592|             ValueCategory = lvalue
-#  592|         1: [AddressOfExpr] & ...
+#  592|         getRValue(): [AddressOfExpr] & ...
 #  592|             Type = [FunctionPointerType] ..(*)(..)
 #  592|             ValueCategory = prvalue
-#  592|           0: [FunctionAccess] FuncPtrTarget
+#  592|           getOperand(): [FunctionAccess] FuncPtrTarget
 #  592|               Type = [RoutineType] ..()(..)
 #  592|               ValueCategory = lvalue
-#  593|     2: [ExprStmt] ExprStmt
-#  593|       0: [AssignExpr] ... = ...
+#  593|     getStmt(2): [ExprStmt] ExprStmt
+#  593|       getExpr(): [AssignExpr] ... = ...
 #  593|           Type = [FunctionPointerType] ..(*)(..)
 #  593|           ValueCategory = lvalue
-#  593|         0: [VariableAccess] pfn
+#  593|         getLValue(): [VariableAccess] pfn
 #  593|             Type = [FunctionPointerType] ..(*)(..)
 #  593|             ValueCategory = lvalue
-#  593|         1: [PointerDereferenceExpr] * ...
+#  593|         getRValue(): [PointerDereferenceExpr] * ...
 #  593|             Type = [FunctionPointerType] ..(*)(..)
 #  593|             ValueCategory = prvalue(load)
-#  593|           0: [FunctionAccess] FuncPtrTarget
+#  593|           getOperand(): [FunctionAccess] FuncPtrTarget
 #  593|               Type = [FunctionPointerType] ..(*)(..)
 #  593|               ValueCategory = prvalue(load)
-#  594|     3: [ExprStmt] ExprStmt
-#  594|       0: [AssignExpr] ... = ...
+#  594|     getStmt(3): [ExprStmt] ExprStmt
+#  594|       getExpr(): [AssignExpr] ... = ...
 #  594|           Type = [FunctionPointerType] ..(*)(..)
 #  594|           ValueCategory = lvalue
-#  594|         0: [VariableAccess] pfn
+#  594|         getLValue(): [VariableAccess] pfn
 #  594|             Type = [FunctionPointerType] ..(*)(..)
 #  594|             ValueCategory = lvalue
-#  594|         1: [PointerDereferenceExpr] * ...
+#  594|         getRValue(): [PointerDereferenceExpr] * ...
 #  594|             Type = [FunctionPointerType] ..(*)(..)
 #  594|             ValueCategory = prvalue(load)
-#  594|           0: [PointerDereferenceExpr] * ...
+#  594|           getOperand(): [PointerDereferenceExpr] * ...
 #  594|               Type = [FunctionPointerType] ..(*)(..)
 #  594|               ValueCategory = prvalue(load)
-#  594|             0: [PointerDereferenceExpr] * ...
+#  594|             getOperand(): [PointerDereferenceExpr] * ...
 #  594|                 Type = [FunctionPointerType] ..(*)(..)
 #  594|                 ValueCategory = prvalue(load)
-#  594|               0: [AddressOfExpr] & ...
+#  594|               getOperand(): [AddressOfExpr] & ...
 #  594|                   Type = [FunctionPointerType] ..(*)(..)
 #  594|                   ValueCategory = prvalue
-#  594|                 0: [FunctionAccess] FuncPtrTarget
+#  594|                 getOperand(): [FunctionAccess] FuncPtrTarget
 #  594|                     Type = [RoutineType] ..()(..)
 #  594|                     ValueCategory = lvalue
-#  595|     4: [ReturnStmt] return ...
+#  595|     getStmt(4): [ReturnStmt] return ...
 #  599| [CopyConstructor] void String::String(String const&)
-#  599|   params: 
-#  599|     0: [Parameter] (unnamed parameter 0)
+#  599|   ...: 
+#  599|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  599|         Type = [LValueReferenceType] const String &
 #  600| [MoveConstructor] void String::String(String&&)
-#  600|   params: 
-#  600|     0: [Parameter] (unnamed parameter 0)
+#  600|   ...: 
+#  600|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  600|         Type = [RValueReferenceType] String &&
 #  601| [ConversionConstructor] void String::String(char const*)
-#  601|   params: 
-#  601|     0: [Parameter] (unnamed parameter 0)
+#  601|   ...: 
+#  601|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  601|         Type = [PointerType] const char *
 #  602| [Destructor] void String::~String()
-#  602|   params: 
+#  602|   ...: 
 #  604| [CopyAssignmentOperator] String& String::operator=(String const&)
-#  604|   params: 
-#  604|     0: [Parameter] (unnamed parameter 0)
+#  604|   ...: 
+#  604|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  604|         Type = [LValueReferenceType] const String &
 #  605| [MoveAssignmentOperator] String& String::operator=(String&&)
-#  605|   params: 
-#  605|     0: [Parameter] (unnamed parameter 0)
+#  605|   ...: 
+#  605|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  605|         Type = [RValueReferenceType] String &&
 #  607| [ConstMemberFunction] char const* String::c_str() const
-#  607|   params: 
+#  607|   ...: 
 #  613| [TopLevelFunction] String ReturnObject()
-#  613|   params: 
+#  613|   ...: 
 #  615| [TopLevelFunction] void DeclareObject()
-#  615|   params: 
-#  615|   body: [BlockStmt] { ... }
-#  616|     0: [DeclStmt] declaration
-#  616|       0: [VariableDeclarationEntry] definition of s1
+#  615|   ...: 
+#  615|   getEntryPoint(): [BlockStmt] { ... }
+#  616|     getStmt(0): [DeclStmt] declaration
+#  616|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s1
 #  616|           Type = [Struct] String
-#  616|         init: [Initializer] initializer for s1
-#  616|           expr: [ConstructorCall] call to String
+#  616|         getVariable().getInitializer(): [Initializer] initializer for s1
+#  616|           getExpr(): [ConstructorCall] call to String
 #  616|               Type = [VoidType] void
 #  616|               ValueCategory = prvalue
-#  617|     1: [DeclStmt] declaration
-#  617|       0: [VariableDeclarationEntry] definition of s2
+#  617|     getStmt(1): [DeclStmt] declaration
+#  617|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s2
 #  617|           Type = [Struct] String
-#  617|         init: [Initializer] initializer for s2
-#  617|           expr: [ConstructorCall] call to String
+#  617|         getVariable().getInitializer(): [Initializer] initializer for s2
+#  617|           getExpr(): [ConstructorCall] call to String
 #  617|               Type = [VoidType] void
 #  617|               ValueCategory = prvalue
-#  617|             0: hello
+#  617|             getArgument(0): hello
 #  617|                 Type = [ArrayType] const char[6]
 #  617|                 Value = [StringLiteral] "hello"
 #  617|                 ValueCategory = lvalue
-#  617|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  617|             : [ArrayToPointerConversion] array to pointer conversion
 #  617|                 Type = [PointerType] const char *
 #  617|                 ValueCategory = prvalue
-#  618|     2: [DeclStmt] declaration
-#  618|       0: [VariableDeclarationEntry] definition of s3
+#  618|     getStmt(2): [DeclStmt] declaration
+#  618|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s3
 #  618|           Type = [Struct] String
-#  618|         init: [Initializer] initializer for s3
-#  618|           expr: [FunctionCall] call to ReturnObject
+#  618|         getVariable().getInitializer(): [Initializer] initializer for s3
+#  618|           getExpr(): [FunctionCall] call to ReturnObject
 #  618|               Type = [Struct] String
 #  618|               ValueCategory = prvalue
-#  619|     3: [DeclStmt] declaration
-#  619|       0: [VariableDeclarationEntry] definition of s4
+#  619|     getStmt(3): [DeclStmt] declaration
+#  619|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s4
 #  619|           Type = [Struct] String
-#  619|         init: [Initializer] initializer for s4
-#  619|           expr: [ConstructorCall] call to String
+#  619|         getVariable().getInitializer(): [Initializer] initializer for s4
+#  619|           getExpr(): [ConstructorCall] call to String
 #  619|               Type = [VoidType] void
 #  619|               ValueCategory = prvalue
-#  619|             0: test
+#  619|             getArgument(0): test
 #  619|                 Type = [ArrayType] const char[5]
 #  619|                 Value = [StringLiteral] "test"
 #  619|                 ValueCategory = lvalue
-#  619|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  619|             : [ArrayToPointerConversion] array to pointer conversion
 #  619|                 Type = [PointerType] const char *
 #  619|                 ValueCategory = prvalue
-#  620|     4: [ReturnStmt] return ...
+#  620|     getStmt(4): [ReturnStmt] return ...
 #  622| [TopLevelFunction] void CallMethods(String&, String*, String)
-#  622|   params: 
-#  622|     0: [Parameter] r
+#  622|   ...: 
+#  622|     getParameter(0): [Parameter] r
 #  622|         Type = [LValueReferenceType] String &
-#  622|     1: [Parameter] p
+#  622|     getParameter(1): [Parameter] p
 #  622|         Type = [PointerType] String *
-#  622|     2: [Parameter] s
+#  622|     getParameter(2): [Parameter] s
 #  622|         Type = [Struct] String
-#  622|   body: [BlockStmt] { ... }
-#  623|     0: [ExprStmt] ExprStmt
-#  623|       0: [FunctionCall] call to c_str
+#  622|   getEntryPoint(): [BlockStmt] { ... }
+#  623|     getStmt(0): [ExprStmt] ExprStmt
+#  623|       getExpr(): [FunctionCall] call to c_str
 #  623|           Type = [PointerType] const char *
 #  623|           ValueCategory = prvalue
-#  623|         -1: [VariableAccess] r
+#  623|         getQualifier(): [VariableAccess] r
 #  623|             Type = [LValueReferenceType] String &
 #  623|             ValueCategory = prvalue(load)
-#  623|         -1: [CStyleCast] (const String)...
+#  623|         getQualifier(): [CStyleCast] (const String)...
 #  623|             Conversion = [GlvalueConversion] glvalue conversion
 #  623|             Type = [SpecifiedType] const String
 #  623|             ValueCategory = lvalue
-#  623|           expr: [ReferenceDereferenceExpr] (reference dereference)
+#  623|           getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #  623|               Type = [Struct] String
 #  623|               ValueCategory = lvalue
-#  624|     1: [ExprStmt] ExprStmt
-#  624|       0: [FunctionCall] call to c_str
+#  624|     getStmt(1): [ExprStmt] ExprStmt
+#  624|       getExpr(): [FunctionCall] call to c_str
 #  624|           Type = [PointerType] const char *
 #  624|           ValueCategory = prvalue
-#  624|         -1: [VariableAccess] p
+#  624|         getQualifier(): [VariableAccess] p
 #  624|             Type = [PointerType] String *
 #  624|             ValueCategory = prvalue(load)
-#  624|         -1: [CStyleCast] (const String *)...
+#  624|         getQualifier(): [CStyleCast] (const String *)...
 #  624|             Conversion = [PointerConversion] pointer conversion
 #  624|             Type = [PointerType] const String *
 #  624|             ValueCategory = prvalue
-#  625|     2: [ExprStmt] ExprStmt
-#  625|       0: [FunctionCall] call to c_str
+#  625|     getStmt(2): [ExprStmt] ExprStmt
+#  625|       getExpr(): [FunctionCall] call to c_str
 #  625|           Type = [PointerType] const char *
 #  625|           ValueCategory = prvalue
-#  625|         -1: [VariableAccess] s
+#  625|         getQualifier(): [VariableAccess] s
 #  625|             Type = [Struct] String
 #  625|             ValueCategory = lvalue
-#  625|         -1: [CStyleCast] (const String)...
+#  625|         getQualifier(): [CStyleCast] (const String)...
 #  625|             Conversion = [GlvalueConversion] glvalue conversion
 #  625|             Type = [SpecifiedType] const String
 #  625|             ValueCategory = lvalue
-#  626|     3: [ReturnStmt] return ...
+#  626|     getStmt(3): [ReturnStmt] return ...
 #  628| [CopyAssignmentOperator] C& C::operator=(C const&)
-#  628|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  628|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveAssignmentOperator] C& C::operator=(C&&)
-#  628|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  628|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [CopyConstructor] void C::C(C const&)
-#  628|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  628|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveConstructor] void C::C(C&&)
-#  628|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  628|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [Destructor] void C::~C()
-#  628|   params: 
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ReturnStmt] return ...
-#  628|   destructions: 
-#  628|     0: [DestructorFieldDestruction] destructor field destruction of m_f
+#  628|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ReturnStmt] return ...
+#  628|   ...: 
+#  628|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of m_f
 #  628|         Type = [Struct] String
 #  628|         ValueCategory = prvalue
-#  628|       0: [DestructorCall] call to ~String
+#  628|       getExpr(): [DestructorCall] call to ~String
 #  628|           Type = [VoidType] void
 #  628|           ValueCategory = prvalue
-#  628|         -1: [ImplicitThisFieldAccess] m_f
+#  628|         getQualifier(): [ImplicitThisFieldAccess] m_f
 #  628|             Type = [Struct] String
 #  628|             ValueCategory = lvalue
-#  628|     1: [DestructorFieldDestruction] destructor field destruction of m_b
+#  628|     getDestruction(1): [DestructorFieldDestruction] destructor field destruction of m_b
 #  628|         Type = [Struct] String
 #  628|         ValueCategory = prvalue
-#  628|       0: [DestructorCall] call to ~String
+#  628|       getExpr(): [DestructorCall] call to ~String
 #  628|           Type = [VoidType] void
 #  628|           ValueCategory = prvalue
-#  628|         -1: [ImplicitThisFieldAccess] m_b
+#  628|         getQualifier(): [ImplicitThisFieldAccess] m_b
 #  628|             Type = [Struct] String
 #  628|             ValueCategory = lvalue
 #  630| [MemberFunction] int C::StaticMemberFunction(int)
-#  630|   params: 
-#  630|     0: [Parameter] x
+#  630|   ...: 
+#  630|     getParameter(0): [Parameter] x
 #  630|         Type = [IntType] int
-#  630|   body: [BlockStmt] { ... }
-#  631|     0: [ReturnStmt] return ...
-#  631|       0: [VariableAccess] x
+#  630|   getEntryPoint(): [BlockStmt] { ... }
+#  631|     getStmt(0): [ReturnStmt] return ...
+#  631|       getExpr(): [VariableAccess] x
 #  631|           Type = [IntType] int
 #  631|           ValueCategory = prvalue(load)
 #  634| [MemberFunction] int C::InstanceMemberFunction(int)
-#  634|   params: 
-#  634|     0: [Parameter] x
+#  634|   ...: 
+#  634|     getParameter(0): [Parameter] x
 #  634|         Type = [IntType] int
-#  634|   body: [BlockStmt] { ... }
-#  635|     0: [ReturnStmt] return ...
-#  635|       0: [VariableAccess] x
+#  634|   getEntryPoint(): [BlockStmt] { ... }
+#  635|     getStmt(0): [ReturnStmt] return ...
+#  635|       getExpr(): [VariableAccess] x
 #  635|           Type = [IntType] int
 #  635|           ValueCategory = prvalue(load)
 #  638| [VirtualFunction] int C::VirtualMemberFunction(int)
-#  638|   params: 
-#  638|     0: [Parameter] x
+#  638|   ...: 
+#  638|     getParameter(0): [Parameter] x
 #  638|         Type = [IntType] int
-#  638|   body: [BlockStmt] { ... }
-#  639|     0: [ReturnStmt] return ...
-#  639|       0: [VariableAccess] x
+#  638|   getEntryPoint(): [BlockStmt] { ... }
+#  639|     getStmt(0): [ReturnStmt] return ...
+#  639|       getExpr(): [VariableAccess] x
 #  639|           Type = [IntType] int
 #  639|           ValueCategory = prvalue(load)
 #  642| [MemberFunction] void C::FieldAccess()
-#  642|   params: 
-#  642|   body: [BlockStmt] { ... }
-#  643|     0: [ExprStmt] ExprStmt
-#  643|       0: [AssignExpr] ... = ...
+#  642|   ...: 
+#  642|   getEntryPoint(): [BlockStmt] { ... }
+#  643|     getStmt(0): [ExprStmt] ExprStmt
+#  643|       getExpr(): [AssignExpr] ... = ...
 #  643|           Type = [IntType] int
 #  643|           ValueCategory = lvalue
-#  643|         0: [PointerFieldAccess] m_a
+#  643|         getLValue(): [PointerFieldAccess] m_a
 #  643|             Type = [IntType] int
 #  643|             ValueCategory = lvalue
-#  643|           -1: [ThisExpr] this
+#  643|           getQualifier(): [ThisExpr] this
 #  643|               Type = [PointerType] C *
 #  643|               ValueCategory = prvalue(load)
-#  643|         1: [Literal] 0
+#  643|         getRValue(): [Literal] 0
 #  643|             Type = [IntType] int
 #  643|             Value = [Literal] 0
 #  643|             ValueCategory = prvalue
-#  644|     1: [ExprStmt] ExprStmt
-#  644|       0: [AssignExpr] ... = ...
+#  644|     getStmt(1): [ExprStmt] ExprStmt
+#  644|       getExpr(): [AssignExpr] ... = ...
 #  644|           Type = [IntType] int
 #  644|           ValueCategory = lvalue
-#  644|         0: [ValueFieldAccess] m_a
+#  644|         getLValue(): [ValueFieldAccess] m_a
 #  644|             Type = [IntType] int
 #  644|             ValueCategory = lvalue
-#  644|           -1: [PointerDereferenceExpr] * ...
+#  644|           getQualifier(): [PointerDereferenceExpr] * ...
 #  644|               Type = [Class] C
 #  644|               ValueCategory = lvalue
-#  644|             0: [ThisExpr] this
+#  644|             getOperand(): [ThisExpr] this
 #  644|                 Type = [PointerType] C *
 #  644|                 ValueCategory = prvalue(load)
-#  644|           -1: [ParenthesisExpr] (...)
+#  644|           getQualifier(): [ParenthesisExpr] (...)
 #  644|               Type = [Class] C
 #  644|               ValueCategory = lvalue
-#  644|         1: [Literal] 1
+#  644|         getRValue(): [Literal] 1
 #  644|             Type = [IntType] int
 #  644|             Value = [Literal] 1
 #  644|             ValueCategory = prvalue
-#  645|     2: [ExprStmt] ExprStmt
-#  645|       0: [AssignExpr] ... = ...
+#  645|     getStmt(2): [ExprStmt] ExprStmt
+#  645|       getExpr(): [AssignExpr] ... = ...
 #  645|           Type = [IntType] int
 #  645|           ValueCategory = lvalue
-#  645|         0: [PointerFieldAccess] m_a
+#  645|         getLValue(): [PointerFieldAccess] m_a
 #  645|             Type = [IntType] int
 #  645|             ValueCategory = lvalue
-#  645|           -1: [ThisExpr] this
+#  645|           getQualifier(): [ThisExpr] this
 #  645|               Type = [PointerType] C *
 #  645|               ValueCategory = prvalue(load)
-#  645|         1: [Literal] 2
+#  645|         getRValue(): [Literal] 2
 #  645|             Type = [IntType] int
 #  645|             Value = [Literal] 2
 #  645|             ValueCategory = prvalue
-#  646|     3: [DeclStmt] declaration
-#  646|       0: [VariableDeclarationEntry] definition of x
+#  646|     getStmt(3): [DeclStmt] declaration
+#  646|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  646|           Type = [IntType] int
-#  647|     4: [ExprStmt] ExprStmt
-#  647|       0: [AssignExpr] ... = ...
+#  647|     getStmt(4): [ExprStmt] ExprStmt
+#  647|       getExpr(): [AssignExpr] ... = ...
 #  647|           Type = [IntType] int
 #  647|           ValueCategory = lvalue
-#  647|         0: [VariableAccess] x
+#  647|         getLValue(): [VariableAccess] x
 #  647|             Type = [IntType] int
 #  647|             ValueCategory = lvalue
-#  647|         1: [PointerFieldAccess] m_a
+#  647|         getRValue(): [PointerFieldAccess] m_a
 #  647|             Type = [IntType] int
 #  647|             ValueCategory = prvalue(load)
-#  647|           -1: [ThisExpr] this
+#  647|           getQualifier(): [ThisExpr] this
 #  647|               Type = [PointerType] C *
 #  647|               ValueCategory = prvalue(load)
-#  648|     5: [ExprStmt] ExprStmt
-#  648|       0: [AssignExpr] ... = ...
+#  648|     getStmt(5): [ExprStmt] ExprStmt
+#  648|       getExpr(): [AssignExpr] ... = ...
 #  648|           Type = [IntType] int
 #  648|           ValueCategory = lvalue
-#  648|         0: [VariableAccess] x
+#  648|         getLValue(): [VariableAccess] x
 #  648|             Type = [IntType] int
 #  648|             ValueCategory = lvalue
-#  648|         1: [ValueFieldAccess] m_a
+#  648|         getRValue(): [ValueFieldAccess] m_a
 #  648|             Type = [IntType] int
 #  648|             ValueCategory = prvalue(load)
-#  648|           -1: [PointerDereferenceExpr] * ...
+#  648|           getQualifier(): [PointerDereferenceExpr] * ...
 #  648|               Type = [Class] C
 #  648|               ValueCategory = lvalue
-#  648|             0: [ThisExpr] this
+#  648|             getOperand(): [ThisExpr] this
 #  648|                 Type = [PointerType] C *
 #  648|                 ValueCategory = prvalue(load)
-#  648|           -1: [ParenthesisExpr] (...)
+#  648|           getQualifier(): [ParenthesisExpr] (...)
 #  648|               Type = [Class] C
 #  648|               ValueCategory = lvalue
-#  649|     6: [ExprStmt] ExprStmt
-#  649|       0: [AssignExpr] ... = ...
+#  649|     getStmt(6): [ExprStmt] ExprStmt
+#  649|       getExpr(): [AssignExpr] ... = ...
 #  649|           Type = [IntType] int
 #  649|           ValueCategory = lvalue
-#  649|         0: [VariableAccess] x
+#  649|         getLValue(): [VariableAccess] x
 #  649|             Type = [IntType] int
 #  649|             ValueCategory = lvalue
-#  649|         1: [PointerFieldAccess] m_a
+#  649|         getRValue(): [PointerFieldAccess] m_a
 #  649|             Type = [IntType] int
 #  649|             ValueCategory = prvalue(load)
-#  649|           -1: [ThisExpr] this
+#  649|           getQualifier(): [ThisExpr] this
 #  649|               Type = [PointerType] C *
 #  649|               ValueCategory = prvalue(load)
-#  650|     7: [ReturnStmt] return ...
+#  650|     getStmt(7): [ReturnStmt] return ...
 #  652| [MemberFunction] void C::MethodCalls()
-#  652|   params: 
-#  652|   body: [BlockStmt] { ... }
-#  653|     0: [ExprStmt] ExprStmt
-#  653|       0: [FunctionCall] call to InstanceMemberFunction
+#  652|   ...: 
+#  652|   getEntryPoint(): [BlockStmt] { ... }
+#  653|     getStmt(0): [ExprStmt] ExprStmt
+#  653|       getExpr(): [FunctionCall] call to InstanceMemberFunction
 #  653|           Type = [IntType] int
 #  653|           ValueCategory = prvalue
-#  653|         -1: [ThisExpr] this
+#  653|         getQualifier(): [ThisExpr] this
 #  653|             Type = [PointerType] C *
 #  653|             ValueCategory = prvalue(load)
-#  653|         0: [Literal] 0
+#  653|         getArgument(0): [Literal] 0
 #  653|             Type = [IntType] int
 #  653|             Value = [Literal] 0
 #  653|             ValueCategory = prvalue
-#  654|     1: [ExprStmt] ExprStmt
-#  654|       0: [FunctionCall] call to InstanceMemberFunction
+#  654|     getStmt(1): [ExprStmt] ExprStmt
+#  654|       getExpr(): [FunctionCall] call to InstanceMemberFunction
 #  654|           Type = [IntType] int
 #  654|           ValueCategory = prvalue
-#  654|         -1: [PointerDereferenceExpr] * ...
+#  654|         getQualifier(): [PointerDereferenceExpr] * ...
 #  654|             Type = [Class] C
 #  654|             ValueCategory = lvalue
-#  654|           0: [ThisExpr] this
+#  654|           getOperand(): [ThisExpr] this
 #  654|               Type = [PointerType] C *
 #  654|               ValueCategory = prvalue(load)
-#  654|         0: [ParenthesisExpr] (...)
+#  654|         getArgument(0): [ParenthesisExpr] (...)
 #  654|             Type = [Class] C
 #  654|             ValueCategory = lvalue
-#  654|         0: [Literal] 1
+#  654|         getArgument(0): [Literal] 1
 #  654|             Type = [IntType] int
 #  654|             Value = [Literal] 1
 #  654|             ValueCategory = prvalue
-#  655|     2: [ExprStmt] ExprStmt
-#  655|       0: [FunctionCall] call to InstanceMemberFunction
+#  655|     getStmt(2): [ExprStmt] ExprStmt
+#  655|       getExpr(): [FunctionCall] call to InstanceMemberFunction
 #  655|           Type = [IntType] int
 #  655|           ValueCategory = prvalue
-#  655|         -1: [ThisExpr] this
+#  655|         getQualifier(): [ThisExpr] this
 #  655|             Type = [PointerType] C *
 #  655|             ValueCategory = prvalue(load)
-#  655|         0: [Literal] 2
+#  655|         getArgument(0): [Literal] 2
 #  655|             Type = [IntType] int
 #  655|             Value = [Literal] 2
 #  655|             ValueCategory = prvalue
-#  656|     3: [ReturnStmt] return ...
+#  656|     getStmt(3): [ReturnStmt] return ...
 #  658| [Constructor] void C::C()
-#  658|   params: 
-#  658|   initializations: 
-#  659|     0: [ConstructorFieldInit] constructor init of field m_a
+#  658|   ...: 
+#  658|   ...: 
+#  659|     getInitializer(0): [ConstructorFieldInit] constructor init of field m_a
 #  659|         Type = [IntType] int
 #  659|         ValueCategory = prvalue
-#  659|       0: [Literal] 1
+#  659|       getExpr(): [Literal] 1
 #  659|           Type = [IntType] int
 #  659|           Value = [Literal] 1
 #  659|           ValueCategory = prvalue
-#  663|     1: [ConstructorFieldInit] constructor init of field m_b
+#  663|     getInitializer(1): [ConstructorFieldInit] constructor init of field m_b
 #  663|         Type = [Struct] String
 #  663|         ValueCategory = prvalue
-#  663|       0: [ConstructorCall] call to String
+#  663|       getExpr(): [ConstructorCall] call to String
 #  663|           Type = [VoidType] void
 #  663|           ValueCategory = prvalue
-#  660|     2: [ConstructorFieldInit] constructor init of field m_c
+#  660|     getInitializer(2): [ConstructorFieldInit] constructor init of field m_c
 #  660|         Type = [PlainCharType] char
 #  660|         ValueCategory = prvalue
-#  660|       0: [Literal] 3
+#  660|       getExpr(): [Literal] 3
 #  660|           Type = [IntType] int
 #  660|           Value = [Literal] 3
 #  660|           ValueCategory = prvalue
-#  660|       0 converted: [CStyleCast] (char)...
+#  660|       : [CStyleCast] (char)...
 #  660|           Conversion = [IntegralConversion] integral conversion
 #  660|           Type = [PlainCharType] char
 #  660|           Value = [CStyleCast] 3
 #  660|           ValueCategory = prvalue
-#  661|     3: [ConstructorFieldInit] constructor init of field m_e
+#  661|     getInitializer(3): [ConstructorFieldInit] constructor init of field m_e
 #  661|         Type = [VoidPointerType] void *
 #  661|         ValueCategory = prvalue
-#  661|       0: [Literal] 0
+#  661|       getExpr(): [Literal] 0
 #  661|           Type = [VoidPointerType] void *
 #  661|           Value = [Literal] 0
 #  661|           ValueCategory = prvalue
-#  662|     4: [ConstructorFieldInit] constructor init of field m_f
+#  662|     getInitializer(4): [ConstructorFieldInit] constructor init of field m_f
 #  662|         Type = [Struct] String
 #  662|         ValueCategory = prvalue
-#  662|       0: [ConstructorCall] call to String
+#  662|       getExpr(): [ConstructorCall] call to String
 #  662|           Type = [VoidType] void
 #  662|           ValueCategory = prvalue
-#  662|         0: test
+#  662|         getArgument(0): test
 #  662|             Type = [ArrayType] const char[5]
 #  662|             Value = [StringLiteral] "test"
 #  662|             ValueCategory = lvalue
-#  662|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  662|         : [ArrayToPointerConversion] array to pointer conversion
 #  662|             Type = [PointerType] const char *
 #  662|             ValueCategory = prvalue
-#  663|   body: [BlockStmt] { ... }
-#  664|     0: [ReturnStmt] return ...
+#  663|   getEntryPoint(): [BlockStmt] { ... }
+#  664|     getStmt(0): [ReturnStmt] return ...
 #  675| [TopLevelFunction] int DerefReference(int&)
-#  675|   params: 
-#  675|     0: [Parameter] r
+#  675|   ...: 
+#  675|     getParameter(0): [Parameter] r
 #  675|         Type = [LValueReferenceType] int &
-#  675|   body: [BlockStmt] { ... }
-#  676|     0: [ReturnStmt] return ...
-#  676|       0: [VariableAccess] r
+#  675|   getEntryPoint(): [BlockStmt] { ... }
+#  676|     getStmt(0): [ReturnStmt] return ...
+#  676|       getExpr(): [VariableAccess] r
 #  676|           Type = [LValueReferenceType] int &
 #  676|           ValueCategory = prvalue(load)
-#  676|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  676|       : [ReferenceDereferenceExpr] (reference dereference)
 #  676|           Type = [IntType] int
 #  676|           ValueCategory = prvalue(load)
 #  679| [TopLevelFunction] int& TakeReference()
-#  679|   params: 
-#  679|   body: [BlockStmt] { ... }
-#  680|     0: [ReturnStmt] return ...
-#  680|       0: [VariableAccess] g
+#  679|   ...: 
+#  679|   getEntryPoint(): [BlockStmt] { ... }
+#  680|     getStmt(0): [ReturnStmt] return ...
+#  680|       getExpr(): [VariableAccess] g
 #  680|           Type = [IntType] int
 #  680|           ValueCategory = lvalue
-#  680|       0 converted: [ReferenceToExpr] (reference to)
+#  680|       : [ReferenceToExpr] (reference to)
 #  680|           Type = [LValueReferenceType] int &
 #  680|           ValueCategory = prvalue
 #  683| [TopLevelFunction] String& ReturnReference()
-#  683|   params: 
+#  683|   ...: 
 #  685| [TopLevelFunction] void InitReference(int)
-#  685|   params: 
-#  685|     0: [Parameter] x
+#  685|   ...: 
+#  685|     getParameter(0): [Parameter] x
 #  685|         Type = [IntType] int
-#  685|   body: [BlockStmt] { ... }
-#  686|     0: [DeclStmt] declaration
-#  686|       0: [VariableDeclarationEntry] definition of r
+#  685|   getEntryPoint(): [BlockStmt] { ... }
+#  686|     getStmt(0): [DeclStmt] declaration
+#  686|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
 #  686|           Type = [LValueReferenceType] int &
-#  686|         init: [Initializer] initializer for r
-#  686|           expr: [VariableAccess] x
+#  686|         getVariable().getInitializer(): [Initializer] initializer for r
+#  686|           getExpr(): [VariableAccess] x
 #  686|               Type = [IntType] int
 #  686|               ValueCategory = lvalue
-#  686|           expr converted: [ReferenceToExpr] (reference to)
+#  686|           : [ReferenceToExpr] (reference to)
 #  686|               Type = [LValueReferenceType] int &
 #  686|               ValueCategory = prvalue
-#  687|     1: [DeclStmt] declaration
-#  687|       0: [VariableDeclarationEntry] definition of r2
+#  687|     getStmt(1): [DeclStmt] declaration
+#  687|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r2
 #  687|           Type = [LValueReferenceType] int &
-#  687|         init: [Initializer] initializer for r2
-#  687|           expr: [VariableAccess] r
+#  687|         getVariable().getInitializer(): [Initializer] initializer for r2
+#  687|           getExpr(): [VariableAccess] r
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue(load)
-#  687|           expr converted: [ReferenceToExpr] (reference to)
+#  687|           : [ReferenceToExpr] (reference to)
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue
-#  687|             expr: [ReferenceDereferenceExpr] (reference dereference)
+#  687|             getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #  687|                 Type = [IntType] int
 #  687|                 ValueCategory = lvalue
-#  688|     2: [DeclStmt] declaration
-#  688|       0: [VariableDeclarationEntry] definition of r3
+#  688|     getStmt(2): [DeclStmt] declaration
+#  688|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r3
 #  688|           Type = [LValueReferenceType] const String &
-#  688|         init: [Initializer] initializer for r3
-#  688|           expr: [FunctionCall] call to ReturnReference
+#  688|         getVariable().getInitializer(): [Initializer] initializer for r3
+#  688|           getExpr(): [FunctionCall] call to ReturnReference
 #  688|               Type = [LValueReferenceType] String &
 #  688|               ValueCategory = prvalue
-#  688|           expr converted: [ReferenceToExpr] (reference to)
+#  688|           : [ReferenceToExpr] (reference to)
 #  688|               Type = [LValueReferenceType] const String &
 #  688|               ValueCategory = prvalue
-#  688|             expr: [CStyleCast] (const String)...
+#  688|             getExpr(): [CStyleCast] (const String)...
 #  688|                 Conversion = [GlvalueConversion] glvalue conversion
 #  688|                 Type = [SpecifiedType] const String
 #  688|                 ValueCategory = lvalue
-#  688|               expr: [ReferenceDereferenceExpr] (reference dereference)
+#  688|               getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #  688|                   Type = [Struct] String
 #  688|                   ValueCategory = lvalue
-#  689|     3: [ReturnStmt] return ...
+#  689|     getStmt(3): [ReturnStmt] return ...
 #  691| [TopLevelFunction] void ArrayReferences()
-#  691|   params: 
-#  691|   body: [BlockStmt] { ... }
-#  692|     0: [DeclStmt] declaration
-#  692|       0: [VariableDeclarationEntry] definition of a
+#  691|   ...: 
+#  691|   getEntryPoint(): [BlockStmt] { ... }
+#  692|     getStmt(0): [DeclStmt] declaration
+#  692|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 #  692|           Type = [ArrayType] int[10]
-#  693|     1: [DeclStmt] declaration
-#  693|       0: [VariableDeclarationEntry] definition of ra
+#  693|     getStmt(1): [DeclStmt] declaration
+#  693|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ra
 #  693|           Type = [LValueReferenceType] int(&)[10]
-#  693|         init: [Initializer] initializer for ra
-#  693|           expr: [VariableAccess] a
+#  693|         getVariable().getInitializer(): [Initializer] initializer for ra
+#  693|           getExpr(): [VariableAccess] a
 #  693|               Type = [ArrayType] int[10]
 #  693|               ValueCategory = lvalue
-#  693|           expr converted: [ReferenceToExpr] (reference to)
+#  693|           : [ReferenceToExpr] (reference to)
 #  693|               Type = [LValueReferenceType] int(&)[10]
 #  693|               ValueCategory = prvalue
-#  694|     2: [DeclStmt] declaration
-#  694|       0: [VariableDeclarationEntry] definition of x
+#  694|     getStmt(2): [DeclStmt] declaration
+#  694|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  694|           Type = [IntType] int
-#  694|         init: [Initializer] initializer for x
-#  694|           expr: [ArrayExpr] access to array
+#  694|         getVariable().getInitializer(): [Initializer] initializer for x
+#  694|           getExpr(): [ArrayExpr] access to array
 #  694|               Type = [IntType] int
 #  694|               ValueCategory = prvalue(load)
-#  694|             0: [VariableAccess] ra
+#  694|             getArrayBase(): [VariableAccess] ra
 #  694|                 Type = [LValueReferenceType] int(&)[10]
 #  694|                 ValueCategory = prvalue(load)
-#  694|             1: [Literal] 5
+#  694|             getArrayOffset(): [Literal] 5
 #  694|                 Type = [IntType] int
 #  694|                 Value = [Literal] 5
 #  694|                 ValueCategory = prvalue
-#  694|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  694|             : [ArrayToPointerConversion] array to pointer conversion
 #  694|                 Type = [IntPointerType] int *
 #  694|                 ValueCategory = prvalue
-#  694|               expr: [ReferenceDereferenceExpr] (reference dereference)
+#  694|               getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 #  694|                   Type = [ArrayType] int[10]
 #  694|                   ValueCategory = lvalue
-#  695|     3: [ReturnStmt] return ...
+#  695|     getStmt(3): [ReturnStmt] return ...
 #  697| [TopLevelFunction] void FunctionReferences()
-#  697|   params: 
-#  697|   body: [BlockStmt] { ... }
-#  698|     0: [DeclStmt] declaration
-#  698|       0: [VariableDeclarationEntry] definition of rfn
+#  697|   ...: 
+#  697|   getEntryPoint(): [BlockStmt] { ... }
+#  698|     getStmt(0): [DeclStmt] declaration
+#  698|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rfn
 #  698|           Type = [FunctionReferenceType] ..(&)(..)
-#  698|         init: [Initializer] initializer for rfn
-#  698|           expr: [FunctionAccess] FuncPtrTarget
+#  698|         getVariable().getInitializer(): [Initializer] initializer for rfn
+#  698|           getExpr(): [FunctionAccess] FuncPtrTarget
 #  698|               Type = [RoutineType] ..()(..)
 #  698|               ValueCategory = lvalue
-#  698|           expr converted: [ReferenceToExpr] (reference to)
+#  698|           : [ReferenceToExpr] (reference to)
 #  698|               Type = [FunctionReferenceType] ..(&)(..)
 #  698|               ValueCategory = prvalue
-#  699|     1: [DeclStmt] declaration
-#  699|       0: [VariableDeclarationEntry] definition of pfn
+#  699|     getStmt(1): [DeclStmt] declaration
+#  699|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pfn
 #  699|           Type = [FunctionPointerType] ..(*)(..)
-#  699|         init: [Initializer] initializer for pfn
-#  699|           expr: [VariableAccess] rfn
+#  699|         getVariable().getInitializer(): [Initializer] initializer for pfn
+#  699|           getExpr(): [VariableAccess] rfn
 #  699|               Type = [FunctionReferenceType] ..(&)(..)
 #  699|               ValueCategory = prvalue(load)
-#  699|           expr converted: [ReferenceDereferenceExpr] (reference dereference)
+#  699|           : [ReferenceDereferenceExpr] (reference dereference)
 #  699|               Type = [FunctionPointerType] ..(*)(..)
 #  699|               ValueCategory = prvalue(load)
-#  700|     2: [ExprStmt] ExprStmt
-#  700|       0: [VariableCall] call to expression
+#  700|     getStmt(2): [ExprStmt] ExprStmt
+#  700|       getExpr(): [VariableCall] call to expression
 #  700|           Type = [IntType] int
 #  700|           ValueCategory = prvalue
-#  700|         0: [VariableAccess] rfn
+#  700|         getExpr(): [VariableAccess] rfn
 #  700|             Type = [FunctionReferenceType] ..(&)(..)
 #  700|             ValueCategory = prvalue(load)
-#  700|         1: [Literal] 5
+#  700|         getArgument(0): [Literal] 5
 #  700|             Type = [IntType] int
 #  700|             Value = [Literal] 5
 #  700|             ValueCategory = prvalue
-#  700|         0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  700|         : [ReferenceDereferenceExpr] (reference dereference)
 #  700|             Type = [FunctionPointerType] ..(*)(..)
 #  700|             ValueCategory = prvalue(load)
-#  701|     3: [ReturnStmt] return ...
+#  701|     getStmt(3): [ReturnStmt] return ...
 #  704| [TemplateFunction,TopLevelFunction] T min<T>(T, T)
-#  704|   params: 
-#  704|     0: [Parameter] x
+#  704|   ...: 
+#  704|     getParameter(0): [Parameter] x
 #  704|         Type = [TemplateParameter] T
-#  704|     1: [Parameter] y
+#  704|     getParameter(1): [Parameter] y
 #  704|         Type = [TemplateParameter] T
-#  704|   body: [BlockStmt] { ... }
-#  705|     0: [ReturnStmt] return ...
-#  705|       0: [ConditionalExpr] ... ? ... : ...
+#  704|   getEntryPoint(): [BlockStmt] { ... }
+#  705|     getStmt(0): [ReturnStmt] return ...
+#  705|       getExpr(): [ConditionalExpr] ... ? ... : ...
 #  705|           Type = [UnknownType] unknown
 #  705|           ValueCategory = prvalue
-#  705|         0: [LTExpr] ... < ...
+#  705|         getCondition(): [LTExpr] ... < ...
 #  705|             Type = [UnknownType] unknown
 #  705|             ValueCategory = prvalue
-#  705|           0: [VariableAccess] x
+#  705|           getLesserOperand(): [VariableAccess] x
 #  705|               Type = [TemplateParameter] T
 #  705|               ValueCategory = lvalue
-#  705|           1: [VariableAccess] y
+#  705|           getGreaterOperand(): [VariableAccess] y
 #  705|               Type = [TemplateParameter] T
 #  705|               ValueCategory = lvalue
-#  705|         1: [VariableAccess] x
+#  705|         getThen(): [VariableAccess] x
 #  705|             Type = [TemplateParameter] T
 #  705|             ValueCategory = lvalue
-#  705|         2: [VariableAccess] y
+#  705|         getElse(): [VariableAccess] y
 #  705|             Type = [TemplateParameter] T
 #  705|             ValueCategory = lvalue
-#  705|         0 converted: [CStyleCast] (bool)...
+#  705|         : [CStyleCast] (bool)...
 #  705|             Conversion = [BoolConversion] conversion to bool
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
-#  705|           expr: [ParenthesisExpr] (...)
+#  705|           getExpr(): [ParenthesisExpr] (...)
 #  705|               Type = [UnknownType] unknown
 #  705|               ValueCategory = prvalue
 #  704| [FunctionTemplateInstantiation,TopLevelFunction] int min<int>(int, int)
-#  704|   params: 
-#  704|     0: [Parameter] x
+#  704|   ...: 
+#  704|     getParameter(0): [Parameter] x
 #  704|         Type = [IntType] int
-#  704|     1: [Parameter] y
+#  704|     getParameter(1): [Parameter] y
 #  704|         Type = [IntType] int
-#  704|   body: [BlockStmt] { ... }
-#  705|     0: [ReturnStmt] return ...
-#  705|       0: [ConditionalExpr] ... ? ... : ...
+#  704|   getEntryPoint(): [BlockStmt] { ... }
+#  705|     getStmt(0): [ReturnStmt] return ...
+#  705|       getExpr(): [ConditionalExpr] ... ? ... : ...
 #  705|           Type = [IntType] int
 #  705|           ValueCategory = prvalue
-#  705|         0: [LTExpr] ... < ...
+#  705|         getCondition(): [LTExpr] ... < ...
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
-#  705|           0: [VariableAccess] x
+#  705|           getLesserOperand(): [VariableAccess] x
 #  705|               Type = [IntType] int
 #  705|               ValueCategory = prvalue(load)
-#  705|           1: [VariableAccess] y
+#  705|           getGreaterOperand(): [VariableAccess] y
 #  705|               Type = [IntType] int
 #  705|               ValueCategory = prvalue(load)
-#  705|         1: [VariableAccess] x
+#  705|         getThen(): [VariableAccess] x
 #  705|             Type = [IntType] int
 #  705|             ValueCategory = prvalue(load)
-#  705|         2: [VariableAccess] y
+#  705|         getElse(): [VariableAccess] y
 #  705|             Type = [IntType] int
 #  705|             ValueCategory = prvalue(load)
-#  705|         0 converted: [ParenthesisExpr] (...)
+#  705|         : [ParenthesisExpr] (...)
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
 #  708| [TopLevelFunction] int CallMin(int, int)
-#  708|   params: 
-#  708|     0: [Parameter] x
+#  708|   ...: 
+#  708|     getParameter(0): [Parameter] x
 #  708|         Type = [IntType] int
-#  708|     1: [Parameter] y
+#  708|     getParameter(1): [Parameter] y
 #  708|         Type = [IntType] int
-#  708|   body: [BlockStmt] { ... }
-#  709|     0: [ReturnStmt] return ...
-#  709|       0: [FunctionCall] call to min
+#  708|   getEntryPoint(): [BlockStmt] { ... }
+#  709|     getStmt(0): [ReturnStmt] return ...
+#  709|       getExpr(): [FunctionCall] call to min
 #  709|           Type = [IntType] int
 #  709|           ValueCategory = prvalue
-#  709|         0: [VariableAccess] x
+#  709|         getArgument(0): [VariableAccess] x
 #  709|             Type = [IntType] int
 #  709|             ValueCategory = prvalue(load)
-#  709|         1: [VariableAccess] y
+#  709|         getArgument(1): [VariableAccess] y
 #  709|             Type = [IntType] int
 #  709|             ValueCategory = prvalue(load)
 #  713| [CopyAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long> const&)
-#  713|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  713|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Outer<long> &
 #  713| [MoveAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long>&&)
-#  713|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  713|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Outer<long> &&
 #  715| [MemberFunction,TemplateFunction] T Outer<T>::Func<U, V>(U, V)
-#  715|   params: 
-#  715|     0: [Parameter] x
+#  715|   ...: 
+#  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
-#  715|     1: [Parameter] y
+#  715|     getParameter(1): [Parameter] y
 #  715|         Type = [TemplateParameter] V
-#  715|   body: [BlockStmt] { ... }
-#  716|     0: [ReturnStmt] return ...
-#  716|       0: [Literal] 0
+#  715|   getEntryPoint(): [BlockStmt] { ... }
+#  716|     getStmt(0): [ReturnStmt] return ...
+#  716|       getExpr(): [Literal] 0
 #  716|           Type = [TemplateParameter] T
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  715| [MemberFunction,TemplateFunction] long Outer<long>::Func<U, V>(U, V)
-#  715|   params: 
-#  715|     0: [Parameter] x
+#  715|   ...: 
+#  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
-#  715|     1: [Parameter] y
+#  715|     getParameter(1): [Parameter] y
 #  715|         Type = [TemplateParameter] V
 #  715| [FunctionTemplateInstantiation,MemberFunction] long Outer<long>::Func<void*, char>(void*, char)
-#  715|   params: 
-#  715|     0: [Parameter] x
+#  715|   ...: 
+#  715|     getParameter(0): [Parameter] x
 #  715|         Type = [VoidPointerType] void *
-#  715|     1: [Parameter] y
+#  715|     getParameter(1): [Parameter] y
 #  715|         Type = [PlainCharType] char
-#  715|   body: [BlockStmt] { ... }
-#  716|     0: [ReturnStmt] return ...
-#  716|       0: [Literal] 0
+#  715|   getEntryPoint(): [BlockStmt] { ... }
+#  716|     getStmt(0): [ReturnStmt] return ...
+#  716|       getExpr(): [Literal] 0
 #  716|           Type = [LongType] long
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  720| [TopLevelFunction] double CallNestedTemplateFunc()
-#  720|   params: 
-#  720|   body: [BlockStmt] { ... }
-#  721|     0: [ReturnStmt] return ...
-#  721|       0: [FunctionCall] call to Func
+#  720|   ...: 
+#  720|   getEntryPoint(): [BlockStmt] { ... }
+#  721|     getStmt(0): [ReturnStmt] return ...
+#  721|       getExpr(): [FunctionCall] call to Func
 #  721|           Type = [LongType] long
 #  721|           ValueCategory = prvalue
-#  721|         0: [Literal] 0
+#  721|         getArgument(0): [Literal] 0
 #  721|             Type = [NullPointerType] decltype(nullptr)
 #  721|             Value = [Literal] 0
 #  721|             ValueCategory = prvalue
-#  721|         1: [CharLiteral] 111
+#  721|         getArgument(1): [CharLiteral] 111
 #  721|             Type = [PlainCharType] char
 #  721|             Value = [CharLiteral] 111
 #  721|             ValueCategory = prvalue
-#  721|         0 converted: [CStyleCast] (void *)...
+#  721|         : [CStyleCast] (void *)...
 #  721|             Conversion = [PointerConversion] pointer conversion
 #  721|             Type = [VoidPointerType] void *
 #  721|             Value = [CStyleCast] 0
 #  721|             ValueCategory = prvalue
-#  721|       0 converted: [CStyleCast] (double)...
+#  721|       : [CStyleCast] (double)...
 #  721|           Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  721|           Type = [DoubleType] double
 #  721|           ValueCategory = prvalue
 #  724| [TopLevelFunction] void TryCatch(bool)
-#  724|   params: 
-#  724|     0: [Parameter] b
+#  724|   ...: 
+#  724|     getParameter(0): [Parameter] b
 #  724|         Type = [BoolType] bool
-#  724|   body: [BlockStmt] { ... }
-#  725|     0: [TryStmt] try { ... }
-#  725|       0: [BlockStmt] { ... }
-#  726|         0: [DeclStmt] declaration
-#  726|           0: [VariableDeclarationEntry] definition of x
+#  724|   getEntryPoint(): [BlockStmt] { ... }
+#  725|     getStmt(0): [TryStmt] try { ... }
+#  725|       getStmt(): [BlockStmt] { ... }
+#  726|         getStmt(0): [DeclStmt] declaration
+#  726|           getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 #  726|               Type = [IntType] int
-#  726|             init: [Initializer] initializer for x
-#  726|               expr: [Literal] 5
+#  726|             getVariable().getInitializer(): [Initializer] initializer for x
+#  726|               getExpr(): [Literal] 5
 #  726|                   Type = [IntType] int
 #  726|                   Value = [Literal] 5
 #  726|                   ValueCategory = prvalue
-#  727|         1: [IfStmt] if (...) ... 
-#  727|           0: [VariableAccess] b
+#  727|         getStmt(1): [IfStmt] if (...) ... 
+#  727|           getCondition(): [VariableAccess] b
 #  727|               Type = [BoolType] bool
 #  727|               ValueCategory = prvalue(load)
-#  727|           1: [BlockStmt] { ... }
-#  728|             0: [ExprStmt] ExprStmt
-#  728|               0: [ThrowExpr] throw ...
+#  727|           getThen(): [BlockStmt] { ... }
+#  728|             getStmt(0): [ExprStmt] ExprStmt
+#  728|               getExpr(): [ThrowExpr] throw ...
 #  728|                   Type = [PointerType] const char *
 #  728|                   ValueCategory = prvalue
-#  728|                 0: string literal
+#  728|                 getExpr(): string literal
 #  728|                     Type = [ArrayType] const char[15]
 #  728|                     Value = [StringLiteral] "string literal"
 #  728|                     ValueCategory = lvalue
-#  728|                 0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  728|                 : [ArrayToPointerConversion] array to pointer conversion
 #  728|                     Type = [PointerType] const char *
 #  728|                     ValueCategory = prvalue
-#  730|           2: [IfStmt] if (...) ... 
-#  730|             0: [LTExpr] ... < ...
+#  730|           getElse(): [IfStmt] if (...) ... 
+#  730|             getCondition(): [LTExpr] ... < ...
 #  730|                 Type = [BoolType] bool
 #  730|                 ValueCategory = prvalue
-#  730|               0: [VariableAccess] x
+#  730|               getLesserOperand(): [VariableAccess] x
 #  730|                   Type = [IntType] int
 #  730|                   ValueCategory = prvalue(load)
-#  730|               1: [Literal] 2
+#  730|               getGreaterOperand(): [Literal] 2
 #  730|                   Type = [IntType] int
 #  730|                   Value = [Literal] 2
 #  730|                   ValueCategory = prvalue
-#  730|             1: [BlockStmt] { ... }
-#  731|               0: [ExprStmt] ExprStmt
-#  731|                 0: [AssignExpr] ... = ...
+#  730|             getThen(): [BlockStmt] { ... }
+#  731|               getStmt(0): [ExprStmt] ExprStmt
+#  731|                 getExpr(): [AssignExpr] ... = ...
 #  731|                     Type = [IntType] int
 #  731|                     ValueCategory = lvalue
-#  731|                   0: [VariableAccess] x
+#  731|                   getLValue(): [VariableAccess] x
 #  731|                       Type = [IntType] int
 #  731|                       ValueCategory = lvalue
-#  731|                   1: [ConditionalExpr] ... ? ... : ...
+#  731|                   getRValue(): [ConditionalExpr] ... ? ... : ...
 #  731|                       Type = [IntType] int
 #  731|                       ValueCategory = prvalue
-#  731|                     0: [VariableAccess] b
+#  731|                     getCondition(): [VariableAccess] b
 #  731|                         Type = [BoolType] bool
 #  731|                         ValueCategory = prvalue(load)
-#  731|                     1: [Literal] 7
+#  731|                     getThen(): [Literal] 7
 #  731|                         Type = [IntType] int
 #  731|                         Value = [Literal] 7
 #  731|                         ValueCategory = prvalue
-#  731|                     2: [ThrowExpr] throw ...
+#  731|                     getElse(): [ThrowExpr] throw ...
 #  731|                         Type = [Struct] String
 #  731|                         ValueCategory = prvalue
-#  731|                       0: [ConstructorCall] call to String
+#  731|                       getExpr(): [ConstructorCall] call to String
 #  731|                           Type = [VoidType] void
 #  731|                           ValueCategory = prvalue
-#  731|                         0: String object
+#  731|                         getArgument(0): String object
 #  731|                             Type = [ArrayType] const char[14]
 #  731|                             Value = [StringLiteral] "String object"
 #  731|                             ValueCategory = lvalue
-#  731|                         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  731|                         : [ArrayToPointerConversion] array to pointer conversion
 #  731|                             Type = [PointerType] const char *
 #  731|                             ValueCategory = prvalue
-#  733|         2: [ExprStmt] ExprStmt
-#  733|           0: [AssignExpr] ... = ...
+#  733|         getStmt(2): [ExprStmt] ExprStmt
+#  733|           getExpr(): [AssignExpr] ... = ...
 #  733|               Type = [IntType] int
 #  733|               ValueCategory = lvalue
-#  733|             0: [VariableAccess] x
+#  733|             getLValue(): [VariableAccess] x
 #  733|                 Type = [IntType] int
 #  733|                 ValueCategory = lvalue
-#  733|             1: [Literal] 7
+#  733|             getRValue(): [Literal] 7
 #  733|                 Type = [IntType] int
 #  733|                 Value = [Literal] 7
 #  733|                 ValueCategory = prvalue
-#  735|       1: [Handler] <handler>
-#  735|         0: [CatchBlock] { ... }
-#  736|           0: [ExprStmt] ExprStmt
-#  736|             0: [ThrowExpr] throw ...
+#  735|       getChild(1): [Handler] <handler>
+#  735|         getBlock(): [CatchBlock] { ... }
+#  736|           getStmt(0): [ExprStmt] ExprStmt
+#  736|             getExpr(): [ThrowExpr] throw ...
 #  736|                 Type = [Struct] String
 #  736|                 ValueCategory = prvalue
-#  736|               0: [ConstructorCall] call to String
+#  736|               getExpr(): [ConstructorCall] call to String
 #  736|                   Type = [VoidType] void
 #  736|                   ValueCategory = prvalue
-#  736|                 0: [VariableAccess] s
+#  736|                 getArgument(0): [VariableAccess] s
 #  736|                     Type = [PointerType] const char *
 #  736|                     ValueCategory = prvalue(load)
-#  738|       2: [Handler] <handler>
-#  738|         0: [CatchBlock] { ... }
-#  740|       3: [Handler] <handler>
-#  740|         0: [CatchAnyBlock] { ... }
-#  741|           0: [ExprStmt] ExprStmt
-#  741|             0: [ReThrowExpr] re-throw exception 
+#  738|       getChild(2): [Handler] <handler>
+#  738|         getBlock(): [CatchBlock] { ... }
+#  740|       getChild(3): [Handler] <handler>
+#  740|         getBlock(): [CatchAnyBlock] { ... }
+#  741|           getStmt(0): [ExprStmt] ExprStmt
+#  741|             getExpr(): [ReThrowExpr] re-throw exception 
 #  741|                 Type = [VoidType] void
 #  741|                 ValueCategory = prvalue
-#  743|     1: [ReturnStmt] return ...
+#  743|     getStmt(1): [ReturnStmt] return ...
 #  745| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#  745|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  745|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ExprStmt] ExprStmt
-#  745|       0: [FunctionCall] call to operator=
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ExprStmt] ExprStmt
+#  745|       getExpr(): [FunctionCall] call to operator=
 #  745|           Type = [LValueReferenceType] String &
 #  745|           ValueCategory = prvalue
-#  745|         -1: [AddressOfExpr] & ...
+#  745|         getQualifier(): [AddressOfExpr] & ...
 #  745|             Type = [PointerType] String *
 #  745|             ValueCategory = prvalue
-#  745|           0: [PointerFieldAccess] base_s
+#  745|           getOperand(): [PointerFieldAccess] base_s
 #  745|               Type = [Struct] String
 #  745|               ValueCategory = lvalue
-#  745|             -1: [ThisExpr] this
+#  745|             getQualifier(): [ThisExpr] this
 #  745|                 Type = [PointerType] Base *
 #  745|                 ValueCategory = prvalue(load)
-#  745|         0: [ReferenceFieldAccess] base_s
+#  745|         getArgument(0): [ReferenceFieldAccess] base_s
 #  745|             Type = [Struct] String
 #  745|             ValueCategory = lvalue
-#  745|           -1: [VariableAccess] (unnamed parameter 0)
+#  745|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  745|               Type = [LValueReferenceType] const Base &
 #  745|               ValueCategory = prvalue(load)
-#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Base
 #-----|               ValueCategory = lvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#-----|     1: [ReturnStmt] return ...
-#-----|       0: [PointerDereferenceExpr] * ...
+#-----|     getStmt(1): [ReturnStmt] return ...
+#-----|       getExpr(): [PointerDereferenceExpr] * ...
 #-----|           Type = [Struct,VirtualBaseClass] Base
 #-----|           ValueCategory = lvalue
-#-----|         0: [ThisExpr] this
+#-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue(load)
-#-----|       0 converted: [ReferenceToExpr] (reference to)
+#-----|       : [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #  745| [CopyConstructor] void Base::Base(Base const&)
-#  745|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  745|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
-#  745|   initializations: 
-#  745|     0: [ConstructorFieldInit] constructor init of field base_s
+#  745|   ...: 
+#  745|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  745|         Type = [Struct] String
 #  745|         ValueCategory = prvalue
-#  745|       0: [ConstructorCall] call to String
+#  745|       getExpr(): [ConstructorCall] call to String
 #  745|           Type = [VoidType] void
 #  745|           ValueCategory = prvalue
-#  745|   body: [BlockStmt] { ... }
-#  745|     0: [ReturnStmt] return ...
+#  745|   getEntryPoint(): [BlockStmt] { ... }
+#  745|     getStmt(0): [ReturnStmt] return ...
 #  748| [Constructor] void Base::Base()
-#  748|   params: 
-#  748|   initializations: 
-#  748|     0: [ConstructorFieldInit] constructor init of field base_s
+#  748|   ...: 
+#  748|   ...: 
+#  748|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  748|         Type = [Struct] String
 #  748|         ValueCategory = prvalue
-#  748|       0: [ConstructorCall] call to String
+#  748|       getExpr(): [ConstructorCall] call to String
 #  748|           Type = [VoidType] void
 #  748|           ValueCategory = prvalue
-#  748|   body: [BlockStmt] { ... }
-#  749|     0: [ReturnStmt] return ...
+#  748|   getEntryPoint(): [BlockStmt] { ... }
+#  749|     getStmt(0): [ReturnStmt] return ...
 #  750| [Destructor] void Base::~Base()
-#  750|   params: 
-#  750|   body: [BlockStmt] { ... }
-#  751|     0: [ReturnStmt] return ...
-#  750|   destructions: 
-#  751|     0: [DestructorFieldDestruction] destructor field destruction of base_s
+#  750|   ...: 
+#  750|   getEntryPoint(): [BlockStmt] { ... }
+#  751|     getStmt(0): [ReturnStmt] return ...
+#  750|   ...: 
+#  751|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of base_s
 #  751|         Type = [Struct] String
 #  751|         ValueCategory = prvalue
-#  751|       0: [DestructorCall] call to ~String
+#  751|       getExpr(): [DestructorCall] call to ~String
 #  751|           Type = [VoidType] void
 #  751|           ValueCategory = prvalue
-#  751|         -1: [ImplicitThisFieldAccess] base_s
+#  751|         getQualifier(): [ImplicitThisFieldAccess] base_s
 #  751|             Type = [Struct] String
 #  751|             ValueCategory = lvalue
 #  754| [CopyAssignmentOperator] Middle& Middle::operator=(Middle const&)
-#  754|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  754|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ExprStmt] ExprStmt
-#  754|       0: [FunctionCall] call to operator=
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ExprStmt] ExprStmt
+#  754|       getExpr(): [FunctionCall] call to operator=
 #  754|           Type = [LValueReferenceType] Base &
 #  754|           ValueCategory = prvalue
-#  754|         -1: [ThisExpr] this
+#  754|         getQualifier(): [ThisExpr] this
 #  754|             Type = [PointerType] Middle *
 #  754|             ValueCategory = prvalue(load)
-#-----|         0: [CStyleCast] (Base *)...
+#-----|         getArgument(0): [CStyleCast] (Base *)...
 #-----|             Conversion = [BaseClassConversion] base class conversion
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue
-#  754|         0: [PointerDereferenceExpr] * ...
+#  754|         getArgument(0): [PointerDereferenceExpr] * ...
 #  754|             Type = [SpecifiedType] const Base
 #  754|             ValueCategory = lvalue
-#  754|           0: [AddressOfExpr] & ...
+#  754|           getOperand(): [AddressOfExpr] & ...
 #  754|               Type = [PointerType] const Middle *
 #  754|               ValueCategory = prvalue
-#  754|             0: [VariableAccess] (unnamed parameter 0)
+#  754|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #  754|                 Type = [LValueReferenceType] const Middle &
 #  754|                 ValueCategory = prvalue(load)
-#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|             : [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Middle
 #-----|                 ValueCategory = lvalue
-#-----|           0 converted: [CStyleCast] (const Base *)...
+#-----|           : [CStyleCast] (const Base *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Base *
 #-----|               ValueCategory = prvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Base &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct,VirtualBaseClass] Base
 #-----|           ValueCategory = lvalue
-#-----|     1: [ExprStmt] ExprStmt
-#  754|       0: [FunctionCall] call to operator=
+#-----|     getStmt(1): [ExprStmt] ExprStmt
+#  754|       getExpr(): [FunctionCall] call to operator=
 #  754|           Type = [LValueReferenceType] String &
 #  754|           ValueCategory = prvalue
-#  754|         -1: [AddressOfExpr] & ...
+#  754|         getQualifier(): [AddressOfExpr] & ...
 #  754|             Type = [PointerType] String *
 #  754|             ValueCategory = prvalue
-#  754|           0: [PointerFieldAccess] middle_s
+#  754|           getOperand(): [PointerFieldAccess] middle_s
 #  754|               Type = [Struct] String
 #  754|               ValueCategory = lvalue
-#  754|             -1: [ThisExpr] this
+#  754|             getQualifier(): [ThisExpr] this
 #  754|                 Type = [PointerType] Middle *
 #  754|                 ValueCategory = prvalue(load)
-#  754|         0: [ReferenceFieldAccess] middle_s
+#  754|         getArgument(0): [ReferenceFieldAccess] middle_s
 #  754|             Type = [Struct] String
 #  754|             ValueCategory = lvalue
-#  754|           -1: [VariableAccess] (unnamed parameter 0)
+#  754|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  754|               Type = [LValueReferenceType] const Middle &
 #  754|               ValueCategory = prvalue(load)
-#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Middle
 #-----|               ValueCategory = lvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#-----|     2: [ReturnStmt] return ...
-#-----|       0: [PointerDereferenceExpr] * ...
+#-----|     getStmt(2): [ReturnStmt] return ...
+#-----|       getExpr(): [PointerDereferenceExpr] * ...
 #-----|           Type = [Struct] Middle
 #-----|           ValueCategory = lvalue
-#-----|         0: [ThisExpr] this
+#-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Middle *
 #-----|             ValueCategory = prvalue(load)
-#-----|       0 converted: [ReferenceToExpr] (reference to)
+#-----|       : [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Middle &
 #-----|           ValueCategory = prvalue
 #  754| [CopyConstructor] void Middle::Middle(Middle const&)
-#  754|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  754|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
 #  757| [Constructor] void Middle::Middle()
-#  757|   params: 
-#  757|   initializations: 
-#  757|     0: [ConstructorDirectInit] call to Base
+#  757|   ...: 
+#  757|   ...: 
+#  757|     getInitializer(0): [ConstructorDirectInit] call to Base
 #  757|         Type = [VoidType] void
 #  757|         ValueCategory = prvalue
-#  757|     1: [ConstructorFieldInit] constructor init of field middle_s
+#  757|     getInitializer(1): [ConstructorFieldInit] constructor init of field middle_s
 #  757|         Type = [Struct] String
 #  757|         ValueCategory = prvalue
-#  757|       0: [ConstructorCall] call to String
+#  757|       getExpr(): [ConstructorCall] call to String
 #  757|           Type = [VoidType] void
 #  757|           ValueCategory = prvalue
-#  757|   body: [BlockStmt] { ... }
-#  758|     0: [ReturnStmt] return ...
+#  757|   getEntryPoint(): [BlockStmt] { ... }
+#  758|     getStmt(0): [ReturnStmt] return ...
 #  759| [Destructor] void Middle::~Middle()
-#  759|   params: 
-#  759|   body: [BlockStmt] { ... }
-#  760|     0: [ReturnStmt] return ...
-#  759|   destructions: 
-#  760|     0: [DestructorFieldDestruction] destructor field destruction of middle_s
+#  759|   ...: 
+#  759|   getEntryPoint(): [BlockStmt] { ... }
+#  760|     getStmt(0): [ReturnStmt] return ...
+#  759|   ...: 
+#  760|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middle_s
 #  760|         Type = [Struct] String
 #  760|         ValueCategory = prvalue
-#  760|       0: [DestructorCall] call to ~String
+#  760|       getExpr(): [DestructorCall] call to ~String
 #  760|           Type = [VoidType] void
 #  760|           ValueCategory = prvalue
-#  760|         -1: [ImplicitThisFieldAccess] middle_s
+#  760|         getQualifier(): [ImplicitThisFieldAccess] middle_s
 #  760|             Type = [Struct] String
 #  760|             ValueCategory = lvalue
-#  760|     1: [DestructorDirectDestruction] call to ~Base
+#  760|     getDestruction(1): [DestructorDirectDestruction] call to ~Base
 #  760|         Type = [VoidType] void
 #  760|         ValueCategory = prvalue
 #  763| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#  763|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  763|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ExprStmt] ExprStmt
-#  763|       0: [FunctionCall] call to operator=
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ExprStmt] ExprStmt
+#  763|       getExpr(): [FunctionCall] call to operator=
 #  763|           Type = [LValueReferenceType] Middle &
 #  763|           ValueCategory = prvalue
-#  763|         -1: [ThisExpr] this
+#  763|         getQualifier(): [ThisExpr] this
 #  763|             Type = [PointerType] Derived *
 #  763|             ValueCategory = prvalue(load)
-#-----|         0: [CStyleCast] (Middle *)...
+#-----|         getArgument(0): [CStyleCast] (Middle *)...
 #-----|             Conversion = [BaseClassConversion] base class conversion
 #-----|             Type = [PointerType] Middle *
 #-----|             ValueCategory = prvalue
-#  763|         0: [PointerDereferenceExpr] * ...
+#  763|         getArgument(0): [PointerDereferenceExpr] * ...
 #  763|             Type = [SpecifiedType] const Middle
 #  763|             ValueCategory = lvalue
-#  763|           0: [AddressOfExpr] & ...
+#  763|           getOperand(): [AddressOfExpr] & ...
 #  763|               Type = [PointerType] const Derived *
 #  763|               ValueCategory = prvalue
-#  763|             0: [VariableAccess] (unnamed parameter 0)
+#  763|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #  763|                 Type = [LValueReferenceType] const Derived &
 #  763|                 ValueCategory = prvalue(load)
-#-----|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|             : [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Derived
 #-----|                 ValueCategory = lvalue
-#-----|           0 converted: [CStyleCast] (const Middle *)...
+#-----|           : [CStyleCast] (const Middle *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Middle *
 #-----|               ValueCategory = prvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Middle &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] Middle
 #-----|           ValueCategory = lvalue
-#-----|     1: [ExprStmt] ExprStmt
-#  763|       0: [FunctionCall] call to operator=
+#-----|     getStmt(1): [ExprStmt] ExprStmt
+#  763|       getExpr(): [FunctionCall] call to operator=
 #  763|           Type = [LValueReferenceType] String &
 #  763|           ValueCategory = prvalue
-#  763|         -1: [AddressOfExpr] & ...
+#  763|         getQualifier(): [AddressOfExpr] & ...
 #  763|             Type = [PointerType] String *
 #  763|             ValueCategory = prvalue
-#  763|           0: [PointerFieldAccess] derived_s
+#  763|           getOperand(): [PointerFieldAccess] derived_s
 #  763|               Type = [Struct] String
 #  763|               ValueCategory = lvalue
-#  763|             -1: [ThisExpr] this
+#  763|             getQualifier(): [ThisExpr] this
 #  763|                 Type = [PointerType] Derived *
 #  763|                 ValueCategory = prvalue(load)
-#  763|         0: [ReferenceFieldAccess] derived_s
+#  763|         getArgument(0): [ReferenceFieldAccess] derived_s
 #  763|             Type = [Struct] String
 #  763|             ValueCategory = lvalue
-#  763|           -1: [VariableAccess] (unnamed parameter 0)
+#  763|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  763|               Type = [LValueReferenceType] const Derived &
 #  763|               ValueCategory = prvalue(load)
-#-----|           -1: [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Derived
 #-----|               ValueCategory = lvalue
-#-----|         0 converted: [ReferenceToExpr] (reference to)
+#-----|         : [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#-----|       : [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
-#-----|     2: [ReturnStmt] return ...
-#-----|       0: [PointerDereferenceExpr] * ...
+#-----|     getStmt(2): [ReturnStmt] return ...
+#-----|       getExpr(): [PointerDereferenceExpr] * ...
 #-----|           Type = [Struct] Derived
 #-----|           ValueCategory = lvalue
-#-----|         0: [ThisExpr] this
+#-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Derived *
 #-----|             ValueCategory = prvalue(load)
-#-----|       0 converted: [ReferenceToExpr] (reference to)
+#-----|       : [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #  763| [CopyConstructor] void Derived::Derived(Derived const&)
-#  763|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  763|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #  766| [Constructor] void Derived::Derived()
-#  766|   params: 
-#  766|   initializations: 
-#  766|     0: [ConstructorDirectInit] call to Middle
+#  766|   ...: 
+#  766|   ...: 
+#  766|     getInitializer(0): [ConstructorDirectInit] call to Middle
 #  766|         Type = [VoidType] void
 #  766|         ValueCategory = prvalue
-#  766|     1: [ConstructorFieldInit] constructor init of field derived_s
+#  766|     getInitializer(1): [ConstructorFieldInit] constructor init of field derived_s
 #  766|         Type = [Struct] String
 #  766|         ValueCategory = prvalue
-#  766|       0: [ConstructorCall] call to String
+#  766|       getExpr(): [ConstructorCall] call to String
 #  766|           Type = [VoidType] void
 #  766|           ValueCategory = prvalue
-#  766|   body: [BlockStmt] { ... }
-#  767|     0: [ReturnStmt] return ...
+#  766|   getEntryPoint(): [BlockStmt] { ... }
+#  767|     getStmt(0): [ReturnStmt] return ...
 #  768| [Destructor] void Derived::~Derived()
-#  768|   params: 
-#  768|   body: [BlockStmt] { ... }
-#  769|     0: [ReturnStmt] return ...
-#  768|   destructions: 
-#  769|     0: [DestructorFieldDestruction] destructor field destruction of derived_s
+#  768|   ...: 
+#  768|   getEntryPoint(): [BlockStmt] { ... }
+#  769|     getStmt(0): [ReturnStmt] return ...
+#  768|   ...: 
+#  769|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derived_s
 #  769|         Type = [Struct] String
 #  769|         ValueCategory = prvalue
-#  769|       0: [DestructorCall] call to ~String
+#  769|       getExpr(): [DestructorCall] call to ~String
 #  769|           Type = [VoidType] void
 #  769|           ValueCategory = prvalue
-#  769|         -1: [ImplicitThisFieldAccess] derived_s
+#  769|         getQualifier(): [ImplicitThisFieldAccess] derived_s
 #  769|             Type = [Struct] String
 #  769|             ValueCategory = lvalue
-#  769|     1: [DestructorDirectDestruction] call to ~Middle
+#  769|     getDestruction(1): [DestructorDirectDestruction] call to ~Middle
 #  769|         Type = [VoidType] void
 #  769|         ValueCategory = prvalue
 #  772| [CopyAssignmentOperator] MiddleVB1& MiddleVB1::operator=(MiddleVB1 const&)
-#  772|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  772|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  772| [CopyConstructor] void MiddleVB1::MiddleVB1(MiddleVB1 const&)
-#  772|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  772|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  775| [Constructor] void MiddleVB1::MiddleVB1()
-#  775|   params: 
-#  775|   initializations: 
-#  775|     0: [ConstructorVirtualInit] call to Base
+#  775|   ...: 
+#  775|   ...: 
+#  775|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  775|         Type = [VoidType] void
 #  775|         ValueCategory = prvalue
-#  775|     1: [ConstructorFieldInit] constructor init of field middlevb1_s
+#  775|     getInitializer(1): [ConstructorFieldInit] constructor init of field middlevb1_s
 #  775|         Type = [Struct] String
 #  775|         ValueCategory = prvalue
-#  775|       0: [ConstructorCall] call to String
+#  775|       getExpr(): [ConstructorCall] call to String
 #  775|           Type = [VoidType] void
 #  775|           ValueCategory = prvalue
-#  775|   body: [BlockStmt] { ... }
-#  776|     0: [ReturnStmt] return ...
+#  775|   getEntryPoint(): [BlockStmt] { ... }
+#  776|     getStmt(0): [ReturnStmt] return ...
 #  777| [Destructor] void MiddleVB1::~MiddleVB1()
-#  777|   params: 
-#  777|   body: [BlockStmt] { ... }
-#  778|     0: [ReturnStmt] return ...
-#  777|   destructions: 
-#  778|     0: [DestructorFieldDestruction] destructor field destruction of middlevb1_s
+#  777|   ...: 
+#  777|   getEntryPoint(): [BlockStmt] { ... }
+#  778|     getStmt(0): [ReturnStmt] return ...
+#  777|   ...: 
+#  778|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb1_s
 #  778|         Type = [Struct] String
 #  778|         ValueCategory = prvalue
-#  778|       0: [DestructorCall] call to ~String
+#  778|       getExpr(): [DestructorCall] call to ~String
 #  778|           Type = [VoidType] void
 #  778|           ValueCategory = prvalue
-#  778|         -1: [ImplicitThisFieldAccess] middlevb1_s
+#  778|         getQualifier(): [ImplicitThisFieldAccess] middlevb1_s
 #  778|             Type = [Struct] String
 #  778|             ValueCategory = lvalue
-#  778|     1: [DestructorVirtualDestruction] call to ~Base
+#  778|     getDestruction(1): [DestructorVirtualDestruction] call to ~Base
 #  778|         Type = [VoidType] void
 #  778|         ValueCategory = prvalue
 #  781| [CopyAssignmentOperator] MiddleVB2& MiddleVB2::operator=(MiddleVB2 const&)
-#  781|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  781|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  781| [CopyConstructor] void MiddleVB2::MiddleVB2(MiddleVB2 const&)
-#  781|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  781|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  784| [Constructor] void MiddleVB2::MiddleVB2()
-#  784|   params: 
-#  784|   initializations: 
-#  784|     0: [ConstructorVirtualInit] call to Base
+#  784|   ...: 
+#  784|   ...: 
+#  784|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  784|         Type = [VoidType] void
 #  784|         ValueCategory = prvalue
-#  784|     1: [ConstructorFieldInit] constructor init of field middlevb2_s
+#  784|     getInitializer(1): [ConstructorFieldInit] constructor init of field middlevb2_s
 #  784|         Type = [Struct] String
 #  784|         ValueCategory = prvalue
-#  784|       0: [ConstructorCall] call to String
+#  784|       getExpr(): [ConstructorCall] call to String
 #  784|           Type = [VoidType] void
 #  784|           ValueCategory = prvalue
-#  784|   body: [BlockStmt] { ... }
-#  785|     0: [ReturnStmt] return ...
+#  784|   getEntryPoint(): [BlockStmt] { ... }
+#  785|     getStmt(0): [ReturnStmt] return ...
 #  786| [Destructor] void MiddleVB2::~MiddleVB2()
-#  786|   params: 
-#  786|   body: [BlockStmt] { ... }
-#  787|     0: [ReturnStmt] return ...
-#  786|   destructions: 
-#  787|     0: [DestructorFieldDestruction] destructor field destruction of middlevb2_s
+#  786|   ...: 
+#  786|   getEntryPoint(): [BlockStmt] { ... }
+#  787|     getStmt(0): [ReturnStmt] return ...
+#  786|   ...: 
+#  787|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb2_s
 #  787|         Type = [Struct] String
 #  787|         ValueCategory = prvalue
-#  787|       0: [DestructorCall] call to ~String
+#  787|       getExpr(): [DestructorCall] call to ~String
 #  787|           Type = [VoidType] void
 #  787|           ValueCategory = prvalue
-#  787|         -1: [ImplicitThisFieldAccess] middlevb2_s
+#  787|         getQualifier(): [ImplicitThisFieldAccess] middlevb2_s
 #  787|             Type = [Struct] String
 #  787|             ValueCategory = lvalue
-#  787|     1: [DestructorVirtualDestruction] call to ~Base
+#  787|     getDestruction(1): [DestructorVirtualDestruction] call to ~Base
 #  787|         Type = [VoidType] void
 #  787|         ValueCategory = prvalue
 #  790| [CopyAssignmentOperator] DerivedVB& DerivedVB::operator=(DerivedVB const&)
-#  790|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  790|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  790| [CopyConstructor] void DerivedVB::DerivedVB(DerivedVB const&)
-#  790|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  790|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  793| [Constructor] void DerivedVB::DerivedVB()
-#  793|   params: 
-#  793|   initializations: 
-#  793|     0: [ConstructorVirtualInit] call to Base
+#  793|   ...: 
+#  793|   ...: 
+#  793|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  793|         Type = [VoidType] void
 #  793|         ValueCategory = prvalue
-#  793|     1: [ConstructorDirectInit] call to MiddleVB1
+#  793|     getInitializer(1): [ConstructorDirectInit] call to MiddleVB1
 #  793|         Type = [VoidType] void
 #  793|         ValueCategory = prvalue
-#  793|     2: [ConstructorDirectInit] call to MiddleVB2
+#  793|     getInitializer(2): [ConstructorDirectInit] call to MiddleVB2
 #  793|         Type = [VoidType] void
 #  793|         ValueCategory = prvalue
-#  793|     3: [ConstructorFieldInit] constructor init of field derivedvb_s
+#  793|     getInitializer(3): [ConstructorFieldInit] constructor init of field derivedvb_s
 #  793|         Type = [Struct] String
 #  793|         ValueCategory = prvalue
-#  793|       0: [ConstructorCall] call to String
+#  793|       getExpr(): [ConstructorCall] call to String
 #  793|           Type = [VoidType] void
 #  793|           ValueCategory = prvalue
-#  793|   body: [BlockStmt] { ... }
-#  794|     0: [ReturnStmt] return ...
+#  793|   getEntryPoint(): [BlockStmt] { ... }
+#  794|     getStmt(0): [ReturnStmt] return ...
 #  795| [Destructor] void DerivedVB::~DerivedVB()
-#  795|   params: 
-#  795|   body: [BlockStmt] { ... }
-#  796|     0: [ReturnStmt] return ...
-#  795|   destructions: 
-#  796|     0: [DestructorFieldDestruction] destructor field destruction of derivedvb_s
+#  795|   ...: 
+#  795|   getEntryPoint(): [BlockStmt] { ... }
+#  796|     getStmt(0): [ReturnStmt] return ...
+#  795|   ...: 
+#  796|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derivedvb_s
 #  796|         Type = [Struct] String
 #  796|         ValueCategory = prvalue
-#  796|       0: [DestructorCall] call to ~String
+#  796|       getExpr(): [DestructorCall] call to ~String
 #  796|           Type = [VoidType] void
 #  796|           ValueCategory = prvalue
-#  796|         -1: [ImplicitThisFieldAccess] derivedvb_s
+#  796|         getQualifier(): [ImplicitThisFieldAccess] derivedvb_s
 #  796|             Type = [Struct] String
 #  796|             ValueCategory = lvalue
-#  796|     1: [DestructorDirectDestruction] call to ~MiddleVB2
+#  796|     getDestruction(1): [DestructorDirectDestruction] call to ~MiddleVB2
 #  796|         Type = [VoidType] void
 #  796|         ValueCategory = prvalue
-#  796|     2: [DestructorDirectDestruction] call to ~MiddleVB1
+#  796|     getDestruction(2): [DestructorDirectDestruction] call to ~MiddleVB1
 #  796|         Type = [VoidType] void
 #  796|         ValueCategory = prvalue
-#  796|     3: [DestructorVirtualDestruction] call to ~Base
+#  796|     getDestruction(3): [DestructorVirtualDestruction] call to ~Base
 #  796|         Type = [VoidType] void
 #  796|         ValueCategory = prvalue
 #  799| [TopLevelFunction] void HierarchyConversions()
-#  799|   params: 
-#  799|   body: [BlockStmt] { ... }
-#  800|     0: [DeclStmt] declaration
-#  800|       0: [VariableDeclarationEntry] definition of b
+#  799|   ...: 
+#  799|   getEntryPoint(): [BlockStmt] { ... }
+#  800|     getStmt(0): [DeclStmt] declaration
+#  800|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  800|           Type = [Struct,VirtualBaseClass] Base
-#  800|         init: [Initializer] initializer for b
-#  800|           expr: [ConstructorCall] call to Base
+#  800|         getVariable().getInitializer(): [Initializer] initializer for b
+#  800|           getExpr(): [ConstructorCall] call to Base
 #  800|               Type = [VoidType] void
 #  800|               ValueCategory = prvalue
-#  801|     1: [DeclStmt] declaration
-#  801|       0: [VariableDeclarationEntry] definition of m
+#  801|     getStmt(1): [DeclStmt] declaration
+#  801|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of m
 #  801|           Type = [Struct] Middle
-#  801|         init: [Initializer] initializer for m
-#  801|           expr: [ConstructorCall] call to Middle
+#  801|         getVariable().getInitializer(): [Initializer] initializer for m
+#  801|           getExpr(): [ConstructorCall] call to Middle
 #  801|               Type = [VoidType] void
 #  801|               ValueCategory = prvalue
-#  802|     2: [DeclStmt] declaration
-#  802|       0: [VariableDeclarationEntry] definition of d
+#  802|     getStmt(2): [DeclStmt] declaration
+#  802|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #  802|           Type = [Struct] Derived
-#  802|         init: [Initializer] initializer for d
-#  802|           expr: [ConstructorCall] call to Derived
+#  802|         getVariable().getInitializer(): [Initializer] initializer for d
+#  802|           getExpr(): [ConstructorCall] call to Derived
 #  802|               Type = [VoidType] void
 #  802|               ValueCategory = prvalue
-#  804|     3: [DeclStmt] declaration
-#  804|       0: [VariableDeclarationEntry] definition of pb
+#  804|     getStmt(3): [DeclStmt] declaration
+#  804|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pb
 #  804|           Type = [PointerType] Base *
-#  804|         init: [Initializer] initializer for pb
-#  804|           expr: [AddressOfExpr] & ...
+#  804|         getVariable().getInitializer(): [Initializer] initializer for pb
+#  804|           getExpr(): [AddressOfExpr] & ...
 #  804|               Type = [PointerType] Base *
 #  804|               ValueCategory = prvalue
-#  804|             0: [VariableAccess] b
+#  804|             getOperand(): [VariableAccess] b
 #  804|                 Type = [Struct,VirtualBaseClass] Base
 #  804|                 ValueCategory = lvalue
-#  805|     4: [DeclStmt] declaration
-#  805|       0: [VariableDeclarationEntry] definition of pm
+#  805|     getStmt(4): [DeclStmt] declaration
+#  805|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pm
 #  805|           Type = [PointerType] Middle *
-#  805|         init: [Initializer] initializer for pm
-#  805|           expr: [AddressOfExpr] & ...
+#  805|         getVariable().getInitializer(): [Initializer] initializer for pm
+#  805|           getExpr(): [AddressOfExpr] & ...
 #  805|               Type = [PointerType] Middle *
 #  805|               ValueCategory = prvalue
-#  805|             0: [VariableAccess] m
+#  805|             getOperand(): [VariableAccess] m
 #  805|                 Type = [Struct] Middle
 #  805|                 ValueCategory = lvalue
-#  806|     5: [DeclStmt] declaration
-#  806|       0: [VariableDeclarationEntry] definition of pd
+#  806|     getStmt(5): [DeclStmt] declaration
+#  806|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pd
 #  806|           Type = [PointerType] Derived *
-#  806|         init: [Initializer] initializer for pd
-#  806|           expr: [AddressOfExpr] & ...
+#  806|         getVariable().getInitializer(): [Initializer] initializer for pd
+#  806|           getExpr(): [AddressOfExpr] & ...
 #  806|               Type = [PointerType] Derived *
 #  806|               ValueCategory = prvalue
-#  806|             0: [VariableAccess] d
+#  806|             getOperand(): [VariableAccess] d
 #  806|                 Type = [Struct] Derived
 #  806|                 ValueCategory = lvalue
-#  808|     6: [ExprStmt] ExprStmt
-#  808|       0: [FunctionCall] call to operator=
+#  808|     getStmt(6): [ExprStmt] ExprStmt
+#  808|       getExpr(): [FunctionCall] call to operator=
 #  808|           Type = [LValueReferenceType] Base &
 #  808|           ValueCategory = prvalue
-#  808|         -1: [VariableAccess] b
+#  808|         getQualifier(): [VariableAccess] b
 #  808|             Type = [Struct,VirtualBaseClass] Base
 #  808|             ValueCategory = lvalue
-#  808|         0: [VariableAccess] m
+#  808|         getArgument(0): [VariableAccess] m
 #  808|             Type = [Struct] Middle
 #  808|             ValueCategory = lvalue
-#  808|         0 converted: [ReferenceToExpr] (reference to)
+#  808|         : [ReferenceToExpr] (reference to)
 #  808|             Type = [LValueReferenceType] const Base &
 #  808|             ValueCategory = prvalue
-#  808|           expr: [CStyleCast] (const Base)...
+#  808|           getExpr(): [CStyleCast] (const Base)...
 #  808|               Conversion = [BaseClassConversion] base class conversion
 #  808|               Type = [SpecifiedType] const Base
 #  808|               ValueCategory = lvalue
-#  808|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  808|       : [ReferenceDereferenceExpr] (reference dereference)
 #  808|           Type = [Struct,VirtualBaseClass] Base
 #  808|           ValueCategory = lvalue
-#  809|     7: [ExprStmt] ExprStmt
-#  809|       0: [FunctionCall] call to operator=
+#  809|     getStmt(7): [ExprStmt] ExprStmt
+#  809|       getExpr(): [FunctionCall] call to operator=
 #  809|           Type = [LValueReferenceType] Base &
 #  809|           ValueCategory = prvalue
-#  809|         -1: [VariableAccess] b
+#  809|         getQualifier(): [VariableAccess] b
 #  809|             Type = [Struct,VirtualBaseClass] Base
 #  809|             ValueCategory = lvalue
-#  809|         0: [ConstructorCall] call to Base
+#  809|         getArgument(0): [ConstructorCall] call to Base
 #  809|             Type = [VoidType] void
 #  809|             ValueCategory = prvalue
-#  809|           0: [VariableAccess] m
+#  809|           getArgument(0): [VariableAccess] m
 #  809|               Type = [Struct] Middle
 #  809|               ValueCategory = lvalue
-#  809|           0 converted: [ReferenceToExpr] (reference to)
+#  809|           : [ReferenceToExpr] (reference to)
 #  809|               Type = [LValueReferenceType] const Base &
 #  809|               ValueCategory = prvalue
-#  809|             expr: [CStyleCast] (const Base)...
+#  809|             getExpr(): [CStyleCast] (const Base)...
 #  809|                 Conversion = [BaseClassConversion] base class conversion
 #  809|                 Type = [SpecifiedType] const Base
 #  809|                 ValueCategory = lvalue
-#  809|         0 converted: [ReferenceToExpr] (reference to)
+#  809|         : [ReferenceToExpr] (reference to)
 #  809|             Type = [LValueReferenceType] const Base &
 #  809|             ValueCategory = prvalue
-#  809|           expr: [CStyleCast] (const Base)...
+#  809|           getExpr(): [CStyleCast] (const Base)...
 #  809|               Conversion = [GlvalueConversion] glvalue conversion
 #  809|               Type = [SpecifiedType] const Base
 #  809|               ValueCategory = lvalue
-#  809|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  809|       : [ReferenceDereferenceExpr] (reference dereference)
 #  809|           Type = [Struct,VirtualBaseClass] Base
 #  809|           ValueCategory = lvalue
-#  810|     8: [ExprStmt] ExprStmt
-#  810|       0: [FunctionCall] call to operator=
+#  810|     getStmt(8): [ExprStmt] ExprStmt
+#  810|       getExpr(): [FunctionCall] call to operator=
 #  810|           Type = [LValueReferenceType] Base &
 #  810|           ValueCategory = prvalue
-#  810|         -1: [VariableAccess] b
+#  810|         getQualifier(): [VariableAccess] b
 #  810|             Type = [Struct,VirtualBaseClass] Base
 #  810|             ValueCategory = lvalue
-#  810|         0: [ConstructorCall] call to Base
+#  810|         getArgument(0): [ConstructorCall] call to Base
 #  810|             Type = [VoidType] void
 #  810|             ValueCategory = prvalue
-#  810|           0: [VariableAccess] m
+#  810|           getArgument(0): [VariableAccess] m
 #  810|               Type = [Struct] Middle
 #  810|               ValueCategory = lvalue
-#  810|           0 converted: [ReferenceToExpr] (reference to)
+#  810|           : [ReferenceToExpr] (reference to)
 #  810|               Type = [LValueReferenceType] const Base &
 #  810|               ValueCategory = prvalue
-#  810|             expr: [CStyleCast] (const Base)...
+#  810|             getExpr(): [CStyleCast] (const Base)...
 #  810|                 Conversion = [BaseClassConversion] base class conversion
 #  810|                 Type = [SpecifiedType] const Base
 #  810|                 ValueCategory = lvalue
-#  810|         0 converted: [ReferenceToExpr] (reference to)
+#  810|         : [ReferenceToExpr] (reference to)
 #  810|             Type = [LValueReferenceType] const Base &
 #  810|             ValueCategory = prvalue
-#  810|           expr: [CStyleCast] (const Base)...
+#  810|           getExpr(): [CStyleCast] (const Base)...
 #  810|               Conversion = [GlvalueConversion] glvalue conversion
 #  810|               Type = [SpecifiedType] const Base
 #  810|               ValueCategory = lvalue
-#  810|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  810|       : [ReferenceDereferenceExpr] (reference dereference)
 #  810|           Type = [Struct,VirtualBaseClass] Base
 #  810|           ValueCategory = lvalue
-#  811|     9: [ExprStmt] ExprStmt
-#  811|       0: [AssignExpr] ... = ...
+#  811|     getStmt(9): [ExprStmt] ExprStmt
+#  811|       getExpr(): [AssignExpr] ... = ...
 #  811|           Type = [PointerType] Base *
 #  811|           ValueCategory = lvalue
-#  811|         0: [VariableAccess] pb
+#  811|         getLValue(): [VariableAccess] pb
 #  811|             Type = [PointerType] Base *
 #  811|             ValueCategory = lvalue
-#  811|         1: [VariableAccess] pm
+#  811|         getRValue(): [VariableAccess] pm
 #  811|             Type = [PointerType] Middle *
 #  811|             ValueCategory = prvalue(load)
-#  811|         1 converted: [CStyleCast] (Base *)...
+#  811|         : [CStyleCast] (Base *)...
 #  811|             Conversion = [BaseClassConversion] base class conversion
 #  811|             Type = [PointerType] Base *
 #  811|             ValueCategory = prvalue
-#  812|     10: [ExprStmt] ExprStmt
-#  812|       0: [AssignExpr] ... = ...
+#  812|     getStmt(10): [ExprStmt] ExprStmt
+#  812|       getExpr(): [AssignExpr] ... = ...
 #  812|           Type = [PointerType] Base *
 #  812|           ValueCategory = lvalue
-#  812|         0: [VariableAccess] pb
+#  812|         getLValue(): [VariableAccess] pb
 #  812|             Type = [PointerType] Base *
 #  812|             ValueCategory = lvalue
-#  812|         1: [VariableAccess] pm
+#  812|         getRValue(): [VariableAccess] pm
 #  812|             Type = [PointerType] Middle *
 #  812|             ValueCategory = prvalue(load)
-#  812|         1 converted: [CStyleCast] (Base *)...
+#  812|         : [CStyleCast] (Base *)...
 #  812|             Conversion = [BaseClassConversion] base class conversion
 #  812|             Type = [PointerType] Base *
 #  812|             ValueCategory = prvalue
-#  813|     11: [ExprStmt] ExprStmt
-#  813|       0: [AssignExpr] ... = ...
+#  813|     getStmt(11): [ExprStmt] ExprStmt
+#  813|       getExpr(): [AssignExpr] ... = ...
 #  813|           Type = [PointerType] Base *
 #  813|           ValueCategory = lvalue
-#  813|         0: [VariableAccess] pb
+#  813|         getLValue(): [VariableAccess] pb
 #  813|             Type = [PointerType] Base *
 #  813|             ValueCategory = lvalue
-#  813|         1: [VariableAccess] pm
+#  813|         getRValue(): [VariableAccess] pm
 #  813|             Type = [PointerType] Middle *
 #  813|             ValueCategory = prvalue(load)
-#  813|         1 converted: [StaticCast] static_cast<Base *>...
+#  813|         : [StaticCast] static_cast<Base *>...
 #  813|             Conversion = [BaseClassConversion] base class conversion
 #  813|             Type = [PointerType] Base *
 #  813|             ValueCategory = prvalue
-#  814|     12: [ExprStmt] ExprStmt
-#  814|       0: [AssignExpr] ... = ...
+#  814|     getStmt(12): [ExprStmt] ExprStmt
+#  814|       getExpr(): [AssignExpr] ... = ...
 #  814|           Type = [PointerType] Base *
 #  814|           ValueCategory = lvalue
-#  814|         0: [VariableAccess] pb
+#  814|         getLValue(): [VariableAccess] pb
 #  814|             Type = [PointerType] Base *
 #  814|             ValueCategory = lvalue
-#  814|         1: [VariableAccess] pm
+#  814|         getRValue(): [VariableAccess] pm
 #  814|             Type = [PointerType] Middle *
 #  814|             ValueCategory = prvalue(load)
-#  814|         1 converted: [ReinterpretCast] reinterpret_cast<Base *>...
+#  814|         : [ReinterpretCast] reinterpret_cast<Base *>...
 #  814|             Conversion = [PointerConversion] pointer conversion
 #  814|             Type = [PointerType] Base *
 #  814|             ValueCategory = prvalue
-#  816|     13: [ExprStmt] ExprStmt
-#  816|       0: [FunctionCall] call to operator=
+#  816|     getStmt(13): [ExprStmt] ExprStmt
+#  816|       getExpr(): [FunctionCall] call to operator=
 #  816|           Type = [LValueReferenceType] Middle &
 #  816|           ValueCategory = prvalue
-#  816|         -1: [VariableAccess] m
+#  816|         getQualifier(): [VariableAccess] m
 #  816|             Type = [Struct] Middle
 #  816|             ValueCategory = lvalue
-#  816|         0: [VariableAccess] b
+#  816|         getArgument(0): [VariableAccess] b
 #  816|             Type = [Struct,VirtualBaseClass] Base
 #  816|             ValueCategory = lvalue
-#  816|         0 converted: [ReferenceToExpr] (reference to)
+#  816|         : [ReferenceToExpr] (reference to)
 #  816|             Type = [LValueReferenceType] const Middle &
 #  816|             ValueCategory = prvalue
-#  816|           expr: [CStyleCast] (const Middle)...
+#  816|           getExpr(): [CStyleCast] (const Middle)...
 #  816|               Conversion = [GlvalueConversion] glvalue conversion
 #  816|               Type = [SpecifiedType] const Middle
 #  816|               ValueCategory = lvalue
-#  816|             expr: [CStyleCast] (Middle)...
+#  816|             getExpr(): [CStyleCast] (Middle)...
 #  816|                 Conversion = [DerivedClassConversion] derived class conversion
 #  816|                 Type = [Struct] Middle
 #  816|                 ValueCategory = lvalue
-#  816|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  816|       : [ReferenceDereferenceExpr] (reference dereference)
 #  816|           Type = [Struct] Middle
 #  816|           ValueCategory = lvalue
-#  817|     14: [ExprStmt] ExprStmt
-#  817|       0: [FunctionCall] call to operator=
+#  817|     getStmt(14): [ExprStmt] ExprStmt
+#  817|       getExpr(): [FunctionCall] call to operator=
 #  817|           Type = [LValueReferenceType] Middle &
 #  817|           ValueCategory = prvalue
-#  817|         -1: [VariableAccess] m
+#  817|         getQualifier(): [VariableAccess] m
 #  817|             Type = [Struct] Middle
 #  817|             ValueCategory = lvalue
-#  817|         0: [VariableAccess] b
+#  817|         getArgument(0): [VariableAccess] b
 #  817|             Type = [Struct,VirtualBaseClass] Base
 #  817|             ValueCategory = lvalue
-#  817|         0 converted: [ReferenceToExpr] (reference to)
+#  817|         : [ReferenceToExpr] (reference to)
 #  817|             Type = [LValueReferenceType] const Middle &
 #  817|             ValueCategory = prvalue
-#  817|           expr: [CStyleCast] (const Middle)...
+#  817|           getExpr(): [CStyleCast] (const Middle)...
 #  817|               Conversion = [GlvalueConversion] glvalue conversion
 #  817|               Type = [SpecifiedType] const Middle
 #  817|               ValueCategory = lvalue
-#  817|             expr: [StaticCast] static_cast<Middle>...
+#  817|             getExpr(): [StaticCast] static_cast<Middle>...
 #  817|                 Conversion = [DerivedClassConversion] derived class conversion
 #  817|                 Type = [Struct] Middle
 #  817|                 ValueCategory = lvalue
-#  817|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  817|       : [ReferenceDereferenceExpr] (reference dereference)
 #  817|           Type = [Struct] Middle
 #  817|           ValueCategory = lvalue
-#  818|     15: [ExprStmt] ExprStmt
-#  818|       0: [AssignExpr] ... = ...
+#  818|     getStmt(15): [ExprStmt] ExprStmt
+#  818|       getExpr(): [AssignExpr] ... = ...
 #  818|           Type = [PointerType] Middle *
 #  818|           ValueCategory = lvalue
-#  818|         0: [VariableAccess] pm
+#  818|         getLValue(): [VariableAccess] pm
 #  818|             Type = [PointerType] Middle *
 #  818|             ValueCategory = lvalue
-#  818|         1: [VariableAccess] pb
+#  818|         getRValue(): [VariableAccess] pb
 #  818|             Type = [PointerType] Base *
 #  818|             ValueCategory = prvalue(load)
-#  818|         1 converted: [CStyleCast] (Middle *)...
+#  818|         : [CStyleCast] (Middle *)...
 #  818|             Conversion = [DerivedClassConversion] derived class conversion
 #  818|             Type = [PointerType] Middle *
 #  818|             ValueCategory = prvalue
-#  819|     16: [ExprStmt] ExprStmt
-#  819|       0: [AssignExpr] ... = ...
+#  819|     getStmt(16): [ExprStmt] ExprStmt
+#  819|       getExpr(): [AssignExpr] ... = ...
 #  819|           Type = [PointerType] Middle *
 #  819|           ValueCategory = lvalue
-#  819|         0: [VariableAccess] pm
+#  819|         getLValue(): [VariableAccess] pm
 #  819|             Type = [PointerType] Middle *
 #  819|             ValueCategory = lvalue
-#  819|         1: [VariableAccess] pb
+#  819|         getRValue(): [VariableAccess] pb
 #  819|             Type = [PointerType] Base *
 #  819|             ValueCategory = prvalue(load)
-#  819|         1 converted: [StaticCast] static_cast<Middle *>...
+#  819|         : [StaticCast] static_cast<Middle *>...
 #  819|             Conversion = [DerivedClassConversion] derived class conversion
 #  819|             Type = [PointerType] Middle *
 #  819|             ValueCategory = prvalue
-#  820|     17: [ExprStmt] ExprStmt
-#  820|       0: [AssignExpr] ... = ...
+#  820|     getStmt(17): [ExprStmt] ExprStmt
+#  820|       getExpr(): [AssignExpr] ... = ...
 #  820|           Type = [PointerType] Middle *
 #  820|           ValueCategory = lvalue
-#  820|         0: [VariableAccess] pm
+#  820|         getLValue(): [VariableAccess] pm
 #  820|             Type = [PointerType] Middle *
 #  820|             ValueCategory = lvalue
-#  820|         1: [VariableAccess] pb
+#  820|         getRValue(): [VariableAccess] pb
 #  820|             Type = [PointerType] Base *
 #  820|             ValueCategory = prvalue(load)
-#  820|         1 converted: [ReinterpretCast] reinterpret_cast<Middle *>...
+#  820|         : [ReinterpretCast] reinterpret_cast<Middle *>...
 #  820|             Conversion = [PointerConversion] pointer conversion
 #  820|             Type = [PointerType] Middle *
 #  820|             ValueCategory = prvalue
-#  822|     18: [ExprStmt] ExprStmt
-#  822|       0: [FunctionCall] call to operator=
+#  822|     getStmt(18): [ExprStmt] ExprStmt
+#  822|       getExpr(): [FunctionCall] call to operator=
 #  822|           Type = [LValueReferenceType] Base &
 #  822|           ValueCategory = prvalue
-#  822|         -1: [VariableAccess] b
+#  822|         getQualifier(): [VariableAccess] b
 #  822|             Type = [Struct,VirtualBaseClass] Base
 #  822|             ValueCategory = lvalue
-#  822|         0: [VariableAccess] d
+#  822|         getArgument(0): [VariableAccess] d
 #  822|             Type = [Struct] Derived
 #  822|             ValueCategory = lvalue
-#  822|         0 converted: [ReferenceToExpr] (reference to)
+#  822|         : [ReferenceToExpr] (reference to)
 #  822|             Type = [LValueReferenceType] const Base &
 #  822|             ValueCategory = prvalue
-#  822|           expr: [CStyleCast] (const Base)...
+#  822|           getExpr(): [CStyleCast] (const Base)...
 #  822|               Conversion = [BaseClassConversion] base class conversion
 #  822|               Type = [SpecifiedType] const Base
 #  822|               ValueCategory = lvalue
-#  822|             expr: [CStyleCast] (const Middle)...
+#  822|             getExpr(): [CStyleCast] (const Middle)...
 #  822|                 Conversion = [BaseClassConversion] base class conversion
 #  822|                 Type = [SpecifiedType] const Middle
 #  822|                 ValueCategory = lvalue
-#  822|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  822|       : [ReferenceDereferenceExpr] (reference dereference)
 #  822|           Type = [Struct,VirtualBaseClass] Base
 #  822|           ValueCategory = lvalue
-#  823|     19: [ExprStmt] ExprStmt
-#  823|       0: [FunctionCall] call to operator=
+#  823|     getStmt(19): [ExprStmt] ExprStmt
+#  823|       getExpr(): [FunctionCall] call to operator=
 #  823|           Type = [LValueReferenceType] Base &
 #  823|           ValueCategory = prvalue
-#  823|         -1: [VariableAccess] b
+#  823|         getQualifier(): [VariableAccess] b
 #  823|             Type = [Struct,VirtualBaseClass] Base
 #  823|             ValueCategory = lvalue
-#  823|         0: [ConstructorCall] call to Base
+#  823|         getArgument(0): [ConstructorCall] call to Base
 #  823|             Type = [VoidType] void
 #  823|             ValueCategory = prvalue
-#  823|           0: [VariableAccess] d
+#  823|           getArgument(0): [VariableAccess] d
 #  823|               Type = [Struct] Derived
 #  823|               ValueCategory = lvalue
-#  823|           0 converted: [ReferenceToExpr] (reference to)
+#  823|           : [ReferenceToExpr] (reference to)
 #  823|               Type = [LValueReferenceType] const Base &
 #  823|               ValueCategory = prvalue
-#  823|             expr: [CStyleCast] (const Base)...
+#  823|             getExpr(): [CStyleCast] (const Base)...
 #  823|                 Conversion = [BaseClassConversion] base class conversion
 #  823|                 Type = [SpecifiedType] const Base
 #  823|                 ValueCategory = lvalue
-#  823|               expr: [CStyleCast] (const Middle)...
+#  823|               getExpr(): [CStyleCast] (const Middle)...
 #  823|                   Conversion = [BaseClassConversion] base class conversion
 #  823|                   Type = [SpecifiedType] const Middle
 #  823|                   ValueCategory = lvalue
-#  823|         0 converted: [ReferenceToExpr] (reference to)
+#  823|         : [ReferenceToExpr] (reference to)
 #  823|             Type = [LValueReferenceType] const Base &
 #  823|             ValueCategory = prvalue
-#  823|           expr: [CStyleCast] (const Base)...
+#  823|           getExpr(): [CStyleCast] (const Base)...
 #  823|               Conversion = [GlvalueConversion] glvalue conversion
 #  823|               Type = [SpecifiedType] const Base
 #  823|               ValueCategory = lvalue
-#  823|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  823|       : [ReferenceDereferenceExpr] (reference dereference)
 #  823|           Type = [Struct,VirtualBaseClass] Base
 #  823|           ValueCategory = lvalue
-#  824|     20: [ExprStmt] ExprStmt
-#  824|       0: [FunctionCall] call to operator=
+#  824|     getStmt(20): [ExprStmt] ExprStmt
+#  824|       getExpr(): [FunctionCall] call to operator=
 #  824|           Type = [LValueReferenceType] Base &
 #  824|           ValueCategory = prvalue
-#  824|         -1: [VariableAccess] b
+#  824|         getQualifier(): [VariableAccess] b
 #  824|             Type = [Struct,VirtualBaseClass] Base
 #  824|             ValueCategory = lvalue
-#  824|         0: [ConstructorCall] call to Base
+#  824|         getArgument(0): [ConstructorCall] call to Base
 #  824|             Type = [VoidType] void
 #  824|             ValueCategory = prvalue
-#  824|           0: [VariableAccess] d
+#  824|           getArgument(0): [VariableAccess] d
 #  824|               Type = [Struct] Derived
 #  824|               ValueCategory = lvalue
-#  824|           0 converted: [ReferenceToExpr] (reference to)
+#  824|           : [ReferenceToExpr] (reference to)
 #  824|               Type = [LValueReferenceType] const Base &
 #  824|               ValueCategory = prvalue
-#  824|             expr: [CStyleCast] (const Base)...
+#  824|             getExpr(): [CStyleCast] (const Base)...
 #  824|                 Conversion = [BaseClassConversion] base class conversion
 #  824|                 Type = [SpecifiedType] const Base
 #  824|                 ValueCategory = lvalue
-#  824|               expr: [CStyleCast] (const Middle)...
+#  824|               getExpr(): [CStyleCast] (const Middle)...
 #  824|                   Conversion = [BaseClassConversion] base class conversion
 #  824|                   Type = [SpecifiedType] const Middle
 #  824|                   ValueCategory = lvalue
-#  824|         0 converted: [ReferenceToExpr] (reference to)
+#  824|         : [ReferenceToExpr] (reference to)
 #  824|             Type = [LValueReferenceType] const Base &
 #  824|             ValueCategory = prvalue
-#  824|           expr: [CStyleCast] (const Base)...
+#  824|           getExpr(): [CStyleCast] (const Base)...
 #  824|               Conversion = [GlvalueConversion] glvalue conversion
 #  824|               Type = [SpecifiedType] const Base
 #  824|               ValueCategory = lvalue
-#  824|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  824|       : [ReferenceDereferenceExpr] (reference dereference)
 #  824|           Type = [Struct,VirtualBaseClass] Base
 #  824|           ValueCategory = lvalue
-#  825|     21: [ExprStmt] ExprStmt
-#  825|       0: [AssignExpr] ... = ...
+#  825|     getStmt(21): [ExprStmt] ExprStmt
+#  825|       getExpr(): [AssignExpr] ... = ...
 #  825|           Type = [PointerType] Base *
 #  825|           ValueCategory = lvalue
-#  825|         0: [VariableAccess] pb
+#  825|         getLValue(): [VariableAccess] pb
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = lvalue
-#  825|         1: [VariableAccess] pd
+#  825|         getRValue(): [VariableAccess] pd
 #  825|             Type = [PointerType] Derived *
 #  825|             ValueCategory = prvalue(load)
-#  825|         1 converted: [CStyleCast] (Base *)...
+#  825|         : [CStyleCast] (Base *)...
 #  825|             Conversion = [BaseClassConversion] base class conversion
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = prvalue
-#  825|           expr: [CStyleCast] (Middle *)...
+#  825|           getExpr(): [CStyleCast] (Middle *)...
 #  825|               Conversion = [BaseClassConversion] base class conversion
 #  825|               Type = [PointerType] Middle *
 #  825|               ValueCategory = prvalue
-#  826|     22: [ExprStmt] ExprStmt
-#  826|       0: [AssignExpr] ... = ...
+#  826|     getStmt(22): [ExprStmt] ExprStmt
+#  826|       getExpr(): [AssignExpr] ... = ...
 #  826|           Type = [PointerType] Base *
 #  826|           ValueCategory = lvalue
-#  826|         0: [VariableAccess] pb
+#  826|         getLValue(): [VariableAccess] pb
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = lvalue
-#  826|         1: [VariableAccess] pd
+#  826|         getRValue(): [VariableAccess] pd
 #  826|             Type = [PointerType] Derived *
 #  826|             ValueCategory = prvalue(load)
-#  826|         1 converted: [CStyleCast] (Base *)...
+#  826|         : [CStyleCast] (Base *)...
 #  826|             Conversion = [BaseClassConversion] base class conversion
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = prvalue
-#  826|           expr: [CStyleCast] (Middle *)...
+#  826|           getExpr(): [CStyleCast] (Middle *)...
 #  826|               Conversion = [BaseClassConversion] base class conversion
 #  826|               Type = [PointerType] Middle *
 #  826|               ValueCategory = prvalue
-#  827|     23: [ExprStmt] ExprStmt
-#  827|       0: [AssignExpr] ... = ...
+#  827|     getStmt(23): [ExprStmt] ExprStmt
+#  827|       getExpr(): [AssignExpr] ... = ...
 #  827|           Type = [PointerType] Base *
 #  827|           ValueCategory = lvalue
-#  827|         0: [VariableAccess] pb
+#  827|         getLValue(): [VariableAccess] pb
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = lvalue
-#  827|         1: [VariableAccess] pd
+#  827|         getRValue(): [VariableAccess] pd
 #  827|             Type = [PointerType] Derived *
 #  827|             ValueCategory = prvalue(load)
-#  827|         1 converted: [StaticCast] static_cast<Base *>...
+#  827|         : [StaticCast] static_cast<Base *>...
 #  827|             Conversion = [BaseClassConversion] base class conversion
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = prvalue
-#  827|           expr: [CStyleCast] (Middle *)...
+#  827|           getExpr(): [CStyleCast] (Middle *)...
 #  827|               Conversion = [BaseClassConversion] base class conversion
 #  827|               Type = [PointerType] Middle *
 #  827|               ValueCategory = prvalue
-#  828|     24: [ExprStmt] ExprStmt
-#  828|       0: [AssignExpr] ... = ...
+#  828|     getStmt(24): [ExprStmt] ExprStmt
+#  828|       getExpr(): [AssignExpr] ... = ...
 #  828|           Type = [PointerType] Base *
 #  828|           ValueCategory = lvalue
-#  828|         0: [VariableAccess] pb
+#  828|         getLValue(): [VariableAccess] pb
 #  828|             Type = [PointerType] Base *
 #  828|             ValueCategory = lvalue
-#  828|         1: [VariableAccess] pd
+#  828|         getRValue(): [VariableAccess] pd
 #  828|             Type = [PointerType] Derived *
 #  828|             ValueCategory = prvalue(load)
-#  828|         1 converted: [ReinterpretCast] reinterpret_cast<Base *>...
+#  828|         : [ReinterpretCast] reinterpret_cast<Base *>...
 #  828|             Conversion = [PointerConversion] pointer conversion
 #  828|             Type = [PointerType] Base *
 #  828|             ValueCategory = prvalue
-#  830|     25: [ExprStmt] ExprStmt
-#  830|       0: [FunctionCall] call to operator=
+#  830|     getStmt(25): [ExprStmt] ExprStmt
+#  830|       getExpr(): [FunctionCall] call to operator=
 #  830|           Type = [LValueReferenceType] Derived &
 #  830|           ValueCategory = prvalue
-#  830|         -1: [VariableAccess] d
+#  830|         getQualifier(): [VariableAccess] d
 #  830|             Type = [Struct] Derived
 #  830|             ValueCategory = lvalue
-#  830|         0: [VariableAccess] b
+#  830|         getArgument(0): [VariableAccess] b
 #  830|             Type = [Struct,VirtualBaseClass] Base
 #  830|             ValueCategory = lvalue
-#  830|         0 converted: [ReferenceToExpr] (reference to)
+#  830|         : [ReferenceToExpr] (reference to)
 #  830|             Type = [LValueReferenceType] const Derived &
 #  830|             ValueCategory = prvalue
-#  830|           expr: [CStyleCast] (const Derived)...
+#  830|           getExpr(): [CStyleCast] (const Derived)...
 #  830|               Conversion = [GlvalueConversion] glvalue conversion
 #  830|               Type = [SpecifiedType] const Derived
 #  830|               ValueCategory = lvalue
-#  830|             expr: [CStyleCast] (Derived)...
+#  830|             getExpr(): [CStyleCast] (Derived)...
 #  830|                 Conversion = [DerivedClassConversion] derived class conversion
 #  830|                 Type = [Struct] Derived
 #  830|                 ValueCategory = lvalue
-#  830|               expr: [CStyleCast] (Middle)...
+#  830|               getExpr(): [CStyleCast] (Middle)...
 #  830|                   Conversion = [DerivedClassConversion] derived class conversion
 #  830|                   Type = [Struct] Middle
 #  830|                   ValueCategory = lvalue
-#  830|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  830|       : [ReferenceDereferenceExpr] (reference dereference)
 #  830|           Type = [Struct] Derived
 #  830|           ValueCategory = lvalue
-#  831|     26: [ExprStmt] ExprStmt
-#  831|       0: [FunctionCall] call to operator=
+#  831|     getStmt(26): [ExprStmt] ExprStmt
+#  831|       getExpr(): [FunctionCall] call to operator=
 #  831|           Type = [LValueReferenceType] Derived &
 #  831|           ValueCategory = prvalue
-#  831|         -1: [VariableAccess] d
+#  831|         getQualifier(): [VariableAccess] d
 #  831|             Type = [Struct] Derived
 #  831|             ValueCategory = lvalue
-#  831|         0: [VariableAccess] b
+#  831|         getArgument(0): [VariableAccess] b
 #  831|             Type = [Struct,VirtualBaseClass] Base
 #  831|             ValueCategory = lvalue
-#  831|         0 converted: [ReferenceToExpr] (reference to)
+#  831|         : [ReferenceToExpr] (reference to)
 #  831|             Type = [LValueReferenceType] const Derived &
 #  831|             ValueCategory = prvalue
-#  831|           expr: [CStyleCast] (const Derived)...
+#  831|           getExpr(): [CStyleCast] (const Derived)...
 #  831|               Conversion = [GlvalueConversion] glvalue conversion
 #  831|               Type = [SpecifiedType] const Derived
 #  831|               ValueCategory = lvalue
-#  831|             expr: [StaticCast] static_cast<Derived>...
+#  831|             getExpr(): [StaticCast] static_cast<Derived>...
 #  831|                 Conversion = [DerivedClassConversion] derived class conversion
 #  831|                 Type = [Struct] Derived
 #  831|                 ValueCategory = lvalue
-#  831|               expr: [CStyleCast] (Middle)...
+#  831|               getExpr(): [CStyleCast] (Middle)...
 #  831|                   Conversion = [DerivedClassConversion] derived class conversion
 #  831|                   Type = [Struct] Middle
 #  831|                   ValueCategory = lvalue
-#  831|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+#  831|       : [ReferenceDereferenceExpr] (reference dereference)
 #  831|           Type = [Struct] Derived
 #  831|           ValueCategory = lvalue
-#  832|     27: [ExprStmt] ExprStmt
-#  832|       0: [AssignExpr] ... = ...
+#  832|     getStmt(27): [ExprStmt] ExprStmt
+#  832|       getExpr(): [AssignExpr] ... = ...
 #  832|           Type = [PointerType] Derived *
 #  832|           ValueCategory = lvalue
-#  832|         0: [VariableAccess] pd
+#  832|         getLValue(): [VariableAccess] pd
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = lvalue
-#  832|         1: [VariableAccess] pb
+#  832|         getRValue(): [VariableAccess] pb
 #  832|             Type = [PointerType] Base *
 #  832|             ValueCategory = prvalue(load)
-#  832|         1 converted: [CStyleCast] (Derived *)...
+#  832|         : [CStyleCast] (Derived *)...
 #  832|             Conversion = [DerivedClassConversion] derived class conversion
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = prvalue
-#  832|           expr: [CStyleCast] (Middle *)...
+#  832|           getExpr(): [CStyleCast] (Middle *)...
 #  832|               Conversion = [DerivedClassConversion] derived class conversion
 #  832|               Type = [PointerType] Middle *
 #  832|               ValueCategory = prvalue
-#  833|     28: [ExprStmt] ExprStmt
-#  833|       0: [AssignExpr] ... = ...
+#  833|     getStmt(28): [ExprStmt] ExprStmt
+#  833|       getExpr(): [AssignExpr] ... = ...
 #  833|           Type = [PointerType] Derived *
 #  833|           ValueCategory = lvalue
-#  833|         0: [VariableAccess] pd
+#  833|         getLValue(): [VariableAccess] pd
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = lvalue
-#  833|         1: [VariableAccess] pb
+#  833|         getRValue(): [VariableAccess] pb
 #  833|             Type = [PointerType] Base *
 #  833|             ValueCategory = prvalue(load)
-#  833|         1 converted: [StaticCast] static_cast<Derived *>...
+#  833|         : [StaticCast] static_cast<Derived *>...
 #  833|             Conversion = [DerivedClassConversion] derived class conversion
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = prvalue
-#  833|           expr: [CStyleCast] (Middle *)...
+#  833|           getExpr(): [CStyleCast] (Middle *)...
 #  833|               Conversion = [DerivedClassConversion] derived class conversion
 #  833|               Type = [PointerType] Middle *
 #  833|               ValueCategory = prvalue
-#  834|     29: [ExprStmt] ExprStmt
-#  834|       0: [AssignExpr] ... = ...
+#  834|     getStmt(29): [ExprStmt] ExprStmt
+#  834|       getExpr(): [AssignExpr] ... = ...
 #  834|           Type = [PointerType] Derived *
 #  834|           ValueCategory = lvalue
-#  834|         0: [VariableAccess] pd
+#  834|         getLValue(): [VariableAccess] pd
 #  834|             Type = [PointerType] Derived *
 #  834|             ValueCategory = lvalue
-#  834|         1: [VariableAccess] pb
+#  834|         getRValue(): [VariableAccess] pb
 #  834|             Type = [PointerType] Base *
 #  834|             ValueCategory = prvalue(load)
-#  834|         1 converted: [ReinterpretCast] reinterpret_cast<Derived *>...
+#  834|         : [ReinterpretCast] reinterpret_cast<Derived *>...
 #  834|             Conversion = [PointerConversion] pointer conversion
 #  834|             Type = [PointerType] Derived *
 #  834|             ValueCategory = prvalue
-#  836|     30: [DeclStmt] declaration
-#  836|       0: [VariableDeclarationEntry] definition of pmv
+#  836|     getStmt(30): [DeclStmt] declaration
+#  836|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pmv
 #  836|           Type = [PointerType] MiddleVB1 *
-#  836|         init: [Initializer] initializer for pmv
-#  836|           expr: [Literal] 0
+#  836|         getVariable().getInitializer(): [Initializer] initializer for pmv
+#  836|           getExpr(): [Literal] 0
 #  836|               Type = [NullPointerType] decltype(nullptr)
 #  836|               Value = [Literal] 0
 #  836|               ValueCategory = prvalue
-#  836|           expr converted: [CStyleCast] (MiddleVB1 *)...
+#  836|           : [CStyleCast] (MiddleVB1 *)...
 #  836|               Conversion = [PointerConversion] pointer conversion
 #  836|               Type = [PointerType] MiddleVB1 *
 #  836|               Value = [CStyleCast] 0
 #  836|               ValueCategory = prvalue
-#  837|     31: [DeclStmt] declaration
-#  837|       0: [VariableDeclarationEntry] definition of pdv
+#  837|     getStmt(31): [DeclStmt] declaration
+#  837|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pdv
 #  837|           Type = [PointerType] DerivedVB *
-#  837|         init: [Initializer] initializer for pdv
-#  837|           expr: [Literal] 0
+#  837|         getVariable().getInitializer(): [Initializer] initializer for pdv
+#  837|           getExpr(): [Literal] 0
 #  837|               Type = [NullPointerType] decltype(nullptr)
 #  837|               Value = [Literal] 0
 #  837|               ValueCategory = prvalue
-#  837|           expr converted: [CStyleCast] (DerivedVB *)...
+#  837|           : [CStyleCast] (DerivedVB *)...
 #  837|               Conversion = [PointerConversion] pointer conversion
 #  837|               Type = [PointerType] DerivedVB *
 #  837|               Value = [CStyleCast] 0
 #  837|               ValueCategory = prvalue
-#  838|     32: [ExprStmt] ExprStmt
-#  838|       0: [AssignExpr] ... = ...
+#  838|     getStmt(32): [ExprStmt] ExprStmt
+#  838|       getExpr(): [AssignExpr] ... = ...
 #  838|           Type = [PointerType] Base *
 #  838|           ValueCategory = lvalue
-#  838|         0: [VariableAccess] pb
+#  838|         getLValue(): [VariableAccess] pb
 #  838|             Type = [PointerType] Base *
 #  838|             ValueCategory = lvalue
-#  838|         1: [VariableAccess] pmv
+#  838|         getRValue(): [VariableAccess] pmv
 #  838|             Type = [PointerType] MiddleVB1 *
 #  838|             ValueCategory = prvalue(load)
-#  838|         1 converted: [CStyleCast] (Base *)...
+#  838|         : [CStyleCast] (Base *)...
 #  838|             Conversion = [BaseClassConversion] base class conversion
 #  838|             Type = [PointerType] Base *
 #  838|             ValueCategory = prvalue
-#  839|     33: [ExprStmt] ExprStmt
-#  839|       0: [AssignExpr] ... = ...
+#  839|     getStmt(33): [ExprStmt] ExprStmt
+#  839|       getExpr(): [AssignExpr] ... = ...
 #  839|           Type = [PointerType] Base *
 #  839|           ValueCategory = lvalue
-#  839|         0: [VariableAccess] pb
+#  839|         getLValue(): [VariableAccess] pb
 #  839|             Type = [PointerType] Base *
 #  839|             ValueCategory = lvalue
-#  839|         1: [VariableAccess] pdv
+#  839|         getRValue(): [VariableAccess] pdv
 #  839|             Type = [PointerType] DerivedVB *
 #  839|             ValueCategory = prvalue(load)
-#  839|         1 converted: [CStyleCast] (Base *)...
+#  839|         : [CStyleCast] (Base *)...
 #  839|             Conversion = [BaseClassConversion] base class conversion
 #  839|             Type = [PointerType] Base *
 #  839|             ValueCategory = prvalue
-#  840|     34: [ReturnStmt] return ...
+#  840|     getStmt(34): [ReturnStmt] return ...
 #  842| [CopyAssignmentOperator] PolymorphicBase& PolymorphicBase::operator=(PolymorphicBase const&)
-#  842|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  842|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  842| [Constructor] void PolymorphicBase::PolymorphicBase()
-#  842|   params: 
-#  842|   initializations: 
-#  842|   body: [BlockStmt] { ... }
-#  842|     0: [ReturnStmt] return ...
+#  842|   ...: 
+#  842|   ...: 
+#  842|   getEntryPoint(): [BlockStmt] { ... }
+#  842|     getStmt(0): [ReturnStmt] return ...
 #  842| [CopyConstructor] void PolymorphicBase::PolymorphicBase(PolymorphicBase const&)
-#  842|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  842|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  843| [Destructor,VirtualFunction] void PolymorphicBase::~PolymorphicBase()
-#  843|   params: 
+#  843|   ...: 
 #  846| [CopyAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived const&)
-#  846|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  846|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived&&)
-#  846|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  846|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Constructor] void PolymorphicDerived::PolymorphicDerived()
-#  846|   params: 
-#  846|   initializations: 
-#  846|     0: [ConstructorDirectInit] call to PolymorphicBase
+#  846|   ...: 
+#  846|   ...: 
+#  846|     getInitializer(0): [ConstructorDirectInit] call to PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
-#  846|   body: [BlockStmt] { ... }
-#  846|     0: [ReturnStmt] return ...
+#  846|   getEntryPoint(): [BlockStmt] { ... }
+#  846|     getStmt(0): [ReturnStmt] return ...
 #  846| [CopyConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived const&)
-#  846|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  846|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived&&)
-#  846|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  846|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Destructor,VirtualFunction] void PolymorphicDerived::~PolymorphicDerived()
-#  846|   params: 
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ReturnStmt] return ...
-#  846|   destructions: 
-#  846|     0: [DestructorDirectDestruction] call to ~PolymorphicBase
+#  846|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ReturnStmt] return ...
+#  846|   ...: 
+#  846|     getDestruction(0): [DestructorDirectDestruction] call to ~PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
 #  849| [TopLevelFunction] void DynamicCast()
-#  849|   params: 
-#  849|   body: [BlockStmt] { ... }
-#  850|     0: [DeclStmt] declaration
-#  850|       0: [VariableDeclarationEntry] definition of b
+#  849|   ...: 
+#  849|   getEntryPoint(): [BlockStmt] { ... }
+#  850|     getStmt(0): [DeclStmt] declaration
+#  850|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  850|           Type = [Struct] PolymorphicBase
-#  850|         init: [Initializer] initializer for b
-#-----|           expr: [ConstructorCall] call to PolymorphicBase
+#  850|         getVariable().getInitializer(): [Initializer] initializer for b
+#-----|           getExpr(): [ConstructorCall] call to PolymorphicBase
 #-----|               Type = [VoidType] void
 #-----|               ValueCategory = prvalue
-#  851|     1: [DeclStmt] declaration
-#  851|       0: [VariableDeclarationEntry] definition of d
+#  851|     getStmt(1): [DeclStmt] declaration
+#  851|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #  851|           Type = [Struct] PolymorphicDerived
-#  851|         init: [Initializer] initializer for d
-#-----|           expr: [ConstructorCall] call to PolymorphicDerived
+#  851|         getVariable().getInitializer(): [Initializer] initializer for d
+#-----|           getExpr(): [ConstructorCall] call to PolymorphicDerived
 #-----|               Type = [VoidType] void
 #-----|               ValueCategory = prvalue
-#  853|     2: [DeclStmt] declaration
-#  853|       0: [VariableDeclarationEntry] definition of pb
+#  853|     getStmt(2): [DeclStmt] declaration
+#  853|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pb
 #  853|           Type = [PointerType] PolymorphicBase *
-#  853|         init: [Initializer] initializer for pb
-#  853|           expr: [AddressOfExpr] & ...
+#  853|         getVariable().getInitializer(): [Initializer] initializer for pb
+#  853|           getExpr(): [AddressOfExpr] & ...
 #  853|               Type = [PointerType] PolymorphicBase *
 #  853|               ValueCategory = prvalue
-#  853|             0: [VariableAccess] b
+#  853|             getOperand(): [VariableAccess] b
 #  853|                 Type = [Struct] PolymorphicBase
 #  853|                 ValueCategory = lvalue
-#  854|     3: [DeclStmt] declaration
-#  854|       0: [VariableDeclarationEntry] definition of pd
+#  854|     getStmt(3): [DeclStmt] declaration
+#  854|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pd
 #  854|           Type = [PointerType] PolymorphicDerived *
-#  854|         init: [Initializer] initializer for pd
-#  854|           expr: [AddressOfExpr] & ...
+#  854|         getVariable().getInitializer(): [Initializer] initializer for pd
+#  854|           getExpr(): [AddressOfExpr] & ...
 #  854|               Type = [PointerType] PolymorphicDerived *
 #  854|               ValueCategory = prvalue
-#  854|             0: [VariableAccess] d
+#  854|             getOperand(): [VariableAccess] d
 #  854|                 Type = [Struct] PolymorphicDerived
 #  854|                 ValueCategory = lvalue
-#  857|     4: [ExprStmt] ExprStmt
-#  857|       0: [AssignExpr] ... = ...
+#  857|     getStmt(4): [ExprStmt] ExprStmt
+#  857|       getExpr(): [AssignExpr] ... = ...
 #  857|           Type = [PointerType] PolymorphicBase *
 #  857|           ValueCategory = lvalue
-#  857|         0: [VariableAccess] pb
+#  857|         getLValue(): [VariableAccess] pb
 #  857|             Type = [PointerType] PolymorphicBase *
 #  857|             ValueCategory = lvalue
-#  857|         1: [VariableAccess] pd
+#  857|         getRValue(): [VariableAccess] pd
 #  857|             Type = [PointerType] PolymorphicDerived *
 #  857|             ValueCategory = prvalue(load)
-#  857|         1 converted: [DynamicCast] dynamic_cast<PolymorphicBase *>...
+#  857|         : [DynamicCast] dynamic_cast<PolymorphicBase *>...
 #  857|             Conversion = [DynamicCast] dynamic_cast
 #  857|             Type = [PointerType] PolymorphicBase *
 #  857|             ValueCategory = prvalue
-#  858|     5: [DeclStmt] declaration
-#  858|       0: [VariableDeclarationEntry] definition of rb
+#  858|     getStmt(5): [DeclStmt] declaration
+#  858|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rb
 #  858|           Type = [LValueReferenceType] PolymorphicBase &
-#  858|         init: [Initializer] initializer for rb
-#  858|           expr: [VariableAccess] d
+#  858|         getVariable().getInitializer(): [Initializer] initializer for rb
+#  858|           getExpr(): [VariableAccess] d
 #  858|               Type = [Struct] PolymorphicDerived
 #  858|               ValueCategory = lvalue
-#  858|           expr converted: [ReferenceToExpr] (reference to)
+#  858|           : [ReferenceToExpr] (reference to)
 #  858|               Type = [LValueReferenceType] PolymorphicBase &
 #  858|               ValueCategory = prvalue
-#  858|             expr: [DynamicCast] dynamic_cast<PolymorphicBase>...
+#  858|             getExpr(): [DynamicCast] dynamic_cast<PolymorphicBase>...
 #  858|                 Conversion = [DynamicCast] dynamic_cast
 #  858|                 Type = [Struct] PolymorphicBase
 #  858|                 ValueCategory = lvalue
-#  860|     6: [ExprStmt] ExprStmt
-#  860|       0: [AssignExpr] ... = ...
+#  860|     getStmt(6): [ExprStmt] ExprStmt
+#  860|       getExpr(): [AssignExpr] ... = ...
 #  860|           Type = [PointerType] PolymorphicDerived *
 #  860|           ValueCategory = lvalue
-#  860|         0: [VariableAccess] pd
+#  860|         getLValue(): [VariableAccess] pd
 #  860|             Type = [PointerType] PolymorphicDerived *
 #  860|             ValueCategory = lvalue
-#  860|         1: [VariableAccess] pb
+#  860|         getRValue(): [VariableAccess] pb
 #  860|             Type = [PointerType] PolymorphicBase *
 #  860|             ValueCategory = prvalue(load)
-#  860|         1 converted: [DynamicCast] dynamic_cast<PolymorphicDerived *>...
+#  860|         : [DynamicCast] dynamic_cast<PolymorphicDerived *>...
 #  860|             Conversion = [DynamicCast] dynamic_cast
 #  860|             Type = [PointerType] PolymorphicDerived *
 #  860|             ValueCategory = prvalue
-#  861|     7: [DeclStmt] declaration
-#  861|       0: [VariableDeclarationEntry] definition of rd
+#  861|     getStmt(7): [DeclStmt] declaration
+#  861|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rd
 #  861|           Type = [LValueReferenceType] PolymorphicDerived &
-#  861|         init: [Initializer] initializer for rd
-#  861|           expr: [VariableAccess] b
+#  861|         getVariable().getInitializer(): [Initializer] initializer for rd
+#  861|           getExpr(): [VariableAccess] b
 #  861|               Type = [Struct] PolymorphicBase
 #  861|               ValueCategory = lvalue
-#  861|           expr converted: [ReferenceToExpr] (reference to)
+#  861|           : [ReferenceToExpr] (reference to)
 #  861|               Type = [LValueReferenceType] PolymorphicDerived &
 #  861|               ValueCategory = prvalue
-#  861|             expr: [DynamicCast] dynamic_cast<PolymorphicDerived>...
+#  861|             getExpr(): [DynamicCast] dynamic_cast<PolymorphicDerived>...
 #  861|                 Conversion = [DynamicCast] dynamic_cast
 #  861|                 Type = [Struct] PolymorphicDerived
 #  861|                 ValueCategory = lvalue
-#  863|     8: [DeclStmt] declaration
-#  863|       0: [VariableDeclarationEntry] definition of pv
+#  863|     getStmt(8): [DeclStmt] declaration
+#  863|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pv
 #  863|           Type = [VoidPointerType] void *
-#  863|         init: [Initializer] initializer for pv
-#  863|           expr: [VariableAccess] pb
+#  863|         getVariable().getInitializer(): [Initializer] initializer for pv
+#  863|           getExpr(): [VariableAccess] pb
 #  863|               Type = [PointerType] PolymorphicBase *
 #  863|               ValueCategory = prvalue(load)
-#  863|           expr converted: [DynamicCast] dynamic_cast<void *>...
+#  863|           : [DynamicCast] dynamic_cast<void *>...
 #  863|               Conversion = [DynamicCast] dynamic_cast
 #  863|               Type = [VoidPointerType] void *
 #  863|               ValueCategory = prvalue
-#  864|     9: [DeclStmt] declaration
-#  864|       0: [VariableDeclarationEntry] definition of pcv
+#  864|     getStmt(9): [DeclStmt] declaration
+#  864|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pcv
 #  864|           Type = [PointerType] const void *
-#  864|         init: [Initializer] initializer for pcv
-#  864|           expr: [VariableAccess] pd
+#  864|         getVariable().getInitializer(): [Initializer] initializer for pcv
+#  864|           getExpr(): [VariableAccess] pd
 #  864|               Type = [PointerType] PolymorphicDerived *
 #  864|               ValueCategory = prvalue(load)
-#  864|           expr converted: [DynamicCast] dynamic_cast<const void *>...
+#  864|           : [DynamicCast] dynamic_cast<const void *>...
 #  864|               Conversion = [DynamicCast] dynamic_cast
 #  864|               Type = [PointerType] const void *
 #  864|               ValueCategory = prvalue
-#  865|     10: [ReturnStmt] return ...
+#  865|     getStmt(10): [ReturnStmt] return ...
 #  867| [Constructor] void String::String()
-#  867|   params: 
-#  867|   initializations: 
-#  868|     0: [ConstructorDelegationInit] call to String
+#  867|   ...: 
+#  867|   ...: 
+#  868|     getInitializer(0): [ConstructorDelegationInit] call to String
 #  868|         Type = [VoidType] void
 #  868|         ValueCategory = prvalue
-#  868|       0: 
+#  868|       getArgument(0): 
 #  868|           Type = [ArrayType] const char[1]
 #  868|           Value = [StringLiteral] ""
 #  868|           ValueCategory = lvalue
-#  868|       0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  868|       : [ArrayToPointerConversion] array to pointer conversion
 #  868|           Type = [PointerType] const char *
 #  868|           ValueCategory = prvalue
-#  868|   body: [BlockStmt] { ... }
-#  869|     0: [ReturnStmt] return ...
+#  868|   getEntryPoint(): [BlockStmt] { ... }
+#  869|     getStmt(0): [ReturnStmt] return ...
 #  871| [TopLevelFunction] void ArrayConversions()
-#  871|   params: 
-#  871|   body: [BlockStmt] { ... }
-#  872|     0: [DeclStmt] declaration
-#  872|       0: [VariableDeclarationEntry] definition of a
+#  871|   ...: 
+#  871|   getEntryPoint(): [BlockStmt] { ... }
+#  872|     getStmt(0): [DeclStmt] declaration
+#  872|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 #  872|           Type = [ArrayType] char[5]
-#  873|     1: [DeclStmt] declaration
-#  873|       0: [VariableDeclarationEntry] definition of p
+#  873|     getStmt(1): [DeclStmt] declaration
+#  873|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
 #  873|           Type = [PointerType] const char *
-#  873|         init: [Initializer] initializer for p
-#  873|           expr: [VariableAccess] a
+#  873|         getVariable().getInitializer(): [Initializer] initializer for p
+#  873|           getExpr(): [VariableAccess] a
 #  873|               Type = [ArrayType] char[5]
 #  873|               ValueCategory = lvalue
-#  873|           expr converted: [CStyleCast] (const char *)...
+#  873|           : [CStyleCast] (const char *)...
 #  873|               Conversion = [PointerConversion] pointer conversion
 #  873|               Type = [PointerType] const char *
 #  873|               ValueCategory = prvalue
-#  873|             expr: [ArrayToPointerConversion] array to pointer conversion
+#  873|             getExpr(): [ArrayToPointerConversion] array to pointer conversion
 #  873|                 Type = [CharPointerType] char *
 #  873|                 ValueCategory = prvalue
-#  874|     2: [ExprStmt] ExprStmt
-#  874|       0: [AssignExpr] ... = ...
+#  874|     getStmt(2): [ExprStmt] ExprStmt
+#  874|       getExpr(): [AssignExpr] ... = ...
 #  874|           Type = [PointerType] const char *
 #  874|           ValueCategory = lvalue
-#  874|         0: [VariableAccess] p
+#  874|         getLValue(): [VariableAccess] p
 #  874|             Type = [PointerType] const char *
 #  874|             ValueCategory = lvalue
-#  874|         1: test
+#  874|         getRValue(): test
 #  874|             Type = [ArrayType] const char[5]
 #  874|             Value = [StringLiteral] "test"
 #  874|             ValueCategory = lvalue
-#  874|         1 converted: [ArrayToPointerConversion] array to pointer conversion
+#  874|         : [ArrayToPointerConversion] array to pointer conversion
 #  874|             Type = [PointerType] const char *
 #  874|             ValueCategory = prvalue
-#  875|     3: [ExprStmt] ExprStmt
-#  875|       0: [AssignExpr] ... = ...
+#  875|     getStmt(3): [ExprStmt] ExprStmt
+#  875|       getExpr(): [AssignExpr] ... = ...
 #  875|           Type = [PointerType] const char *
 #  875|           ValueCategory = lvalue
-#  875|         0: [VariableAccess] p
+#  875|         getLValue(): [VariableAccess] p
 #  875|             Type = [PointerType] const char *
 #  875|             ValueCategory = lvalue
-#  875|         1: [AddressOfExpr] & ...
+#  875|         getRValue(): [AddressOfExpr] & ...
 #  875|             Type = [CharPointerType] char *
 #  875|             ValueCategory = prvalue
-#  875|           0: [ArrayExpr] access to array
+#  875|           getOperand(): [ArrayExpr] access to array
 #  875|               Type = [PlainCharType] char
 #  875|               ValueCategory = lvalue
-#  875|             0: [VariableAccess] a
+#  875|             getArrayBase(): [VariableAccess] a
 #  875|                 Type = [ArrayType] char[5]
 #  875|                 ValueCategory = lvalue
-#  875|             1: [Literal] 0
+#  875|             getArrayOffset(): [Literal] 0
 #  875|                 Type = [IntType] int
 #  875|                 Value = [Literal] 0
 #  875|                 ValueCategory = prvalue
-#  875|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  875|             : [ArrayToPointerConversion] array to pointer conversion
 #  875|                 Type = [CharPointerType] char *
 #  875|                 ValueCategory = prvalue
-#  875|         1 converted: [CStyleCast] (const char *)...
+#  875|         : [CStyleCast] (const char *)...
 #  875|             Conversion = [PointerConversion] pointer conversion
 #  875|             Type = [PointerType] const char *
 #  875|             ValueCategory = prvalue
-#  876|     4: [ExprStmt] ExprStmt
-#  876|       0: [AssignExpr] ... = ...
+#  876|     getStmt(4): [ExprStmt] ExprStmt
+#  876|       getExpr(): [AssignExpr] ... = ...
 #  876|           Type = [PointerType] const char *
 #  876|           ValueCategory = lvalue
-#  876|         0: [VariableAccess] p
+#  876|         getLValue(): [VariableAccess] p
 #  876|             Type = [PointerType] const char *
 #  876|             ValueCategory = lvalue
-#  876|         1: [AddressOfExpr] & ...
+#  876|         getRValue(): [AddressOfExpr] & ...
 #  876|             Type = [PointerType] const char *
 #  876|             ValueCategory = prvalue
-#  876|           0: [ArrayExpr] access to array
+#  876|           getOperand(): [ArrayExpr] access to array
 #  876|               Type = [SpecifiedType] const char
 #  876|               ValueCategory = lvalue
-#  876|             0: test
+#  876|             getArrayBase(): test
 #  876|                 Type = [ArrayType] const char[5]
 #  876|                 Value = [StringLiteral] "test"
 #  876|                 ValueCategory = lvalue
-#  876|             1: [Literal] 0
+#  876|             getArrayOffset(): [Literal] 0
 #  876|                 Type = [IntType] int
 #  876|                 Value = [Literal] 0
 #  876|                 ValueCategory = prvalue
-#  876|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  876|             : [ArrayToPointerConversion] array to pointer conversion
 #  876|                 Type = [PointerType] const char *
 #  876|                 ValueCategory = prvalue
-#  877|     5: [DeclStmt] declaration
-#  877|       0: [VariableDeclarationEntry] definition of ra
+#  877|     getStmt(5): [DeclStmt] declaration
+#  877|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of ra
 #  877|           Type = [LValueReferenceType] char(&)[5]
-#  877|         init: [Initializer] initializer for ra
-#  877|           expr: [VariableAccess] a
+#  877|         getVariable().getInitializer(): [Initializer] initializer for ra
+#  877|           getExpr(): [VariableAccess] a
 #  877|               Type = [ArrayType] char[5]
 #  877|               ValueCategory = lvalue
-#  877|           expr converted: [ReferenceToExpr] (reference to)
+#  877|           : [ReferenceToExpr] (reference to)
 #  877|               Type = [LValueReferenceType] char(&)[5]
 #  877|               ValueCategory = prvalue
-#  878|     6: [DeclStmt] declaration
-#  878|       0: [VariableDeclarationEntry] definition of rs
+#  878|     getStmt(6): [DeclStmt] declaration
+#  878|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rs
 #  878|           Type = [LValueReferenceType] const char(&)[5]
-#  878|         init: [Initializer] initializer for rs
-#  878|           expr: test
+#  878|         getVariable().getInitializer(): [Initializer] initializer for rs
+#  878|           getExpr(): test
 #  878|               Type = [ArrayType] const char[5]
 #  878|               Value = [StringLiteral] "test"
 #  878|               ValueCategory = lvalue
-#  878|           expr converted: [ReferenceToExpr] (reference to)
+#  878|           : [ReferenceToExpr] (reference to)
 #  878|               Type = [LValueReferenceType] const char(&)[5]
 #  878|               ValueCategory = prvalue
-#  879|     7: [DeclStmt] declaration
-#  879|       0: [VariableDeclarationEntry] definition of pa
+#  879|     getStmt(7): [DeclStmt] declaration
+#  879|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pa
 #  879|           Type = [PointerType] const char(*)[5]
-#  879|         init: [Initializer] initializer for pa
-#  879|           expr: [AddressOfExpr] & ...
+#  879|         getVariable().getInitializer(): [Initializer] initializer for pa
+#  879|           getExpr(): [AddressOfExpr] & ...
 #  879|               Type = [PointerType] char(*)[5]
 #  879|               ValueCategory = prvalue
-#  879|             0: [VariableAccess] a
+#  879|             getOperand(): [VariableAccess] a
 #  879|                 Type = [ArrayType] char[5]
 #  879|                 ValueCategory = lvalue
-#  879|           expr converted: [CStyleCast] (const char(*)[5])...
+#  879|           : [CStyleCast] (const char(*)[5])...
 #  879|               Conversion = [PointerConversion] pointer conversion
 #  879|               Type = [PointerType] const char(*)[5]
 #  879|               ValueCategory = prvalue
-#  880|     8: [ExprStmt] ExprStmt
-#  880|       0: [AssignExpr] ... = ...
+#  880|     getStmt(8): [ExprStmt] ExprStmt
+#  880|       getExpr(): [AssignExpr] ... = ...
 #  880|           Type = [PointerType] const char(*)[5]
 #  880|           ValueCategory = lvalue
-#  880|         0: [VariableAccess] pa
+#  880|         getLValue(): [VariableAccess] pa
 #  880|             Type = [PointerType] const char(*)[5]
 #  880|             ValueCategory = lvalue
-#  880|         1: [AddressOfExpr] & ...
+#  880|         getRValue(): [AddressOfExpr] & ...
 #  880|             Type = [PointerType] const char(*)[5]
 #  880|             ValueCategory = prvalue
-#  880|           0: test
+#  880|           getOperand(): test
 #  880|               Type = [ArrayType] const char[5]
 #  880|               Value = [StringLiteral] "test"
 #  880|               ValueCategory = lvalue
-#  881|     9: [ReturnStmt] return ...
+#  881|     getStmt(9): [ReturnStmt] return ...
 #  883| [TopLevelFunction] void FuncPtrConversions(int(*)(int), void*)
-#  883|   params: 
-#  883|     0: [Parameter] pfn
+#  883|   ...: 
+#  883|     getParameter(0): [Parameter] pfn
 #  883|         Type = [FunctionPointerType] ..(*)(..)
-#  883|     1: [Parameter] p
+#  883|     getParameter(1): [Parameter] p
 #  883|         Type = [VoidPointerType] void *
-#  883|   body: [BlockStmt] { ... }
-#  884|     0: [ExprStmt] ExprStmt
-#  884|       0: [AssignExpr] ... = ...
+#  883|   getEntryPoint(): [BlockStmt] { ... }
+#  884|     getStmt(0): [ExprStmt] ExprStmt
+#  884|       getExpr(): [AssignExpr] ... = ...
 #  884|           Type = [VoidPointerType] void *
 #  884|           ValueCategory = lvalue
-#  884|         0: [VariableAccess] p
+#  884|         getLValue(): [VariableAccess] p
 #  884|             Type = [VoidPointerType] void *
 #  884|             ValueCategory = lvalue
-#  884|         1: [VariableAccess] pfn
+#  884|         getRValue(): [VariableAccess] pfn
 #  884|             Type = [FunctionPointerType] ..(*)(..)
 #  884|             ValueCategory = prvalue(load)
-#  884|         1 converted: [CStyleCast] (void *)...
+#  884|         : [CStyleCast] (void *)...
 #  884|             Conversion = [PointerConversion] pointer conversion
 #  884|             Type = [VoidPointerType] void *
 #  884|             ValueCategory = prvalue
-#  885|     1: [ExprStmt] ExprStmt
-#  885|       0: [AssignExpr] ... = ...
+#  885|     getStmt(1): [ExprStmt] ExprStmt
+#  885|       getExpr(): [AssignExpr] ... = ...
 #  885|           Type = [FunctionPointerType] ..(*)(..)
 #  885|           ValueCategory = lvalue
-#  885|         0: [VariableAccess] pfn
+#  885|         getLValue(): [VariableAccess] pfn
 #  885|             Type = [FunctionPointerType] ..(*)(..)
 #  885|             ValueCategory = lvalue
-#  885|         1: [VariableAccess] p
+#  885|         getRValue(): [VariableAccess] p
 #  885|             Type = [VoidPointerType] void *
 #  885|             ValueCategory = prvalue(load)
-#  885|         1 converted: [CStyleCast] (..(*)(..))...
+#  885|         : [CStyleCast] (..(*)(..))...
 #  885|             Conversion = [PointerConversion] pointer conversion
 #  885|             Type = [FunctionPointerType] ..(*)(..)
 #  885|             ValueCategory = prvalue
-#  886|     2: [ReturnStmt] return ...
+#  886|     getStmt(2): [ReturnStmt] return ...
 #  888| [TopLevelFunction] void VAListUsage(int, __va_list_tag[1])
-#  888|   params: 
-#  888|     0: [Parameter] x
+#  888|   ...: 
+#  888|     getParameter(0): [Parameter] x
 #  888|         Type = [IntType] int
-#  888|     1: [Parameter] args
+#  888|     getParameter(1): [Parameter] args
 #  888|         Type = [ArrayType] __va_list_tag[1]
-#  888|   body: [BlockStmt] { ... }
-#  889|     0: [DeclStmt] declaration
-#  889|       0: [VariableDeclarationEntry] definition of args2
+#  888|   getEntryPoint(): [BlockStmt] { ... }
+#  889|     getStmt(0): [DeclStmt] declaration
+#  889|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of args2
 #  889|           Type = [ArrayType] __va_list_tag[1]
-#  890|     1: [ExprStmt] ExprStmt
-#  890|       0: [BuiltInVarArgCopy] __builtin_va_copy
+#  890|     getStmt(1): [ExprStmt] ExprStmt
+#  890|       getExpr(): [BuiltInVarArgCopy] __builtin_va_copy
 #  890|           Type = [VoidType] void
 #  890|           ValueCategory = prvalue
-#  890|         0: [VariableAccess] args2
+#  890|         getDestinationVAList(): [VariableAccess] args2
 #  890|             Type = [ArrayType] __va_list_tag[1]
 #  890|             ValueCategory = lvalue
-#  890|         1: [VariableAccess] args
+#  890|         getSourceVAList(): [VariableAccess] args
 #  890|             Type = [PointerType] __va_list_tag *
 #  890|             ValueCategory = prvalue(load)
-#  890|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  890|         : [ArrayToPointerConversion] array to pointer conversion
 #  890|             Type = [PointerType] __va_list_tag *
 #  890|             ValueCategory = prvalue
-#  891|     2: [DeclStmt] declaration
-#  891|       0: [VariableDeclarationEntry] definition of d
+#  891|     getStmt(2): [DeclStmt] declaration
+#  891|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #  891|           Type = [DoubleType] double
-#  891|         init: [Initializer] initializer for d
-#  891|           expr: [BuiltInVarArg] __builtin_va_arg
+#  891|         getVariable().getInitializer(): [Initializer] initializer for d
+#  891|           getExpr(): [BuiltInVarArg] __builtin_va_arg
 #  891|               Type = [DoubleType] double
 #  891|               ValueCategory = prvalue(load)
-#  891|             0: [VariableAccess] args
+#  891|             getVAList(): [VariableAccess] args
 #  891|                 Type = [PointerType] __va_list_tag *
 #  891|                 ValueCategory = prvalue(load)
-#  892|     3: [DeclStmt] declaration
-#  892|       0: [VariableDeclarationEntry] definition of f
+#  892|     getStmt(3): [DeclStmt] declaration
+#  892|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
 #  892|           Type = [FloatType] float
-#  892|         init: [Initializer] initializer for f
-#  892|           expr: [BuiltInVarArg] __builtin_va_arg
+#  892|         getVariable().getInitializer(): [Initializer] initializer for f
+#  892|           getExpr(): [BuiltInVarArg] __builtin_va_arg
 #  892|               Type = [IntType] int
 #  892|               ValueCategory = prvalue(load)
-#  892|             0: [VariableAccess] args
+#  892|             getVAList(): [VariableAccess] args
 #  892|                 Type = [PointerType] __va_list_tag *
 #  892|                 ValueCategory = prvalue(load)
-#  892|           expr converted: [CStyleCast] (float)...
+#  892|           : [CStyleCast] (float)...
 #  892|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  892|               Type = [FloatType] float
 #  892|               ValueCategory = prvalue
-#  893|     4: [ExprStmt] ExprStmt
-#  893|       0: [BuiltInVarArgsEnd] __builtin_va_end
+#  893|     getStmt(4): [ExprStmt] ExprStmt
+#  893|       getExpr(): [BuiltInVarArgsEnd] __builtin_va_end
 #  893|           Type = [VoidType] void
 #  893|           ValueCategory = prvalue
-#  893|         0: [VariableAccess] args2
+#  893|         getVAList(): [VariableAccess] args2
 #  893|             Type = [ArrayType] __va_list_tag[1]
 #  893|             ValueCategory = lvalue
-#  893|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  893|         : [ArrayToPointerConversion] array to pointer conversion
 #  893|             Type = [PointerType] __va_list_tag *
 #  893|             ValueCategory = prvalue
-#  894|     5: [ReturnStmt] return ...
+#  894|     getStmt(5): [ReturnStmt] return ...
 #  896| [TopLevelFunction] void VarArgUsage(int)
-#  896|   params: 
-#  896|     0: [Parameter] x
+#  896|   ...: 
+#  896|     getParameter(0): [Parameter] x
 #  896|         Type = [IntType] int
-#  896|   body: [BlockStmt] { ... }
-#  897|     0: [DeclStmt] declaration
-#  897|       0: [VariableDeclarationEntry] definition of args
+#  896|   getEntryPoint(): [BlockStmt] { ... }
+#  897|     getStmt(0): [DeclStmt] declaration
+#  897|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of args
 #  897|           Type = [ArrayType] __va_list_tag[1]
-#  899|     1: [ExprStmt] ExprStmt
-#  899|       0: [BuiltInVarArgsStart] __builtin_va_start
+#  899|     getStmt(1): [ExprStmt] ExprStmt
+#  899|       getExpr(): [BuiltInVarArgsStart] __builtin_va_start
 #  899|           Type = [VoidType] void
 #  899|           ValueCategory = prvalue
-#  899|         0: [VariableAccess] args
+#  899|         getVAList(): [VariableAccess] args
 #  899|             Type = [ArrayType] __va_list_tag[1]
 #  899|             ValueCategory = lvalue
-#  899|         1: [VariableAccess] x
+#  899|         getLastNamedParameter(): [VariableAccess] x
 #  899|             Type = [IntType] int
 #  899|             ValueCategory = lvalue
-#  899|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  899|         : [ArrayToPointerConversion] array to pointer conversion
 #  899|             Type = [PointerType] __va_list_tag *
 #  899|             ValueCategory = prvalue
-#  900|     2: [DeclStmt] declaration
-#  900|       0: [VariableDeclarationEntry] definition of args2
+#  900|     getStmt(2): [DeclStmt] declaration
+#  900|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of args2
 #  900|           Type = [ArrayType] __va_list_tag[1]
-#  901|     3: [ExprStmt] ExprStmt
-#  901|       0: [BuiltInVarArgCopy] __builtin_va_copy
+#  901|     getStmt(3): [ExprStmt] ExprStmt
+#  901|       getExpr(): [BuiltInVarArgCopy] __builtin_va_copy
 #  901|           Type = [VoidType] void
 #  901|           ValueCategory = prvalue
-#  901|         0: [VariableAccess] args2
+#  901|         getDestinationVAList(): [VariableAccess] args2
 #  901|             Type = [ArrayType] __va_list_tag[1]
 #  901|             ValueCategory = lvalue
-#  901|         1: [VariableAccess] args
+#  901|         getSourceVAList(): [VariableAccess] args
 #  901|             Type = [ArrayType] __va_list_tag[1]
 #  901|             ValueCategory = lvalue
-#  901|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  901|         : [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
-#  901|         1 converted: [ArrayToPointerConversion] array to pointer conversion
+#  901|         : [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
-#  902|     4: [DeclStmt] declaration
-#  902|       0: [VariableDeclarationEntry] definition of d
+#  902|     getStmt(4): [DeclStmt] declaration
+#  902|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 #  902|           Type = [DoubleType] double
-#  902|         init: [Initializer] initializer for d
-#  902|           expr: [BuiltInVarArg] __builtin_va_arg
+#  902|         getVariable().getInitializer(): [Initializer] initializer for d
+#  902|           getExpr(): [BuiltInVarArg] __builtin_va_arg
 #  902|               Type = [DoubleType] double
 #  902|               ValueCategory = prvalue(load)
-#  902|             0: [VariableAccess] args
+#  902|             getVAList(): [VariableAccess] args
 #  902|                 Type = [ArrayType] __va_list_tag[1]
 #  902|                 ValueCategory = lvalue
-#  902|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  902|             : [ArrayToPointerConversion] array to pointer conversion
 #  902|                 Type = [PointerType] __va_list_tag *
 #  902|                 ValueCategory = prvalue
-#  903|     5: [DeclStmt] declaration
-#  903|       0: [VariableDeclarationEntry] definition of f
+#  903|     getStmt(5): [DeclStmt] declaration
+#  903|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
 #  903|           Type = [FloatType] float
-#  903|         init: [Initializer] initializer for f
-#  903|           expr: [BuiltInVarArg] __builtin_va_arg
+#  903|         getVariable().getInitializer(): [Initializer] initializer for f
+#  903|           getExpr(): [BuiltInVarArg] __builtin_va_arg
 #  903|               Type = [IntType] int
 #  903|               ValueCategory = prvalue(load)
-#  903|             0: [VariableAccess] args
+#  903|             getVAList(): [VariableAccess] args
 #  903|                 Type = [ArrayType] __va_list_tag[1]
 #  903|                 ValueCategory = lvalue
-#  903|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  903|             : [ArrayToPointerConversion] array to pointer conversion
 #  903|                 Type = [PointerType] __va_list_tag *
 #  903|                 ValueCategory = prvalue
-#  903|           expr converted: [CStyleCast] (float)...
+#  903|           : [CStyleCast] (float)...
 #  903|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  903|               Type = [FloatType] float
 #  903|               ValueCategory = prvalue
-#  904|     6: [ExprStmt] ExprStmt
-#  904|       0: [BuiltInVarArgsEnd] __builtin_va_end
+#  904|     getStmt(6): [ExprStmt] ExprStmt
+#  904|       getExpr(): [BuiltInVarArgsEnd] __builtin_va_end
 #  904|           Type = [VoidType] void
 #  904|           ValueCategory = prvalue
-#  904|         0: [VariableAccess] args
+#  904|         getVAList(): [VariableAccess] args
 #  904|             Type = [ArrayType] __va_list_tag[1]
 #  904|             ValueCategory = lvalue
-#  904|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  904|         : [ArrayToPointerConversion] array to pointer conversion
 #  904|             Type = [PointerType] __va_list_tag *
 #  904|             ValueCategory = prvalue
-#  905|     7: [ExprStmt] ExprStmt
-#  905|       0: [FunctionCall] call to VAListUsage
+#  905|     getStmt(7): [ExprStmt] ExprStmt
+#  905|       getExpr(): [FunctionCall] call to VAListUsage
 #  905|           Type = [VoidType] void
 #  905|           ValueCategory = prvalue
-#  905|         0: [VariableAccess] x
+#  905|         getArgument(0): [VariableAccess] x
 #  905|             Type = [IntType] int
 #  905|             ValueCategory = prvalue(load)
-#  905|         1: [VariableAccess] args2
+#  905|         getArgument(1): [VariableAccess] args2
 #  905|             Type = [ArrayType] __va_list_tag[1]
 #  905|             ValueCategory = lvalue
-#  905|         1 converted: [ArrayToPointerConversion] array to pointer conversion
+#  905|         : [ArrayToPointerConversion] array to pointer conversion
 #  905|             Type = [PointerType] __va_list_tag *
 #  905|             ValueCategory = prvalue
-#  906|     8: [ExprStmt] ExprStmt
-#  906|       0: [BuiltInVarArgsEnd] __builtin_va_end
+#  906|     getStmt(8): [ExprStmt] ExprStmt
+#  906|       getExpr(): [BuiltInVarArgsEnd] __builtin_va_end
 #  906|           Type = [VoidType] void
 #  906|           ValueCategory = prvalue
-#  906|         0: [VariableAccess] args2
+#  906|         getVAList(): [VariableAccess] args2
 #  906|             Type = [ArrayType] __va_list_tag[1]
 #  906|             ValueCategory = lvalue
-#  906|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  906|         : [ArrayToPointerConversion] array to pointer conversion
 #  906|             Type = [PointerType] __va_list_tag *
 #  906|             ValueCategory = prvalue
-#  907|     9: [ReturnStmt] return ...
+#  907|     getStmt(9): [ReturnStmt] return ...
 #  909| [TopLevelFunction] void CastToVoid(int)
-#  909|   params: 
-#  909|     0: [Parameter] x
+#  909|   ...: 
+#  909|     getParameter(0): [Parameter] x
 #  909|         Type = [IntType] int
-#  909|   body: [BlockStmt] { ... }
-#  910|     0: [ExprStmt] ExprStmt
-#  910|       0: [VariableAccess] x
+#  909|   getEntryPoint(): [BlockStmt] { ... }
+#  910|     getStmt(0): [ExprStmt] ExprStmt
+#  910|       getExpr(): [VariableAccess] x
 #  910|           Type = [IntType] int
 #  910|           ValueCategory = lvalue
-#  910|       0 converted: [CStyleCast] (void)...
+#  910|       : [CStyleCast] (void)...
 #  910|           Conversion = [VoidConversion] conversion to void
 #  910|           Type = [VoidType] void
 #  910|           ValueCategory = prvalue
-#  911|     1: [ReturnStmt] return ...
+#  911|     getStmt(1): [ReturnStmt] return ...
 #  913| [TopLevelFunction] void ConstantConditions(int)
-#  913|   params: 
-#  913|     0: [Parameter] x
+#  913|   ...: 
+#  913|     getParameter(0): [Parameter] x
 #  913|         Type = [IntType] int
-#  913|   body: [BlockStmt] { ... }
-#  914|     0: [DeclStmt] declaration
-#  914|       0: [VariableDeclarationEntry] definition of a
+#  913|   getEntryPoint(): [BlockStmt] { ... }
+#  914|     getStmt(0): [DeclStmt] declaration
+#  914|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 #  914|           Type = [BoolType] bool
-#  914|         init: [Initializer] initializer for a
-#  914|           expr: [LogicalAndExpr] ... && ...
+#  914|         getVariable().getInitializer(): [Initializer] initializer for a
+#  914|           getExpr(): [LogicalAndExpr] ... && ...
 #  914|               Type = [BoolType] bool
 #  914|               Value = [LogicalAndExpr] 1
 #  914|               ValueCategory = prvalue
-#  914|             0: [Literal] 1
+#  914|             getLeftOperand(): [Literal] 1
 #  914|                 Type = [BoolType] bool
 #  914|                 Value = [Literal] 1
 #  914|                 ValueCategory = prvalue
-#  914|             1: [Literal] 1
+#  914|             getRightOperand(): [Literal] 1
 #  914|                 Type = [BoolType] bool
 #  914|                 Value = [Literal] 1
 #  914|                 ValueCategory = prvalue
-#  915|     1: [DeclStmt] declaration
-#  915|       0: [VariableDeclarationEntry] definition of b
+#  915|     getStmt(1): [DeclStmt] declaration
+#  915|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 #  915|           Type = [IntType] int
-#  915|         init: [Initializer] initializer for b
-#  915|           expr: [ConditionalExpr] ... ? ... : ...
+#  915|         getVariable().getInitializer(): [Initializer] initializer for b
+#  915|           getExpr(): [ConditionalExpr] ... ? ... : ...
 #  915|               Type = [IntType] int
 #  915|               ValueCategory = prvalue
-#  915|             0: [Literal] 1
+#  915|             getCondition(): [Literal] 1
 #  915|                 Type = [BoolType] bool
 #  915|                 Value = [Literal] 1
 #  915|                 ValueCategory = prvalue
-#  915|             1: [VariableAccess] x
+#  915|             getThen(): [VariableAccess] x
 #  915|                 Type = [IntType] int
 #  915|                 ValueCategory = prvalue(load)
-#  915|             2: [VariableAccess] x
+#  915|             getElse(): [VariableAccess] x
 #  915|                 Type = [IntType] int
 #  915|                 ValueCategory = prvalue(load)
-#  915|             0 converted: [ParenthesisExpr] (...)
+#  915|             : [ParenthesisExpr] (...)
 #  915|                 Type = [BoolType] bool
 #  915|                 Value = [ParenthesisExpr] 1
 #  915|                 ValueCategory = prvalue
-#  916|     2: [ReturnStmt] return ...
+#  916|     getStmt(2): [ReturnStmt] return ...
 #  924| [Operator,TopLevelFunction] void* operator new(size_t, float)
-#  924|   params: 
-#  924|     0: [Parameter] (unnamed parameter 0)
+#  924|   ...: 
+#  924|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  924|         Type = [CTypedefType,Size_t] size_t
-#  924|     1: [Parameter] (unnamed parameter 1)
+#  924|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  924|         Type = [FloatType] float
 #  925| [Operator,TopLevelFunction] void* operator new[](size_t, float)
-#  925|   params: 
-#  925|     0: [Parameter] (unnamed parameter 0)
+#  925|   ...: 
+#  925|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  925|         Type = [CTypedefType,Size_t] size_t
-#  925|     1: [Parameter] (unnamed parameter 1)
+#  925|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  925|         Type = [FloatType] float
 #  926| [Operator,TopLevelFunction] void* operator new(size_t, std::align_val_t, float)
-#  926|   params: 
-#  926|     0: [Parameter] (unnamed parameter 0)
+#  926|   ...: 
+#  926|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  926|         Type = [CTypedefType,Size_t] size_t
-#  926|     1: [Parameter] (unnamed parameter 1)
+#  926|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  926|         Type = [ScopedEnum] align_val_t
-#  926|     2: [Parameter] (unnamed parameter 2)
+#  926|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  926|         Type = [FloatType] float
 #  927| [Operator,TopLevelFunction] void* operator new[](size_t, std::align_val_t, float)
-#  927|   params: 
-#  927|     0: [Parameter] (unnamed parameter 0)
+#  927|   ...: 
+#  927|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  927|         Type = [CTypedefType,Size_t] size_t
-#  927|     1: [Parameter] (unnamed parameter 1)
+#  927|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  927|         Type = [ScopedEnum] align_val_t
-#  927|     2: [Parameter] (unnamed parameter 2)
+#  927|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  927|         Type = [FloatType] float
 #  928| [Operator,TopLevelFunction] void operator delete(void*, float)
-#  928|   params: 
-#  928|     0: [Parameter] (unnamed parameter 0)
+#  928|   ...: 
+#  928|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  928|         Type = [VoidPointerType] void *
-#  928|     1: [Parameter] (unnamed parameter 1)
+#  928|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  928|         Type = [FloatType] float
 #  929| [Operator,TopLevelFunction] void operator delete[](void*, float)
-#  929|   params: 
-#  929|     0: [Parameter] (unnamed parameter 0)
+#  929|   ...: 
+#  929|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  929|         Type = [VoidPointerType] void *
-#  929|     1: [Parameter] (unnamed parameter 1)
+#  929|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  929|         Type = [FloatType] float
 #  930| [Operator,TopLevelFunction] void operator delete(void*, std::align_val_t, float)
-#  930|   params: 
-#  930|     0: [Parameter] (unnamed parameter 0)
+#  930|   ...: 
+#  930|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  930|         Type = [VoidPointerType] void *
-#  930|     1: [Parameter] (unnamed parameter 1)
+#  930|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  930|         Type = [ScopedEnum] align_val_t
-#  930|     2: [Parameter] (unnamed parameter 2)
+#  930|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  930|         Type = [FloatType] float
 #  931| [Operator,TopLevelFunction] void operator delete[](void*, std::align_val_t, float)
-#  931|   params: 
-#  931|     0: [Parameter] (unnamed parameter 0)
+#  931|   ...: 
+#  931|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  931|         Type = [VoidPointerType] void *
-#  931|     1: [Parameter] (unnamed parameter 1)
+#  931|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  931|         Type = [ScopedEnum] align_val_t
-#  931|     2: [Parameter] (unnamed parameter 2)
+#  931|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  931|         Type = [FloatType] float
 #  933| [CopyAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc const&)
-#  933|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  933|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const SizedDealloc &
 #  933| [MoveAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc&&)
-#  933|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  933|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] SizedDealloc &&
 #  935| [MemberFunction] void* SizedDealloc::operator new(size_t)
-#  935|   params: 
-#  935|     0: [Parameter] (unnamed parameter 0)
+#  935|   ...: 
+#  935|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  935|         Type = [CTypedefType,Size_t] size_t
 #  936| [MemberFunction] void* SizedDealloc::operator new[](size_t)
-#  936|   params: 
-#  936|     0: [Parameter] (unnamed parameter 0)
+#  936|   ...: 
+#  936|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  936|         Type = [CTypedefType,Size_t] size_t
 #  937| [MemberFunction] void SizedDealloc::operator delete(void*, size_t)
-#  937|   params: 
-#  937|     0: [Parameter] (unnamed parameter 0)
+#  937|   ...: 
+#  937|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  937|         Type = [VoidPointerType] void *
-#  937|     1: [Parameter] (unnamed parameter 1)
+#  937|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  937|         Type = [CTypedefType,Size_t] size_t
 #  938| [MemberFunction] void SizedDealloc::operator delete[](void*, size_t)
-#  938|   params: 
-#  938|     0: [Parameter] (unnamed parameter 0)
+#  938|   ...: 
+#  938|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  938|         Type = [VoidPointerType] void *
-#  938|     1: [Parameter] (unnamed parameter 1)
+#  938|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  938|         Type = [CTypedefType,Size_t] size_t
 #  941| [CopyAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned const&)
-#  941|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  941|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Overaligned &
 #  941| [MoveAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned&&)
-#  941|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  941|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Overaligned &&
 #  945| [CopyAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam const&)
-#  945|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  945|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam&&)
-#  945|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  945|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  945| [CopyConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam const&)
-#  945|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  945|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam&&)
-#  945|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#  945|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  946| [Constructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(double)
-#  946|   params: 
-#  946|     0: [Parameter] d
+#  946|   ...: 
+#  946|     getParameter(0): [Parameter] d
 #  946|         Type = [DoubleType] double
 #  949| [TopLevelFunction] void OperatorNew()
-#  949|   params: 
-#  949|   body: [BlockStmt] { ... }
-#  950|     0: [ExprStmt] ExprStmt
-#  950|       0: [NewExpr] new
+#  949|   ...: 
+#  949|   getEntryPoint(): [BlockStmt] { ... }
+#  950|     getStmt(0): [ExprStmt] ExprStmt
+#  950|       getExpr(): [NewExpr] new
 #  950|           Type = [IntPointerType] int *
 #  950|           ValueCategory = prvalue
-#  951|     1: [ExprStmt] ExprStmt
-#  951|       0: [NewExpr] new
+#  951|     getStmt(1): [ExprStmt] ExprStmt
+#  951|       getExpr(): [NewExpr] new
 #  951|           Type = [IntPointerType] int *
 #  951|           ValueCategory = prvalue
-#  951|         0: [FunctionCall] call to operator new
+#  951|         getAllocatorCall(): [FunctionCall] call to operator new
 #  951|             Type = [VoidPointerType] void *
 #  951|             ValueCategory = prvalue
-#  951|           0: [ErrorExpr] <error expr>
+#  951|           getArgument(0): [ErrorExpr] <error expr>
 #  951|               Type = [LongType] unsigned long
 #  951|               ValueCategory = prvalue
-#  951|           1: [Literal] 1.0
+#  951|           getArgument(1): [Literal] 1.0
 #  951|               Type = [FloatType] float
 #  951|               Value = [Literal] 1.0
 #  951|               ValueCategory = prvalue
-#  952|     2: [ExprStmt] ExprStmt
-#  952|       0: [NewExpr] new
+#  952|     getStmt(2): [ExprStmt] ExprStmt
+#  952|       getExpr(): [NewExpr] new
 #  952|           Type = [IntPointerType] int *
 #  952|           ValueCategory = prvalue
-#  952|         1: [Literal] 0
+#  952|         getInitializer(): [Literal] 0
 #  952|             Type = [IntType] int
 #  952|             Value = [Literal] 0
 #  952|             ValueCategory = prvalue
-#  953|     3: [ExprStmt] ExprStmt
-#  953|       0: [NewExpr] new
+#  953|     getStmt(3): [ExprStmt] ExprStmt
+#  953|       getExpr(): [NewExpr] new
 #  953|           Type = [PointerType] String *
 #  953|           ValueCategory = prvalue
-#  953|         1: [ConstructorCall] call to String
+#  953|         getInitializer(): [ConstructorCall] call to String
 #  953|             Type = [VoidType] void
 #  953|             ValueCategory = prvalue
-#  954|     4: [ExprStmt] ExprStmt
-#  954|       0: [NewExpr] new
+#  954|     getStmt(4): [ExprStmt] ExprStmt
+#  954|       getExpr(): [NewExpr] new
 #  954|           Type = [PointerType] String *
 #  954|           ValueCategory = prvalue
-#  954|         0: [FunctionCall] call to operator new
+#  954|         getAllocatorCall(): [FunctionCall] call to operator new
 #  954|             Type = [VoidPointerType] void *
 #  954|             ValueCategory = prvalue
-#  954|           0: [ErrorExpr] <error expr>
+#  954|           getArgument(0): [ErrorExpr] <error expr>
 #  954|               Type = [LongType] unsigned long
 #  954|               ValueCategory = prvalue
-#  954|           1: [Literal] 1.0
+#  954|           getArgument(1): [Literal] 1.0
 #  954|               Type = [FloatType] float
 #  954|               Value = [Literal] 1.0
 #  954|               ValueCategory = prvalue
-#  954|         1: [ConstructorCall] call to String
+#  954|         getInitializer(): [ConstructorCall] call to String
 #  954|             Type = [VoidType] void
 #  954|             ValueCategory = prvalue
-#  954|           0: hello
+#  954|           getArgument(0): hello
 #  954|               Type = [ArrayType] const char[6]
 #  954|               Value = [StringLiteral] "hello"
 #  954|               ValueCategory = lvalue
-#  954|           0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  954|           : [ArrayToPointerConversion] array to pointer conversion
 #  954|               Type = [PointerType] const char *
 #  954|               ValueCategory = prvalue
-#  955|     5: [ExprStmt] ExprStmt
-#  955|       0: [NewExpr] new
+#  955|     getStmt(5): [ExprStmt] ExprStmt
+#  955|       getExpr(): [NewExpr] new
 #  955|           Type = [PointerType] Overaligned *
 #  955|           ValueCategory = prvalue
-#  955|         3: [Literal] 128
+#  955|         getAlignmentArgument(): [Literal] 128
 #  955|             Type = [ScopedEnum] align_val_t
 #  955|             Value = [Literal] 128
 #  955|             ValueCategory = prvalue
-#  956|     6: [ExprStmt] ExprStmt
-#  956|       0: [NewExpr] new
+#  956|     getStmt(6): [ExprStmt] ExprStmt
+#  956|       getExpr(): [NewExpr] new
 #  956|           Type = [PointerType] Overaligned *
 #  956|           ValueCategory = prvalue
-#  956|         0: [FunctionCall] call to operator new
+#  956|         getAllocatorCall(): [FunctionCall] call to operator new
 #  956|             Type = [VoidPointerType] void *
 #  956|             ValueCategory = prvalue
-#  956|           0: [ErrorExpr] <error expr>
+#  956|           getArgument(0): [ErrorExpr] <error expr>
 #  956|               Type = [LongType] unsigned long
 #  956|               ValueCategory = prvalue
-#  956|           1: [Literal] 128
+#  956|           getArgument(1): [Literal] 128
 #  956|               Type = [ScopedEnum] align_val_t
 #  956|               Value = [Literal] 128
 #  956|               ValueCategory = prvalue
-#  956|           2: [Literal] 1.0
+#  956|           getArgument(2): [Literal] 1.0
 #  956|               Type = [FloatType] float
 #  956|               Value = [Literal] 1.0
 #  956|               ValueCategory = prvalue
-#  956|         1: [Literal] 0
+#  956|         getInitializer(): [Literal] 0
 #  956|             Type = [Struct] Overaligned
 #  956|             Value = [Literal] 0
 #  956|             ValueCategory = prvalue
-#  957|     7: [ReturnStmt] return ...
+#  957|     getStmt(7): [ReturnStmt] return ...
 #  959| [TopLevelFunction] void OperatorNewArray(int)
-#  959|   params: 
-#  959|     0: [Parameter] n
+#  959|   ...: 
+#  959|     getParameter(0): [Parameter] n
 #  959|         Type = [IntType] int
-#  959|   body: [BlockStmt] { ... }
-#  960|     0: [ExprStmt] ExprStmt
-#  960|       0: [NewArrayExpr] new[]
+#  959|   getEntryPoint(): [BlockStmt] { ... }
+#  960|     getStmt(0): [ExprStmt] ExprStmt
+#  960|       getExpr(): [NewArrayExpr] new[]
 #  960|           Type = [IntPointerType] int *
 #  960|           ValueCategory = prvalue
-#  961|     1: [ExprStmt] ExprStmt
-#  961|       0: [NewArrayExpr] new[]
+#  961|     getStmt(1): [ExprStmt] ExprStmt
+#  961|       getExpr(): [NewArrayExpr] new[]
 #  961|           Type = [IntPointerType] int *
 #  961|           ValueCategory = prvalue
-#  961|         2: [VariableAccess] n
+#  961|         getExtent(): [VariableAccess] n
 #  961|             Type = [IntType] int
 #  961|             ValueCategory = prvalue(load)
-#  962|     2: [ExprStmt] ExprStmt
-#  962|       0: [NewArrayExpr] new[]
+#  962|     getStmt(2): [ExprStmt] ExprStmt
+#  962|       getExpr(): [NewArrayExpr] new[]
 #  962|           Type = [IntPointerType] int *
 #  962|           ValueCategory = prvalue
-#  962|         0: [FunctionCall] call to operator new[]
+#  962|         getAllocatorCall(): [FunctionCall] call to operator new[]
 #  962|             Type = [VoidPointerType] void *
 #  962|             ValueCategory = prvalue
-#  962|           0: [ErrorExpr] <error expr>
+#  962|           getArgument(0): [ErrorExpr] <error expr>
 #  962|               Type = [LongType] unsigned long
 #  962|               ValueCategory = prvalue
-#  962|           1: [Literal] 1.0
+#  962|           getArgument(1): [Literal] 1.0
 #  962|               Type = [FloatType] float
 #  962|               Value = [Literal] 1.0
 #  962|               ValueCategory = prvalue
-#  962|         2: [VariableAccess] n
+#  962|         getExtent(): [VariableAccess] n
 #  962|             Type = [IntType] int
 #  962|             ValueCategory = prvalue(load)
-#  963|     3: [ExprStmt] ExprStmt
-#  963|       0: [NewArrayExpr] new[]
+#  963|     getStmt(3): [ExprStmt] ExprStmt
+#  963|       getExpr(): [NewArrayExpr] new[]
 #  963|           Type = [PointerType] String *
 #  963|           ValueCategory = prvalue
-#  963|         1: [ArrayAggregateLiteral] {...}
+#  963|         getInitializer(): [ArrayAggregateLiteral] {...}
 #  963|             Type = [ArrayType] String[]
 #  963|             ValueCategory = prvalue
-#  963|           [0]: [ConstructorCall] call to String
+#  963|           getElementExpr(0): [ConstructorCall] call to String
 #  963|               Type = [VoidType] void
 #  963|               ValueCategory = prvalue
-#  963|         2: [VariableAccess] n
+#  963|         getExtent(): [VariableAccess] n
 #  963|             Type = [IntType] int
 #  963|             ValueCategory = prvalue(load)
-#  964|     4: [ExprStmt] ExprStmt
-#  964|       0: [NewArrayExpr] new[]
+#  964|     getStmt(4): [ExprStmt] ExprStmt
+#  964|       getExpr(): [NewArrayExpr] new[]
 #  964|           Type = [PointerType] Overaligned *
 #  964|           ValueCategory = prvalue
-#  964|         2: [VariableAccess] n
+#  964|         getExtent(): [VariableAccess] n
 #  964|             Type = [IntType] int
 #  964|             ValueCategory = prvalue(load)
-#  964|         3: [Literal] 128
+#  964|         getAlignmentArgument(): [Literal] 128
 #  964|             Type = [ScopedEnum] align_val_t
 #  964|             Value = [Literal] 128
 #  964|             ValueCategory = prvalue
-#  965|     5: [ExprStmt] ExprStmt
-#  965|       0: [NewArrayExpr] new[]
+#  965|     getStmt(5): [ExprStmt] ExprStmt
+#  965|       getExpr(): [NewArrayExpr] new[]
 #  965|           Type = [PointerType] Overaligned *
 #  965|           ValueCategory = prvalue
-#  965|         0: [FunctionCall] call to operator new[]
+#  965|         getAllocatorCall(): [FunctionCall] call to operator new[]
 #  965|             Type = [VoidPointerType] void *
 #  965|             ValueCategory = prvalue
-#  965|           0: [ErrorExpr] <error expr>
+#  965|           getArgument(0): [ErrorExpr] <error expr>
 #  965|               Type = [LongType] unsigned long
 #  965|               ValueCategory = prvalue
-#  965|           1: [Literal] 128
+#  965|           getArgument(1): [Literal] 128
 #  965|               Type = [ScopedEnum] align_val_t
 #  965|               Value = [Literal] 128
 #  965|               ValueCategory = prvalue
-#  965|           2: [Literal] 1.0
+#  965|           getArgument(2): [Literal] 1.0
 #  965|               Type = [FloatType] float
 #  965|               Value = [Literal] 1.0
 #  965|               ValueCategory = prvalue
-#  966|     6: [ExprStmt] ExprStmt
-#  966|       0: [NewArrayExpr] new[]
+#  966|     getStmt(6): [ExprStmt] ExprStmt
+#  966|       getExpr(): [NewArrayExpr] new[]
 #  966|           Type = [PointerType] DefaultCtorWithDefaultParam *
 #  966|           ValueCategory = prvalue
-#  966|         1: [ArrayAggregateLiteral] {...}
+#  966|         getInitializer(): [ArrayAggregateLiteral] {...}
 #  966|             Type = [ArrayType] DefaultCtorWithDefaultParam[]
 #  966|             ValueCategory = prvalue
-#  966|           [0]: [ConstructorCall] call to DefaultCtorWithDefaultParam
+#  966|           getElementExpr(0): [ConstructorCall] call to DefaultCtorWithDefaultParam
 #  966|               Type = [VoidType] void
 #  966|               ValueCategory = prvalue
-#  966|         2: [VariableAccess] n
+#  966|         getExtent(): [VariableAccess] n
 #  966|             Type = [IntType] int
 #  966|             ValueCategory = prvalue(load)
-#  967|     7: [ExprStmt] ExprStmt
-#  967|       0: [NewArrayExpr] new[]
+#  967|     getStmt(7): [ExprStmt] ExprStmt
+#  967|       getExpr(): [NewArrayExpr] new[]
 #  967|           Type = [IntPointerType] int *
 #  967|           ValueCategory = prvalue
-#  967|         1: [ArrayAggregateLiteral] {...}
+#  967|         getInitializer(): [ArrayAggregateLiteral] {...}
 #  967|             Type = [ArrayType] int[3]
 #  967|             ValueCategory = prvalue
-#  967|           [0]: [Literal] 0
+#  967|           getElementExpr(0): [Literal] 0
 #  967|               Type = [IntType] int
 #  967|               Value = [Literal] 0
 #  967|               ValueCategory = prvalue
-#  967|           [1]: [Literal] 1
+#  967|           getElementExpr(1): [Literal] 1
 #  967|               Type = [IntType] int
 #  967|               Value = [Literal] 1
 #  967|               ValueCategory = prvalue
-#  967|           [2]: [Literal] 2
+#  967|           getElementExpr(2): [Literal] 2
 #  967|               Type = [IntType] int
 #  967|               Value = [Literal] 2
 #  967|               ValueCategory = prvalue
-#  967|         2: [VariableAccess] n
+#  967|         getExtent(): [VariableAccess] n
 #  967|             Type = [IntType] int
 #  967|             ValueCategory = prvalue(load)
-#  968|     8: [ReturnStmt] return ...
+#  968|     getStmt(8): [ReturnStmt] return ...
 #  970| [TopLevelFunction] int designatedInit()
-#  970|   params: 
-#  970|   body: [BlockStmt] { ... }
-#  971|     0: [DeclStmt] declaration
-#  971|       0: [VariableDeclarationEntry] definition of a1
+#  970|   ...: 
+#  970|   getEntryPoint(): [BlockStmt] { ... }
+#  971|     getStmt(0): [DeclStmt] declaration
+#  971|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a1
 #  971|           Type = [ArrayType] int[1000]
-#  971|         init: [Initializer] initializer for a1
-#  971|           expr: [ArrayAggregateLiteral] {...}
+#  971|         getVariable().getInitializer(): [Initializer] initializer for a1
+#  971|           getExpr(): [ArrayAggregateLiteral] {...}
 #  971|               Type = [ArrayType] int[1000]
 #  971|               ValueCategory = prvalue
-#  971|             [2]: [Literal] 10002
+#  971|             getElementExpr(2): [Literal] 10002
 #  971|                 Type = [IntType] int
 #  971|                 Value = [Literal] 10002
 #  971|                 ValueCategory = prvalue
-#  971|             [900]: [Literal] 10900
+#  971|             getElementExpr(900): [Literal] 10900
 #  971|                 Type = [IntType] int
 #  971|                 Value = [Literal] 10900
 #  971|                 ValueCategory = prvalue
-#  972|     1: [ReturnStmt] return ...
-#  972|       0: [ArrayExpr] access to array
+#  972|     getStmt(1): [ReturnStmt] return ...
+#  972|       getExpr(): [ArrayExpr] access to array
 #  972|           Type = [IntType] int
 #  972|           ValueCategory = prvalue(load)
-#  972|         0: [VariableAccess] a1
+#  972|         getArrayBase(): [VariableAccess] a1
 #  972|             Type = [ArrayType] int[1000]
 #  972|             ValueCategory = lvalue
-#  972|         1: [Literal] 900
+#  972|         getArrayOffset(): [Literal] 900
 #  972|             Type = [IntType] int
 #  972|             Value = [Literal] 900
 #  972|             ValueCategory = prvalue
-#  972|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#  972|         : [ArrayToPointerConversion] array to pointer conversion
 #  972|             Type = [IntPointerType] int *
 #  972|             ValueCategory = prvalue
 #  975| [TopLevelFunction] void IfStmtWithDeclaration(int, int)
-#  975|   params: 
-#  975|     0: [Parameter] x
+#  975|   ...: 
+#  975|     getParameter(0): [Parameter] x
 #  975|         Type = [IntType] int
-#  975|     1: [Parameter] y
+#  975|     getParameter(1): [Parameter] y
 #  975|         Type = [IntType] int
-#  975|   body: [BlockStmt] { ... }
-#  976|     0: [IfStmt] if (...) ... 
-#  976|       0: [ConditionDeclExpr] (condition decl)
+#  975|   getEntryPoint(): [BlockStmt] { ... }
+#  976|     getStmt(0): [IfStmt] if (...) ... 
+#  976|       getCondition(): [ConditionDeclExpr] (condition decl)
 #  976|           Type = [BoolType] bool
 #  976|           ValueCategory = prvalue
-#  976|         0: [VariableAccess] b
+#  976|         getVariableAccess(): [VariableAccess] b
 #  976|             Type = [BoolType] bool
 #  976|             ValueCategory = prvalue(load)
-#  976|       1: [BlockStmt] { ... }
-#  977|         0: [ExprStmt] ExprStmt
-#  977|           0: [AssignExpr] ... = ...
+#  976|       getThen(): [BlockStmt] { ... }
+#  977|         getStmt(0): [ExprStmt] ExprStmt
+#  977|           getExpr(): [AssignExpr] ... = ...
 #  977|               Type = [IntType] int
 #  977|               ValueCategory = lvalue
-#  977|             0: [VariableAccess] x
+#  977|             getLValue(): [VariableAccess] x
 #  977|                 Type = [IntType] int
 #  977|                 ValueCategory = lvalue
-#  977|             1: [Literal] 5
+#  977|             getRValue(): [Literal] 5
 #  977|                 Type = [IntType] int
 #  977|                 Value = [Literal] 5
 #  977|                 ValueCategory = prvalue
-#  979|       2: [IfStmt] if (...) ... 
-#  979|         0: [ConditionDeclExpr] (condition decl)
+#  979|       getElse(): [IfStmt] if (...) ... 
+#  979|         getCondition(): [ConditionDeclExpr] (condition decl)
 #  979|             Type = [BoolType] bool
 #  979|             ValueCategory = prvalue
-#  979|           0: [VariableAccess] z
+#  979|           getVariableAccess(): [VariableAccess] z
 #  979|               Type = [IntType] int
 #  979|               ValueCategory = prvalue(load)
-#  979|           0 converted: [CStyleCast] (bool)...
+#  979|           : [CStyleCast] (bool)...
 #  979|               Conversion = [BoolConversion] conversion to bool
 #  979|               Type = [BoolType] bool
 #  979|               ValueCategory = prvalue
-#  979|         1: [BlockStmt] { ... }
-#  980|           0: [ExprStmt] ExprStmt
-#  980|             0: [AssignExpr] ... = ...
+#  979|         getThen(): [BlockStmt] { ... }
+#  980|           getStmt(0): [ExprStmt] ExprStmt
+#  980|             getExpr(): [AssignExpr] ... = ...
 #  980|                 Type = [IntType] int
 #  980|                 ValueCategory = lvalue
-#  980|               0: [VariableAccess] y
+#  980|               getLValue(): [VariableAccess] y
 #  980|                   Type = [IntType] int
 #  980|                   ValueCategory = lvalue
-#  980|               1: [Literal] 7
+#  980|               getRValue(): [Literal] 7
 #  980|                   Type = [IntType] int
 #  980|                   Value = [Literal] 7
 #  980|                   ValueCategory = prvalue
-#  982|         2: [IfStmt] if (...) ... 
-#  982|           0: [ConditionDeclExpr] (condition decl)
+#  982|         getElse(): [IfStmt] if (...) ... 
+#  982|           getCondition(): [ConditionDeclExpr] (condition decl)
 #  982|               Type = [BoolType] bool
 #  982|               ValueCategory = prvalue
-#  982|             0: [VariableAccess] p
+#  982|             getVariableAccess(): [VariableAccess] p
 #  982|                 Type = [IntPointerType] int *
 #  982|                 ValueCategory = prvalue(load)
-#  982|             0 converted: [CStyleCast] (bool)...
+#  982|             : [CStyleCast] (bool)...
 #  982|                 Conversion = [BoolConversion] conversion to bool
 #  982|                 Type = [BoolType] bool
 #  982|                 ValueCategory = prvalue
-#  982|           1: [BlockStmt] { ... }
-#  983|             0: [ExprStmt] ExprStmt
-#  983|               0: [AssignExpr] ... = ...
+#  982|           getThen(): [BlockStmt] { ... }
+#  983|             getStmt(0): [ExprStmt] ExprStmt
+#  983|               getExpr(): [AssignExpr] ... = ...
 #  983|                   Type = [IntType] int
 #  983|                   ValueCategory = lvalue
-#  983|                 0: [PointerDereferenceExpr] * ...
+#  983|                 getLValue(): [PointerDereferenceExpr] * ...
 #  983|                     Type = [IntType] int
 #  983|                     ValueCategory = lvalue
-#  983|                   0: [VariableAccess] p
+#  983|                   getOperand(): [VariableAccess] p
 #  983|                       Type = [IntPointerType] int *
 #  983|                       ValueCategory = prvalue(load)
-#  983|                 1: [Literal] 2
+#  983|                 getRValue(): [Literal] 2
 #  983|                     Type = [IntType] int
 #  983|                     Value = [Literal] 2
 #  983|                     ValueCategory = prvalue
-#  985|     1: [ReturnStmt] return ...
+#  985|     getStmt(1): [ReturnStmt] return ...
 #  987| [TopLevelFunction] void WhileStmtWithDeclaration(int, int)
-#  987|   params: 
-#  987|     0: [Parameter] x
+#  987|   ...: 
+#  987|     getParameter(0): [Parameter] x
 #  987|         Type = [IntType] int
-#  987|     1: [Parameter] y
+#  987|     getParameter(1): [Parameter] y
 #  987|         Type = [IntType] int
-#  987|   body: [BlockStmt] { ... }
-#  988|     0: [WhileStmt] while (...) ...
-#  988|       0: [ConditionDeclExpr] (condition decl)
+#  987|   getEntryPoint(): [BlockStmt] { ... }
+#  988|     getStmt(0): [WhileStmt] while (...) ...
+#  988|       getCondition(): [ConditionDeclExpr] (condition decl)
 #  988|           Type = [BoolType] bool
 #  988|           ValueCategory = prvalue
-#  988|         0: [VariableAccess] b
+#  988|         getVariableAccess(): [VariableAccess] b
 #  988|             Type = [BoolType] bool
 #  988|             ValueCategory = prvalue(load)
-#  988|       1: [BlockStmt] { ... }
-#  990|     1: [WhileStmt] while (...) ...
-#  990|       0: [ConditionDeclExpr] (condition decl)
+#  988|       getStmt(): [BlockStmt] { ... }
+#  990|     getStmt(1): [WhileStmt] while (...) ...
+#  990|       getCondition(): [ConditionDeclExpr] (condition decl)
 #  990|           Type = [BoolType] bool
 #  990|           ValueCategory = prvalue
-#  990|         0: [VariableAccess] z
+#  990|         getVariableAccess(): [VariableAccess] z
 #  990|             Type = [IntType] int
 #  990|             ValueCategory = prvalue(load)
-#  990|         0 converted: [CStyleCast] (bool)...
+#  990|         : [CStyleCast] (bool)...
 #  990|             Conversion = [BoolConversion] conversion to bool
 #  990|             Type = [BoolType] bool
 #  990|             ValueCategory = prvalue
-#  990|       1: [BlockStmt] { ... }
-#  992|     2: [WhileStmt] while (...) ...
-#  992|       0: [ConditionDeclExpr] (condition decl)
+#  990|       getStmt(): [BlockStmt] { ... }
+#  992|     getStmt(2): [WhileStmt] while (...) ...
+#  992|       getCondition(): [ConditionDeclExpr] (condition decl)
 #  992|           Type = [BoolType] bool
 #  992|           ValueCategory = prvalue
-#  992|         0: [VariableAccess] p
+#  992|         getVariableAccess(): [VariableAccess] p
 #  992|             Type = [IntPointerType] int *
 #  992|             ValueCategory = prvalue(load)
-#  992|         0 converted: [CStyleCast] (bool)...
+#  992|         : [CStyleCast] (bool)...
 #  992|             Conversion = [BoolConversion] conversion to bool
 #  992|             Type = [BoolType] bool
 #  992|             ValueCategory = prvalue
-#  992|       1: [BlockStmt] { ... }
-#  994|     3: [ReturnStmt] return ...
+#  992|       getStmt(): [BlockStmt] { ... }
+#  994|     getStmt(3): [ReturnStmt] return ...
 #  996| [TopLevelFunction] int PointerDecay(int[], int(float))
-#  996|   params: 
-#  996|     0: [Parameter] a
+#  996|   ...: 
+#  996|     getParameter(0): [Parameter] a
 #  996|         Type = [ArrayType] int[]
-#  996|     1: [Parameter] fn
+#  996|     getParameter(1): [Parameter] fn
 #  996|         Type = [RoutineType] ..()(..)
-#  996|   body: [BlockStmt] { ... }
-#  997|     0: [ReturnStmt] return ...
-#  997|       0: [AddExpr] ... + ...
+#  996|   getEntryPoint(): [BlockStmt] { ... }
+#  997|     getStmt(0): [ReturnStmt] return ...
+#  997|       getExpr(): [AddExpr] ... + ...
 #  997|           Type = [IntType] int
 #  997|           ValueCategory = prvalue
-#  997|         0: [ArrayExpr] access to array
+#  997|         getLeftOperand(): [ArrayExpr] access to array
 #  997|             Type = [IntType] int
 #  997|             ValueCategory = prvalue(load)
-#  997|           0: [VariableAccess] a
+#  997|           getArrayBase(): [VariableAccess] a
 #  997|               Type = [IntPointerType] int *
 #  997|               ValueCategory = prvalue(load)
-#  997|           1: [Literal] 0
+#  997|           getArrayOffset(): [Literal] 0
 #  997|               Type = [IntType] int
 #  997|               Value = [Literal] 0
 #  997|               ValueCategory = prvalue
-#  997|         1: [VariableCall] call to expression
+#  997|         getRightOperand(): [VariableCall] call to expression
 #  997|             Type = [IntType] int
 #  997|             ValueCategory = prvalue
-#  997|           0: [VariableAccess] fn
+#  997|           getExpr(): [VariableAccess] fn
 #  997|               Type = [FunctionPointerType] ..(*)(..)
 #  997|               ValueCategory = prvalue(load)
-#  997|           1: [Literal] 1.0
+#  997|           getArgument(0): [Literal] 1.0
 #  997|               Type = [DoubleType] double
 #  997|               Value = [Literal] 1.0
 #  997|               ValueCategory = prvalue
-#  997|           1 converted: [CStyleCast] (float)...
+#  997|           : [CStyleCast] (float)...
 #  997|               Conversion = [FloatingPointConversion] floating point conversion
 #  997|               Type = [FloatType] float
 #  997|               Value = [CStyleCast] 1.0
 #  997|               ValueCategory = prvalue
 # 1000| [TopLevelFunction] int ExprStmt(int, int, int)
-# 1000|   params: 
-# 1000|     0: [Parameter] b
+# 1000|   ...: 
+# 1000|     getParameter(0): [Parameter] b
 # 1000|         Type = [IntType] int
-# 1000|     1: [Parameter] y
+# 1000|     getParameter(1): [Parameter] y
 # 1000|         Type = [IntType] int
-# 1000|     2: [Parameter] z
+# 1000|     getParameter(2): [Parameter] z
 # 1000|         Type = [IntType] int
-# 1000|   body: [BlockStmt] { ... }
-# 1001|     0: [DeclStmt] declaration
-# 1001|       0: [VariableDeclarationEntry] definition of x
+# 1000|   getEntryPoint(): [BlockStmt] { ... }
+# 1001|     getStmt(0): [DeclStmt] declaration
+# 1001|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 # 1001|           Type = [IntType] int
-# 1001|         init: [Initializer] initializer for x
-# 1001|           expr: [StmtExpr] (statement expression)
+# 1001|         getVariable().getInitializer(): [Initializer] initializer for x
+# 1001|           getExpr(): [StmtExpr] (statement expression)
 # 1001|               Type = [IntType] int
 # 1001|               ValueCategory = prvalue
-# 1011|     1: [ReturnStmt] return ...
-# 1011|       0: [StmtExpr] (statement expression)
+# 1011|     getStmt(1): [ReturnStmt] return ...
+# 1011|       getExpr(): [StmtExpr] (statement expression)
 # 1011|           Type = [IntType] int
 # 1011|           ValueCategory = prvalue
 # 1015| [TopLevelFunction] void OperatorDelete()
-# 1015|   params: 
-# 1015|   body: [BlockStmt] { ... }
-# 1016|     0: [ExprStmt] ExprStmt
-# 1016|       0: [DeleteExpr] delete
+# 1015|   ...: 
+# 1015|   getEntryPoint(): [BlockStmt] { ... }
+# 1016|     getStmt(0): [ExprStmt] ExprStmt
+# 1016|       getExpr(): [DeleteExpr] delete
 # 1016|           Type = [VoidType] void
 # 1016|           ValueCategory = prvalue
-# 1016|         3: [Literal] 0
+# 1016|         getExpr(): [Literal] 0
 # 1016|             Type = [NullPointerType] decltype(nullptr)
 # 1016|             Value = [Literal] 0
 # 1016|             ValueCategory = prvalue
-# 1016|         3 converted: [StaticCast] static_cast<int *>...
+# 1016|         : [StaticCast] static_cast<int *>...
 # 1016|             Conversion = [PointerConversion] pointer conversion
 # 1016|             Type = [IntPointerType] int *
 # 1016|             Value = [StaticCast] 0
 # 1016|             ValueCategory = prvalue
-# 1017|     1: [ExprStmt] ExprStmt
-# 1017|       0: [DeleteExpr] delete
+# 1017|     getStmt(1): [ExprStmt] ExprStmt
+# 1017|       getExpr(): [DeleteExpr] delete
 # 1017|           Type = [VoidType] void
 # 1017|           ValueCategory = prvalue
-# 1017|         1: [DestructorCall] call to ~String
+# 1017|         getDestructorCall(): [DestructorCall] call to ~String
 # 1017|             Type = [VoidType] void
 # 1017|             ValueCategory = prvalue
-# 1017|           -1: [Literal] 0
+# 1017|           getQualifier(): [Literal] 0
 # 1017|               Type = [NullPointerType] decltype(nullptr)
 # 1017|               Value = [Literal] 0
 # 1017|               ValueCategory = prvalue
-# 1017|           -1: [StaticCast] static_cast<String *>...
+# 1017|           getQualifier(): [StaticCast] static_cast<String *>...
 # 1017|               Conversion = [PointerConversion] pointer conversion
 # 1017|               Type = [PointerType] String *
 # 1017|               Value = [StaticCast] 0
 # 1017|               ValueCategory = prvalue
-# 1018|     2: [ExprStmt] ExprStmt
-# 1018|       0: [DeleteExpr] delete
+# 1018|     getStmt(2): [ExprStmt] ExprStmt
+# 1018|       getExpr(): [DeleteExpr] delete
 # 1018|           Type = [VoidType] void
 # 1018|           ValueCategory = prvalue
-# 1018|         0: [FunctionCall] call to operator delete
+# 1018|         getAllocatorCall(): [FunctionCall] call to operator delete
 # 1018|             Type = [VoidType] void
 # 1018|             ValueCategory = prvalue
-# 1018|         3: [Literal] 0
+# 1018|         getExpr(): [Literal] 0
 # 1018|             Type = [NullPointerType] decltype(nullptr)
 # 1018|             Value = [Literal] 0
 # 1018|             ValueCategory = prvalue
-# 1018|         3 converted: [StaticCast] static_cast<SizedDealloc *>...
+# 1018|         : [StaticCast] static_cast<SizedDealloc *>...
 # 1018|             Conversion = [PointerConversion] pointer conversion
 # 1018|             Type = [PointerType] SizedDealloc *
 # 1018|             Value = [StaticCast] 0
 # 1018|             ValueCategory = prvalue
-# 1019|     3: [ExprStmt] ExprStmt
-# 1019|       0: [DeleteExpr] delete
+# 1019|     getStmt(3): [ExprStmt] ExprStmt
+# 1019|       getExpr(): [DeleteExpr] delete
 # 1019|           Type = [VoidType] void
 # 1019|           ValueCategory = prvalue
-# 1019|         3: [Literal] 0
+# 1019|         getExpr(): [Literal] 0
 # 1019|             Type = [NullPointerType] decltype(nullptr)
 # 1019|             Value = [Literal] 0
 # 1019|             ValueCategory = prvalue
-# 1019|         3 converted: [StaticCast] static_cast<Overaligned *>...
+# 1019|         : [StaticCast] static_cast<Overaligned *>...
 # 1019|             Conversion = [PointerConversion] pointer conversion
 # 1019|             Type = [PointerType] Overaligned *
 # 1019|             Value = [StaticCast] 0
 # 1019|             ValueCategory = prvalue
-# 1020|     4: [ExprStmt] ExprStmt
-# 1020|       0: [DeleteExpr] delete
+# 1020|     getStmt(4): [ExprStmt] ExprStmt
+# 1020|       getExpr(): [DeleteExpr] delete
 # 1020|           Type = [VoidType] void
 # 1020|           ValueCategory = prvalue
-# 1020|         1: [DestructorCall] call to ~PolymorphicBase
+# 1020|         getDestructorCall(): [DestructorCall] call to ~PolymorphicBase
 # 1020|             Type = [VoidType] void
 # 1020|             ValueCategory = prvalue
-# 1020|           -1: [Literal] 0
+# 1020|           getQualifier(): [Literal] 0
 # 1020|               Type = [NullPointerType] decltype(nullptr)
 # 1020|               Value = [Literal] 0
 # 1020|               ValueCategory = prvalue
-# 1020|           -1: [StaticCast] static_cast<PolymorphicBase *>...
+# 1020|           getQualifier(): [StaticCast] static_cast<PolymorphicBase *>...
 # 1020|               Conversion = [PointerConversion] pointer conversion
 # 1020|               Type = [PointerType] PolymorphicBase *
 # 1020|               Value = [StaticCast] 0
 # 1020|               ValueCategory = prvalue
-# 1021|     5: [ReturnStmt] return ...
+# 1021|     getStmt(5): [ReturnStmt] return ...
 # 1024| [TopLevelFunction] void OperatorDeleteArray()
-# 1024|   params: 
-# 1024|   body: [BlockStmt] { ... }
-# 1025|     0: [ExprStmt] ExprStmt
-# 1025|       0: [DeleteArrayExpr] delete[]
+# 1024|   ...: 
+# 1024|   getEntryPoint(): [BlockStmt] { ... }
+# 1025|     getStmt(0): [ExprStmt] ExprStmt
+# 1025|       getExpr(): [DeleteArrayExpr] delete[]
 # 1025|           Type = [VoidType] void
 # 1025|           ValueCategory = prvalue
-# 1025|         3: [Literal] 0
+# 1025|         getExpr(): [Literal] 0
 # 1025|             Type = [NullPointerType] decltype(nullptr)
 # 1025|             Value = [Literal] 0
 # 1025|             ValueCategory = prvalue
-# 1025|         3 converted: [StaticCast] static_cast<int *>...
+# 1025|         : [StaticCast] static_cast<int *>...
 # 1025|             Conversion = [PointerConversion] pointer conversion
 # 1025|             Type = [IntPointerType] int *
 # 1025|             Value = [StaticCast] 0
 # 1025|             ValueCategory = prvalue
-# 1026|     1: [ExprStmt] ExprStmt
-# 1026|       0: [DeleteArrayExpr] delete[]
+# 1026|     getStmt(1): [ExprStmt] ExprStmt
+# 1026|       getExpr(): [DeleteArrayExpr] delete[]
 # 1026|           Type = [VoidType] void
 # 1026|           ValueCategory = prvalue
-# 1026|         1: [DestructorCall] call to ~String
+# 1026|         getDestructorCall(): [DestructorCall] call to ~String
 # 1026|             Type = [VoidType] void
 # 1026|             ValueCategory = prvalue
-# 1026|           -1: [Literal] 0
+# 1026|           getQualifier(): [Literal] 0
 # 1026|               Type = [NullPointerType] decltype(nullptr)
 # 1026|               Value = [Literal] 0
 # 1026|               ValueCategory = prvalue
-# 1026|           -1: [StaticCast] static_cast<String *>...
+# 1026|           getQualifier(): [StaticCast] static_cast<String *>...
 # 1026|               Conversion = [PointerConversion] pointer conversion
 # 1026|               Type = [PointerType] String *
 # 1026|               Value = [StaticCast] 0
 # 1026|               ValueCategory = prvalue
-# 1027|     2: [ExprStmt] ExprStmt
-# 1027|       0: [DeleteArrayExpr] delete[]
+# 1027|     getStmt(2): [ExprStmt] ExprStmt
+# 1027|       getExpr(): [DeleteArrayExpr] delete[]
 # 1027|           Type = [VoidType] void
 # 1027|           ValueCategory = prvalue
-# 1027|         0: [FunctionCall] call to operator delete[]
+# 1027|         getAllocatorCall(): [FunctionCall] call to operator delete[]
 # 1027|             Type = [VoidType] void
 # 1027|             ValueCategory = prvalue
-# 1027|         3: [Literal] 0
+# 1027|         getExpr(): [Literal] 0
 # 1027|             Type = [NullPointerType] decltype(nullptr)
 # 1027|             Value = [Literal] 0
 # 1027|             ValueCategory = prvalue
-# 1027|         3 converted: [StaticCast] static_cast<SizedDealloc *>...
+# 1027|         : [StaticCast] static_cast<SizedDealloc *>...
 # 1027|             Conversion = [PointerConversion] pointer conversion
 # 1027|             Type = [PointerType] SizedDealloc *
 # 1027|             Value = [StaticCast] 0
 # 1027|             ValueCategory = prvalue
-# 1028|     3: [ExprStmt] ExprStmt
-# 1028|       0: [DeleteArrayExpr] delete[]
+# 1028|     getStmt(3): [ExprStmt] ExprStmt
+# 1028|       getExpr(): [DeleteArrayExpr] delete[]
 # 1028|           Type = [VoidType] void
 # 1028|           ValueCategory = prvalue
-# 1028|         3: [Literal] 0
+# 1028|         getExpr(): [Literal] 0
 # 1028|             Type = [NullPointerType] decltype(nullptr)
 # 1028|             Value = [Literal] 0
 # 1028|             ValueCategory = prvalue
-# 1028|         3 converted: [StaticCast] static_cast<Overaligned *>...
+# 1028|         : [StaticCast] static_cast<Overaligned *>...
 # 1028|             Conversion = [PointerConversion] pointer conversion
 # 1028|             Type = [PointerType] Overaligned *
 # 1028|             Value = [StaticCast] 0
 # 1028|             ValueCategory = prvalue
-# 1029|     4: [ExprStmt] ExprStmt
-# 1029|       0: [DeleteArrayExpr] delete[]
+# 1029|     getStmt(4): [ExprStmt] ExprStmt
+# 1029|       getExpr(): [DeleteArrayExpr] delete[]
 # 1029|           Type = [VoidType] void
 # 1029|           ValueCategory = prvalue
-# 1029|         1: [DestructorCall] call to ~PolymorphicBase
+# 1029|         getDestructorCall(): [DestructorCall] call to ~PolymorphicBase
 # 1029|             Type = [VoidType] void
 # 1029|             ValueCategory = prvalue
-# 1029|           -1: [Literal] 0
+# 1029|           getQualifier(): [Literal] 0
 # 1029|               Type = [NullPointerType] decltype(nullptr)
 # 1029|               Value = [Literal] 0
 # 1029|               ValueCategory = prvalue
-# 1029|           -1: [StaticCast] static_cast<PolymorphicBase *>...
+# 1029|           getQualifier(): [StaticCast] static_cast<PolymorphicBase *>...
 # 1029|               Conversion = [PointerConversion] pointer conversion
 # 1029|               Type = [PointerType] PolymorphicBase *
 # 1029|               Value = [StaticCast] 0
 # 1029|               ValueCategory = prvalue
-# 1030|     5: [ReturnStmt] return ...
+# 1030|     getStmt(5): [ReturnStmt] return ...
 # 1032| [CopyAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct const&)
-# 1032|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1032|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const EmptyStruct &
 # 1032| [MoveAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct&&)
-# 1032|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1032|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] EmptyStruct &&
 # 1034| [TopLevelFunction] void EmptyStructInit()
-# 1034|   params: 
-# 1034|   body: [BlockStmt] { ... }
-# 1035|     0: [DeclStmt] declaration
-# 1035|       0: [VariableDeclarationEntry] definition of s
+# 1034|   ...: 
+# 1034|   getEntryPoint(): [BlockStmt] { ... }
+# 1035|     getStmt(0): [DeclStmt] declaration
+# 1035|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
 # 1035|           Type = [Struct] EmptyStruct
-# 1035|         init: [Initializer] initializer for s
-# 1035|           expr: [ClassAggregateLiteral] {...}
+# 1035|         getVariable().getInitializer(): [Initializer] initializer for s
+# 1035|           getExpr(): [ClassAggregateLiteral] {...}
 # 1035|               Type = [Struct] EmptyStruct
 # 1035|               ValueCategory = prvalue
-# 1036|     1: [ReturnStmt] return ...
+# 1036|     getStmt(1): [ReturnStmt] return ...
 # 1038| [CopyAssignmentOperator] (lambda [] type at line 1038, col. 12)& (lambda [] type at line 1038, col. 12)::operator=((lambda [] type at line 1038, col. 12) const&)
-# 1038|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1038|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [CopyConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12) const&)
-# 1038|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1038|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [MoveConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12)&&)
-# 1038|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1038|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1038, col. 12 &&
 # 1038| [Constructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)()
-# 1038|   params: 
+# 1038|   ...: 
 # 1038| [MemberFunction] void (lambda [] type at line 1038, col. 12)::_FUN()
-# 1038|   params: 
+# 1038|   ...: 
 # 1038| [ConstMemberFunction] void (lambda [] type at line 1038, col. 12)::operator()() const
-# 1038|   params: 
-# 1038|   body: [BlockStmt] { ... }
-# 1038|     0: [ReturnStmt] return ...
+# 1038|   ...: 
+# 1038|   getEntryPoint(): [BlockStmt] { ... }
+# 1038|     getStmt(0): [ReturnStmt] return ...
 # 1038| [ConstMemberFunction,ConversionOperator] void(* (lambda [] type at line 1038, col. 12)::operator void (*)()() const)()
-# 1038|   params: 
-#-----|   body: [BlockStmt] { ... }
-# 1038|     0: [ReturnStmt] return ...
-# 1038|       0: [FunctionAccess] _FUN
+# 1038|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+# 1038|     getStmt(0): [ReturnStmt] return ...
+# 1038|       getExpr(): [FunctionAccess] _FUN
 # 1038|           Type = [FunctionPointerType] ..(*)(..)
 # 1038|           ValueCategory = prvalue(load)
 # 1040| [TopLevelFunction] void Lambda(int, String const&)
-# 1040|   params: 
-# 1040|     0: [Parameter] x
+# 1040|   ...: 
+# 1040|     getParameter(0): [Parameter] x
 # 1040|         Type = [IntType] int
-# 1040|     1: [Parameter] s
+# 1040|     getParameter(1): [Parameter] s
 # 1040|         Type = [LValueReferenceType] const String &
-# 1040|   body: [BlockStmt] { ... }
-# 1041|     0: [DeclStmt] declaration
-# 1041|       0: [VariableDeclarationEntry] definition of lambda_empty
+# 1040|   getEntryPoint(): [BlockStmt] { ... }
+# 1041|     getStmt(0): [DeclStmt] declaration
+# 1041|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_empty
 # 1041|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1041|         init: [Initializer] initializer for lambda_empty
-# 1041|           expr: [LambdaExpression] [...](...){...}
+# 1041|         getVariable().getInitializer(): [Initializer] initializer for lambda_empty
+# 1041|           getExpr(): [LambdaExpression] [...](...){...}
 # 1041|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1041|               ValueCategory = prvalue
-# 1042|     1: [ExprStmt] ExprStmt
-# 1042|       0: [FunctionCall] call to operator()
+# 1042|     getStmt(1): [ExprStmt] ExprStmt
+# 1042|       getExpr(): [FunctionCall] call to operator()
 # 1042|           Type = [PlainCharType] char
 # 1042|           Value = [FunctionCall] 65
 # 1042|           ValueCategory = prvalue
-# 1042|         -1: [VariableAccess] lambda_empty
+# 1042|         getQualifier(): [VariableAccess] lambda_empty
 # 1042|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1042|             ValueCategory = lvalue
-# 1042|         0: [CStyleCast] (const lambda [] type at line 1041, col. 23)...
+# 1042|         getArgument(0): [CStyleCast] (const lambda [] type at line 1041, col. 23)...
 # 1042|             Conversion = [GlvalueConversion] glvalue conversion
 # 1042|             Type = [SpecifiedType] const lambda [] type at line 1041, col. 23
 # 1042|             ValueCategory = lvalue
-# 1042|         0: [Literal] 0
+# 1042|         getArgument(0): [Literal] 0
 # 1042|             Type = [IntType] int
 # 1042|             Value = [Literal] 0
 # 1042|             ValueCategory = prvalue
-# 1042|         0 converted: [CStyleCast] (float)...
+# 1042|         : [CStyleCast] (float)...
 # 1042|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1042|             Type = [FloatType] float
 # 1042|             Value = [CStyleCast] 0.0
 # 1042|             ValueCategory = prvalue
-# 1043|     2: [DeclStmt] declaration
-# 1043|       0: [VariableDeclarationEntry] definition of lambda_ref
+# 1043|     getStmt(2): [DeclStmt] declaration
+# 1043|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_ref
 # 1043|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1043|         init: [Initializer] initializer for lambda_ref
-# 1043|           expr: [LambdaExpression] [...](...){...}
+# 1043|         getVariable().getInitializer(): [Initializer] initializer for lambda_ref
+# 1043|           getExpr(): [LambdaExpression] [...](...){...}
 # 1043|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1043|               ValueCategory = prvalue
-# 1043|             0: [ClassAggregateLiteral] {...}
+# 1043|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1043|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1043|                 ValueCategory = prvalue
-# 1043|               .s: [VariableAccess] s
+# 1043|               getFieldExpr(s): [VariableAccess] s
 # 1043|                   Type = [LValueReferenceType] const String &
 # 1043|                   ValueCategory = prvalue(load)
-# 1043|               .x: [VariableAccess] x
+# 1043|               getFieldExpr(x): [VariableAccess] x
 # 1043|                   Type = [IntType] int
 # 1043|                   ValueCategory = lvalue
-# 1043|               .s converted: [ReferenceToExpr] (reference to)
+# 1043|               : [ReferenceToExpr] (reference to)
 # 1043|                   Type = [LValueReferenceType] const String &
 # 1043|                   ValueCategory = prvalue
-# 1043|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|                     Type = [SpecifiedType] const String
 # 1043|                     ValueCategory = lvalue
-#-----|               .x converted: [ReferenceToExpr] (reference to)
+#-----|               : [ReferenceToExpr] (reference to)
 #-----|                   Type = [LValueReferenceType] int &
 #-----|                   ValueCategory = prvalue
-# 1044|     3: [ExprStmt] ExprStmt
-# 1044|       0: [FunctionCall] call to operator()
+# 1044|     getStmt(3): [ExprStmt] ExprStmt
+# 1044|       getExpr(): [FunctionCall] call to operator()
 # 1044|           Type = [PlainCharType] char
 # 1044|           ValueCategory = prvalue
-# 1044|         -1: [VariableAccess] lambda_ref
+# 1044|         getQualifier(): [VariableAccess] lambda_ref
 # 1044|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1044|             ValueCategory = lvalue
-# 1044|         0: [CStyleCast] (const lambda [] type at line 1043, col. 21)...
+# 1044|         getArgument(0): [CStyleCast] (const lambda [] type at line 1043, col. 21)...
 # 1044|             Conversion = [GlvalueConversion] glvalue conversion
 # 1044|             Type = [SpecifiedType] const lambda [] type at line 1043, col. 21
 # 1044|             ValueCategory = lvalue
-# 1044|         0: [Literal] 1
+# 1044|         getArgument(0): [Literal] 1
 # 1044|             Type = [IntType] int
 # 1044|             Value = [Literal] 1
 # 1044|             ValueCategory = prvalue
-# 1044|         0 converted: [CStyleCast] (float)...
+# 1044|         : [CStyleCast] (float)...
 # 1044|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1044|             Type = [FloatType] float
 # 1044|             Value = [CStyleCast] 1.0
 # 1044|             ValueCategory = prvalue
-# 1045|     4: [DeclStmt] declaration
-# 1045|       0: [VariableDeclarationEntry] definition of lambda_val
+# 1045|     getStmt(4): [DeclStmt] declaration
+# 1045|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_val
 # 1045|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1045|         init: [Initializer] initializer for lambda_val
-# 1045|           expr: [LambdaExpression] [...](...){...}
+# 1045|         getVariable().getInitializer(): [Initializer] initializer for lambda_val
+# 1045|           getExpr(): [LambdaExpression] [...](...){...}
 # 1045|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1045|               ValueCategory = prvalue
-# 1045|             0: [ClassAggregateLiteral] {...}
+# 1045|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1045|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1045|                 ValueCategory = prvalue
-# 1045|               .s: [ConstructorCall] call to String
+# 1045|               getFieldExpr(s): [ConstructorCall] call to String
 # 1045|                   Type = [VoidType] void
 # 1045|                   ValueCategory = prvalue
-# 1045|               .x: [VariableAccess] x
+# 1045|               getFieldExpr(x): [VariableAccess] x
 # 1045|                   Type = [IntType] int
 # 1045|                   ValueCategory = prvalue(load)
-# 1046|     5: [ExprStmt] ExprStmt
-# 1046|       0: [FunctionCall] call to operator()
+# 1046|     getStmt(5): [ExprStmt] ExprStmt
+# 1046|       getExpr(): [FunctionCall] call to operator()
 # 1046|           Type = [PlainCharType] char
 # 1046|           ValueCategory = prvalue
-# 1046|         -1: [VariableAccess] lambda_val
+# 1046|         getQualifier(): [VariableAccess] lambda_val
 # 1046|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1046|             ValueCategory = lvalue
-# 1046|         0: [CStyleCast] (const lambda [] type at line 1045, col. 21)...
+# 1046|         getArgument(0): [CStyleCast] (const lambda [] type at line 1045, col. 21)...
 # 1046|             Conversion = [GlvalueConversion] glvalue conversion
 # 1046|             Type = [SpecifiedType] const lambda [] type at line 1045, col. 21
 # 1046|             ValueCategory = lvalue
-# 1046|         0: [Literal] 2
+# 1046|         getArgument(0): [Literal] 2
 # 1046|             Type = [IntType] int
 # 1046|             Value = [Literal] 2
 # 1046|             ValueCategory = prvalue
-# 1046|         0 converted: [CStyleCast] (float)...
+# 1046|         : [CStyleCast] (float)...
 # 1046|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1046|             Type = [FloatType] float
 # 1046|             Value = [CStyleCast] 2.0
 # 1046|             ValueCategory = prvalue
-# 1047|     6: [DeclStmt] declaration
-# 1047|       0: [VariableDeclarationEntry] definition of lambda_ref_explicit
+# 1047|     getStmt(6): [DeclStmt] declaration
+# 1047|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_ref_explicit
 # 1047|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1047|         init: [Initializer] initializer for lambda_ref_explicit
-# 1047|           expr: [LambdaExpression] [...](...){...}
+# 1047|         getVariable().getInitializer(): [Initializer] initializer for lambda_ref_explicit
+# 1047|           getExpr(): [LambdaExpression] [...](...){...}
 # 1047|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1047|               ValueCategory = prvalue
-# 1047|             0: [ClassAggregateLiteral] {...}
+# 1047|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1047|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1047|                 ValueCategory = prvalue
-# 1047|               .s: [VariableAccess] s
+# 1047|               getFieldExpr(s): [VariableAccess] s
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue(load)
-# 1047|               .s converted: [ReferenceToExpr] (reference to)
+# 1047|               : [ReferenceToExpr] (reference to)
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue
-# 1047|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1047|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1047|                     Type = [SpecifiedType] const String
 # 1047|                     ValueCategory = lvalue
-# 1048|     7: [ExprStmt] ExprStmt
-# 1048|       0: [FunctionCall] call to operator()
+# 1048|     getStmt(7): [ExprStmt] ExprStmt
+# 1048|       getExpr(): [FunctionCall] call to operator()
 # 1048|           Type = [PlainCharType] char
 # 1048|           ValueCategory = prvalue
-# 1048|         -1: [VariableAccess] lambda_ref_explicit
+# 1048|         getQualifier(): [VariableAccess] lambda_ref_explicit
 # 1048|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1048|             ValueCategory = lvalue
-# 1048|         0: [CStyleCast] (const lambda [] type at line 1047, col. 30)...
+# 1048|         getArgument(0): [CStyleCast] (const lambda [] type at line 1047, col. 30)...
 # 1048|             Conversion = [GlvalueConversion] glvalue conversion
 # 1048|             Type = [SpecifiedType] const lambda [] type at line 1047, col. 30
 # 1048|             ValueCategory = lvalue
-# 1048|         0: [Literal] 3
+# 1048|         getArgument(0): [Literal] 3
 # 1048|             Type = [IntType] int
 # 1048|             Value = [Literal] 3
 # 1048|             ValueCategory = prvalue
-# 1048|         0 converted: [CStyleCast] (float)...
+# 1048|         : [CStyleCast] (float)...
 # 1048|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1048|             Type = [FloatType] float
 # 1048|             Value = [CStyleCast] 3.0
 # 1048|             ValueCategory = prvalue
-# 1049|     8: [DeclStmt] declaration
-# 1049|       0: [VariableDeclarationEntry] definition of lambda_val_explicit
+# 1049|     getStmt(8): [DeclStmt] declaration
+# 1049|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_val_explicit
 # 1049|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1049|         init: [Initializer] initializer for lambda_val_explicit
-# 1049|           expr: [LambdaExpression] [...](...){...}
+# 1049|         getVariable().getInitializer(): [Initializer] initializer for lambda_val_explicit
+# 1049|           getExpr(): [LambdaExpression] [...](...){...}
 # 1049|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1049|               ValueCategory = prvalue
-# 1049|             0: [ClassAggregateLiteral] {...}
+# 1049|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1049|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1049|                 ValueCategory = prvalue
-# 1049|               .s: [ConstructorCall] call to String
+# 1049|               getFieldExpr(s): [ConstructorCall] call to String
 # 1049|                   Type = [VoidType] void
 # 1049|                   ValueCategory = prvalue
-# 1050|     9: [ExprStmt] ExprStmt
-# 1050|       0: [FunctionCall] call to operator()
+# 1050|     getStmt(9): [ExprStmt] ExprStmt
+# 1050|       getExpr(): [FunctionCall] call to operator()
 # 1050|           Type = [PlainCharType] char
 # 1050|           ValueCategory = prvalue
-# 1050|         -1: [VariableAccess] lambda_val_explicit
+# 1050|         getQualifier(): [VariableAccess] lambda_val_explicit
 # 1050|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1050|             ValueCategory = lvalue
-# 1050|         0: [CStyleCast] (const lambda [] type at line 1049, col. 30)...
+# 1050|         getArgument(0): [CStyleCast] (const lambda [] type at line 1049, col. 30)...
 # 1050|             Conversion = [GlvalueConversion] glvalue conversion
 # 1050|             Type = [SpecifiedType] const lambda [] type at line 1049, col. 30
 # 1050|             ValueCategory = lvalue
-# 1050|         0: [Literal] 4
+# 1050|         getArgument(0): [Literal] 4
 # 1050|             Type = [IntType] int
 # 1050|             Value = [Literal] 4
 # 1050|             ValueCategory = prvalue
-# 1050|         0 converted: [CStyleCast] (float)...
+# 1050|         : [CStyleCast] (float)...
 # 1050|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1050|             Type = [FloatType] float
 # 1050|             Value = [CStyleCast] 4.0
 # 1050|             ValueCategory = prvalue
-# 1051|     10: [DeclStmt] declaration
-# 1051|       0: [VariableDeclarationEntry] definition of lambda_mixed_explicit
+# 1051|     getStmt(10): [DeclStmt] declaration
+# 1051|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_mixed_explicit
 # 1051|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1051|         init: [Initializer] initializer for lambda_mixed_explicit
-# 1051|           expr: [LambdaExpression] [...](...){...}
+# 1051|         getVariable().getInitializer(): [Initializer] initializer for lambda_mixed_explicit
+# 1051|           getExpr(): [LambdaExpression] [...](...){...}
 # 1051|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1051|               ValueCategory = prvalue
-# 1051|             0: [ClassAggregateLiteral] {...}
+# 1051|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1051|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1051|                 ValueCategory = prvalue
-# 1051|               .s: [VariableAccess] s
+# 1051|               getFieldExpr(s): [VariableAccess] s
 # 1051|                   Type = [LValueReferenceType] const String &
 # 1051|                   ValueCategory = prvalue(load)
-# 1051|               .x: [VariableAccess] x
+# 1051|               getFieldExpr(x): [VariableAccess] x
 # 1051|                   Type = [IntType] int
 # 1051|                   ValueCategory = prvalue(load)
-# 1051|               .s converted: [ReferenceToExpr] (reference to)
+# 1051|               : [ReferenceToExpr] (reference to)
 # 1051|                   Type = [LValueReferenceType] const String &
 # 1051|                   ValueCategory = prvalue
-# 1051|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1051|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1051|                     Type = [SpecifiedType] const String
 # 1051|                     ValueCategory = lvalue
-# 1052|     11: [ExprStmt] ExprStmt
-# 1052|       0: [FunctionCall] call to operator()
+# 1052|     getStmt(11): [ExprStmt] ExprStmt
+# 1052|       getExpr(): [FunctionCall] call to operator()
 # 1052|           Type = [PlainCharType] char
 # 1052|           ValueCategory = prvalue
-# 1052|         -1: [VariableAccess] lambda_mixed_explicit
+# 1052|         getQualifier(): [VariableAccess] lambda_mixed_explicit
 # 1052|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1052|             ValueCategory = lvalue
-# 1052|         0: [CStyleCast] (const lambda [] type at line 1051, col. 32)...
+# 1052|         getArgument(0): [CStyleCast] (const lambda [] type at line 1051, col. 32)...
 # 1052|             Conversion = [GlvalueConversion] glvalue conversion
 # 1052|             Type = [SpecifiedType] const lambda [] type at line 1051, col. 32
 # 1052|             ValueCategory = lvalue
-# 1052|         0: [Literal] 5
+# 1052|         getArgument(0): [Literal] 5
 # 1052|             Type = [IntType] int
 # 1052|             Value = [Literal] 5
 # 1052|             ValueCategory = prvalue
-# 1052|         0 converted: [CStyleCast] (float)...
+# 1052|         : [CStyleCast] (float)...
 # 1052|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1052|             Type = [FloatType] float
 # 1052|             Value = [CStyleCast] 5.0
 # 1052|             ValueCategory = prvalue
-# 1053|     12: [DeclStmt] declaration
-# 1053|       0: [VariableDeclarationEntry] definition of r
+# 1053|     getStmt(12): [DeclStmt] declaration
+# 1053|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of r
 # 1053|           Type = [IntType] int
-# 1053|         init: [Initializer] initializer for r
-# 1053|           expr: [SubExpr] ... - ...
+# 1053|         getVariable().getInitializer(): [Initializer] initializer for r
+# 1053|           getExpr(): [SubExpr] ... - ...
 # 1053|               Type = [IntType] int
 # 1053|               ValueCategory = prvalue
-# 1053|             0: [VariableAccess] x
+# 1053|             getLeftOperand(): [VariableAccess] x
 # 1053|                 Type = [IntType] int
 # 1053|                 ValueCategory = prvalue(load)
-# 1053|             1: [Literal] 1
+# 1053|             getRightOperand(): [Literal] 1
 # 1053|                 Type = [IntType] int
 # 1053|                 Value = [Literal] 1
 # 1053|                 ValueCategory = prvalue
-# 1054|     13: [DeclStmt] declaration
-# 1054|       0: [VariableDeclarationEntry] definition of lambda_inits
+# 1054|     getStmt(13): [DeclStmt] declaration
+# 1054|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of lambda_inits
 # 1054|           Type = [Closure,LocalClass] decltype([...](...){...})
-# 1054|         init: [Initializer] initializer for lambda_inits
-# 1054|           expr: [LambdaExpression] [...](...){...}
+# 1054|         getVariable().getInitializer(): [Initializer] initializer for lambda_inits
+# 1054|           getExpr(): [LambdaExpression] [...](...){...}
 # 1054|               Type = [Closure,LocalClass] decltype([...](...){...})
 # 1054|               ValueCategory = prvalue
-# 1054|             0: [ClassAggregateLiteral] {...}
+# 1054|             getInitializer(): [ClassAggregateLiteral] {...}
 # 1054|                 Type = [Closure,LocalClass] decltype([...](...){...})
 # 1054|                 ValueCategory = prvalue
-# 1054|               .s: [VariableAccess] s
+# 1054|               getFieldExpr(s): [VariableAccess] s
 # 1054|                   Type = [LValueReferenceType] const String &
 # 1054|                   ValueCategory = prvalue(load)
-# 1054|               .x: [VariableAccess] x
+# 1054|               getFieldExpr(x): [VariableAccess] x
 # 1054|                   Type = [IntType] int
 # 1054|                   ValueCategory = prvalue(load)
-# 1054|               .i: [AddExpr] ... + ...
+# 1054|               getFieldExpr(i): [AddExpr] ... + ...
 # 1054|                   Type = [IntType] int
 # 1054|                   ValueCategory = prvalue
-# 1054|                 0: [VariableAccess] x
+# 1054|                 getLeftOperand(): [VariableAccess] x
 # 1054|                     Type = [IntType] int
 # 1054|                     ValueCategory = prvalue(load)
-# 1054|                 1: [Literal] 1
+# 1054|                 getRightOperand(): [Literal] 1
 # 1054|                     Type = [IntType] int
 # 1054|                     Value = [Literal] 1
 # 1054|                     ValueCategory = prvalue
-# 1054|               .j: [VariableAccess] r
+# 1054|               getFieldExpr(j): [VariableAccess] r
 # 1054|                   Type = [IntType] int
 # 1054|                   ValueCategory = lvalue
-# 1054|               .s converted: [ReferenceToExpr] (reference to)
+# 1054|               : [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] const String &
 # 1054|                   ValueCategory = prvalue
-# 1054|                 expr: [ReferenceDereferenceExpr] (reference dereference)
+# 1054|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1054|                     Type = [SpecifiedType] const String
 # 1054|                     ValueCategory = lvalue
-# 1054|               .j converted: [ReferenceToExpr] (reference to)
+# 1054|               : [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] int &
 # 1054|                   ValueCategory = prvalue
-# 1055|     14: [ExprStmt] ExprStmt
-# 1055|       0: [FunctionCall] call to operator()
+# 1055|     getStmt(14): [ExprStmt] ExprStmt
+# 1055|       getExpr(): [FunctionCall] call to operator()
 # 1055|           Type = [PlainCharType] char
 # 1055|           ValueCategory = prvalue
-# 1055|         -1: [VariableAccess] lambda_inits
+# 1055|         getQualifier(): [VariableAccess] lambda_inits
 # 1055|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1055|             ValueCategory = lvalue
-# 1055|         0: [CStyleCast] (const lambda [] type at line 1054, col. 23)...
+# 1055|         getArgument(0): [CStyleCast] (const lambda [] type at line 1054, col. 23)...
 # 1055|             Conversion = [GlvalueConversion] glvalue conversion
 # 1055|             Type = [SpecifiedType] const lambda [] type at line 1054, col. 23
 # 1055|             ValueCategory = lvalue
-# 1055|         0: [Literal] 6
+# 1055|         getArgument(0): [Literal] 6
 # 1055|             Type = [IntType] int
 # 1055|             Value = [Literal] 6
 # 1055|             ValueCategory = prvalue
-# 1055|         0 converted: [CStyleCast] (float)...
+# 1055|         : [CStyleCast] (float)...
 # 1055|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1055|             Type = [FloatType] float
 # 1055|             Value = [CStyleCast] 6.0
 # 1055|             ValueCategory = prvalue
-# 1056|     15: [ReturnStmt] return ...
+# 1056|     getStmt(15): [ReturnStmt] return ...
 # 1041| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1041|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1041|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)&&)
-# 1041|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1041|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1041, col. 23 &&
 # 1041| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)()
-# 1041|   params: 
+# 1041|   ...: 
 # 1041| [MemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::_FUN(float)
-# 1041|   params: 
-# 1041|     0: [Parameter] f
+# 1041|   ...: 
+# 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
 # 1041| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator()(float) const
-# 1041|   params: 
-# 1041|     0: [Parameter] f
+# 1041|   ...: 
+# 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
-# 1041|   body: [BlockStmt] { ... }
-# 1041|     0: [ReturnStmt] return ...
-# 1041|       0: [CharLiteral] 65
+# 1041|   getEntryPoint(): [BlockStmt] { ... }
+# 1041|     getStmt(0): [ReturnStmt] return ...
+# 1041|       getExpr(): [CharLiteral] 65
 # 1041|           Type = [PlainCharType] char
 # 1041|           Value = [CharLiteral] 65
 # 1041|           ValueCategory = prvalue
 # 1041| [ConstMemberFunction,ConversionOperator] char(* (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator char (*)(float)() const)(float)
-# 1041|   params: 
-#-----|   body: [BlockStmt] { ... }
-# 1041|     0: [ReturnStmt] return ...
-# 1041|       0: [FunctionAccess] _FUN
+# 1041|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+# 1041|     getStmt(0): [ReturnStmt] return ...
+# 1041|       getExpr(): [FunctionAccess] _FUN
 # 1041|           Type = [FunctionPointerType] ..(*)(..)
 # 1041|           ValueCategory = prvalue(load)
 # 1043| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1043|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1043|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)&&)
-# 1043|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1043|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1043, col. 21 &&
 # 1043| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)()
-# 1043|   params: 
+# 1043|   ...: 
 # 1043| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator()(float) const
-# 1043|   params: 
-# 1043|     0: [Parameter] f
+# 1043|   ...: 
+# 1043|     getParameter(0): [Parameter] f
 # 1043|         Type = [FloatType] float
-# 1043|   body: [BlockStmt] { ... }
-# 1043|     0: [ReturnStmt] return ...
-# 1043|       0: [ArrayExpr] access to array
+# 1043|   getEntryPoint(): [BlockStmt] { ... }
+# 1043|     getStmt(0): [ReturnStmt] return ...
+# 1043|       getExpr(): [ArrayExpr] access to array
 # 1043|           Type = [PlainCharType] char
 # 1043|           ValueCategory = prvalue(load)
-# 1043|         0: [FunctionCall] call to c_str
+# 1043|         getArrayBase(): [FunctionCall] call to c_str
 # 1043|             Type = [PointerType] const char *
 # 1043|             ValueCategory = prvalue
-# 1043|           -1: [PointerFieldAccess] s
+# 1043|           getQualifier(): [PointerFieldAccess] s
 # 1043|               Type = [LValueReferenceType] const String &
 # 1043|               ValueCategory = prvalue(load)
-# 1043|             -1: [ThisExpr] this
+# 1043|             getQualifier(): [ThisExpr] this
 # 1043|                 Type = [PointerType] const lambda [] type at line 1043, col. 21 *
 # 1043|                 ValueCategory = prvalue(load)
-# 1043|           -1: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|               Type = [SpecifiedType] const String
 # 1043|               ValueCategory = lvalue
-# 1043|         1: [PointerFieldAccess] x
+# 1043|         getArrayOffset(): [PointerFieldAccess] x
 # 1043|             Type = [LValueReferenceType] int &
 # 1043|             ValueCategory = prvalue(load)
-# 1043|           -1: [ThisExpr] this
+# 1043|           getQualifier(): [ThisExpr] this
 # 1043|               Type = [PointerType] const lambda [] type at line 1043, col. 21 *
 # 1043|               ValueCategory = prvalue(load)
-# 1043|         1 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1043|         : [ReferenceDereferenceExpr] (reference dereference)
 # 1043|             Type = [IntType] int
 # 1043|             ValueCategory = prvalue(load)
 # 1045| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1045|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1045|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)&&)
-# 1045|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1045|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1045, col. 21 &&
 # 1045| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)()
-# 1045|   params: 
+# 1045|   ...: 
 # 1045| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::~<unnamed>()
-# 1045|   params: 
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ReturnStmt] return ...
-# 1045|   destructions: 
-# 1045|     0: [DestructorFieldDestruction] destructor field destruction of s
+# 1045|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ReturnStmt] return ...
+# 1045|   ...: 
+# 1045|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1045|         Type = [SpecifiedType] const String
 # 1045|         ValueCategory = prvalue
-# 1045|       0: [DestructorCall] call to ~String
+# 1045|       getExpr(): [DestructorCall] call to ~String
 # 1045|           Type = [VoidType] void
 # 1045|           ValueCategory = prvalue
-# 1045|         -1: [ImplicitThisFieldAccess] s
+# 1045|         getQualifier(): [ImplicitThisFieldAccess] s
 # 1045|             Type = [SpecifiedType] const String
 # 1045|             ValueCategory = lvalue
 # 1045| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator()(float) const
-# 1045|   params: 
-# 1045|     0: [Parameter] f
+# 1045|   ...: 
+# 1045|     getParameter(0): [Parameter] f
 # 1045|         Type = [FloatType] float
-# 1045|   body: [BlockStmt] { ... }
-# 1045|     0: [ReturnStmt] return ...
-# 1045|       0: [ArrayExpr] access to array
+# 1045|   getEntryPoint(): [BlockStmt] { ... }
+# 1045|     getStmt(0): [ReturnStmt] return ...
+# 1045|       getExpr(): [ArrayExpr] access to array
 # 1045|           Type = [PlainCharType] char
 # 1045|           ValueCategory = prvalue(load)
-# 1045|         0: [FunctionCall] call to c_str
+# 1045|         getArrayBase(): [FunctionCall] call to c_str
 # 1045|             Type = [PointerType] const char *
 # 1045|             ValueCategory = prvalue
-# 1045|           -1: [PointerFieldAccess] s
+# 1045|           getQualifier(): [PointerFieldAccess] s
 # 1045|               Type = [SpecifiedType] const String
 # 1045|               ValueCategory = lvalue
-# 1045|             -1: [ThisExpr] this
+# 1045|             getQualifier(): [ThisExpr] this
 # 1045|                 Type = [PointerType] const lambda [] type at line 1045, col. 21 *
 # 1045|                 ValueCategory = prvalue(load)
-# 1045|         1: [PointerFieldAccess] x
+# 1045|         getArrayOffset(): [PointerFieldAccess] x
 # 1045|             Type = [IntType] int
 # 1045|             ValueCategory = prvalue(load)
-# 1045|           -1: [ThisExpr] this
+# 1045|           getQualifier(): [ThisExpr] this
 # 1045|               Type = [PointerType] const lambda [] type at line 1045, col. 21 *
 # 1045|               ValueCategory = prvalue(load)
 # 1047| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1047|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1047|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)&&)
-# 1047|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1047|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1047, col. 30 &&
 # 1047| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)()
-# 1047|   params: 
+# 1047|   ...: 
 # 1047| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator()(float) const
-# 1047|   params: 
-# 1047|     0: [Parameter] f
+# 1047|   ...: 
+# 1047|     getParameter(0): [Parameter] f
 # 1047|         Type = [FloatType] float
-# 1047|   body: [BlockStmt] { ... }
-# 1047|     0: [ReturnStmt] return ...
-# 1047|       0: [ArrayExpr] access to array
+# 1047|   getEntryPoint(): [BlockStmt] { ... }
+# 1047|     getStmt(0): [ReturnStmt] return ...
+# 1047|       getExpr(): [ArrayExpr] access to array
 # 1047|           Type = [PlainCharType] char
 # 1047|           ValueCategory = prvalue(load)
-# 1047|         0: [FunctionCall] call to c_str
+# 1047|         getArrayBase(): [FunctionCall] call to c_str
 # 1047|             Type = [PointerType] const char *
 # 1047|             ValueCategory = prvalue
-# 1047|           -1: [PointerFieldAccess] s
+# 1047|           getQualifier(): [PointerFieldAccess] s
 # 1047|               Type = [LValueReferenceType] const String &
 # 1047|               ValueCategory = prvalue(load)
-# 1047|             -1: [ThisExpr] this
+# 1047|             getQualifier(): [ThisExpr] this
 # 1047|                 Type = [PointerType] const lambda [] type at line 1047, col. 30 *
 # 1047|                 ValueCategory = prvalue(load)
-# 1047|           -1: [ReferenceDereferenceExpr] (reference dereference)
+# 1047|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 # 1047|               Type = [SpecifiedType] const String
 # 1047|               ValueCategory = lvalue
-# 1047|         1: [Literal] 0
+# 1047|         getArrayOffset(): [Literal] 0
 # 1047|             Type = [IntType] int
 # 1047|             Value = [Literal] 0
 # 1047|             ValueCategory = prvalue
 # 1049| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1049|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1049|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)&&)
-# 1049|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1049|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1049, col. 30 &&
 # 1049| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)()
-# 1049|   params: 
+# 1049|   ...: 
 # 1049| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::~<unnamed>()
-# 1049|   params: 
-#-----|   body: [BlockStmt] { ... }
-#-----|     0: [ReturnStmt] return ...
-# 1049|   destructions: 
-# 1049|     0: [DestructorFieldDestruction] destructor field destruction of s
+# 1049|   ...: 
+#-----|   getEntryPoint(): [BlockStmt] { ... }
+#-----|     getStmt(0): [ReturnStmt] return ...
+# 1049|   ...: 
+# 1049|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1049|         Type = [SpecifiedType] const String
 # 1049|         ValueCategory = prvalue
-# 1049|       0: [DestructorCall] call to ~String
+# 1049|       getExpr(): [DestructorCall] call to ~String
 # 1049|           Type = [VoidType] void
 # 1049|           ValueCategory = prvalue
-# 1049|         -1: [ImplicitThisFieldAccess] s
+# 1049|         getQualifier(): [ImplicitThisFieldAccess] s
 # 1049|             Type = [SpecifiedType] const String
 # 1049|             ValueCategory = lvalue
 # 1049| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator()(float) const
-# 1049|   params: 
-# 1049|     0: [Parameter] f
+# 1049|   ...: 
+# 1049|     getParameter(0): [Parameter] f
 # 1049|         Type = [FloatType] float
-# 1049|   body: [BlockStmt] { ... }
-# 1049|     0: [ReturnStmt] return ...
-# 1049|       0: [ArrayExpr] access to array
+# 1049|   getEntryPoint(): [BlockStmt] { ... }
+# 1049|     getStmt(0): [ReturnStmt] return ...
+# 1049|       getExpr(): [ArrayExpr] access to array
 # 1049|           Type = [PlainCharType] char
 # 1049|           ValueCategory = prvalue(load)
-# 1049|         0: [FunctionCall] call to c_str
+# 1049|         getArrayBase(): [FunctionCall] call to c_str
 # 1049|             Type = [PointerType] const char *
 # 1049|             ValueCategory = prvalue
-# 1049|           -1: [PointerFieldAccess] s
+# 1049|           getQualifier(): [PointerFieldAccess] s
 # 1049|               Type = [SpecifiedType] const String
 # 1049|               ValueCategory = lvalue
-# 1049|             -1: [ThisExpr] this
+# 1049|             getQualifier(): [ThisExpr] this
 # 1049|                 Type = [PointerType] const lambda [] type at line 1049, col. 30 *
 # 1049|                 ValueCategory = prvalue(load)
-# 1049|         1: [Literal] 0
+# 1049|         getArrayOffset(): [Literal] 0
 # 1049|             Type = [IntType] int
 # 1049|             Value = [Literal] 0
 # 1049|             ValueCategory = prvalue
 # 1051| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)& (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1051|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1051|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)&&)
-# 1051|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1051|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1051, col. 32 &&
 # 1051| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)()
-# 1051|   params: 
+# 1051|   ...: 
 # 1051| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator()(float) const
-# 1051|   params: 
-# 1051|     0: [Parameter] f
+# 1051|   ...: 
+# 1051|     getParameter(0): [Parameter] f
 # 1051|         Type = [FloatType] float
-# 1051|   body: [BlockStmt] { ... }
-# 1051|     0: [ReturnStmt] return ...
-# 1051|       0: [ArrayExpr] access to array
+# 1051|   getEntryPoint(): [BlockStmt] { ... }
+# 1051|     getStmt(0): [ReturnStmt] return ...
+# 1051|       getExpr(): [ArrayExpr] access to array
 # 1051|           Type = [PlainCharType] char
 # 1051|           ValueCategory = prvalue(load)
-# 1051|         0: [FunctionCall] call to c_str
+# 1051|         getArrayBase(): [FunctionCall] call to c_str
 # 1051|             Type = [PointerType] const char *
 # 1051|             ValueCategory = prvalue
-# 1051|           -1: [PointerFieldAccess] s
+# 1051|           getQualifier(): [PointerFieldAccess] s
 # 1051|               Type = [LValueReferenceType] const String &
 # 1051|               ValueCategory = prvalue(load)
-# 1051|             -1: [ThisExpr] this
+# 1051|             getQualifier(): [ThisExpr] this
 # 1051|                 Type = [PointerType] const lambda [] type at line 1051, col. 32 *
 # 1051|                 ValueCategory = prvalue(load)
-# 1051|           -1: [ReferenceDereferenceExpr] (reference dereference)
+# 1051|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 # 1051|               Type = [SpecifiedType] const String
 # 1051|               ValueCategory = lvalue
-# 1051|         1: [PointerFieldAccess] x
+# 1051|         getArrayOffset(): [PointerFieldAccess] x
 # 1051|             Type = [IntType] int
 # 1051|             ValueCategory = prvalue(load)
-# 1051|           -1: [ThisExpr] this
+# 1051|           getQualifier(): [ThisExpr] this
 # 1051|               Type = [PointerType] const lambda [] type at line 1051, col. 32 *
 # 1051|               ValueCategory = prvalue(load)
 # 1054| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1054|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1054|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)&&)
-# 1054|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1054|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1054, col. 23 &&
 # 1054| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)()
-# 1054|   params: 
+# 1054|   ...: 
 # 1054| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator()(float) const
-# 1054|   params: 
-# 1054|     0: [Parameter] f
+# 1054|   ...: 
+# 1054|     getParameter(0): [Parameter] f
 # 1054|         Type = [FloatType] float
-# 1054|   body: [BlockStmt] { ... }
-# 1054|     0: [ReturnStmt] return ...
-# 1054|       0: [ArrayExpr] access to array
+# 1054|   getEntryPoint(): [BlockStmt] { ... }
+# 1054|     getStmt(0): [ReturnStmt] return ...
+# 1054|       getExpr(): [ArrayExpr] access to array
 # 1054|           Type = [PlainCharType] char
 # 1054|           ValueCategory = prvalue(load)
-# 1054|         0: [FunctionCall] call to c_str
+# 1054|         getArrayBase(): [FunctionCall] call to c_str
 # 1054|             Type = [PointerType] const char *
 # 1054|             ValueCategory = prvalue
-# 1054|           -1: [PointerFieldAccess] s
+# 1054|           getQualifier(): [PointerFieldAccess] s
 # 1054|               Type = [LValueReferenceType] const String &
 # 1054|               ValueCategory = prvalue(load)
-# 1054|             -1: [ThisExpr] this
+# 1054|             getQualifier(): [ThisExpr] this
 # 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|           -1: [ReferenceDereferenceExpr] (reference dereference)
+# 1054|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [SpecifiedType] const String
 # 1054|               ValueCategory = lvalue
-# 1054|         1: [SubExpr] ... - ...
+# 1054|         getArrayOffset(): [SubExpr] ... - ...
 # 1054|             Type = [IntType] int
 # 1054|             ValueCategory = prvalue
-# 1054|           0: [AddExpr] ... + ...
+# 1054|           getLeftOperand(): [AddExpr] ... + ...
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue
-# 1054|             0: [PointerFieldAccess] x
+# 1054|             getLeftOperand(): [PointerFieldAccess] x
 # 1054|                 Type = [IntType] int
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|               -1: [ThisExpr] this
+# 1054|               getQualifier(): [ThisExpr] this
 # 1054|                   Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                   ValueCategory = prvalue(load)
-# 1054|             1: [PointerFieldAccess] i
+# 1054|             getRightOperand(): [PointerFieldAccess] i
 # 1054|                 Type = [IntType] int
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|               -1: [ThisExpr] this
+# 1054|               getQualifier(): [ThisExpr] this
 # 1054|                   Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                   ValueCategory = prvalue(load)
-# 1054|           1: [PointerFieldAccess] j
+# 1054|           getRightOperand(): [PointerFieldAccess] j
 # 1054|               Type = [LValueReferenceType] int &
 # 1054|               ValueCategory = prvalue(load)
-# 1054|             -1: [ThisExpr] this
+# 1054|             getQualifier(): [ThisExpr] this
 # 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|           1 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1054|           : [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue(load)
 # 1059| [CopyAssignmentOperator] vector<int>& vector<int>::operator=(vector<int> const&)
-# 1059|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1059|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const vector<int> &
 # 1059| [MoveAssignmentOperator] vector<int>& vector<int>::operator=(vector<int>&&)
-# 1059|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1059|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] vector<int> &&
 # 1060| [CopyAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator const public&)
-# 1060|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1060|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const iterator &
 # 1060| [MoveAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator&&)
-# 1060|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1060|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] iterator &&
 # 1062| [MemberFunction] vector<T>::iterator& vector<T>::iterator::operator++()
-# 1062|   params: 
+# 1062|   ...: 
 # 1062| [MemberFunction] vector<int>::iterator& vector<int>::iterator::operator++()
-# 1062|   params: 
+# 1062|   ...: 
 # 1063| [ConstMemberFunction] T& vector<T>::iterator::operator*() const
-# 1063|   params: 
+# 1063|   ...: 
 # 1063| [ConstMemberFunction] int& vector<int>::iterator::operator*() const
-# 1063|   params: 
+# 1063|   ...: 
 # 1065| [ConstMemberFunction] bool vector<T>::iterator::operator!=(vector<T>::iterator) const
-# 1065|   params: 
-# 1065|     0: [Parameter] right
+# 1065|   ...: 
+# 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedClass,TemplateClass] iterator
 # 1065| [ConstMemberFunction] bool vector<int>::iterator::operator!=(vector<int>::iterator) const
-# 1065|   params: 
-# 1065|     0: [Parameter] right
+# 1065|   ...: 
+# 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedStruct] iterator
 # 1068| [ConstMemberFunction] vector<T>::iterator vector<T>::begin() const
-# 1068|   params: 
+# 1068|   ...: 
 # 1068| [ConstMemberFunction] vector<int>::iterator vector<int>::begin() const
-# 1068|   params: 
+# 1068|   ...: 
 # 1069| [ConstMemberFunction] vector<T>::iterator vector<T>::end() const
-# 1069|   params: 
+# 1069|   ...: 
 # 1069| [ConstMemberFunction] vector<int>::iterator vector<int>::end() const
-# 1069|   params: 
+# 1069|   ...: 
 # 1073| [Operator,TemplateFunction,TopLevelFunction] bool operator==<T>(iterator, iterator)
-# 1073|   params: 
-# 1073|     0: [Parameter] left
+# 1073|   ...: 
+# 1073|     getParameter(0): [Parameter] left
 # 1073|         Type = [TemplateParameter] iterator
-# 1073|     1: [Parameter] right
+# 1073|     getParameter(1): [Parameter] right
 # 1073|         Type = [TemplateParameter] iterator
 # 1075| [Operator,TemplateFunction,TopLevelFunction] bool operator!=<T>(iterator, iterator)
-# 1075|   params: 
-# 1075|     0: [Parameter] left
+# 1075|   ...: 
+# 1075|     getParameter(0): [Parameter] left
 # 1075|         Type = [TemplateParameter] iterator
-# 1075|     1: [Parameter] right
+# 1075|     getParameter(1): [Parameter] right
 # 1075|         Type = [TemplateParameter] iterator
 # 1077| [TopLevelFunction] void RangeBasedFor(vector<int> const&)
-# 1077|   params: 
-# 1077|     0: [Parameter] v
+# 1077|   ...: 
+# 1077|     getParameter(0): [Parameter] v
 # 1077|         Type = [LValueReferenceType] const vector<int> &
-# 1077|   body: [BlockStmt] { ... }
-# 1078|     0: [RangeBasedForStmt] for(...:...) ...
-# 1078|       0: [DeclStmt] declaration
-# 1078|       1: [DeclStmt] declaration
-# 1078|       2: [FunctionCall] call to operator!=
+# 1077|   getEntryPoint(): [BlockStmt] { ... }
+# 1078|     getStmt(0): [RangeBasedForStmt] for(...:...) ...
+# 1078|       getChild(0): [DeclStmt] declaration
+# 1078|       getBeginEndDeclaration(): [DeclStmt] declaration
+# 1078|       getCondition(): [FunctionCall] call to operator!=
 # 1078|           Type = [BoolType] bool
 # 1078|           ValueCategory = prvalue
-# 1078|         -1: [VariableAccess] (__begin)
+# 1078|         getQualifier(): [VariableAccess] (__begin)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = lvalue
-#-----|         0: [CStyleCast] (const iterator)...
+#-----|         getArgument(0): [CStyleCast] (const iterator)...
 #-----|             Conversion = [GlvalueConversion] glvalue conversion
 #-----|             Type = [SpecifiedType] const iterator
 #-----|             ValueCategory = lvalue
-# 1078|         0: [VariableAccess] (__end)
+# 1078|         getArgument(0): [VariableAccess] (__end)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = prvalue(load)
-# 1078|       3: [FunctionCall] call to operator++
+# 1078|       getUpdate(): [FunctionCall] call to operator++
 # 1078|           Type = [LValueReferenceType] iterator &
 # 1078|           ValueCategory = prvalue
-# 1078|         -1: [VariableAccess] (__begin)
+# 1078|         getQualifier(): [VariableAccess] (__begin)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = lvalue
-# 1078|       4: [DeclStmt] declaration
-# 1078|       5: [BlockStmt] { ... }
-# 1079|         0: [IfStmt] if (...) ... 
-# 1079|           0: [GTExpr] ... > ...
+# 1078|       getChild(4): [DeclStmt] declaration
+# 1078|       getStmt(): [BlockStmt] { ... }
+# 1079|         getStmt(0): [IfStmt] if (...) ... 
+# 1079|           getCondition(): [GTExpr] ... > ...
 # 1079|               Type = [BoolType] bool
 # 1079|               ValueCategory = prvalue
-# 1079|             0: [VariableAccess] e
+# 1079|             getGreaterOperand(): [VariableAccess] e
 # 1079|                 Type = [IntType] int
 # 1079|                 ValueCategory = prvalue(load)
-# 1079|             1: [Literal] 0
+# 1079|             getLesserOperand(): [Literal] 0
 # 1079|                 Type = [IntType] int
 # 1079|                 Value = [Literal] 0
 # 1079|                 ValueCategory = prvalue
-# 1079|           1: [BlockStmt] { ... }
-# 1080|             0: [ContinueStmt] continue;
-# 1078|         1: [LabelStmt] label ...:
-# 1078|       3 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1079|           getThen(): [BlockStmt] { ... }
+# 1080|             getStmt(0): [ContinueStmt] continue;
+# 1078|         getStmt(1): [LabelStmt] label ...:
+# 1078|       : [ReferenceDereferenceExpr] (reference dereference)
 # 1078|           Type = [NestedStruct] iterator
 # 1078|           ValueCategory = lvalue
-# 1084|     1: [RangeBasedForStmt] for(...:...) ...
-# 1084|       0: [DeclStmt] declaration
-# 1084|       1: [DeclStmt] declaration
-# 1084|       2: [FunctionCall] call to operator!=
+# 1084|     getStmt(1): [RangeBasedForStmt] for(...:...) ...
+# 1084|       getChild(0): [DeclStmt] declaration
+# 1084|       getBeginEndDeclaration(): [DeclStmt] declaration
+# 1084|       getCondition(): [FunctionCall] call to operator!=
 # 1084|           Type = [BoolType] bool
 # 1084|           ValueCategory = prvalue
-# 1084|         -1: [VariableAccess] (__begin)
+# 1084|         getQualifier(): [VariableAccess] (__begin)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = lvalue
-#-----|         0: [CStyleCast] (const iterator)...
+#-----|         getArgument(0): [CStyleCast] (const iterator)...
 #-----|             Conversion = [GlvalueConversion] glvalue conversion
 #-----|             Type = [SpecifiedType] const iterator
 #-----|             ValueCategory = lvalue
-# 1084|         0: [VariableAccess] (__end)
+# 1084|         getArgument(0): [VariableAccess] (__end)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = prvalue(load)
-# 1084|       3: [FunctionCall] call to operator++
+# 1084|       getUpdate(): [FunctionCall] call to operator++
 # 1084|           Type = [LValueReferenceType] iterator &
 # 1084|           ValueCategory = prvalue
-# 1084|         -1: [VariableAccess] (__begin)
+# 1084|         getQualifier(): [VariableAccess] (__begin)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = lvalue
-# 1084|       4: [DeclStmt] declaration
-# 1084|       5: [BlockStmt] { ... }
-# 1085|         0: [IfStmt] if (...) ... 
-# 1085|           0: [LTExpr] ... < ...
+# 1084|       getChild(4): [DeclStmt] declaration
+# 1084|       getStmt(): [BlockStmt] { ... }
+# 1085|         getStmt(0): [IfStmt] if (...) ... 
+# 1085|           getCondition(): [LTExpr] ... < ...
 # 1085|               Type = [BoolType] bool
 # 1085|               ValueCategory = prvalue
-# 1085|             0: [VariableAccess] e
+# 1085|             getLesserOperand(): [VariableAccess] e
 # 1085|                 Type = [LValueReferenceType] const int &
 # 1085|                 ValueCategory = prvalue(load)
-# 1085|             1: [Literal] 5
+# 1085|             getGreaterOperand(): [Literal] 5
 # 1085|                 Type = [IntType] int
 # 1085|                 Value = [Literal] 5
 # 1085|                 ValueCategory = prvalue
-# 1085|             0 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1085|             : [ReferenceDereferenceExpr] (reference dereference)
 # 1085|                 Type = [IntType] int
 # 1085|                 ValueCategory = prvalue(load)
-# 1085|           1: [BlockStmt] { ... }
-# 1086|             0: [BreakStmt] break;
-# 1084|       3 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1085|           getThen(): [BlockStmt] { ... }
+# 1086|             getStmt(0): [BreakStmt] break;
+# 1084|       : [ReferenceDereferenceExpr] (reference dereference)
 # 1084|           Type = [NestedStruct] iterator
 # 1084|           ValueCategory = lvalue
-# 1088|     2: [LabelStmt] label ...:
-# 1089|     3: [ReturnStmt] return ...
+# 1088|     getStmt(2): [LabelStmt] label ...:
+# 1089|     getStmt(3): [ReturnStmt] return ...
 # 1108| [TopLevelFunction] int AsmStmt(int)
-# 1108|   params: 
-# 1108|     0: [Parameter] x
+# 1108|   ...: 
+# 1108|     getParameter(0): [Parameter] x
 # 1108|         Type = [IntType] int
-# 1108|   body: [BlockStmt] { ... }
-# 1109|     0: [AsmStmt] asm statement
-# 1110|     1: [ReturnStmt] return ...
-# 1110|       0: [VariableAccess] x
+# 1108|   getEntryPoint(): [BlockStmt] { ... }
+# 1109|     getStmt(0): [AsmStmt] asm statement
+# 1110|     getStmt(1): [ReturnStmt] return ...
+# 1110|       getExpr(): [VariableAccess] x
 # 1110|           Type = [IntType] int
 # 1110|           ValueCategory = prvalue(load)
 # 1113| [TopLevelFunction] void AsmStmtWithOutputs(unsigned int&, unsigned int, unsigned int&, unsigned int)
-# 1113|   params: 
-# 1113|     0: [Parameter] a
+# 1113|   ...: 
+# 1113|     getParameter(0): [Parameter] a
 # 1113|         Type = [LValueReferenceType] unsigned int &
-# 1113|     1: [Parameter] b
+# 1113|     getParameter(1): [Parameter] b
 # 1113|         Type = [IntType] unsigned int
-# 1113|     2: [Parameter] c
+# 1113|     getParameter(2): [Parameter] c
 # 1113|         Type = [LValueReferenceType] unsigned int &
-# 1113|     3: [Parameter] d
+# 1113|     getParameter(3): [Parameter] d
 # 1113|         Type = [IntType] unsigned int
-# 1114|   body: [BlockStmt] { ... }
-# 1115|     0: [AsmStmt] asm statement
-# 1118|       0: [VariableAccess] a
+# 1114|   getEntryPoint(): [BlockStmt] { ... }
+# 1115|     getStmt(0): [AsmStmt] asm statement
+# 1118|       getChild(0): [VariableAccess] a
 # 1118|           Type = [LValueReferenceType] unsigned int &
 # 1118|           ValueCategory = prvalue(load)
-# 1118|       1: [VariableAccess] b
+# 1118|       getChild(1): [VariableAccess] b
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = lvalue
-# 1118|       2: [VariableAccess] c
+# 1118|       getChild(2): [VariableAccess] c
 # 1118|           Type = [LValueReferenceType] unsigned int &
 # 1118|           ValueCategory = prvalue(load)
-# 1118|       3: [VariableAccess] d
+# 1118|       getChild(3): [VariableAccess] d
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
-# 1118|       0 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1118|       : [ReferenceDereferenceExpr] (reference dereference)
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = lvalue
-# 1118|       2 converted: [ReferenceDereferenceExpr] (reference dereference)
+# 1118|       : [ReferenceDereferenceExpr] (reference dereference)
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
-# 1120|     1: [ReturnStmt] return ...
+# 1120|     getStmt(1): [ReturnStmt] return ...
 # 1122| [TopLevelFunction] void ExternDeclarations()
-# 1122|   params: 
-# 1123|   body: [BlockStmt] { ... }
-# 1124|     0: [DeclStmt] declaration
-# 1124|       0: [VariableDeclarationEntry] declaration of g
+# 1122|   ...: 
+# 1123|   getEntryPoint(): [BlockStmt] { ... }
+# 1124|     getStmt(0): [DeclStmt] declaration
+# 1124|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
 # 1124|           Type = [IntType] int
-# 1125|     1: [DeclStmt] declaration
-# 1125|       0: [VariableDeclarationEntry] definition of x
+# 1125|     getStmt(1): [DeclStmt] declaration
+# 1125|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 # 1125|           Type = [IntType] int
-# 1126|     2: [DeclStmt] declaration
-# 1126|       0: [VariableDeclarationEntry] definition of y
+# 1126|     getStmt(2): [DeclStmt] declaration
+# 1126|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1126|           Type = [IntType] int
-# 1126|       1: [FunctionDeclarationEntry] declaration of f
+# 1126|       getDeclarationEntry(1): [FunctionDeclarationEntry] declaration of f
 # 1126|           Type = [IntType] int
-# 1127|     3: [DeclStmt] declaration
-# 1127|       0: [FunctionDeclarationEntry] declaration of z
+# 1127|     getStmt(3): [DeclStmt] declaration
+# 1127|       getDeclarationEntry(0): [FunctionDeclarationEntry] declaration of z
 # 1127|           Type = [IntType] int
-# 1127|       1: [FunctionDeclarationEntry] declaration of w
+# 1127|       getDeclarationEntry(1): [FunctionDeclarationEntry] declaration of w
 # 1127|           Type = [IntType] int
-# 1127|       2: [VariableDeclarationEntry] definition of h
+# 1127|       getDeclarationEntry(2): [VariableDeclarationEntry] definition of h
 # 1127|           Type = [IntType] int
-# 1128|     4: [DeclStmt] declaration
-# 1128|       0: [TypeDeclarationEntry] declaration of d
+# 1128|     getStmt(4): [DeclStmt] declaration
+# 1128|       getDeclarationEntry(0): [TypeDeclarationEntry] declaration of d
 # 1128|           Type = [CTypedefType,LocalTypedefType] d
-# 1129|     5: [ReturnStmt] return ...
+# 1129|     getStmt(5): [ReturnStmt] return ...
 # 1126| [TopLevelFunction] int f(float)
-# 1126|   params: 
-# 1126|     0: [Parameter] (unnamed parameter 0)
+# 1126|   ...: 
+# 1126|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1126|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int z(float)
-# 1127|   params: 
-# 1127|     0: [Parameter] (unnamed parameter 0)
+# 1127|   ...: 
+# 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int w(float)
-# 1127|   params: 
-# 1127|     0: [Parameter] (unnamed parameter 0)
+# 1127|   ...: 
+# 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1137| [TopLevelFunction] void ExternDeclarationsInMacro()
-# 1137|   params: 
-# 1138|   body: [BlockStmt] { ... }
-# 1139|     0: [DeclStmt] declaration
-# 1139|       0: [VariableDeclarationEntry] declaration of g
+# 1137|   ...: 
+# 1138|   getEntryPoint(): [BlockStmt] { ... }
+# 1139|     getStmt(0): [DeclStmt] declaration
+# 1139|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
 # 1139|           Type = [IntType] int
-# 1139|     1: [ForStmt] for(...;...;...) ...
-# 1139|       0: [DeclStmt] declaration
-# 1139|         0: [VariableDeclarationEntry] definition of i
+# 1139|     getStmt(1): [ForStmt] for(...;...;...) ...
+# 1139|       getInitialization(): [DeclStmt] declaration
+# 1139|         getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
 # 1139|             Type = [IntType] int
-# 1139|           init: [Initializer] initializer for i
-# 1139|             expr: [Literal] 0
+# 1139|           getVariable().getInitializer(): [Initializer] initializer for i
+# 1139|             getExpr(): [Literal] 0
 # 1139|                 Type = [IntType] int
 # 1139|                 Value = [Literal] 0
 # 1139|                 ValueCategory = prvalue
-# 1139|       1: [LTExpr] ... < ...
+# 1139|       getCondition(): [LTExpr] ... < ...
 # 1139|           Type = [BoolType] bool
 # 1139|           ValueCategory = prvalue
-# 1139|         0: [VariableAccess] i
+# 1139|         getLesserOperand(): [VariableAccess] i
 # 1139|             Type = [IntType] int
 # 1139|             ValueCategory = prvalue(load)
-# 1139|         1: [Literal] 10
+# 1139|         getGreaterOperand(): [Literal] 10
 # 1139|             Type = [IntType] int
 # 1139|             Value = [Literal] 10
 # 1139|             ValueCategory = prvalue
-# 1139|       2: [PrefixIncrExpr] ++ ...
+# 1139|       getUpdate(): [PrefixIncrExpr] ++ ...
 # 1139|           Type = [IntType] int
 # 1139|           ValueCategory = lvalue
-# 1139|         0: [VariableAccess] i
+# 1139|         getOperand(): [VariableAccess] i
 # 1139|             Type = [IntType] int
 # 1139|             ValueCategory = lvalue
-# 1139|       3: [BlockStmt] { ... }
-# 1139|         0: [DeclStmt] declaration
-# 1139|           0: [VariableDeclarationEntry] declaration of g
+# 1139|       getStmt(): [BlockStmt] { ... }
+# 1139|         getStmt(0): [DeclStmt] declaration
+# 1139|           getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
 # 1139|               Type = [IntType] int
-# 1139|     2: [EmptyStmt] ;
-# 1140|     3: [ReturnStmt] return ...
+# 1139|     getStmt(2): [EmptyStmt] ;
+# 1140|     getStmt(3): [ReturnStmt] return ...
 # 1142| [TopLevelFunction] void TryCatchNoCatchAny(bool)
-# 1142|   params: 
-# 1142|     0: [Parameter] b
+# 1142|   ...: 
+# 1142|     getParameter(0): [Parameter] b
 # 1142|         Type = [BoolType] bool
-# 1142|   body: [BlockStmt] { ... }
-# 1143|     0: [TryStmt] try { ... }
-# 1143|       0: [BlockStmt] { ... }
-# 1144|         0: [DeclStmt] declaration
-# 1144|           0: [VariableDeclarationEntry] definition of x
+# 1142|   getEntryPoint(): [BlockStmt] { ... }
+# 1143|     getStmt(0): [TryStmt] try { ... }
+# 1143|       getStmt(): [BlockStmt] { ... }
+# 1144|         getStmt(0): [DeclStmt] declaration
+# 1144|           getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 # 1144|               Type = [IntType] int
-# 1144|             init: [Initializer] initializer for x
-# 1144|               expr: [Literal] 5
+# 1144|             getVariable().getInitializer(): [Initializer] initializer for x
+# 1144|               getExpr(): [Literal] 5
 # 1144|                   Type = [IntType] int
 # 1144|                   Value = [Literal] 5
 # 1144|                   ValueCategory = prvalue
-# 1145|         1: [IfStmt] if (...) ... 
-# 1145|           0: [VariableAccess] b
+# 1145|         getStmt(1): [IfStmt] if (...) ... 
+# 1145|           getCondition(): [VariableAccess] b
 # 1145|               Type = [BoolType] bool
 # 1145|               ValueCategory = prvalue(load)
-# 1145|           1: [BlockStmt] { ... }
-# 1146|             0: [ExprStmt] ExprStmt
-# 1146|               0: [ThrowExpr] throw ...
+# 1145|           getThen(): [BlockStmt] { ... }
+# 1146|             getStmt(0): [ExprStmt] ExprStmt
+# 1146|               getExpr(): [ThrowExpr] throw ...
 # 1146|                   Type = [PointerType] const char *
 # 1146|                   ValueCategory = prvalue
-# 1146|                 0: string literal
+# 1146|                 getExpr(): string literal
 # 1146|                     Type = [ArrayType] const char[15]
 # 1146|                     Value = [StringLiteral] "string literal"
 # 1146|                     ValueCategory = lvalue
-# 1146|                 0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1146|                 : [ArrayToPointerConversion] array to pointer conversion
 # 1146|                     Type = [PointerType] const char *
 # 1146|                     ValueCategory = prvalue
-# 1148|           2: [IfStmt] if (...) ... 
-# 1148|             0: [LTExpr] ... < ...
+# 1148|           getElse(): [IfStmt] if (...) ... 
+# 1148|             getCondition(): [LTExpr] ... < ...
 # 1148|                 Type = [BoolType] bool
 # 1148|                 ValueCategory = prvalue
-# 1148|               0: [VariableAccess] x
+# 1148|               getLesserOperand(): [VariableAccess] x
 # 1148|                   Type = [IntType] int
 # 1148|                   ValueCategory = prvalue(load)
-# 1148|               1: [Literal] 2
+# 1148|               getGreaterOperand(): [Literal] 2
 # 1148|                   Type = [IntType] int
 # 1148|                   Value = [Literal] 2
 # 1148|                   ValueCategory = prvalue
-# 1148|             1: [BlockStmt] { ... }
-# 1149|               0: [ExprStmt] ExprStmt
-# 1149|                 0: [AssignExpr] ... = ...
+# 1148|             getThen(): [BlockStmt] { ... }
+# 1149|               getStmt(0): [ExprStmt] ExprStmt
+# 1149|                 getExpr(): [AssignExpr] ... = ...
 # 1149|                     Type = [IntType] int
 # 1149|                     ValueCategory = lvalue
-# 1149|                   0: [VariableAccess] x
+# 1149|                   getLValue(): [VariableAccess] x
 # 1149|                       Type = [IntType] int
 # 1149|                       ValueCategory = lvalue
-# 1149|                   1: [ConditionalExpr] ... ? ... : ...
+# 1149|                   getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1149|                       Type = [IntType] int
 # 1149|                       ValueCategory = prvalue
-# 1149|                     0: [VariableAccess] b
+# 1149|                     getCondition(): [VariableAccess] b
 # 1149|                         Type = [BoolType] bool
 # 1149|                         ValueCategory = prvalue(load)
-# 1149|                     1: [Literal] 7
+# 1149|                     getThen(): [Literal] 7
 # 1149|                         Type = [IntType] int
 # 1149|                         Value = [Literal] 7
 # 1149|                         ValueCategory = prvalue
-# 1149|                     2: [ThrowExpr] throw ...
+# 1149|                     getElse(): [ThrowExpr] throw ...
 # 1149|                         Type = [Struct] String
 # 1149|                         ValueCategory = prvalue
-# 1149|                       0: [ConstructorCall] call to String
+# 1149|                       getExpr(): [ConstructorCall] call to String
 # 1149|                           Type = [VoidType] void
 # 1149|                           ValueCategory = prvalue
-# 1149|                         0: String object
+# 1149|                         getArgument(0): String object
 # 1149|                             Type = [ArrayType] const char[14]
 # 1149|                             Value = [StringLiteral] "String object"
 # 1149|                             ValueCategory = lvalue
-# 1149|                         0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1149|                         : [ArrayToPointerConversion] array to pointer conversion
 # 1149|                             Type = [PointerType] const char *
 # 1149|                             ValueCategory = prvalue
-# 1151|         2: [ExprStmt] ExprStmt
-# 1151|           0: [AssignExpr] ... = ...
+# 1151|         getStmt(2): [ExprStmt] ExprStmt
+# 1151|           getExpr(): [AssignExpr] ... = ...
 # 1151|               Type = [IntType] int
 # 1151|               ValueCategory = lvalue
-# 1151|             0: [VariableAccess] x
+# 1151|             getLValue(): [VariableAccess] x
 # 1151|                 Type = [IntType] int
 # 1151|                 ValueCategory = lvalue
-# 1151|             1: [Literal] 7
+# 1151|             getRValue(): [Literal] 7
 # 1151|                 Type = [IntType] int
 # 1151|                 Value = [Literal] 7
 # 1151|                 ValueCategory = prvalue
-# 1153|       1: [Handler] <handler>
-# 1153|         0: [CatchBlock] { ... }
-# 1154|           0: [ExprStmt] ExprStmt
-# 1154|             0: [ThrowExpr] throw ...
+# 1153|       getChild(1): [Handler] <handler>
+# 1153|         getBlock(): [CatchBlock] { ... }
+# 1154|           getStmt(0): [ExprStmt] ExprStmt
+# 1154|             getExpr(): [ThrowExpr] throw ...
 # 1154|                 Type = [Struct] String
 # 1154|                 ValueCategory = prvalue
-# 1154|               0: [ConstructorCall] call to String
+# 1154|               getExpr(): [ConstructorCall] call to String
 # 1154|                   Type = [VoidType] void
 # 1154|                   ValueCategory = prvalue
-# 1154|                 0: [VariableAccess] s
+# 1154|                 getArgument(0): [VariableAccess] s
 # 1154|                     Type = [PointerType] const char *
 # 1154|                     ValueCategory = prvalue(load)
-# 1156|       2: [Handler] <handler>
-# 1156|         0: [CatchBlock] { ... }
-# 1158|     1: [ReturnStmt] return ...
+# 1156|       getChild(2): [Handler] <handler>
+# 1156|         getBlock(): [CatchBlock] { ... }
+# 1158|     getStmt(1): [ReturnStmt] return ...
 # 1162| [TopLevelFunction] void VectorTypes(int)
-# 1162|   params: 
-# 1162|     0: [Parameter] i
+# 1162|   ...: 
+# 1162|     getParameter(0): [Parameter] i
 # 1162|         Type = [IntType] int
-# 1162|   body: [BlockStmt] { ... }
-# 1163|     0: [DeclStmt] declaration
-# 1163|       0: [VariableDeclarationEntry] definition of vi4
+# 1162|   getEntryPoint(): [BlockStmt] { ... }
+# 1163|     getStmt(0): [DeclStmt] declaration
+# 1163|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of vi4
 # 1163|           Type = [SpecifiedType] __attribute((vector_size(16UL))) int
-# 1163|         init: [Initializer] initializer for vi4
-# 1163|           expr: [VectorAggregateLiteral] {...}
+# 1163|         getVariable().getInitializer(): [Initializer] initializer for vi4
+# 1163|           getExpr(): [VectorAggregateLiteral] {...}
 # 1163|               Type = [GNUVectorType] __attribute((vector_size(16UL))) int
 # 1163|               ValueCategory = prvalue
-# 1163|             0: [Literal] 0
+# 1163|             getElementExpr(0): [Literal] 0
 # 1163|                 Type = [IntType] int
 # 1163|                 Value = [Literal] 0
 # 1163|                 ValueCategory = prvalue
-# 1163|             1: [Literal] 1
+# 1163|             getElementExpr(1): [Literal] 1
 # 1163|                 Type = [IntType] int
 # 1163|                 Value = [Literal] 1
 # 1163|                 ValueCategory = prvalue
-# 1163|             2: [Literal] 2
+# 1163|             getElementExpr(2): [Literal] 2
 # 1163|                 Type = [IntType] int
 # 1163|                 Value = [Literal] 2
 # 1163|                 ValueCategory = prvalue
-# 1163|             3: [Literal] 3
+# 1163|             getElementExpr(3): [Literal] 3
 # 1163|                 Type = [IntType] int
 # 1163|                 Value = [Literal] 3
 # 1163|                 ValueCategory = prvalue
-# 1164|     1: [DeclStmt] declaration
-# 1164|       0: [VariableDeclarationEntry] definition of x
+# 1164|     getStmt(1): [DeclStmt] declaration
+# 1164|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
 # 1164|           Type = [IntType] int
-# 1164|         init: [Initializer] initializer for x
-# 1164|           expr: [ArrayExpr] access to array
+# 1164|         getVariable().getInitializer(): [Initializer] initializer for x
+# 1164|           getExpr(): [ArrayExpr] access to array
 # 1164|               Type = [IntType] int
 # 1164|               ValueCategory = prvalue(load)
-# 1164|             0: [VariableAccess] vi4
+# 1164|             getArrayBase(): [VariableAccess] vi4
 # 1164|                 Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1164|                 ValueCategory = lvalue
-# 1164|             1: [VariableAccess] i
+# 1164|             getArrayOffset(): [VariableAccess] i
 # 1164|                 Type = [IntType] int
 # 1164|                 ValueCategory = prvalue(load)
-# 1165|     2: [ExprStmt] ExprStmt
-# 1165|       0: [AssignExpr] ... = ...
+# 1165|     getStmt(2): [ExprStmt] ExprStmt
+# 1165|       getExpr(): [AssignExpr] ... = ...
 # 1165|           Type = [IntType] int
 # 1165|           ValueCategory = lvalue
-# 1165|         0: [ArrayExpr] access to array
+# 1165|         getLValue(): [ArrayExpr] access to array
 # 1165|             Type = [IntType] int
 # 1165|             ValueCategory = lvalue
-# 1165|           0: [VariableAccess] vi4
+# 1165|           getArrayBase(): [VariableAccess] vi4
 # 1165|               Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1165|               ValueCategory = lvalue
-# 1165|           1: [VariableAccess] i
+# 1165|           getArrayOffset(): [VariableAccess] i
 # 1165|               Type = [IntType] int
 # 1165|               ValueCategory = prvalue(load)
-# 1165|         1: [VariableAccess] x
+# 1165|         getRValue(): [VariableAccess] x
 # 1165|             Type = [IntType] int
 # 1165|             ValueCategory = prvalue(load)
-# 1166|     3: [DeclStmt] declaration
-# 1166|       0: [VariableDeclarationEntry] definition of vi4_shuffle
+# 1166|     getStmt(3): [DeclStmt] declaration
+# 1166|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of vi4_shuffle
 # 1166|           Type = [SpecifiedType] __attribute((vector_size(16UL))) int
-# 1166|         init: [Initializer] initializer for vi4_shuffle
-# 1166|           expr: [BuiltInOperationBuiltInShuffleVector] __builtin_shufflevector
+# 1166|         getVariable().getInitializer(): [Initializer] initializer for vi4_shuffle
+# 1166|           getExpr(): [BuiltInOperationBuiltInShuffleVector] __builtin_shufflevector
 # 1166|               Type = [GNUVectorType] __attribute((vector_size(16))) int
 # 1166|               ValueCategory = prvalue
-# 1166|             0: [VariableAccess] vi4
+# 1166|             getChild(0): [VariableAccess] vi4
 # 1166|                 Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1166|                 ValueCategory = prvalue(load)
-# 1166|             1: [VariableAccess] vi4
+# 1166|             getChild(1): [VariableAccess] vi4
 # 1166|                 Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1166|                 ValueCategory = prvalue(load)
-# 1166|             2: [AddExpr] ... + ...
+# 1166|             getChild(2): [AddExpr] ... + ...
 # 1166|                 Type = [IntType] int
 # 1166|                 Value = [AddExpr] 3
 # 1166|                 ValueCategory = prvalue
-# 1166|               0: [Literal] 3
+# 1166|               getLeftOperand(): [Literal] 3
 # 1166|                   Type = [IntType] int
 # 1166|                   Value = [Literal] 3
 # 1166|                   ValueCategory = prvalue
-# 1166|               1: [Literal] 0
+# 1166|               getRightOperand(): [Literal] 0
 # 1166|                   Type = [IntType] int
 # 1166|                   Value = [Literal] 0
 # 1166|                   ValueCategory = prvalue
-# 1166|             3: [Literal] 2
+# 1166|             getChild(3): [Literal] 2
 # 1166|                 Type = [IntType] int
 # 1166|                 Value = [Literal] 2
 # 1166|                 ValueCategory = prvalue
-# 1166|             4: [Literal] 1
+# 1166|             getChild(4): [Literal] 1
 # 1166|                 Type = [IntType] int
 # 1166|                 Value = [Literal] 1
 # 1166|                 ValueCategory = prvalue
-# 1166|             5: [Literal] 0
+# 1166|             getChild(5): [Literal] 0
 # 1166|                 Type = [IntType] int
 # 1166|                 Value = [Literal] 0
 # 1166|                 ValueCategory = prvalue
-# 1167|     4: [ExprStmt] ExprStmt
-# 1167|       0: [AssignExpr] ... = ...
+# 1167|     getStmt(4): [ExprStmt] ExprStmt
+# 1167|       getExpr(): [AssignExpr] ... = ...
 # 1167|           Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1167|           ValueCategory = lvalue
-# 1167|         0: [VariableAccess] vi4
+# 1167|         getLValue(): [VariableAccess] vi4
 # 1167|             Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1167|             ValueCategory = lvalue
-# 1167|         1: [AddExpr] ... + ...
+# 1167|         getRValue(): [AddExpr] ... + ...
 # 1167|             Type = [GNUVectorType] __attribute((vector_size(16UL))) int
 # 1167|             ValueCategory = prvalue
-# 1167|           0: [VariableAccess] vi4
+# 1167|           getLeftOperand(): [VariableAccess] vi4
 # 1167|               Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1167|               ValueCategory = prvalue(load)
-# 1167|           1: [VariableAccess] vi4_shuffle
+# 1167|           getRightOperand(): [VariableAccess] vi4_shuffle
 # 1167|               Type = [SpecifiedType] __attribute((vector_size(16UL))) int
 # 1167|               ValueCategory = prvalue(load)
-# 1168|     5: [ReturnStmt] return ...
+# 1168|     getStmt(5): [ReturnStmt] return ...
 # 1170| [TopLevelFunction] void* memcpy(void*, void*, int)
-# 1170|   params: 
-# 1170|     0: [Parameter] dst
+# 1170|   ...: 
+# 1170|     getParameter(0): [Parameter] dst
 # 1170|         Type = [VoidPointerType] void *
-# 1170|     1: [Parameter] src
+# 1170|     getParameter(1): [Parameter] src
 # 1170|         Type = [VoidPointerType] void *
-# 1170|     2: [Parameter] size
+# 1170|     getParameter(2): [Parameter] size
 # 1170|         Type = [IntType] int
 # 1172| [TopLevelFunction] int ModeledCallTarget(int)
-# 1172|   params: 
-# 1172|     0: [Parameter] x
+# 1172|   ...: 
+# 1172|     getParameter(0): [Parameter] x
 # 1172|         Type = [IntType] int
-# 1172|   body: [BlockStmt] { ... }
-# 1173|     0: [DeclStmt] declaration
-# 1173|       0: [VariableDeclarationEntry] definition of y
+# 1172|   getEntryPoint(): [BlockStmt] { ... }
+# 1173|     getStmt(0): [DeclStmt] declaration
+# 1173|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1173|           Type = [IntType] int
-# 1174|     1: [ExprStmt] ExprStmt
-# 1174|       0: [FunctionCall] call to memcpy
+# 1174|     getStmt(1): [ExprStmt] ExprStmt
+# 1174|       getExpr(): [FunctionCall] call to memcpy
 # 1174|           Type = [VoidPointerType] void *
 # 1174|           ValueCategory = prvalue
-# 1174|         0: [AddressOfExpr] & ...
+# 1174|         getArgument(0): [AddressOfExpr] & ...
 # 1174|             Type = [IntPointerType] int *
 # 1174|             ValueCategory = prvalue
-# 1174|           0: [VariableAccess] y
+# 1174|           getOperand(): [VariableAccess] y
 # 1174|               Type = [IntType] int
 # 1174|               ValueCategory = lvalue
-# 1174|         1: [AddressOfExpr] & ...
+# 1174|         getArgument(1): [AddressOfExpr] & ...
 # 1174|             Type = [IntPointerType] int *
 # 1174|             ValueCategory = prvalue
-# 1174|           0: [VariableAccess] x
+# 1174|           getOperand(): [VariableAccess] x
 # 1174|               Type = [IntType] int
 # 1174|               ValueCategory = lvalue
-# 1174|         2: [SizeofTypeOperator] sizeof(int)
+# 1174|         getArgument(2): [SizeofTypeOperator] sizeof(int)
 # 1174|             Type = [LongType] unsigned long
 # 1174|             Value = [SizeofTypeOperator] 4
 # 1174|             ValueCategory = prvalue
-# 1174|         0 converted: [CStyleCast] (void *)...
+# 1174|         : [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|         1 converted: [CStyleCast] (void *)...
+# 1174|         : [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|         2 converted: [CStyleCast] (int)...
+# 1174|         : [CStyleCast] (int)...
 # 1174|             Conversion = [IntegralConversion] integral conversion
 # 1174|             Type = [IntType] int
 # 1174|             Value = [CStyleCast] 4
 # 1174|             ValueCategory = prvalue
-# 1175|     2: [ReturnStmt] return ...
-# 1175|       0: [VariableAccess] y
+# 1175|     getStmt(2): [ReturnStmt] return ...
+# 1175|       getExpr(): [VariableAccess] y
 # 1175|           Type = [IntType] int
 # 1175|           ValueCategory = prvalue(load)
 # 1178| [TopLevelFunction] String ReturnObjectImpl()
-# 1178|   params: 
-# 1178|   body: [BlockStmt] { ... }
-# 1179|     0: [ReturnStmt] return ...
-# 1179|       0: [ConstructorCall] call to String
+# 1178|   ...: 
+# 1178|   getEntryPoint(): [BlockStmt] { ... }
+# 1179|     getStmt(0): [ReturnStmt] return ...
+# 1179|       getExpr(): [ConstructorCall] call to String
 # 1179|           Type = [Struct] String
 # 1179|           ValueCategory = prvalue
-# 1179|         0: foo
+# 1179|         getArgument(0): foo
 # 1179|             Type = [ArrayType] const char[4]
 # 1179|             Value = [StringLiteral] "foo"
 # 1179|             ValueCategory = lvalue
-# 1179|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1179|         : [ArrayToPointerConversion] array to pointer conversion
 # 1179|             Type = [PointerType] const char *
 # 1179|             ValueCategory = prvalue
 # 1182| [TopLevelFunction] void switch1Case(int)
-# 1182|   params: 
-# 1182|     0: [Parameter] x
+# 1182|   ...: 
+# 1182|     getParameter(0): [Parameter] x
 # 1182|         Type = [IntType] int
-# 1182|   body: [BlockStmt] { ... }
-# 1183|     0: [DeclStmt] declaration
-# 1183|       0: [VariableDeclarationEntry] definition of y
+# 1182|   getEntryPoint(): [BlockStmt] { ... }
+# 1183|     getStmt(0): [DeclStmt] declaration
+# 1183|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1183|           Type = [IntType] int
-# 1183|         init: [Initializer] initializer for y
-# 1183|           expr: [Literal] 0
+# 1183|         getVariable().getInitializer(): [Initializer] initializer for y
+# 1183|           getExpr(): [Literal] 0
 # 1183|               Type = [IntType] int
 # 1183|               Value = [Literal] 0
 # 1183|               ValueCategory = prvalue
-# 1184|     1: [SwitchStmt] switch (...) ... 
-# 1184|       0: [VariableAccess] x
+# 1184|     getStmt(1): [SwitchStmt] switch (...) ... 
+# 1184|       getExpr(): [VariableAccess] x
 # 1184|           Type = [IntType] int
 # 1184|           ValueCategory = prvalue(load)
-# 1184|       1: [BlockStmt] { ... }
-# 1185|         0: [SwitchCase] case ...:
-# 1185|           0: [Literal] 1
+# 1184|       getStmt(): [BlockStmt] { ... }
+# 1185|         getStmt(0): [SwitchCase] case ...:
+# 1185|           getExpr(): [Literal] 1
 # 1185|               Type = [IntType] int
 # 1185|               Value = [Literal] 1
 # 1185|               ValueCategory = prvalue
-# 1186|         1: [ExprStmt] ExprStmt
-# 1186|           0: [AssignExpr] ... = ...
+# 1186|         getStmt(1): [ExprStmt] ExprStmt
+# 1186|           getExpr(): [AssignExpr] ... = ...
 # 1186|               Type = [IntType] int
 # 1186|               ValueCategory = lvalue
-# 1186|             0: [VariableAccess] y
+# 1186|             getLValue(): [VariableAccess] y
 # 1186|                 Type = [IntType] int
 # 1186|                 ValueCategory = lvalue
-# 1186|             1: [Literal] 2
+# 1186|             getRValue(): [Literal] 2
 # 1186|                 Type = [IntType] int
 # 1186|                 Value = [Literal] 2
 # 1186|                 ValueCategory = prvalue
-# 1188|     2: [DeclStmt] declaration
-# 1188|       0: [VariableDeclarationEntry] definition of z
+# 1188|     getStmt(2): [DeclStmt] declaration
+# 1188|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 # 1188|           Type = [IntType] int
-# 1188|         init: [Initializer] initializer for z
-# 1188|           expr: [VariableAccess] y
+# 1188|         getVariable().getInitializer(): [Initializer] initializer for z
+# 1188|           getExpr(): [VariableAccess] y
 # 1188|               Type = [IntType] int
 # 1188|               ValueCategory = prvalue(load)
-# 1189|     3: [ReturnStmt] return ...
+# 1189|     getStmt(3): [ReturnStmt] return ...
 # 1191| [TopLevelFunction] void switch2Case_fallthrough(int)
-# 1191|   params: 
-# 1191|     0: [Parameter] x
+# 1191|   ...: 
+# 1191|     getParameter(0): [Parameter] x
 # 1191|         Type = [IntType] int
-# 1191|   body: [BlockStmt] { ... }
-# 1192|     0: [DeclStmt] declaration
-# 1192|       0: [VariableDeclarationEntry] definition of y
+# 1191|   getEntryPoint(): [BlockStmt] { ... }
+# 1192|     getStmt(0): [DeclStmt] declaration
+# 1192|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1192|           Type = [IntType] int
-# 1192|         init: [Initializer] initializer for y
-# 1192|           expr: [Literal] 0
+# 1192|         getVariable().getInitializer(): [Initializer] initializer for y
+# 1192|           getExpr(): [Literal] 0
 # 1192|               Type = [IntType] int
 # 1192|               Value = [Literal] 0
 # 1192|               ValueCategory = prvalue
-# 1193|     1: [SwitchStmt] switch (...) ... 
-# 1193|       0: [VariableAccess] x
+# 1193|     getStmt(1): [SwitchStmt] switch (...) ... 
+# 1193|       getExpr(): [VariableAccess] x
 # 1193|           Type = [IntType] int
 # 1193|           ValueCategory = prvalue(load)
-# 1193|       1: [BlockStmt] { ... }
-# 1194|         0: [SwitchCase] case ...:
-# 1194|           0: [Literal] 1
+# 1193|       getStmt(): [BlockStmt] { ... }
+# 1194|         getStmt(0): [SwitchCase] case ...:
+# 1194|           getExpr(): [Literal] 1
 # 1194|               Type = [IntType] int
 # 1194|               Value = [Literal] 1
 # 1194|               ValueCategory = prvalue
-# 1195|         1: [ExprStmt] ExprStmt
-# 1195|           0: [AssignExpr] ... = ...
+# 1195|         getStmt(1): [ExprStmt] ExprStmt
+# 1195|           getExpr(): [AssignExpr] ... = ...
 # 1195|               Type = [IntType] int
 # 1195|               ValueCategory = lvalue
-# 1195|             0: [VariableAccess] y
+# 1195|             getLValue(): [VariableAccess] y
 # 1195|                 Type = [IntType] int
 # 1195|                 ValueCategory = lvalue
-# 1195|             1: [Literal] 2
+# 1195|             getRValue(): [Literal] 2
 # 1195|                 Type = [IntType] int
 # 1195|                 Value = [Literal] 2
 # 1195|                 ValueCategory = prvalue
-# 1196|         2: [SwitchCase] case ...:
-# 1196|           0: [Literal] 2
+# 1196|         getStmt(2): [SwitchCase] case ...:
+# 1196|           getExpr(): [Literal] 2
 # 1196|               Type = [IntType] int
 # 1196|               Value = [Literal] 2
 # 1196|               ValueCategory = prvalue
-# 1197|         3: [ExprStmt] ExprStmt
-# 1197|           0: [AssignExpr] ... = ...
+# 1197|         getStmt(3): [ExprStmt] ExprStmt
+# 1197|           getExpr(): [AssignExpr] ... = ...
 # 1197|               Type = [IntType] int
 # 1197|               ValueCategory = lvalue
-# 1197|             0: [VariableAccess] y
+# 1197|             getLValue(): [VariableAccess] y
 # 1197|                 Type = [IntType] int
 # 1197|                 ValueCategory = lvalue
-# 1197|             1: [Literal] 3
+# 1197|             getRValue(): [Literal] 3
 # 1197|                 Type = [IntType] int
 # 1197|                 Value = [Literal] 3
 # 1197|                 ValueCategory = prvalue
-# 1199|     2: [DeclStmt] declaration
-# 1199|       0: [VariableDeclarationEntry] definition of z
+# 1199|     getStmt(2): [DeclStmt] declaration
+# 1199|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 # 1199|           Type = [IntType] int
-# 1199|         init: [Initializer] initializer for z
-# 1199|           expr: [VariableAccess] y
+# 1199|         getVariable().getInitializer(): [Initializer] initializer for z
+# 1199|           getExpr(): [VariableAccess] y
 # 1199|               Type = [IntType] int
 # 1199|               ValueCategory = prvalue(load)
-# 1200|     3: [ReturnStmt] return ...
+# 1200|     getStmt(3): [ReturnStmt] return ...
 # 1202| [TopLevelFunction] void switch2Case(int)
-# 1202|   params: 
-# 1202|     0: [Parameter] x
+# 1202|   ...: 
+# 1202|     getParameter(0): [Parameter] x
 # 1202|         Type = [IntType] int
-# 1202|   body: [BlockStmt] { ... }
-# 1203|     0: [DeclStmt] declaration
-# 1203|       0: [VariableDeclarationEntry] definition of y
+# 1202|   getEntryPoint(): [BlockStmt] { ... }
+# 1203|     getStmt(0): [DeclStmt] declaration
+# 1203|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1203|           Type = [IntType] int
-# 1203|         init: [Initializer] initializer for y
-# 1203|           expr: [Literal] 0
+# 1203|         getVariable().getInitializer(): [Initializer] initializer for y
+# 1203|           getExpr(): [Literal] 0
 # 1203|               Type = [IntType] int
 # 1203|               Value = [Literal] 0
 # 1203|               ValueCategory = prvalue
-# 1204|     1: [SwitchStmt] switch (...) ... 
-# 1204|       0: [VariableAccess] x
+# 1204|     getStmt(1): [SwitchStmt] switch (...) ... 
+# 1204|       getExpr(): [VariableAccess] x
 # 1204|           Type = [IntType] int
 # 1204|           ValueCategory = prvalue(load)
-# 1204|       1: [BlockStmt] { ... }
-# 1205|         0: [SwitchCase] case ...:
-# 1205|           0: [Literal] 1
+# 1204|       getStmt(): [BlockStmt] { ... }
+# 1205|         getStmt(0): [SwitchCase] case ...:
+# 1205|           getExpr(): [Literal] 1
 # 1205|               Type = [IntType] int
 # 1205|               Value = [Literal] 1
 # 1205|               ValueCategory = prvalue
-# 1206|         1: [ExprStmt] ExprStmt
-# 1206|           0: [AssignExpr] ... = ...
+# 1206|         getStmt(1): [ExprStmt] ExprStmt
+# 1206|           getExpr(): [AssignExpr] ... = ...
 # 1206|               Type = [IntType] int
 # 1206|               ValueCategory = lvalue
-# 1206|             0: [VariableAccess] y
+# 1206|             getLValue(): [VariableAccess] y
 # 1206|                 Type = [IntType] int
 # 1206|                 ValueCategory = lvalue
-# 1206|             1: [Literal] 2
+# 1206|             getRValue(): [Literal] 2
 # 1206|                 Type = [IntType] int
 # 1206|                 Value = [Literal] 2
 # 1206|                 ValueCategory = prvalue
-# 1207|         2: [BreakStmt] break;
-# 1208|         3: [SwitchCase] case ...:
-# 1208|           0: [Literal] 2
+# 1207|         getStmt(2): [BreakStmt] break;
+# 1208|         getStmt(3): [SwitchCase] case ...:
+# 1208|           getExpr(): [Literal] 2
 # 1208|               Type = [IntType] int
 # 1208|               Value = [Literal] 2
 # 1208|               ValueCategory = prvalue
-# 1209|         4: [ExprStmt] ExprStmt
-# 1209|           0: [AssignExpr] ... = ...
+# 1209|         getStmt(4): [ExprStmt] ExprStmt
+# 1209|           getExpr(): [AssignExpr] ... = ...
 # 1209|               Type = [IntType] int
 # 1209|               ValueCategory = lvalue
-# 1209|             0: [VariableAccess] y
+# 1209|             getLValue(): [VariableAccess] y
 # 1209|                 Type = [IntType] int
 # 1209|                 ValueCategory = lvalue
-# 1209|             1: [Literal] 3
+# 1209|             getRValue(): [Literal] 3
 # 1209|                 Type = [IntType] int
 # 1209|                 Value = [Literal] 3
 # 1209|                 ValueCategory = prvalue
-# 1210|     2: [LabelStmt] label ...:
-# 1211|     3: [DeclStmt] declaration
-# 1211|       0: [VariableDeclarationEntry] definition of z
+# 1210|     getStmt(2): [LabelStmt] label ...:
+# 1211|     getStmt(3): [DeclStmt] declaration
+# 1211|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 # 1211|           Type = [IntType] int
-# 1211|         init: [Initializer] initializer for z
-# 1211|           expr: [VariableAccess] y
+# 1211|         getVariable().getInitializer(): [Initializer] initializer for z
+# 1211|           getExpr(): [VariableAccess] y
 # 1211|               Type = [IntType] int
 # 1211|               ValueCategory = prvalue(load)
-# 1212|     4: [ReturnStmt] return ...
+# 1212|     getStmt(4): [ReturnStmt] return ...
 # 1214| [TopLevelFunction] void switch2Case_default(int)
-# 1214|   params: 
-# 1214|     0: [Parameter] x
+# 1214|   ...: 
+# 1214|     getParameter(0): [Parameter] x
 # 1214|         Type = [IntType] int
-# 1214|   body: [BlockStmt] { ... }
-# 1215|     0: [DeclStmt] declaration
-# 1215|       0: [VariableDeclarationEntry] definition of y
+# 1214|   getEntryPoint(): [BlockStmt] { ... }
+# 1215|     getStmt(0): [DeclStmt] declaration
+# 1215|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of y
 # 1215|           Type = [IntType] int
-# 1215|         init: [Initializer] initializer for y
-# 1215|           expr: [Literal] 0
+# 1215|         getVariable().getInitializer(): [Initializer] initializer for y
+# 1215|           getExpr(): [Literal] 0
 # 1215|               Type = [IntType] int
 # 1215|               Value = [Literal] 0
 # 1215|               ValueCategory = prvalue
-# 1216|     1: [SwitchStmt] switch (...) ... 
-# 1216|       0: [VariableAccess] x
+# 1216|     getStmt(1): [SwitchStmt] switch (...) ... 
+# 1216|       getExpr(): [VariableAccess] x
 # 1216|           Type = [IntType] int
 # 1216|           ValueCategory = prvalue(load)
-# 1216|       1: [BlockStmt] { ... }
-# 1217|         0: [SwitchCase] case ...:
-# 1217|           0: [Literal] 1
+# 1216|       getStmt(): [BlockStmt] { ... }
+# 1217|         getStmt(0): [SwitchCase] case ...:
+# 1217|           getExpr(): [Literal] 1
 # 1217|               Type = [IntType] int
 # 1217|               Value = [Literal] 1
 # 1217|               ValueCategory = prvalue
-# 1218|         1: [ExprStmt] ExprStmt
-# 1218|           0: [AssignExpr] ... = ...
+# 1218|         getStmt(1): [ExprStmt] ExprStmt
+# 1218|           getExpr(): [AssignExpr] ... = ...
 # 1218|               Type = [IntType] int
 # 1218|               ValueCategory = lvalue
-# 1218|             0: [VariableAccess] y
+# 1218|             getLValue(): [VariableAccess] y
 # 1218|                 Type = [IntType] int
 # 1218|                 ValueCategory = lvalue
-# 1218|             1: [Literal] 2
+# 1218|             getRValue(): [Literal] 2
 # 1218|                 Type = [IntType] int
 # 1218|                 Value = [Literal] 2
 # 1218|                 ValueCategory = prvalue
-# 1219|         2: [BreakStmt] break;
-# 1221|         3: [SwitchCase] case ...:
-# 1221|           0: [Literal] 2
+# 1219|         getStmt(2): [BreakStmt] break;
+# 1221|         getStmt(3): [SwitchCase] case ...:
+# 1221|           getExpr(): [Literal] 2
 # 1221|               Type = [IntType] int
 # 1221|               Value = [Literal] 2
 # 1221|               ValueCategory = prvalue
-# 1222|         4: [ExprStmt] ExprStmt
-# 1222|           0: [AssignExpr] ... = ...
+# 1222|         getStmt(4): [ExprStmt] ExprStmt
+# 1222|           getExpr(): [AssignExpr] ... = ...
 # 1222|               Type = [IntType] int
 # 1222|               ValueCategory = lvalue
-# 1222|             0: [VariableAccess] y
+# 1222|             getLValue(): [VariableAccess] y
 # 1222|                 Type = [IntType] int
 # 1222|                 ValueCategory = lvalue
-# 1222|             1: [Literal] 3
+# 1222|             getRValue(): [Literal] 3
 # 1222|                 Type = [IntType] int
 # 1222|                 Value = [Literal] 3
 # 1222|                 ValueCategory = prvalue
-# 1223|         5: [BreakStmt] break;
-# 1225|         6: [SwitchCase] default: 
-# 1226|         7: [ExprStmt] ExprStmt
-# 1226|           0: [AssignExpr] ... = ...
+# 1223|         getStmt(5): [BreakStmt] break;
+# 1225|         getStmt(6): [SwitchCase] default: 
+# 1226|         getStmt(7): [ExprStmt] ExprStmt
+# 1226|           getExpr(): [AssignExpr] ... = ...
 # 1226|               Type = [IntType] int
 # 1226|               ValueCategory = lvalue
-# 1226|             0: [VariableAccess] y
+# 1226|             getLValue(): [VariableAccess] y
 # 1226|                 Type = [IntType] int
 # 1226|                 ValueCategory = lvalue
-# 1226|             1: [Literal] 4
+# 1226|             getRValue(): [Literal] 4
 # 1226|                 Type = [IntType] int
 # 1226|                 Value = [Literal] 4
 # 1226|                 ValueCategory = prvalue
-# 1227|     2: [LabelStmt] label ...:
-# 1228|     3: [DeclStmt] declaration
-# 1228|       0: [VariableDeclarationEntry] definition of z
+# 1227|     getStmt(2): [LabelStmt] label ...:
+# 1228|     getStmt(3): [DeclStmt] declaration
+# 1228|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 # 1228|           Type = [IntType] int
-# 1228|         init: [Initializer] initializer for z
-# 1228|           expr: [VariableAccess] y
+# 1228|         getVariable().getInitializer(): [Initializer] initializer for z
+# 1228|           getExpr(): [VariableAccess] y
 # 1228|               Type = [IntType] int
 # 1228|               ValueCategory = prvalue(load)
-# 1229|     4: [ReturnStmt] return ...
+# 1229|     getStmt(4): [ReturnStmt] return ...
 # 1231| [TopLevelFunction] int staticLocalInit(int)
-# 1231|   params: 
-# 1231|     0: [Parameter] x
+# 1231|   ...: 
+# 1231|     getParameter(0): [Parameter] x
 # 1231|         Type = [IntType] int
-# 1231|   body: [BlockStmt] { ... }
-# 1232|     0: [DeclStmt] declaration
-# 1232|       0: [VariableDeclarationEntry] definition of a
+# 1231|   getEntryPoint(): [BlockStmt] { ... }
+# 1232|     getStmt(0): [DeclStmt] declaration
+# 1232|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 # 1232|           Type = [IntType] int
-# 1232|         init: [Initializer] initializer for a
-# 1232|           expr: [Literal] 0
+# 1232|         getVariable().getInitializer(): [Initializer] initializer for a
+# 1232|           getExpr(): [Literal] 0
 # 1232|               Type = [IntType] int
 # 1232|               Value = [Literal] 0
 # 1232|               ValueCategory = prvalue
-# 1233|     1: [DeclStmt] declaration
-# 1233|       0: [VariableDeclarationEntry] definition of b
+# 1233|     getStmt(1): [DeclStmt] declaration
+# 1233|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 # 1233|           Type = [IntType] int
-# 1233|         init: [Initializer] initializer for b
-# 1233|           expr: [SizeofExprOperator] sizeof(<expr>)
+# 1233|         getVariable().getInitializer(): [Initializer] initializer for b
+# 1233|           getExpr(): [SizeofExprOperator] sizeof(<expr>)
 # 1233|               Type = [LongType] unsigned long
 # 1233|               Value = [SizeofExprOperator] 4
 # 1233|               ValueCategory = prvalue
-# 1233|             0: [VariableAccess] x
+# 1233|             getExprOperand(): [VariableAccess] x
 # 1233|                 Type = [IntType] int
 # 1233|                 ValueCategory = lvalue
-# 1233|             0 converted: [ParenthesisExpr] (...)
+# 1233|             : [ParenthesisExpr] (...)
 # 1233|                 Type = [IntType] int
 # 1233|                 ValueCategory = lvalue
-# 1233|           expr converted: [CStyleCast] (int)...
+# 1233|           : [CStyleCast] (int)...
 # 1233|               Conversion = [IntegralConversion] integral conversion
 # 1233|               Type = [IntType] int
 # 1233|               Value = [CStyleCast] 4
 # 1233|               ValueCategory = prvalue
-# 1234|     2: [DeclStmt] declaration
-# 1234|       0: [VariableDeclarationEntry] definition of c
+# 1234|     getStmt(2): [DeclStmt] declaration
+# 1234|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 # 1234|           Type = [IntType] int
-# 1234|         init: [Initializer] initializer for c
-# 1234|           expr: [VariableAccess] x
+# 1234|         getVariable().getInitializer(): [Initializer] initializer for c
+# 1234|           getExpr(): [VariableAccess] x
 # 1234|               Type = [IntType] int
 # 1234|               ValueCategory = prvalue(load)
-# 1235|     3: [DeclStmt] declaration
-# 1235|       0: [VariableDeclarationEntry] definition of d
+# 1235|     getStmt(3): [DeclStmt] declaration
+# 1235|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of d
 # 1235|           Type = [IntType] int
-# 1237|     4: [ReturnStmt] return ...
-# 1237|       0: [AddExpr] ... + ...
+# 1237|     getStmt(4): [ReturnStmt] return ...
+# 1237|       getExpr(): [AddExpr] ... + ...
 # 1237|           Type = [IntType] int
 # 1237|           ValueCategory = prvalue
-# 1237|         0: [AddExpr] ... + ...
+# 1237|         getLeftOperand(): [AddExpr] ... + ...
 # 1237|             Type = [IntType] int
 # 1237|             ValueCategory = prvalue
-# 1237|           0: [AddExpr] ... + ...
+# 1237|           getLeftOperand(): [AddExpr] ... + ...
 # 1237|               Type = [IntType] int
 # 1237|               ValueCategory = prvalue
-# 1237|             0: [VariableAccess] a
+# 1237|             getLeftOperand(): [VariableAccess] a
 # 1237|                 Type = [IntType] int
 # 1237|                 ValueCategory = prvalue(load)
-# 1237|             1: [VariableAccess] b
+# 1237|             getRightOperand(): [VariableAccess] b
 # 1237|                 Type = [IntType] int
 # 1237|                 ValueCategory = prvalue(load)
-# 1237|           1: [VariableAccess] c
+# 1237|           getRightOperand(): [VariableAccess] c
 # 1237|               Type = [IntType] int
 # 1237|               ValueCategory = prvalue(load)
-# 1237|         1: [VariableAccess] d
+# 1237|         getRightOperand(): [VariableAccess] d
 # 1237|             Type = [IntType] int
 # 1237|             ValueCategory = prvalue(load)
 # 1240| [TopLevelFunction] void staticLocalWithConstructor(char const*)
-# 1240|   params: 
-# 1240|     0: [Parameter] dynamic
+# 1240|   ...: 
+# 1240|     getParameter(0): [Parameter] dynamic
 # 1240|         Type = [PointerType] const char *
-# 1240|   body: [BlockStmt] { ... }
-# 1241|     0: [DeclStmt] declaration
-# 1241|       0: [VariableDeclarationEntry] definition of a
+# 1240|   getEntryPoint(): [BlockStmt] { ... }
+# 1241|     getStmt(0): [DeclStmt] declaration
+# 1241|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 # 1241|           Type = [Struct] String
-#-----|         init: [Initializer] initializer for a
-#-----|           expr: [ConstructorCall] call to String
+#-----|         getVariable().getInitializer(): [Initializer] initializer for a
+#-----|           getExpr(): [ConstructorCall] call to String
 #-----|               Type = [VoidType] void
 #-----|               ValueCategory = prvalue
-# 1242|     1: [DeclStmt] declaration
-# 1242|       0: [VariableDeclarationEntry] definition of b
+# 1242|     getStmt(1): [DeclStmt] declaration
+# 1242|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
 # 1242|           Type = [Struct] String
-# 1242|         init: [Initializer] initializer for b
-# 1242|           expr: [ConstructorCall] call to String
+# 1242|         getVariable().getInitializer(): [Initializer] initializer for b
+# 1242|           getExpr(): [ConstructorCall] call to String
 # 1242|               Type = [VoidType] void
 # 1242|               ValueCategory = prvalue
-# 1242|             0: static
+# 1242|             getArgument(0): static
 # 1242|                 Type = [ArrayType] const char[7]
 # 1242|                 Value = [StringLiteral] "static"
 # 1242|                 ValueCategory = lvalue
-# 1242|             0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1242|             : [ArrayToPointerConversion] array to pointer conversion
 # 1242|                 Type = [PointerType] const char *
 # 1242|                 ValueCategory = prvalue
-# 1243|     2: [DeclStmt] declaration
-# 1243|       0: [VariableDeclarationEntry] definition of c
+# 1243|     getStmt(2): [DeclStmt] declaration
+# 1243|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 # 1243|           Type = [Struct] String
-# 1243|         init: [Initializer] initializer for c
-# 1243|           expr: [ConstructorCall] call to String
+# 1243|         getVariable().getInitializer(): [Initializer] initializer for c
+# 1243|           getExpr(): [ConstructorCall] call to String
 # 1243|               Type = [VoidType] void
 # 1243|               ValueCategory = prvalue
-# 1243|             0: [VariableAccess] dynamic
+# 1243|             getArgument(0): [VariableAccess] dynamic
 # 1243|                 Type = [PointerType] const char *
 # 1243|                 ValueCategory = prvalue(load)
-# 1244|     3: [ReturnStmt] return ...
+# 1244|     getStmt(3): [ReturnStmt] return ...
 # 1248| [TopLevelFunction] char* strcpy(char*, char const*)
-# 1248|   params: 
-# 1248|     0: [Parameter] destination
+# 1248|   ...: 
+# 1248|     getParameter(0): [Parameter] destination
 # 1248|         Type = [CharPointerType] char *
-# 1248|     1: [Parameter] source
+# 1248|     getParameter(1): [Parameter] source
 # 1248|         Type = [PointerType] const char *
 # 1249| [TopLevelFunction] char* strcat(char*, char const*)
-# 1249|   params: 
-# 1249|     0: [Parameter] destination
+# 1249|   ...: 
+# 1249|     getParameter(0): [Parameter] destination
 # 1249|         Type = [CharPointerType] char *
-# 1249|     1: [Parameter] source
+# 1249|     getParameter(1): [Parameter] source
 # 1249|         Type = [PointerType] const char *
 # 1251| [TopLevelFunction] void test_strings(char*, char*)
-# 1251|   params: 
-# 1251|     0: [Parameter] s1
+# 1251|   ...: 
+# 1251|     getParameter(0): [Parameter] s1
 # 1251|         Type = [CharPointerType] char *
-# 1251|     1: [Parameter] s2
+# 1251|     getParameter(1): [Parameter] s2
 # 1251|         Type = [CharPointerType] char *
-# 1251|   body: [BlockStmt] { ... }
-# 1252|     0: [DeclStmt] declaration
-# 1252|       0: [VariableDeclarationEntry] definition of buffer
+# 1251|   getEntryPoint(): [BlockStmt] { ... }
+# 1252|     getStmt(0): [DeclStmt] declaration
+# 1252|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of buffer
 # 1252|           Type = [ArrayType] char[1024]
-# 1252|         init: [Initializer] initializer for buffer
-# 1252|           expr: [ArrayAggregateLiteral] {...}
+# 1252|         getVariable().getInitializer(): [Initializer] initializer for buffer
+# 1252|           getExpr(): [ArrayAggregateLiteral] {...}
 # 1252|               Type = [ArrayType] char[1024]
 # 1252|               ValueCategory = prvalue
-# 1252|             [0]: [Literal] 0
+# 1252|             getElementExpr(0): [Literal] 0
 # 1252|                 Type = [IntType] int
 # 1252|                 Value = [Literal] 0
 # 1252|                 ValueCategory = prvalue
-# 1252|             [0] converted: [CStyleCast] (char)...
+# 1252|             : [CStyleCast] (char)...
 # 1252|                 Conversion = [IntegralConversion] integral conversion
 # 1252|                 Type = [PlainCharType] char
 # 1252|                 Value = [CStyleCast] 0
 # 1252|                 ValueCategory = prvalue
-# 1254|     1: [ExprStmt] ExprStmt
-# 1254|       0: [FunctionCall] call to strcpy
+# 1254|     getStmt(1): [ExprStmt] ExprStmt
+# 1254|       getExpr(): [FunctionCall] call to strcpy
 # 1254|           Type = [CharPointerType] char *
 # 1254|           ValueCategory = prvalue
-# 1254|         0: [VariableAccess] buffer
+# 1254|         getArgument(0): [VariableAccess] buffer
 # 1254|             Type = [ArrayType] char[1024]
 # 1254|             ValueCategory = lvalue
-# 1254|         1: [VariableAccess] s1
+# 1254|         getArgument(1): [VariableAccess] s1
 # 1254|             Type = [CharPointerType] char *
 # 1254|             ValueCategory = prvalue(load)
-# 1254|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1254|         : [ArrayToPointerConversion] array to pointer conversion
 # 1254|             Type = [CharPointerType] char *
 # 1254|             ValueCategory = prvalue
-# 1254|         1 converted: [CStyleCast] (const char *)...
+# 1254|         : [CStyleCast] (const char *)...
 # 1254|             Conversion = [PointerConversion] pointer conversion
 # 1254|             Type = [PointerType] const char *
 # 1254|             ValueCategory = prvalue
-# 1255|     2: [ExprStmt] ExprStmt
-# 1255|       0: [FunctionCall] call to strcat
+# 1255|     getStmt(2): [ExprStmt] ExprStmt
+# 1255|       getExpr(): [FunctionCall] call to strcat
 # 1255|           Type = [CharPointerType] char *
 # 1255|           ValueCategory = prvalue
-# 1255|         0: [VariableAccess] buffer
+# 1255|         getArgument(0): [VariableAccess] buffer
 # 1255|             Type = [ArrayType] char[1024]
 # 1255|             ValueCategory = lvalue
-# 1255|         1: [VariableAccess] s2
+# 1255|         getArgument(1): [VariableAccess] s2
 # 1255|             Type = [CharPointerType] char *
 # 1255|             ValueCategory = prvalue(load)
-# 1255|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+# 1255|         : [ArrayToPointerConversion] array to pointer conversion
 # 1255|             Type = [CharPointerType] char *
 # 1255|             ValueCategory = prvalue
-# 1255|         1 converted: [CStyleCast] (const char *)...
+# 1255|         : [CStyleCast] (const char *)...
 # 1255|             Conversion = [PointerConversion] pointer conversion
 # 1255|             Type = [PointerType] const char *
 # 1255|             ValueCategory = prvalue
-# 1256|     3: [ReturnStmt] return ...
+# 1256|     getStmt(3): [ReturnStmt] return ...
 # 1258| [CopyAssignmentOperator] A& A::operator=(A const&)
-# 1258|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1258|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const A &
 # 1258| [MoveAssignmentOperator] A& A::operator=(A&&)
-# 1258|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+# 1258|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] A &&
 # 1261| [MemberFunction] void A::static_member(A*, int)
-# 1261|   params: 
-# 1261|     0: [Parameter] a
+# 1261|   ...: 
+# 1261|     getParameter(0): [Parameter] a
 # 1261|         Type = [PointerType] A *
-# 1261|     1: [Parameter] x
+# 1261|     getParameter(1): [Parameter] x
 # 1261|         Type = [IntType] int
-# 1261|   body: [BlockStmt] { ... }
-# 1262|     0: [ExprStmt] ExprStmt
-# 1262|       0: [AssignExpr] ... = ...
+# 1261|   getEntryPoint(): [BlockStmt] { ... }
+# 1262|     getStmt(0): [ExprStmt] ExprStmt
+# 1262|       getExpr(): [AssignExpr] ... = ...
 # 1262|           Type = [IntType] int
 # 1262|           ValueCategory = lvalue
-# 1262|         0: [PointerFieldAccess] member
+# 1262|         getLValue(): [PointerFieldAccess] member
 # 1262|             Type = [IntType] int
 # 1262|             ValueCategory = lvalue
-# 1262|           -1: [VariableAccess] a
+# 1262|           getQualifier(): [VariableAccess] a
 # 1262|               Type = [PointerType] A *
 # 1262|               ValueCategory = prvalue(load)
-# 1262|         1: [VariableAccess] x
+# 1262|         getRValue(): [VariableAccess] x
 # 1262|             Type = [IntType] int
 # 1262|             ValueCategory = prvalue(load)
-# 1263|     1: [ReturnStmt] return ...
+# 1263|     getStmt(1): [ReturnStmt] return ...
 # 1265| [MemberFunction] void A::static_member_without_def()
-# 1265|   params: 
+# 1265|   ...: 
 # 1268| [TopLevelFunction] A* getAnInstanceOfA()
-# 1268|   params: 
+# 1268|   ...: 
 # 1270| [TopLevelFunction] void test_static_member_functions(int, A*)
-# 1270|   params: 
-# 1270|     0: [Parameter] int_arg
+# 1270|   ...: 
+# 1270|     getParameter(0): [Parameter] int_arg
 # 1270|         Type = [IntType] int
-# 1270|     1: [Parameter] a_arg
+# 1270|     getParameter(1): [Parameter] a_arg
 # 1270|         Type = [PointerType] A *
-# 1270|   body: [BlockStmt] { ... }
-# 1271|     0: [DeclStmt] declaration
-# 1271|       0: [VariableDeclarationEntry] definition of c
+# 1270|   getEntryPoint(): [BlockStmt] { ... }
+# 1271|     getStmt(0): [DeclStmt] declaration
+# 1271|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c
 # 1271|           Type = [Class] C
-# 1271|         init: [Initializer] initializer for c
-# 1271|           expr: [ConstructorCall] call to C
+# 1271|         getVariable().getInitializer(): [Initializer] initializer for c
+# 1271|           getExpr(): [ConstructorCall] call to C
 # 1271|               Type = [VoidType] void
 # 1271|               ValueCategory = prvalue
-# 1272|     1: [ExprStmt] ExprStmt
-# 1272|       0: [FunctionCall] call to StaticMemberFunction
+# 1272|     getStmt(1): [ExprStmt] ExprStmt
+# 1272|       getExpr(): [FunctionCall] call to StaticMemberFunction
 # 1272|           Type = [IntType] int
 # 1272|           ValueCategory = prvalue
-# 1272|         -1: [VariableAccess] c
+# 1272|         getQualifier(): [VariableAccess] c
 # 1272|             Type = [Class] C
 # 1272|             ValueCategory = lvalue
-# 1272|         0: [Literal] 10
+# 1272|         getArgument(0): [Literal] 10
 # 1272|             Type = [IntType] int
 # 1272|             Value = [Literal] 10
 # 1272|             ValueCategory = prvalue
-# 1273|     2: [ExprStmt] ExprStmt
-# 1273|       0: [FunctionCall] call to StaticMemberFunction
+# 1273|     getStmt(2): [ExprStmt] ExprStmt
+# 1273|       getExpr(): [FunctionCall] call to StaticMemberFunction
 # 1273|           Type = [IntType] int
 # 1273|           ValueCategory = prvalue
-# 1273|         0: [Literal] 10
+# 1273|         getArgument(0): [Literal] 10
 # 1273|             Type = [IntType] int
 # 1273|             Value = [Literal] 10
 # 1273|             ValueCategory = prvalue
-# 1275|     3: [DeclStmt] declaration
-# 1275|       0: [VariableDeclarationEntry] definition of a
+# 1275|     getStmt(3): [DeclStmt] declaration
+# 1275|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
 # 1275|           Type = [Struct] A
-# 1276|     4: [ExprStmt] ExprStmt
-# 1276|       0: [FunctionCall] call to static_member
+# 1276|     getStmt(4): [ExprStmt] ExprStmt
+# 1276|       getExpr(): [FunctionCall] call to static_member
 # 1276|           Type = [VoidType] void
 # 1276|           ValueCategory = prvalue
-# 1276|         -1: [VariableAccess] a
+# 1276|         getQualifier(): [VariableAccess] a
 # 1276|             Type = [Struct] A
 # 1276|             ValueCategory = lvalue
-# 1276|         0: [AddressOfExpr] & ...
+# 1276|         getArgument(0): [AddressOfExpr] & ...
 # 1276|             Type = [PointerType] A *
 # 1276|             ValueCategory = prvalue
-# 1276|           0: [VariableAccess] a
+# 1276|           getOperand(): [VariableAccess] a
 # 1276|               Type = [Struct] A
 # 1276|               ValueCategory = lvalue
-# 1276|         1: [VariableAccess] int_arg
+# 1276|         getArgument(1): [VariableAccess] int_arg
 # 1276|             Type = [IntType] int
 # 1276|             ValueCategory = prvalue(load)
-# 1277|     5: [ExprStmt] ExprStmt
-# 1277|       0: [FunctionCall] call to static_member
+# 1277|     getStmt(5): [ExprStmt] ExprStmt
+# 1277|       getExpr(): [FunctionCall] call to static_member
 # 1277|           Type = [VoidType] void
 # 1277|           ValueCategory = prvalue
-# 1277|         0: [AddressOfExpr] & ...
+# 1277|         getArgument(0): [AddressOfExpr] & ...
 # 1277|             Type = [PointerType] A *
 # 1277|             ValueCategory = prvalue
-# 1277|           0: [VariableAccess] a
+# 1277|           getOperand(): [VariableAccess] a
 # 1277|               Type = [Struct] A
 # 1277|               ValueCategory = lvalue
-# 1277|         1: [VariableAccess] int_arg
+# 1277|         getArgument(1): [VariableAccess] int_arg
 # 1277|             Type = [IntType] int
 # 1277|             ValueCategory = prvalue(load)
-# 1279|     6: [ExprStmt] ExprStmt
-# 1279|       0: [FunctionCall] call to static_member
+# 1279|     getStmt(6): [ExprStmt] ExprStmt
+# 1279|       getExpr(): [FunctionCall] call to static_member
 # 1279|           Type = [VoidType] void
 # 1279|           ValueCategory = prvalue
-# 1279|         -1: [AddressOfExpr] & ...
+# 1279|         getQualifier(): [AddressOfExpr] & ...
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue
-# 1279|           0: [VariableAccess] a
+# 1279|           getOperand(): [VariableAccess] a
 # 1279|               Type = [Struct] A
 # 1279|               ValueCategory = lvalue
-# 1279|         0: [VariableAccess] a_arg
+# 1279|         getArgument(0): [VariableAccess] a_arg
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue(load)
-# 1279|         1: [ParenthesisExpr] (...)
+# 1279|         getArgument(1): [ParenthesisExpr] (...)
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue
-# 1279|         1: [AddExpr] ... + ...
+# 1279|         getArgument(1): [AddExpr] ... + ...
 # 1279|             Type = [IntType] int
 # 1279|             ValueCategory = prvalue
-# 1279|           0: [VariableAccess] int_arg
+# 1279|           getLeftOperand(): [VariableAccess] int_arg
 # 1279|               Type = [IntType] int
 # 1279|               ValueCategory = prvalue(load)
-# 1279|           1: [Literal] 2
+# 1279|           getRightOperand(): [Literal] 2
 # 1279|               Type = [IntType] int
 # 1279|               Value = [Literal] 2
 # 1279|               ValueCategory = prvalue
-# 1280|     7: [ExprStmt] ExprStmt
-# 1280|       0: [FunctionCall] call to static_member
+# 1280|     getStmt(7): [ExprStmt] ExprStmt
+# 1280|       getExpr(): [FunctionCall] call to static_member
 # 1280|           Type = [VoidType] void
 # 1280|           ValueCategory = prvalue
-# 1280|         -1: [PointerDereferenceExpr] * ...
+# 1280|         getQualifier(): [PointerDereferenceExpr] * ...
 # 1280|             Type = [Struct] A
 # 1280|             ValueCategory = lvalue
-# 1280|           0: [VariableAccess] a_arg
+# 1280|           getOperand(): [VariableAccess] a_arg
 # 1280|               Type = [PointerType] A *
 # 1280|               ValueCategory = prvalue(load)
-# 1280|         0: [AddressOfExpr] & ...
+# 1280|         getArgument(0): [AddressOfExpr] & ...
 # 1280|             Type = [PointerType] A *
 # 1280|             ValueCategory = prvalue
-# 1280|           0: [VariableAccess] a
+# 1280|           getOperand(): [VariableAccess] a
 # 1280|               Type = [Struct] A
 # 1280|               ValueCategory = lvalue
-# 1280|         1: [ParenthesisExpr] (...)
+# 1280|         getArgument(1): [ParenthesisExpr] (...)
 # 1280|             Type = [Struct] A
 # 1280|             ValueCategory = lvalue
-# 1280|         1: [Literal] 99
+# 1280|         getArgument(1): [Literal] 99
 # 1280|             Type = [IntType] int
 # 1280|             Value = [Literal] 99
 # 1280|             ValueCategory = prvalue
-# 1281|     8: [ExprStmt] ExprStmt
-# 1281|       0: [FunctionCall] call to static_member
+# 1281|     getStmt(8): [ExprStmt] ExprStmt
+# 1281|       getExpr(): [FunctionCall] call to static_member
 # 1281|           Type = [VoidType] void
 # 1281|           ValueCategory = prvalue
-# 1281|         -1: [VariableAccess] a_arg
+# 1281|         getQualifier(): [VariableAccess] a_arg
 # 1281|             Type = [PointerType] A *
 # 1281|             ValueCategory = prvalue(load)
-# 1281|         0: [VariableAccess] a_arg
+# 1281|         getArgument(0): [VariableAccess] a_arg
 # 1281|             Type = [PointerType] A *
 # 1281|             ValueCategory = prvalue(load)
-# 1281|         1: [UnaryMinusExpr] - ...
+# 1281|         getArgument(1): [UnaryMinusExpr] - ...
 # 1281|             Type = [IntType] int
 # 1281|             Value = [UnaryMinusExpr] -1
 # 1281|             ValueCategory = prvalue
-# 1281|           0: [Literal] 1
+# 1281|           getOperand(): [Literal] 1
 # 1281|               Type = [IntType] int
 # 1281|               Value = [Literal] 1
 # 1281|               ValueCategory = prvalue
-# 1283|     9: [ExprStmt] ExprStmt
-# 1283|       0: [FunctionCall] call to static_member_without_def
+# 1283|     getStmt(9): [ExprStmt] ExprStmt
+# 1283|       getExpr(): [FunctionCall] call to static_member_without_def
 # 1283|           Type = [VoidType] void
 # 1283|           ValueCategory = prvalue
-# 1283|         -1: [VariableAccess] a
+# 1283|         getQualifier(): [VariableAccess] a
 # 1283|             Type = [Struct] A
 # 1283|             ValueCategory = lvalue
-# 1284|     10: [ExprStmt] ExprStmt
-# 1284|       0: [FunctionCall] call to static_member_without_def
+# 1284|     getStmt(10): [ExprStmt] ExprStmt
+# 1284|       getExpr(): [FunctionCall] call to static_member_without_def
 # 1284|           Type = [VoidType] void
 # 1284|           ValueCategory = prvalue
-# 1286|     11: [ExprStmt] ExprStmt
-# 1286|       0: [FunctionCall] call to static_member_without_def
+# 1286|     getStmt(11): [ExprStmt] ExprStmt
+# 1286|       getExpr(): [FunctionCall] call to static_member_without_def
 # 1286|           Type = [VoidType] void
 # 1286|           ValueCategory = prvalue
-# 1286|         -1: [FunctionCall] call to getAnInstanceOfA
+# 1286|         getQualifier(): [FunctionCall] call to getAnInstanceOfA
 # 1286|             Type = [PointerType] A *
 # 1286|             ValueCategory = prvalue
-# 1287|     12: [ReturnStmt] return ...
+# 1287|     getStmt(12): [ReturnStmt] return ...
 # 1289| [TopLevelFunction] int missingReturnValue(bool, int)
-# 1289|   params: 
-# 1289|     0: [Parameter] b
+# 1289|   ...: 
+# 1289|     getParameter(0): [Parameter] b
 # 1289|         Type = [BoolType] bool
-# 1289|     1: [Parameter] x
+# 1289|     getParameter(1): [Parameter] x
 # 1289|         Type = [IntType] int
-# 1289|   body: [BlockStmt] { ... }
-# 1290|     0: [IfStmt] if (...) ... 
-# 1290|       0: [VariableAccess] b
+# 1289|   getEntryPoint(): [BlockStmt] { ... }
+# 1290|     getStmt(0): [IfStmt] if (...) ... 
+# 1290|       getCondition(): [VariableAccess] b
 # 1290|           Type = [BoolType] bool
 # 1290|           ValueCategory = prvalue(load)
-# 1290|       1: [BlockStmt] { ... }
-# 1291|         0: [ReturnStmt] return ...
-# 1291|           0: [VariableAccess] x
+# 1290|       getThen(): [BlockStmt] { ... }
+# 1291|         getStmt(0): [ReturnStmt] return ...
+# 1291|           getExpr(): [VariableAccess] x
 # 1291|               Type = [IntType] int
 # 1291|               ValueCategory = prvalue(load)
-# 1293|     1: [ReturnStmt] return ...
+# 1293|     getStmt(1): [ReturnStmt] return ...
 # 1295| [TopLevelFunction] void returnVoid(int, int)
-# 1295|   params: 
-# 1295|     0: [Parameter] x
+# 1295|   ...: 
+# 1295|     getParameter(0): [Parameter] x
 # 1295|         Type = [IntType] int
-# 1295|     1: [Parameter] y
+# 1295|     getParameter(1): [Parameter] y
 # 1295|         Type = [IntType] int
-# 1295|   body: [BlockStmt] { ... }
-# 1296|     0: [ReturnStmt] return ...
-# 1296|       0: [FunctionCall] call to IntegerOps
+# 1295|   getEntryPoint(): [BlockStmt] { ... }
+# 1296|     getStmt(0): [ReturnStmt] return ...
+# 1296|       getExpr(): [FunctionCall] call to IntegerOps
 # 1296|           Type = [VoidType] void
 # 1296|           ValueCategory = prvalue
-# 1296|         0: [VariableAccess] x
+# 1296|         getArgument(0): [VariableAccess] x
 # 1296|             Type = [IntType] int
 # 1296|             ValueCategory = prvalue(load)
-# 1296|         1: [VariableAccess] y
+# 1296|         getArgument(1): [VariableAccess] y
 # 1296|             Type = [IntType] int
 # 1296|             ValueCategory = prvalue(load)
 # 1299| [TopLevelFunction] void gccBinaryConditional(bool, int, long)
-# 1299|   params: 
-# 1299|     0: [Parameter] b
+# 1299|   ...: 
+# 1299|     getParameter(0): [Parameter] b
 # 1299|         Type = [BoolType] bool
-# 1299|     1: [Parameter] x
+# 1299|     getParameter(1): [Parameter] x
 # 1299|         Type = [IntType] int
-# 1299|     2: [Parameter] y
+# 1299|     getParameter(2): [Parameter] y
 # 1299|         Type = [LongType] long
-# 1299|   body: [BlockStmt] { ... }
-# 1300|     0: [DeclStmt] declaration
-# 1300|       0: [VariableDeclarationEntry] definition of z
+# 1299|   getEntryPoint(): [BlockStmt] { ... }
+# 1300|     getStmt(0): [DeclStmt] declaration
+# 1300|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of z
 # 1300|           Type = [IntType] int
-# 1300|         init: [Initializer] initializer for z
-# 1300|           expr: [VariableAccess] x
+# 1300|         getVariable().getInitializer(): [Initializer] initializer for z
+# 1300|           getExpr(): [VariableAccess] x
 # 1300|               Type = [IntType] int
 # 1300|               ValueCategory = prvalue(load)
-# 1301|     1: [ExprStmt] ExprStmt
-# 1301|       0: [AssignExpr] ... = ...
+# 1301|     getStmt(1): [ExprStmt] ExprStmt
+# 1301|       getExpr(): [AssignExpr] ... = ...
 # 1301|           Type = [IntType] int
 # 1301|           ValueCategory = lvalue
-# 1301|         0: [VariableAccess] z
+# 1301|         getLValue(): [VariableAccess] z
 # 1301|             Type = [IntType] int
 # 1301|             ValueCategory = lvalue
-# 1301|         1: [ConditionalExpr] ... ? ... : ...
+# 1301|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1301|             Type = [IntType] int
 # 1301|             ValueCategory = prvalue
-# 1301|           0: [VariableAccess] b
+# 1301|           getCondition(): [VariableAccess] b
 # 1301|               Type = [BoolType] bool
 # 1301|               ValueCategory = prvalue(load)
-# 1301|           1: [VariableAccess] x
+# 1301|           getElse(): [VariableAccess] x
 # 1301|               Type = [IntType] int
 # 1301|               ValueCategory = prvalue(load)
-# 1302|     2: [ExprStmt] ExprStmt
-# 1302|       0: [AssignExpr] ... = ...
+# 1302|     getStmt(2): [ExprStmt] ExprStmt
+# 1302|       getExpr(): [AssignExpr] ... = ...
 # 1302|           Type = [IntType] int
 # 1302|           ValueCategory = lvalue
-# 1302|         0: [VariableAccess] z
+# 1302|         getLValue(): [VariableAccess] z
 # 1302|             Type = [IntType] int
 # 1302|             ValueCategory = lvalue
-# 1302|         1: [ConditionalExpr] ... ? ... : ...
+# 1302|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1302|             Type = [LongType] long
 # 1302|             ValueCategory = prvalue
-# 1302|           0: [VariableAccess] b
+# 1302|           getCondition(): [VariableAccess] b
 # 1302|               Type = [BoolType] bool
 # 1302|               ValueCategory = prvalue(load)
-# 1302|           1: [VariableAccess] y
+# 1302|           getElse(): [VariableAccess] y
 # 1302|               Type = [LongType] long
 # 1302|               ValueCategory = prvalue(load)
-# 1302|         1 converted: [CStyleCast] (int)...
+# 1302|         : [CStyleCast] (int)...
 # 1302|             Conversion = [IntegralConversion] integral conversion
 # 1302|             Type = [IntType] int
 # 1302|             ValueCategory = prvalue
-# 1303|     3: [ExprStmt] ExprStmt
-# 1303|       0: [AssignExpr] ... = ...
+# 1303|     getStmt(3): [ExprStmt] ExprStmt
+# 1303|       getExpr(): [AssignExpr] ... = ...
 # 1303|           Type = [IntType] int
 # 1303|           ValueCategory = lvalue
-# 1303|         0: [VariableAccess] z
+# 1303|         getLValue(): [VariableAccess] z
 # 1303|             Type = [IntType] int
 # 1303|             ValueCategory = lvalue
-# 1303|         1: [ConditionalExpr] ... ? ... : ...
+# 1303|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1303|             Type = [IntType] int
 # 1303|             ValueCategory = prvalue
-# 1303|           0: [VariableAccess] x
+# 1303|           getCondition(): [VariableAccess] x
 # 1303|               Type = [IntType] int
 # 1303|               ValueCategory = prvalue(load)
-# 1303|           1: [VariableAccess] x
+# 1303|           getElse(): [VariableAccess] x
 # 1303|               Type = [IntType] int
 # 1303|               ValueCategory = prvalue(load)
-# 1303|           0 converted: [CStyleCast] (bool)...
+# 1303|           : [CStyleCast] (bool)...
 # 1303|               Conversion = [BoolConversion] conversion to bool
 # 1303|               Type = [BoolType] bool
 # 1303|               ValueCategory = prvalue
-# 1304|     4: [ExprStmt] ExprStmt
-# 1304|       0: [AssignExpr] ... = ...
+# 1304|     getStmt(4): [ExprStmt] ExprStmt
+# 1304|       getExpr(): [AssignExpr] ... = ...
 # 1304|           Type = [IntType] int
 # 1304|           ValueCategory = lvalue
-# 1304|         0: [VariableAccess] z
+# 1304|         getLValue(): [VariableAccess] z
 # 1304|             Type = [IntType] int
 # 1304|             ValueCategory = lvalue
-# 1304|         1: [ConditionalExpr] ... ? ... : ...
+# 1304|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1304|             Type = [LongType] long
 # 1304|             ValueCategory = prvalue
-# 1304|           0: [VariableAccess] x
+# 1304|           getCondition(): [VariableAccess] x
 # 1304|               Type = [IntType] int
 # 1304|               ValueCategory = prvalue(load)
-# 1304|           1: [VariableAccess] y
+# 1304|           getElse(): [VariableAccess] y
 # 1304|               Type = [LongType] long
 # 1304|               ValueCategory = prvalue(load)
-# 1304|           0 converted: [CStyleCast] (bool)...
+# 1304|           : [CStyleCast] (bool)...
 # 1304|               Conversion = [BoolConversion] conversion to bool
 # 1304|               Type = [BoolType] bool
 # 1304|               ValueCategory = prvalue
-# 1304|         1 converted: [CStyleCast] (int)...
+# 1304|         : [CStyleCast] (int)...
 # 1304|             Conversion = [IntegralConversion] integral conversion
 # 1304|             Type = [IntType] int
 # 1304|             ValueCategory = prvalue
-# 1305|     5: [ExprStmt] ExprStmt
-# 1305|       0: [AssignExpr] ... = ...
+# 1305|     getStmt(5): [ExprStmt] ExprStmt
+# 1305|       getExpr(): [AssignExpr] ... = ...
 # 1305|           Type = [IntType] int
 # 1305|           ValueCategory = lvalue
-# 1305|         0: [VariableAccess] z
+# 1305|         getLValue(): [VariableAccess] z
 # 1305|             Type = [IntType] int
 # 1305|             ValueCategory = lvalue
-# 1305|         1: [ConditionalExpr] ... ? ... : ...
+# 1305|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1305|             Type = [LongType] long
 # 1305|             ValueCategory = prvalue
-# 1305|           0: [VariableAccess] y
+# 1305|           getCondition(): [VariableAccess] y
 # 1305|               Type = [LongType] long
 # 1305|               ValueCategory = prvalue(load)
-# 1305|           1: [VariableAccess] x
+# 1305|           getElse(): [VariableAccess] x
 # 1305|               Type = [IntType] int
 # 1305|               ValueCategory = prvalue(load)
-# 1305|           0 converted: [CStyleCast] (bool)...
+# 1305|           : [CStyleCast] (bool)...
 # 1305|               Conversion = [BoolConversion] conversion to bool
 # 1305|               Type = [BoolType] bool
 # 1305|               ValueCategory = prvalue
-# 1305|           1 converted: [CStyleCast] (long)...
+# 1305|           : [CStyleCast] (long)...
 # 1305|               Conversion = [IntegralConversion] integral conversion
 # 1305|               Type = [LongType] long
 # 1305|               ValueCategory = prvalue
-# 1305|         1 converted: [CStyleCast] (int)...
+# 1305|         : [CStyleCast] (int)...
 # 1305|             Conversion = [IntegralConversion] integral conversion
 # 1305|             Type = [IntType] int
 # 1305|             ValueCategory = prvalue
-# 1306|     6: [ExprStmt] ExprStmt
-# 1306|       0: [AssignExpr] ... = ...
+# 1306|     getStmt(6): [ExprStmt] ExprStmt
+# 1306|       getExpr(): [AssignExpr] ... = ...
 # 1306|           Type = [IntType] int
 # 1306|           ValueCategory = lvalue
-# 1306|         0: [VariableAccess] z
+# 1306|         getLValue(): [VariableAccess] z
 # 1306|             Type = [IntType] int
 # 1306|             ValueCategory = lvalue
-# 1306|         1: [ConditionalExpr] ... ? ... : ...
+# 1306|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1306|             Type = [LongType] long
 # 1306|             ValueCategory = prvalue
-# 1306|           0: [VariableAccess] y
+# 1306|           getCondition(): [VariableAccess] y
 # 1306|               Type = [LongType] long
 # 1306|               ValueCategory = prvalue(load)
-# 1306|           1: [VariableAccess] y
+# 1306|           getElse(): [VariableAccess] y
 # 1306|               Type = [LongType] long
 # 1306|               ValueCategory = prvalue(load)
-# 1306|           0 converted: [CStyleCast] (bool)...
+# 1306|           : [CStyleCast] (bool)...
 # 1306|               Conversion = [BoolConversion] conversion to bool
 # 1306|               Type = [BoolType] bool
 # 1306|               ValueCategory = prvalue
-# 1306|         1 converted: [CStyleCast] (int)...
+# 1306|         : [CStyleCast] (int)...
 # 1306|             Conversion = [IntegralConversion] integral conversion
 # 1306|             Type = [IntType] int
 # 1306|             ValueCategory = prvalue
-# 1308|     7: [ExprStmt] ExprStmt
-# 1308|       0: [AssignExpr] ... = ...
+# 1308|     getStmt(7): [ExprStmt] ExprStmt
+# 1308|       getExpr(): [AssignExpr] ... = ...
 # 1308|           Type = [IntType] int
 # 1308|           ValueCategory = lvalue
-# 1308|         0: [VariableAccess] z
+# 1308|         getLValue(): [VariableAccess] z
 # 1308|             Type = [IntType] int
 # 1308|             ValueCategory = lvalue
-# 1308|         1: [ConditionalExpr] ... ? ... : ...
+# 1308|         getRValue(): [ConditionalExpr] ... ? ... : ...
 # 1308|             Type = [IntType] int
 # 1308|             ValueCategory = prvalue
-# 1308|           0: [LogicalOrExpr] ... || ...
+# 1308|           getCondition(): [LogicalOrExpr] ... || ...
 # 1308|               Type = [BoolType] bool
 # 1308|               ValueCategory = prvalue
-# 1308|             0: [LogicalAndExpr] ... && ...
+# 1308|             getLeftOperand(): [LogicalAndExpr] ... && ...
 # 1308|                 Type = [BoolType] bool
 # 1308|                 ValueCategory = prvalue
-# 1308|               0: [VariableAccess] x
+# 1308|               getLeftOperand(): [VariableAccess] x
 # 1308|                   Type = [IntType] int
 # 1308|                   ValueCategory = prvalue(load)
-# 1308|               1: [VariableAccess] b
+# 1308|               getRightOperand(): [VariableAccess] b
 # 1308|                   Type = [BoolType] bool
 # 1308|                   ValueCategory = prvalue(load)
-# 1308|               0 converted: [CStyleCast] (bool)...
+# 1308|               : [CStyleCast] (bool)...
 # 1308|                   Conversion = [BoolConversion] conversion to bool
 # 1308|                   Type = [BoolType] bool
 # 1308|                   ValueCategory = prvalue
-# 1308|             1: [VariableAccess] y
+# 1308|             getRightOperand(): [VariableAccess] y
 # 1308|                 Type = [LongType] long
 # 1308|                 ValueCategory = prvalue(load)
-# 1308|             1 converted: [CStyleCast] (bool)...
+# 1308|             : [CStyleCast] (bool)...
 # 1308|                 Conversion = [BoolConversion] conversion to bool
 # 1308|                 Type = [BoolType] bool
 # 1308|                 ValueCategory = prvalue
-# 1308|           1: [VariableAccess] x
+# 1308|           getElse(): [VariableAccess] x
 # 1308|               Type = [IntType] int
 # 1308|               ValueCategory = prvalue(load)
-# 1308|           0 converted: [ParenthesisExpr] (...)
+# 1308|           : [ParenthesisExpr] (...)
 # 1308|               Type = [BoolType] bool
 # 1308|               ValueCategory = prvalue
-# 1309|     8: [ReturnStmt] return ...
+# 1309|     getStmt(8): [ReturnStmt] return ...
 # 1311| [TopLevelFunction] bool predicateA()
-# 1311|   params: 
+# 1311|   ...: 
 # 1312| [TopLevelFunction] bool predicateB()
-# 1312|   params: 
+# 1312|   ...: 
 # 1314| [TopLevelFunction] int shortCircuitConditional(int, int)
-# 1314|   params: 
-# 1314|     0: [Parameter] x
+# 1314|   ...: 
+# 1314|     getParameter(0): [Parameter] x
 # 1314|         Type = [IntType] int
-# 1314|     1: [Parameter] y
+# 1314|     getParameter(1): [Parameter] y
 # 1314|         Type = [IntType] int
-# 1314|   body: [BlockStmt] { ... }
-# 1315|     0: [ReturnStmt] return ...
-# 1315|       0: [ConditionalExpr] ... ? ... : ...
+# 1314|   getEntryPoint(): [BlockStmt] { ... }
+# 1315|     getStmt(0): [ReturnStmt] return ...
+# 1315|       getExpr(): [ConditionalExpr] ... ? ... : ...
 # 1315|           Type = [IntType] int
 # 1315|           ValueCategory = prvalue
-# 1315|         0: [LogicalAndExpr] ... && ...
+# 1315|         getCondition(): [LogicalAndExpr] ... && ...
 # 1315|             Type = [BoolType] bool
 # 1315|             ValueCategory = prvalue
-# 1315|           0: [FunctionCall] call to predicateA
+# 1315|           getLeftOperand(): [FunctionCall] call to predicateA
 # 1315|               Type = [BoolType] bool
 # 1315|               ValueCategory = prvalue
-# 1315|           1: [FunctionCall] call to predicateB
+# 1315|           getRightOperand(): [FunctionCall] call to predicateB
 # 1315|               Type = [BoolType] bool
 # 1315|               ValueCategory = prvalue
-# 1315|         1: [VariableAccess] x
+# 1315|         getThen(): [VariableAccess] x
 # 1315|             Type = [IntType] int
 # 1315|             ValueCategory = prvalue(load)
-# 1315|         2: [VariableAccess] y
+# 1315|         getElse(): [VariableAccess] y
 # 1315|             Type = [IntType] int
 # 1315|             ValueCategory = prvalue(load)
 # 1318| [Operator,TopLevelFunction] void* operator new(size_t, void*)
-# 1318|   params: 
-# 1318|     0: [Parameter] (unnamed parameter 0)
+# 1318|   ...: 
+# 1318|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1318|         Type = [CTypedefType,Size_t] size_t
-# 1318|     1: [Parameter] (unnamed parameter 1)
+# 1318|     getParameter(1): [Parameter] (unnamed parameter 1)
 # 1318|         Type = [VoidPointerType] void *
 # 1320| [TopLevelFunction] void f(int*)
-# 1320|   params: 
-# 1320|     0: [Parameter] p
+# 1320|   ...: 
+# 1320|     getParameter(0): [Parameter] p
 # 1320|         Type = [IntPointerType] int *
-# 1321|   body: [BlockStmt] { ... }
-# 1322|     0: [ExprStmt] ExprStmt
-# 1322|       0: [NewExpr] new
+# 1321|   getEntryPoint(): [BlockStmt] { ... }
+# 1322|     getStmt(0): [ExprStmt] ExprStmt
+# 1322|       getExpr(): [NewExpr] new
 # 1322|           Type = [IntPointerType] int *
 # 1322|           ValueCategory = prvalue
-# 1322|         0: [FunctionCall] call to operator new
+# 1322|         getAllocatorCall(): [FunctionCall] call to operator new
 # 1322|             Type = [VoidPointerType] void *
 # 1322|             ValueCategory = prvalue
-# 1322|           0: [ErrorExpr] <error expr>
+# 1322|           getArgument(0): [ErrorExpr] <error expr>
 # 1322|               Type = [LongType] unsigned long
 # 1322|               ValueCategory = prvalue
-# 1322|           1: [VariableAccess] p
+# 1322|           getArgument(1): [VariableAccess] p
 # 1322|               Type = [IntPointerType] int *
 # 1322|               ValueCategory = prvalue(load)
-# 1322|           1 converted: [CStyleCast] (void *)...
+# 1322|           : [CStyleCast] (void *)...
 # 1322|               Conversion = [PointerConversion] pointer conversion
 # 1322|               Type = [VoidPointerType] void *
 # 1322|               ValueCategory = prvalue
-# 1323|     1: [ReturnStmt] return ...
+# 1323|     getStmt(1): [ReturnStmt] return ...
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveAssignmentOperator] Big& Big::operator=(Big&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    4| [CopyConstructor] void Big::Big(Big const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveConstructor] void Big::Big(Big&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    6| [Constructor] void Big::Big()
-#    6|   params: 
-#    6|   initializations: 
-#    6|     0: [ConstructorFieldInit] constructor init of field buffer
+#    6|   ...: 
+#    6|   ...: 
+#    6|     getInitializer(0): [ConstructorFieldInit] constructor init of field buffer
 #    6|         Type = [ArrayType] char[1073741824]
 #    6|         ValueCategory = prvalue
-#    6|       0: [ArrayAggregateLiteral] {...}
+#    6|       getExpr(): [ArrayAggregateLiteral] {...}
 #    6|           Type = [ArrayType] char[1073741824]
 #    6|           ValueCategory = prvalue
-#    6|   body: [BlockStmt] { ... }
-#    6|     0: [ReturnStmt] return ...
+#    6|   getEntryPoint(): [BlockStmt] { ... }
+#    6|     getStmt(0): [ReturnStmt] return ...
 #    9| [TopLevelFunction] int main()
-#    9|   params: 
-#    9|   body: [BlockStmt] { ... }
-#   10|     0: [DeclStmt] declaration
-#   10|       0: [VariableDeclarationEntry] definition of big
+#    9|   ...: 
+#    9|   getEntryPoint(): [BlockStmt] { ... }
+#   10|     getStmt(0): [DeclStmt] declaration
+#   10|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of big
 #   10|           Type = [PointerType] Big *
-#   10|         init: [Initializer] initializer for big
-#   10|           expr: [NewExpr] new
+#   10|         getVariable().getInitializer(): [Initializer] initializer for big
+#   10|           getExpr(): [NewExpr] new
 #   10|               Type = [PointerType] Big *
 #   10|               ValueCategory = prvalue
-#   10|             1: [ConstructorCall] call to Big
+#   10|             getInitializer(): [ConstructorCall] call to Big
 #   10|                 Type = [VoidType] void
 #   10|                 ValueCategory = prvalue
-#   12|     1: [ReturnStmt] return ...
-#   12|       0: [Literal] 0
+#   12|     getStmt(1): [ReturnStmt] return ...
+#   12|       getExpr(): [Literal] 0
 #   12|           Type = [IntType] int
 #   12|           Value = [Literal] 0
 #   12|           ValueCategory = prvalue
 struct_init.cpp:
 #    1| [TopLevelFunction] int handler1(void*)
-#    1|   params: 
-#    1|     0: [Parameter] p
+#    1|   ...: 
+#    1|     getParameter(0): [Parameter] p
 #    1|         Type = [VoidPointerType] void *
 #    2| [TopLevelFunction] int handler2(void*)
-#    2|   params: 
-#    2|     0: [Parameter] p
+#    2|   ...: 
+#    2|     getParameter(0): [Parameter] p
 #    2|         Type = [VoidPointerType] void *
 #    4| [CopyAssignmentOperator] Info& Info::operator=(Info const&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Info &
 #    4| [MoveAssignmentOperator] Info& Info::operator=(Info&&)
-#    4|   params: 
-#-----|     0: [Parameter] (unnamed parameter 0)
+#    4|   ...: 
+#-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Info &&
 #   16| [TopLevelFunction] void let_info_escape(Info*)
-#   16|   params: 
-#   16|     0: [Parameter] info
+#   16|   ...: 
+#   16|     getParameter(0): [Parameter] info
 #   16|         Type = [PointerType] Info *
-#   16|   body: [BlockStmt] { ... }
-#   17|     0: [ExprStmt] ExprStmt
-#   17|       0: [AssignExpr] ... = ...
+#   16|   getEntryPoint(): [BlockStmt] { ... }
+#   17|     getStmt(0): [ExprStmt] ExprStmt
+#   17|       getExpr(): [AssignExpr] ... = ...
 #   17|           Type = [PointerType] Info *
 #   17|           ValueCategory = lvalue
-#   17|         0: [VariableAccess] global_pointer
+#   17|         getLValue(): [VariableAccess] global_pointer
 #   17|             Type = [PointerType] Info *
 #   17|             ValueCategory = lvalue
-#   17|         1: [VariableAccess] info
+#   17|         getRValue(): [VariableAccess] info
 #   17|             Type = [PointerType] Info *
 #   17|             ValueCategory = prvalue(load)
-#   18|     1: [ReturnStmt] return ...
+#   18|     getStmt(1): [ReturnStmt] return ...
 #   20| [TopLevelFunction] void declare_static_infos()
-#   20|   params: 
-#   20|   body: [BlockStmt] { ... }
-#   21|     0: [DeclStmt] declaration
-#   21|       0: [VariableDeclarationEntry] definition of static_infos
+#   20|   ...: 
+#   20|   getEntryPoint(): [BlockStmt] { ... }
+#   21|     getStmt(0): [DeclStmt] declaration
+#   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of static_infos
 #   21|           Type = [ArrayType] Info[]
-#   21|         init: [Initializer] initializer for static_infos
-#   21|           expr: [ArrayAggregateLiteral] {...}
+#   21|         getVariable().getInitializer(): [Initializer] initializer for static_infos
+#   21|           getExpr(): [ArrayAggregateLiteral] {...}
 #   21|               Type = [ArrayType] Info[2]
 #   21|               ValueCategory = prvalue
-#   22|             [0]: [ClassAggregateLiteral] {...}
+#   22|             getElementExpr(0): [ClassAggregateLiteral] {...}
 #   22|                 Type = [Struct] Info
 #   22|                 ValueCategory = prvalue
-#   22|               .name: 1
+#   22|               getFieldExpr(name): 1
 #   22|                   Type = [ArrayType] const char[2]
 #   22|                   Value = [StringLiteral] "1"
 #   22|                   ValueCategory = lvalue
-#   22|               .handler: [FunctionAccess] handler1
+#   22|               getFieldExpr(handler): [FunctionAccess] handler1
 #   22|                   Type = [FunctionPointerType] ..(*)(..)
 #   22|                   ValueCategory = prvalue(load)
-#   22|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   22|               : [ArrayToPointerConversion] array to pointer conversion
 #   22|                   Type = [PointerType] const char *
 #   22|                   ValueCategory = prvalue
-#   23|             [1]: [ClassAggregateLiteral] {...}
+#   23|             getElementExpr(1): [ClassAggregateLiteral] {...}
 #   23|                 Type = [Struct] Info
 #   23|                 ValueCategory = prvalue
-#   23|               .name: 2
+#   23|               getFieldExpr(name): 2
 #   23|                   Type = [ArrayType] const char[2]
 #   23|                   Value = [StringLiteral] "2"
 #   23|                   ValueCategory = lvalue
-#   23|               .handler: [AddressOfExpr] & ...
+#   23|               getFieldExpr(handler): [AddressOfExpr] & ...
 #   23|                   Type = [FunctionPointerType] ..(*)(..)
 #   23|                   ValueCategory = prvalue
-#   23|                 0: [FunctionAccess] handler2
+#   23|                 getOperand(): [FunctionAccess] handler2
 #   23|                     Type = [RoutineType] ..()(..)
 #   23|                     ValueCategory = lvalue
-#   23|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   23|               : [ArrayToPointerConversion] array to pointer conversion
 #   23|                   Type = [PointerType] const char *
 #   23|                   ValueCategory = prvalue
-#   25|     1: [ExprStmt] ExprStmt
-#   25|       0: [FunctionCall] call to let_info_escape
+#   25|     getStmt(1): [ExprStmt] ExprStmt
+#   25|       getExpr(): [FunctionCall] call to let_info_escape
 #   25|           Type = [VoidType] void
 #   25|           ValueCategory = prvalue
-#   25|         0: [VariableAccess] static_infos
+#   25|         getArgument(0): [VariableAccess] static_infos
 #   25|             Type = [ArrayType] Info[2]
 #   25|             ValueCategory = lvalue
-#   25|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   25|         : [ArrayToPointerConversion] array to pointer conversion
 #   25|             Type = [PointerType] Info *
 #   25|             ValueCategory = prvalue
-#   26|     2: [ReturnStmt] return ...
+#   26|     getStmt(2): [ReturnStmt] return ...
 #   28| [TopLevelFunction] void declare_local_infos()
-#   28|   params: 
-#   28|   body: [BlockStmt] { ... }
-#   29|     0: [DeclStmt] declaration
-#   29|       0: [VariableDeclarationEntry] definition of local_infos
+#   28|   ...: 
+#   28|   getEntryPoint(): [BlockStmt] { ... }
+#   29|     getStmt(0): [DeclStmt] declaration
+#   29|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of local_infos
 #   29|           Type = [ArrayType] Info[]
-#   29|         init: [Initializer] initializer for local_infos
-#   29|           expr: [ArrayAggregateLiteral] {...}
+#   29|         getVariable().getInitializer(): [Initializer] initializer for local_infos
+#   29|           getExpr(): [ArrayAggregateLiteral] {...}
 #   29|               Type = [ArrayType] Info[2]
 #   29|               ValueCategory = prvalue
-#   30|             [0]: [ClassAggregateLiteral] {...}
+#   30|             getElementExpr(0): [ClassAggregateLiteral] {...}
 #   30|                 Type = [Struct] Info
 #   30|                 ValueCategory = prvalue
-#   30|               .name: 1
+#   30|               getFieldExpr(name): 1
 #   30|                   Type = [ArrayType] const char[2]
 #   30|                   Value = [StringLiteral] "1"
 #   30|                   ValueCategory = lvalue
-#   30|               .handler: [FunctionAccess] handler1
+#   30|               getFieldExpr(handler): [FunctionAccess] handler1
 #   30|                   Type = [FunctionPointerType] ..(*)(..)
 #   30|                   ValueCategory = prvalue(load)
-#   30|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   30|               : [ArrayToPointerConversion] array to pointer conversion
 #   30|                   Type = [PointerType] const char *
 #   30|                   ValueCategory = prvalue
-#   31|             [1]: [ClassAggregateLiteral] {...}
+#   31|             getElementExpr(1): [ClassAggregateLiteral] {...}
 #   31|                 Type = [Struct] Info
 #   31|                 ValueCategory = prvalue
-#   31|               .name: 2
+#   31|               getFieldExpr(name): 2
 #   31|                   Type = [ArrayType] const char[2]
 #   31|                   Value = [StringLiteral] "2"
 #   31|                   ValueCategory = lvalue
-#   31|               .handler: [AddressOfExpr] & ...
+#   31|               getFieldExpr(handler): [AddressOfExpr] & ...
 #   31|                   Type = [FunctionPointerType] ..(*)(..)
 #   31|                   ValueCategory = prvalue
-#   31|                 0: [FunctionAccess] handler2
+#   31|                 getOperand(): [FunctionAccess] handler2
 #   31|                     Type = [RoutineType] ..()(..)
 #   31|                     ValueCategory = lvalue
-#   31|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   31|               : [ArrayToPointerConversion] array to pointer conversion
 #   31|                   Type = [PointerType] const char *
 #   31|                   ValueCategory = prvalue
-#   33|     1: [ExprStmt] ExprStmt
-#   33|       0: [FunctionCall] call to let_info_escape
+#   33|     getStmt(1): [ExprStmt] ExprStmt
+#   33|       getExpr(): [FunctionCall] call to let_info_escape
 #   33|           Type = [VoidType] void
 #   33|           ValueCategory = prvalue
-#   33|         0: [VariableAccess] local_infos
+#   33|         getArgument(0): [VariableAccess] local_infos
 #   33|             Type = [ArrayType] Info[2]
 #   33|             ValueCategory = lvalue
-#   33|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   33|         : [ArrayToPointerConversion] array to pointer conversion
 #   33|             Type = [PointerType] Info *
 #   33|             ValueCategory = prvalue
-#   34|     2: [ReturnStmt] return ...
+#   34|     getStmt(2): [ReturnStmt] return ...
 #   36| [TopLevelFunction] void declare_static_runtime_infos(char const*)
-#   36|   params: 
-#   36|     0: [Parameter] name1
+#   36|   ...: 
+#   36|     getParameter(0): [Parameter] name1
 #   36|         Type = [PointerType] const char *
-#   36|   body: [BlockStmt] { ... }
-#   37|     0: [DeclStmt] declaration
-#   37|       0: [VariableDeclarationEntry] definition of static_infos
+#   36|   getEntryPoint(): [BlockStmt] { ... }
+#   37|     getStmt(0): [DeclStmt] declaration
+#   37|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of static_infos
 #   37|           Type = [ArrayType] Info[]
-#   37|         init: [Initializer] initializer for static_infos
-#   37|           expr: [ArrayAggregateLiteral] {...}
+#   37|         getVariable().getInitializer(): [Initializer] initializer for static_infos
+#   37|           getExpr(): [ArrayAggregateLiteral] {...}
 #   37|               Type = [ArrayType] Info[2]
 #   37|               ValueCategory = prvalue
-#   38|             [0]: [ClassAggregateLiteral] {...}
+#   38|             getElementExpr(0): [ClassAggregateLiteral] {...}
 #   38|                 Type = [Struct] Info
 #   38|                 ValueCategory = prvalue
-#   38|               .name: [VariableAccess] name1
+#   38|               getFieldExpr(name): [VariableAccess] name1
 #   38|                   Type = [PointerType] const char *
 #   38|                   ValueCategory = prvalue(load)
-#   38|               .handler: [FunctionAccess] handler1
+#   38|               getFieldExpr(handler): [FunctionAccess] handler1
 #   38|                   Type = [FunctionPointerType] ..(*)(..)
 #   38|                   ValueCategory = prvalue(load)
-#   39|             [1]: [ClassAggregateLiteral] {...}
+#   39|             getElementExpr(1): [ClassAggregateLiteral] {...}
 #   39|                 Type = [Struct] Info
 #   39|                 ValueCategory = prvalue
-#   39|               .name: 2
+#   39|               getFieldExpr(name): 2
 #   39|                   Type = [ArrayType] const char[2]
 #   39|                   Value = [StringLiteral] "2"
 #   39|                   ValueCategory = lvalue
-#   39|               .handler: [AddressOfExpr] & ...
+#   39|               getFieldExpr(handler): [AddressOfExpr] & ...
 #   39|                   Type = [FunctionPointerType] ..(*)(..)
 #   39|                   ValueCategory = prvalue
-#   39|                 0: [FunctionAccess] handler2
+#   39|                 getOperand(): [FunctionAccess] handler2
 #   39|                     Type = [RoutineType] ..()(..)
 #   39|                     ValueCategory = lvalue
-#   39|               .name converted: [ArrayToPointerConversion] array to pointer conversion
+#   39|               : [ArrayToPointerConversion] array to pointer conversion
 #   39|                   Type = [PointerType] const char *
 #   39|                   ValueCategory = prvalue
-#   41|     1: [ExprStmt] ExprStmt
-#   41|       0: [FunctionCall] call to let_info_escape
+#   41|     getStmt(1): [ExprStmt] ExprStmt
+#   41|       getExpr(): [FunctionCall] call to let_info_escape
 #   41|           Type = [VoidType] void
 #   41|           ValueCategory = prvalue
-#   41|         0: [VariableAccess] static_infos
+#   41|         getArgument(0): [VariableAccess] static_infos
 #   41|             Type = [ArrayType] Info[2]
 #   41|             ValueCategory = lvalue
-#   41|         0 converted: [ArrayToPointerConversion] array to pointer conversion
+#   41|         : [ArrayToPointerConversion] array to pointer conversion
 #   41|             Type = [PointerType] Info *
 #   41|             ValueCategory = prvalue
-#   42|     2: [ReturnStmt] return ...
+#   42|     getStmt(2): [ReturnStmt] return ...

--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -1,23 +1,23 @@
 #-----| [CopyAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag const&)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const __va_list_tag &
 #-----| [MoveAssignmentOperator] __va_list_tag& __va_list_tag::operator=(__va_list_tag&&)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] __va_list_tag &&
 #-----| [Operator,TopLevelFunction] void operator delete(void*)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete(void*, unsigned long, std::align_val_t)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -25,13 +25,13 @@
 #-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void operator delete[](void*, unsigned long, std::align_val_t)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [VoidPointerType] void *
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -39,36 +39,36 @@
 #-----|     getParameter(2): [Parameter] (unnamed parameter 2)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new(unsigned long, std::align_val_t)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----| [Operator,TopLevelFunction] void* operator new[](unsigned long, std::align_val_t)
-#-----|   : 
+#-----|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LongType] unsigned long
 #-----|     getParameter(1): [Parameter] (unnamed parameter 1)
 #-----|         Type = [ScopedEnum] align_val_t
 bad_asts.cpp:
 #    5| [CopyAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S const&)
-#    5|   : 
+#    5|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const S &
 #    5| [MoveAssignmentOperator] Bad::S& Bad::S::operator=(Bad::S&&)
-#    5|   : 
+#    5|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] S &&
 #    9| [FunctionTemplateInstantiation,MemberFunction] int Bad::S::MemberFunction<int 6>(int)
-#    9|   : 
+#    9|   <params>: 
 #    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
 #    9|   getEntryPoint(): [BlockStmt] { ... }
@@ -93,7 +93,7 @@ bad_asts.cpp:
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #    9| [MemberFunction,TemplateFunction] int Bad::S::MemberFunction<int t>(int)
-#    9|   : 
+#    9|   <params>: 
 #    9|     getParameter(0): [Parameter] y
 #    9|         Type = [IntType] int
 #    9|   getEntryPoint(): [BlockStmt] { ... }
@@ -118,7 +118,7 @@ bad_asts.cpp:
 #   10|             Type = [IntType] int
 #   10|             ValueCategory = prvalue(load)
 #   14| [TopLevelFunction] void Bad::CallBadMemberFunction()
-#   14|   : 
+#   14|   <params>: 
 #   14|   getEntryPoint(): [BlockStmt] { ... }
 #   15|     getStmt(0): [DeclStmt] declaration
 #   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -140,18 +140,18 @@ bad_asts.cpp:
 #   16|             ValueCategory = prvalue
 #   17|     getStmt(2): [ReturnStmt] return ...
 #   19| [CopyAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point const&)
-#   19|   : 
+#   19|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #   19| [MoveAssignmentOperator] Bad::Point& Bad::Point::operator=(Bad::Point&&)
-#   19|   : 
+#   19|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   19| [CopyConstructor] void Bad::Point::Point(Bad::Point const&)
-#   19|   : 
+#   19|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
-#   19|   : 
+#   19|   <initializations>: 
 #   19|     getInitializer(0): [ConstructorFieldInit] constructor init of field x
 #   19|         Type = [IntType] int
 #   19|         ValueCategory = prvalue
@@ -167,16 +167,16 @@ bad_asts.cpp:
 #   19|   getEntryPoint(): [BlockStmt] { ... }
 #   19|     getStmt(0): [ReturnStmt] return ...
 #   19| [MoveConstructor] void Bad::Point::Point(Bad::Point&&)
-#   19|   : 
+#   19|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #   22| [Constructor] void Bad::Point::Point()
-#   22|   : 
-#   22|   : 
+#   22|   <params>: 
+#   22|   <initializations>: 
 #   22|   getEntryPoint(): [BlockStmt] { ... }
 #   23|     getStmt(0): [ReturnStmt] return ...
 #   26| [TopLevelFunction] void Bad::CallCopyConstructor(Bad::Point const&)
-#   26|   : 
+#   26|   <params>: 
 #   26|     getParameter(0): [Parameter] a
 #   26|         Type = [LValueReferenceType] const Point &
 #   26|   getEntryPoint(): [BlockStmt] { ... }
@@ -187,7 +187,7 @@ bad_asts.cpp:
 #   27|           getExpr(): [VariableAccess] a
 #   27|               Type = [LValueReferenceType] const Point &
 #   27|               ValueCategory = prvalue(load)
-#   27|           : [CStyleCast] (Point)...
+#   27|           getExpr().getFullyConverted(): [CStyleCast] (Point)...
 #   27|               Conversion = [GlvalueConversion] glvalue conversion
 #   27|               Type = [Struct] Point
 #   27|               ValueCategory = prvalue(load)
@@ -196,7 +196,7 @@ bad_asts.cpp:
 #   27|                 ValueCategory = lvalue
 #   28|     getStmt(1): [ReturnStmt] return ...
 #   30| [TopLevelFunction] void Bad::errorExpr()
-#   30|   : 
+#   30|   <params>: 
 #   30|   getEntryPoint(): [BlockStmt] { ... }
 #   31|     getStmt(0): [DeclStmt] declaration
 #   31|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of intref
@@ -225,7 +225,7 @@ bad_asts.cpp:
 #   34|     getStmt(3): [ReturnStmt] return ...
 clang.cpp:
 #    5| [TopLevelFunction] int* globalIntAddress()
-#    5|   : 
+#    5|   <params>: 
 #    5|   getEntryPoint(): [BlockStmt] { ... }
 #    6|     getStmt(0): [ReturnStmt] return ...
 #    6|       getExpr(): [BuiltInOperationBuiltInAddressOf] __builtin_addressof ...
@@ -236,7 +236,7 @@ clang.cpp:
 #    6|             ValueCategory = lvalue
 complex.c:
 #    1| [TopLevelFunction] void complex_literals()
-#    1|   : 
+#    1|   <params>: 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of cf
@@ -246,7 +246,7 @@ complex.c:
 #    2|               Type = [DoubleType] double
 #    2|               Value = [Literal] 2.0
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (_Complex float)...
+#    2|           getExpr().getFullyConverted(): [CStyleCast] (_Complex float)...
 #    2|               Conversion = [FloatingPointConversion] floating point conversion
 #    2|               Type = [ArithmeticType] _Complex float
 #    2|               ValueCategory = prvalue
@@ -261,7 +261,7 @@ complex.c:
 #    3|             Type = [ArithmeticType] _Imaginary float
 #    3|             Value = [Literal] 1.0i
 #    3|             ValueCategory = prvalue
-#    3|         : [CStyleCast] (_Complex float)...
+#    3|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #    3|             Conversion = [FloatingPointConversion] floating point conversion
 #    3|             Type = [ArithmeticType] _Complex float
 #    3|             ValueCategory = prvalue
@@ -273,7 +273,7 @@ complex.c:
 #    4|               Type = [DoubleType] double
 #    4|               Value = [Literal] 3.0
 #    4|               ValueCategory = prvalue
-#    4|           : [CStyleCast] (_Complex double)...
+#    4|           getExpr().getFullyConverted(): [CStyleCast] (_Complex double)...
 #    4|               Conversion = [FloatingPointConversion] floating point conversion
 #    4|               Type = [ArithmeticType] _Complex double
 #    4|               ValueCategory = prvalue
@@ -288,7 +288,7 @@ complex.c:
 #    5|             Type = [ArithmeticType] _Imaginary float
 #    5|             Value = [Literal] 1.0i
 #    5|             ValueCategory = prvalue
-#    5|         : [CStyleCast] (_Complex double)...
+#    5|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #    5|             Conversion = [FloatingPointConversion] floating point conversion
 #    5|             Type = [ArithmeticType] _Complex double
 #    5|             ValueCategory = prvalue
@@ -300,7 +300,7 @@ complex.c:
 #    6|               Type = [DoubleType] double
 #    6|               Value = [Literal] 5.0
 #    6|               ValueCategory = prvalue
-#    6|           : [CStyleCast] (_Complex long double)...
+#    6|           getExpr().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #    6|               Conversion = [FloatingPointConversion] floating point conversion
 #    6|               Type = [ArithmeticType] _Complex long double
 #    6|               ValueCategory = prvalue
@@ -315,7 +315,7 @@ complex.c:
 #    7|             Type = [ArithmeticType] _Imaginary float
 #    7|             Value = [Literal] 1.0i
 #    7|             ValueCategory = prvalue
-#    7|         : [CStyleCast] (_Complex long double)...
+#    7|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #    7|             Conversion = [FloatingPointConversion] floating point conversion
 #    7|             Type = [ArithmeticType] _Complex long double
 #    7|             ValueCategory = prvalue
@@ -335,7 +335,7 @@ complex.c:
 #   10|               Type = [ArithmeticType] _Imaginary float
 #   10|               Value = [Literal] 1.0i
 #   10|               ValueCategory = prvalue
-#   10|           : [CStyleCast] (_Imaginary double)...
+#   10|           getExpr().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #   10|               Conversion = [FloatingPointConversion] floating point conversion
 #   10|               Type = [ArithmeticType] _Imaginary double
 #   10|               ValueCategory = prvalue
@@ -347,13 +347,13 @@ complex.c:
 #   11|               Type = [ArithmeticType] _Imaginary float
 #   11|               Value = [Literal] 1.0i
 #   11|               ValueCategory = prvalue
-#   11|           : [CStyleCast] (_Imaginary long double)...
+#   11|           getExpr().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #   11|               Conversion = [FloatingPointConversion] floating point conversion
 #   11|               Type = [ArithmeticType] _Imaginary long double
 #   11|               ValueCategory = prvalue
 #   12|     getStmt(9): [ReturnStmt] return ...
 #   14| [TopLevelFunction] void complex_arithmetic()
-#   14|   : 
+#   14|   <params>: 
 #   14|   getEntryPoint(): [BlockStmt] { ... }
 #   15|     getStmt(0): [DeclStmt] declaration
 #   15|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f1
@@ -363,7 +363,7 @@ complex.c:
 #   15|               Type = [DoubleType] double
 #   15|               Value = [Literal] 5.0
 #   15|               ValueCategory = prvalue
-#   15|           : [CStyleCast] (float)...
+#   15|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #   15|               Conversion = [FloatingPointConversion] floating point conversion
 #   15|               Type = [FloatType] float
 #   15|               Value = [CStyleCast] 5.0
@@ -376,7 +376,7 @@ complex.c:
 #   16|               Type = [DoubleType] double
 #   16|               Value = [Literal] 7.0
 #   16|               ValueCategory = prvalue
-#   16|           : [CStyleCast] (float)...
+#   16|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #   16|               Conversion = [FloatingPointConversion] floating point conversion
 #   16|               Type = [FloatType] float
 #   16|               Value = [CStyleCast] 7.0
@@ -392,7 +392,7 @@ complex.c:
 #   18|               Type = [DoubleType] double
 #   18|               Value = [Literal] 2.0
 #   18|               ValueCategory = prvalue
-#   18|           : [CStyleCast] (_Complex float)...
+#   18|           getExpr().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   18|               Conversion = [FloatingPointConversion] floating point conversion
 #   18|               Type = [ArithmeticType] _Complex float
 #   18|               ValueCategory = prvalue
@@ -404,7 +404,7 @@ complex.c:
 #   19|               Type = [ArithmeticType] _Imaginary float
 #   19|               Value = [Literal] 1.0i
 #   19|               ValueCategory = prvalue
-#   19|           : [CStyleCast] (_Complex float)...
+#   19|           getExpr().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   19|               Conversion = [FloatingPointConversion] floating point conversion
 #   19|               Type = [ArithmeticType] _Complex float
 #   19|               ValueCategory = prvalue
@@ -740,7 +740,7 @@ complex.c:
 #   55|               ValueCategory = prvalue(load)
 #   56|     getStmt(29): [ReturnStmt] return ...
 #   58| [TopLevelFunction] void complex_conversions()
-#   58|   : 
+#   58|   <params>: 
 #   58|   getEntryPoint(): [BlockStmt] { ... }
 #   59|     getStmt(0): [DeclStmt] declaration
 #   59|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of f
@@ -750,7 +750,7 @@ complex.c:
 #   59|               Type = [DoubleType] double
 #   59|               Value = [Literal] 2.0
 #   59|               ValueCategory = prvalue
-#   59|           : [CStyleCast] (float)...
+#   59|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #   59|               Conversion = [FloatingPointConversion] floating point conversion
 #   59|               Type = [FloatType] float
 #   59|               Value = [CStyleCast] 2.0
@@ -771,7 +771,7 @@ complex.c:
 #   61|               Type = [DoubleType] double
 #   61|               Value = [Literal] 5.0
 #   61|               ValueCategory = prvalue
-#   61|           : [CStyleCast] (long double)...
+#   61|           getExpr().getFullyConverted(): [CStyleCast] (long double)...
 #   61|               Conversion = [FloatingPointConversion] floating point conversion
 #   61|               Type = [LongDoubleType] long double
 #   61|               Value = [CStyleCast] 5.0
@@ -784,7 +784,7 @@ complex.c:
 #   62|               Type = [DoubleType] double
 #   62|               Value = [Literal] 7.0
 #   62|               ValueCategory = prvalue
-#   62|           : [CStyleCast] (_Complex float)...
+#   62|           getExpr().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   62|               Conversion = [FloatingPointConversion] floating point conversion
 #   62|               Type = [ArithmeticType] _Complex float
 #   62|               ValueCategory = prvalue
@@ -796,7 +796,7 @@ complex.c:
 #   63|               Type = [DoubleType] double
 #   63|               Value = [Literal] 11.0
 #   63|               ValueCategory = prvalue
-#   63|           : [CStyleCast] (_Complex double)...
+#   63|           getExpr().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   63|               Conversion = [FloatingPointConversion] floating point conversion
 #   63|               Type = [ArithmeticType] _Complex double
 #   63|               ValueCategory = prvalue
@@ -808,7 +808,7 @@ complex.c:
 #   64|               Type = [DoubleType] double
 #   64|               Value = [Literal] 13.0
 #   64|               ValueCategory = prvalue
-#   64|           : [CStyleCast] (_Complex long double)...
+#   64|           getExpr().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   64|               Conversion = [FloatingPointConversion] floating point conversion
 #   64|               Type = [ArithmeticType] _Complex long double
 #   64|               ValueCategory = prvalue
@@ -828,7 +828,7 @@ complex.c:
 #   66|               Type = [ArithmeticType] _Imaginary float
 #   66|               Value = [Literal] 1.0i
 #   66|               ValueCategory = prvalue
-#   66|           : [CStyleCast] (_Imaginary double)...
+#   66|           getExpr().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #   66|               Conversion = [FloatingPointConversion] floating point conversion
 #   66|               Type = [ArithmeticType] _Imaginary double
 #   66|               ValueCategory = prvalue
@@ -840,7 +840,7 @@ complex.c:
 #   67|               Type = [ArithmeticType] _Imaginary float
 #   67|               Value = [Literal] 1.0i
 #   67|               ValueCategory = prvalue
-#   67|           : [CStyleCast] (_Imaginary long double)...
+#   67|           getExpr().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #   67|               Conversion = [FloatingPointConversion] floating point conversion
 #   67|               Type = [ArithmeticType] _Imaginary long double
 #   67|               ValueCategory = prvalue
@@ -864,7 +864,7 @@ complex.c:
 #   71|         getRValue(): [VariableAccess] cd
 #   71|             Type = [ArithmeticType] _Complex double
 #   71|             ValueCategory = prvalue(load)
-#   71|         : [CStyleCast] (_Complex float)...
+#   71|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   71|             Conversion = [FloatingPointConversion] floating point conversion
 #   71|             Type = [ArithmeticType] _Complex float
 #   71|             ValueCategory = prvalue
@@ -878,7 +878,7 @@ complex.c:
 #   72|         getRValue(): [VariableAccess] cld
 #   72|             Type = [ArithmeticType] _Complex long double
 #   72|             ValueCategory = prvalue(load)
-#   72|         : [CStyleCast] (_Complex float)...
+#   72|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   72|             Conversion = [FloatingPointConversion] floating point conversion
 #   72|             Type = [ArithmeticType] _Complex float
 #   72|             ValueCategory = prvalue
@@ -892,7 +892,7 @@ complex.c:
 #   73|         getRValue(): [VariableAccess] cf
 #   73|             Type = [ArithmeticType] _Complex float
 #   73|             ValueCategory = prvalue(load)
-#   73|         : [CStyleCast] (_Complex double)...
+#   73|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   73|             Conversion = [FloatingPointConversion] floating point conversion
 #   73|             Type = [ArithmeticType] _Complex double
 #   73|             ValueCategory = prvalue
@@ -916,7 +916,7 @@ complex.c:
 #   75|         getRValue(): [VariableAccess] cld
 #   75|             Type = [ArithmeticType] _Complex long double
 #   75|             ValueCategory = prvalue(load)
-#   75|         : [CStyleCast] (_Complex double)...
+#   75|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   75|             Conversion = [FloatingPointConversion] floating point conversion
 #   75|             Type = [ArithmeticType] _Complex double
 #   75|             ValueCategory = prvalue
@@ -930,7 +930,7 @@ complex.c:
 #   76|         getRValue(): [VariableAccess] cf
 #   76|             Type = [ArithmeticType] _Complex float
 #   76|             ValueCategory = prvalue(load)
-#   76|         : [CStyleCast] (_Complex long double)...
+#   76|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   76|             Conversion = [FloatingPointConversion] floating point conversion
 #   76|             Type = [ArithmeticType] _Complex long double
 #   76|             ValueCategory = prvalue
@@ -944,7 +944,7 @@ complex.c:
 #   77|         getRValue(): [VariableAccess] cd
 #   77|             Type = [ArithmeticType] _Complex double
 #   77|             ValueCategory = prvalue(load)
-#   77|         : [CStyleCast] (_Complex long double)...
+#   77|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   77|             Conversion = [FloatingPointConversion] floating point conversion
 #   77|             Type = [ArithmeticType] _Complex long double
 #   77|             ValueCategory = prvalue
@@ -968,7 +968,7 @@ complex.c:
 #   81|         getRValue(): [VariableAccess] f
 #   81|             Type = [FloatType] float
 #   81|             ValueCategory = prvalue(load)
-#   81|         : [CStyleCast] (_Complex float)...
+#   81|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   81|             Conversion = [FloatingPointConversion] floating point conversion
 #   81|             Type = [ArithmeticType] _Complex float
 #   81|             ValueCategory = prvalue
@@ -982,7 +982,7 @@ complex.c:
 #   82|         getRValue(): [VariableAccess] d
 #   82|             Type = [DoubleType] double
 #   82|             ValueCategory = prvalue(load)
-#   82|         : [CStyleCast] (_Complex float)...
+#   82|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   82|             Conversion = [FloatingPointConversion] floating point conversion
 #   82|             Type = [ArithmeticType] _Complex float
 #   82|             ValueCategory = prvalue
@@ -996,7 +996,7 @@ complex.c:
 #   83|         getRValue(): [VariableAccess] ld
 #   83|             Type = [LongDoubleType] long double
 #   83|             ValueCategory = prvalue(load)
-#   83|         : [CStyleCast] (_Complex float)...
+#   83|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #   83|             Conversion = [FloatingPointConversion] floating point conversion
 #   83|             Type = [ArithmeticType] _Complex float
 #   83|             ValueCategory = prvalue
@@ -1010,7 +1010,7 @@ complex.c:
 #   84|         getRValue(): [VariableAccess] f
 #   84|             Type = [FloatType] float
 #   84|             ValueCategory = prvalue(load)
-#   84|         : [CStyleCast] (_Complex double)...
+#   84|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   84|             Conversion = [FloatingPointConversion] floating point conversion
 #   84|             Type = [ArithmeticType] _Complex double
 #   84|             ValueCategory = prvalue
@@ -1024,7 +1024,7 @@ complex.c:
 #   85|         getRValue(): [VariableAccess] d
 #   85|             Type = [DoubleType] double
 #   85|             ValueCategory = prvalue(load)
-#   85|         : [CStyleCast] (_Complex double)...
+#   85|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   85|             Conversion = [FloatingPointConversion] floating point conversion
 #   85|             Type = [ArithmeticType] _Complex double
 #   85|             ValueCategory = prvalue
@@ -1038,7 +1038,7 @@ complex.c:
 #   86|         getRValue(): [VariableAccess] ld
 #   86|             Type = [LongDoubleType] long double
 #   86|             ValueCategory = prvalue(load)
-#   86|         : [CStyleCast] (_Complex double)...
+#   86|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #   86|             Conversion = [FloatingPointConversion] floating point conversion
 #   86|             Type = [ArithmeticType] _Complex double
 #   86|             ValueCategory = prvalue
@@ -1052,7 +1052,7 @@ complex.c:
 #   87|         getRValue(): [VariableAccess] f
 #   87|             Type = [FloatType] float
 #   87|             ValueCategory = prvalue(load)
-#   87|         : [CStyleCast] (_Complex long double)...
+#   87|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   87|             Conversion = [FloatingPointConversion] floating point conversion
 #   87|             Type = [ArithmeticType] _Complex long double
 #   87|             ValueCategory = prvalue
@@ -1066,7 +1066,7 @@ complex.c:
 #   88|         getRValue(): [VariableAccess] d
 #   88|             Type = [DoubleType] double
 #   88|             ValueCategory = prvalue(load)
-#   88|         : [CStyleCast] (_Complex long double)...
+#   88|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   88|             Conversion = [FloatingPointConversion] floating point conversion
 #   88|             Type = [ArithmeticType] _Complex long double
 #   88|             ValueCategory = prvalue
@@ -1080,7 +1080,7 @@ complex.c:
 #   89|         getRValue(): [VariableAccess] ld
 #   89|             Type = [LongDoubleType] long double
 #   89|             ValueCategory = prvalue(load)
-#   89|         : [CStyleCast] (_Complex long double)...
+#   89|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #   89|             Conversion = [FloatingPointConversion] floating point conversion
 #   89|             Type = [ArithmeticType] _Complex long double
 #   89|             ValueCategory = prvalue
@@ -1094,7 +1094,7 @@ complex.c:
 #   92|         getRValue(): [VariableAccess] cf
 #   92|             Type = [ArithmeticType] _Complex float
 #   92|             ValueCategory = prvalue(load)
-#   92|         : [CStyleCast] (float)...
+#   92|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #   92|             Conversion = [FloatingPointConversion] floating point conversion
 #   92|             Type = [FloatType] float
 #   92|             ValueCategory = prvalue
@@ -1108,7 +1108,7 @@ complex.c:
 #   93|         getRValue(): [VariableAccess] cd
 #   93|             Type = [ArithmeticType] _Complex double
 #   93|             ValueCategory = prvalue(load)
-#   93|         : [CStyleCast] (float)...
+#   93|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #   93|             Conversion = [FloatingPointConversion] floating point conversion
 #   93|             Type = [FloatType] float
 #   93|             ValueCategory = prvalue
@@ -1122,7 +1122,7 @@ complex.c:
 #   94|         getRValue(): [VariableAccess] cld
 #   94|             Type = [ArithmeticType] _Complex long double
 #   94|             ValueCategory = prvalue(load)
-#   94|         : [CStyleCast] (float)...
+#   94|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #   94|             Conversion = [FloatingPointConversion] floating point conversion
 #   94|             Type = [FloatType] float
 #   94|             ValueCategory = prvalue
@@ -1136,7 +1136,7 @@ complex.c:
 #   95|         getRValue(): [VariableAccess] cf
 #   95|             Type = [ArithmeticType] _Complex float
 #   95|             ValueCategory = prvalue(load)
-#   95|         : [CStyleCast] (double)...
+#   95|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #   95|             Conversion = [FloatingPointConversion] floating point conversion
 #   95|             Type = [DoubleType] double
 #   95|             ValueCategory = prvalue
@@ -1150,7 +1150,7 @@ complex.c:
 #   96|         getRValue(): [VariableAccess] cd
 #   96|             Type = [ArithmeticType] _Complex double
 #   96|             ValueCategory = prvalue(load)
-#   96|         : [CStyleCast] (double)...
+#   96|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #   96|             Conversion = [FloatingPointConversion] floating point conversion
 #   96|             Type = [DoubleType] double
 #   96|             ValueCategory = prvalue
@@ -1164,7 +1164,7 @@ complex.c:
 #   97|         getRValue(): [VariableAccess] cld
 #   97|             Type = [ArithmeticType] _Complex long double
 #   97|             ValueCategory = prvalue(load)
-#   97|         : [CStyleCast] (double)...
+#   97|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #   97|             Conversion = [FloatingPointConversion] floating point conversion
 #   97|             Type = [DoubleType] double
 #   97|             ValueCategory = prvalue
@@ -1178,7 +1178,7 @@ complex.c:
 #   98|         getRValue(): [VariableAccess] cf
 #   98|             Type = [ArithmeticType] _Complex float
 #   98|             ValueCategory = prvalue(load)
-#   98|         : [CStyleCast] (long double)...
+#   98|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #   98|             Conversion = [FloatingPointConversion] floating point conversion
 #   98|             Type = [LongDoubleType] long double
 #   98|             ValueCategory = prvalue
@@ -1192,7 +1192,7 @@ complex.c:
 #   99|         getRValue(): [VariableAccess] cd
 #   99|             Type = [ArithmeticType] _Complex double
 #   99|             ValueCategory = prvalue(load)
-#   99|         : [CStyleCast] (long double)...
+#   99|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #   99|             Conversion = [FloatingPointConversion] floating point conversion
 #   99|             Type = [LongDoubleType] long double
 #   99|             ValueCategory = prvalue
@@ -1206,7 +1206,7 @@ complex.c:
 #  100|         getRValue(): [VariableAccess] cld
 #  100|             Type = [ArithmeticType] _Complex long double
 #  100|             ValueCategory = prvalue(load)
-#  100|         : [CStyleCast] (long double)...
+#  100|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #  100|             Conversion = [FloatingPointConversion] floating point conversion
 #  100|             Type = [LongDoubleType] long double
 #  100|             ValueCategory = prvalue
@@ -1220,7 +1220,7 @@ complex.c:
 #  103|         getRValue(): [VariableAccess] jf
 #  103|             Type = [ArithmeticType] _Imaginary float
 #  103|             ValueCategory = prvalue(load)
-#  103|         : [CStyleCast] (_Complex float)...
+#  103|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #  103|             Conversion = [FloatingPointConversion] floating point conversion
 #  103|             Type = [ArithmeticType] _Complex float
 #  103|             ValueCategory = prvalue
@@ -1234,7 +1234,7 @@ complex.c:
 #  104|         getRValue(): [VariableAccess] jd
 #  104|             Type = [ArithmeticType] _Imaginary double
 #  104|             ValueCategory = prvalue(load)
-#  104|         : [CStyleCast] (_Complex float)...
+#  104|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #  104|             Conversion = [FloatingPointConversion] floating point conversion
 #  104|             Type = [ArithmeticType] _Complex float
 #  104|             ValueCategory = prvalue
@@ -1248,7 +1248,7 @@ complex.c:
 #  105|         getRValue(): [VariableAccess] jld
 #  105|             Type = [ArithmeticType] _Imaginary long double
 #  105|             ValueCategory = prvalue(load)
-#  105|         : [CStyleCast] (_Complex float)...
+#  105|         getRValue().getFullyConverted(): [CStyleCast] (_Complex float)...
 #  105|             Conversion = [FloatingPointConversion] floating point conversion
 #  105|             Type = [ArithmeticType] _Complex float
 #  105|             ValueCategory = prvalue
@@ -1262,7 +1262,7 @@ complex.c:
 #  106|         getRValue(): [VariableAccess] jf
 #  106|             Type = [ArithmeticType] _Imaginary float
 #  106|             ValueCategory = prvalue(load)
-#  106|         : [CStyleCast] (_Complex double)...
+#  106|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #  106|             Conversion = [FloatingPointConversion] floating point conversion
 #  106|             Type = [ArithmeticType] _Complex double
 #  106|             ValueCategory = prvalue
@@ -1276,7 +1276,7 @@ complex.c:
 #  107|         getRValue(): [VariableAccess] jd
 #  107|             Type = [ArithmeticType] _Imaginary double
 #  107|             ValueCategory = prvalue(load)
-#  107|         : [CStyleCast] (_Complex double)...
+#  107|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #  107|             Conversion = [FloatingPointConversion] floating point conversion
 #  107|             Type = [ArithmeticType] _Complex double
 #  107|             ValueCategory = prvalue
@@ -1290,7 +1290,7 @@ complex.c:
 #  108|         getRValue(): [VariableAccess] jld
 #  108|             Type = [ArithmeticType] _Imaginary long double
 #  108|             ValueCategory = prvalue(load)
-#  108|         : [CStyleCast] (_Complex double)...
+#  108|         getRValue().getFullyConverted(): [CStyleCast] (_Complex double)...
 #  108|             Conversion = [FloatingPointConversion] floating point conversion
 #  108|             Type = [ArithmeticType] _Complex double
 #  108|             ValueCategory = prvalue
@@ -1304,7 +1304,7 @@ complex.c:
 #  109|         getRValue(): [VariableAccess] jf
 #  109|             Type = [ArithmeticType] _Imaginary float
 #  109|             ValueCategory = prvalue(load)
-#  109|         : [CStyleCast] (_Complex long double)...
+#  109|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #  109|             Conversion = [FloatingPointConversion] floating point conversion
 #  109|             Type = [ArithmeticType] _Complex long double
 #  109|             ValueCategory = prvalue
@@ -1318,7 +1318,7 @@ complex.c:
 #  110|         getRValue(): [VariableAccess] jd
 #  110|             Type = [ArithmeticType] _Imaginary double
 #  110|             ValueCategory = prvalue(load)
-#  110|         : [CStyleCast] (_Complex long double)...
+#  110|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #  110|             Conversion = [FloatingPointConversion] floating point conversion
 #  110|             Type = [ArithmeticType] _Complex long double
 #  110|             ValueCategory = prvalue
@@ -1332,7 +1332,7 @@ complex.c:
 #  111|         getRValue(): [VariableAccess] jld
 #  111|             Type = [ArithmeticType] _Imaginary long double
 #  111|             ValueCategory = prvalue(load)
-#  111|         : [CStyleCast] (_Complex long double)...
+#  111|         getRValue().getFullyConverted(): [CStyleCast] (_Complex long double)...
 #  111|             Conversion = [FloatingPointConversion] floating point conversion
 #  111|             Type = [ArithmeticType] _Complex long double
 #  111|             ValueCategory = prvalue
@@ -1346,7 +1346,7 @@ complex.c:
 #  114|         getRValue(): [VariableAccess] cf
 #  114|             Type = [ArithmeticType] _Complex float
 #  114|             ValueCategory = prvalue(load)
-#  114|         : [CStyleCast] (_Imaginary float)...
+#  114|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  114|             Conversion = [FloatingPointConversion] floating point conversion
 #  114|             Type = [ArithmeticType] _Imaginary float
 #  114|             ValueCategory = prvalue
@@ -1360,7 +1360,7 @@ complex.c:
 #  115|         getRValue(): [VariableAccess] cd
 #  115|             Type = [ArithmeticType] _Complex double
 #  115|             ValueCategory = prvalue(load)
-#  115|         : [CStyleCast] (_Imaginary float)...
+#  115|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  115|             Conversion = [FloatingPointConversion] floating point conversion
 #  115|             Type = [ArithmeticType] _Imaginary float
 #  115|             ValueCategory = prvalue
@@ -1374,7 +1374,7 @@ complex.c:
 #  116|         getRValue(): [VariableAccess] cld
 #  116|             Type = [ArithmeticType] _Complex long double
 #  116|             ValueCategory = prvalue(load)
-#  116|         : [CStyleCast] (_Imaginary float)...
+#  116|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  116|             Conversion = [FloatingPointConversion] floating point conversion
 #  116|             Type = [ArithmeticType] _Imaginary float
 #  116|             ValueCategory = prvalue
@@ -1388,7 +1388,7 @@ complex.c:
 #  117|         getRValue(): [VariableAccess] cf
 #  117|             Type = [ArithmeticType] _Complex float
 #  117|             ValueCategory = prvalue(load)
-#  117|         : [CStyleCast] (_Imaginary double)...
+#  117|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  117|             Conversion = [FloatingPointConversion] floating point conversion
 #  117|             Type = [ArithmeticType] _Imaginary double
 #  117|             ValueCategory = prvalue
@@ -1402,7 +1402,7 @@ complex.c:
 #  118|         getRValue(): [VariableAccess] cd
 #  118|             Type = [ArithmeticType] _Complex double
 #  118|             ValueCategory = prvalue(load)
-#  118|         : [CStyleCast] (_Imaginary double)...
+#  118|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  118|             Conversion = [FloatingPointConversion] floating point conversion
 #  118|             Type = [ArithmeticType] _Imaginary double
 #  118|             ValueCategory = prvalue
@@ -1416,7 +1416,7 @@ complex.c:
 #  119|         getRValue(): [VariableAccess] cld
 #  119|             Type = [ArithmeticType] _Complex long double
 #  119|             ValueCategory = prvalue(load)
-#  119|         : [CStyleCast] (_Imaginary double)...
+#  119|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  119|             Conversion = [FloatingPointConversion] floating point conversion
 #  119|             Type = [ArithmeticType] _Imaginary double
 #  119|             ValueCategory = prvalue
@@ -1430,7 +1430,7 @@ complex.c:
 #  120|         getRValue(): [VariableAccess] cf
 #  120|             Type = [ArithmeticType] _Complex float
 #  120|             ValueCategory = prvalue(load)
-#  120|         : [CStyleCast] (_Imaginary long double)...
+#  120|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  120|             Conversion = [FloatingPointConversion] floating point conversion
 #  120|             Type = [ArithmeticType] _Imaginary long double
 #  120|             ValueCategory = prvalue
@@ -1444,7 +1444,7 @@ complex.c:
 #  121|         getRValue(): [VariableAccess] cd
 #  121|             Type = [ArithmeticType] _Complex double
 #  121|             ValueCategory = prvalue(load)
-#  121|         : [CStyleCast] (_Imaginary long double)...
+#  121|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  121|             Conversion = [FloatingPointConversion] floating point conversion
 #  121|             Type = [ArithmeticType] _Imaginary long double
 #  121|             ValueCategory = prvalue
@@ -1458,7 +1458,7 @@ complex.c:
 #  122|         getRValue(): [VariableAccess] cld
 #  122|             Type = [ArithmeticType] _Complex long double
 #  122|             ValueCategory = prvalue(load)
-#  122|         : [CStyleCast] (_Imaginary long double)...
+#  122|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  122|             Conversion = [FloatingPointConversion] floating point conversion
 #  122|             Type = [ArithmeticType] _Imaginary long double
 #  122|             ValueCategory = prvalue
@@ -1472,7 +1472,7 @@ complex.c:
 #  125|         getRValue(): [VariableAccess] f
 #  125|             Type = [FloatType] float
 #  125|             ValueCategory = prvalue(load)
-#  125|         : [CStyleCast] (_Imaginary float)...
+#  125|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  125|             Conversion = [FloatingPointConversion] floating point conversion
 #  125|             Type = [ArithmeticType] _Imaginary float
 #  125|             ValueCategory = prvalue
@@ -1486,7 +1486,7 @@ complex.c:
 #  126|         getRValue(): [VariableAccess] d
 #  126|             Type = [DoubleType] double
 #  126|             ValueCategory = prvalue(load)
-#  126|         : [CStyleCast] (_Imaginary float)...
+#  126|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  126|             Conversion = [FloatingPointConversion] floating point conversion
 #  126|             Type = [ArithmeticType] _Imaginary float
 #  126|             ValueCategory = prvalue
@@ -1500,7 +1500,7 @@ complex.c:
 #  127|         getRValue(): [VariableAccess] ld
 #  127|             Type = [LongDoubleType] long double
 #  127|             ValueCategory = prvalue(load)
-#  127|         : [CStyleCast] (_Imaginary float)...
+#  127|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary float)...
 #  127|             Conversion = [FloatingPointConversion] floating point conversion
 #  127|             Type = [ArithmeticType] _Imaginary float
 #  127|             ValueCategory = prvalue
@@ -1514,7 +1514,7 @@ complex.c:
 #  128|         getRValue(): [VariableAccess] f
 #  128|             Type = [FloatType] float
 #  128|             ValueCategory = prvalue(load)
-#  128|         : [CStyleCast] (_Imaginary double)...
+#  128|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  128|             Conversion = [FloatingPointConversion] floating point conversion
 #  128|             Type = [ArithmeticType] _Imaginary double
 #  128|             ValueCategory = prvalue
@@ -1528,7 +1528,7 @@ complex.c:
 #  129|         getRValue(): [VariableAccess] d
 #  129|             Type = [DoubleType] double
 #  129|             ValueCategory = prvalue(load)
-#  129|         : [CStyleCast] (_Imaginary double)...
+#  129|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  129|             Conversion = [FloatingPointConversion] floating point conversion
 #  129|             Type = [ArithmeticType] _Imaginary double
 #  129|             ValueCategory = prvalue
@@ -1542,7 +1542,7 @@ complex.c:
 #  130|         getRValue(): [VariableAccess] ld
 #  130|             Type = [LongDoubleType] long double
 #  130|             ValueCategory = prvalue(load)
-#  130|         : [CStyleCast] (_Imaginary double)...
+#  130|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary double)...
 #  130|             Conversion = [FloatingPointConversion] floating point conversion
 #  130|             Type = [ArithmeticType] _Imaginary double
 #  130|             ValueCategory = prvalue
@@ -1556,7 +1556,7 @@ complex.c:
 #  131|         getRValue(): [VariableAccess] f
 #  131|             Type = [FloatType] float
 #  131|             ValueCategory = prvalue(load)
-#  131|         : [CStyleCast] (_Imaginary long double)...
+#  131|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  131|             Conversion = [FloatingPointConversion] floating point conversion
 #  131|             Type = [ArithmeticType] _Imaginary long double
 #  131|             ValueCategory = prvalue
@@ -1570,7 +1570,7 @@ complex.c:
 #  132|         getRValue(): [VariableAccess] d
 #  132|             Type = [DoubleType] double
 #  132|             ValueCategory = prvalue(load)
-#  132|         : [CStyleCast] (_Imaginary long double)...
+#  132|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  132|             Conversion = [FloatingPointConversion] floating point conversion
 #  132|             Type = [ArithmeticType] _Imaginary long double
 #  132|             ValueCategory = prvalue
@@ -1584,7 +1584,7 @@ complex.c:
 #  133|         getRValue(): [VariableAccess] ld
 #  133|             Type = [LongDoubleType] long double
 #  133|             ValueCategory = prvalue(load)
-#  133|         : [CStyleCast] (_Imaginary long double)...
+#  133|         getRValue().getFullyConverted(): [CStyleCast] (_Imaginary long double)...
 #  133|             Conversion = [FloatingPointConversion] floating point conversion
 #  133|             Type = [ArithmeticType] _Imaginary long double
 #  133|             ValueCategory = prvalue
@@ -1598,7 +1598,7 @@ complex.c:
 #  136|         getRValue(): [VariableAccess] jf
 #  136|             Type = [ArithmeticType] _Imaginary float
 #  136|             ValueCategory = prvalue(load)
-#  136|         : [CStyleCast] (float)...
+#  136|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #  136|             Conversion = [FloatingPointConversion] floating point conversion
 #  136|             Type = [FloatType] float
 #  136|             ValueCategory = prvalue
@@ -1612,7 +1612,7 @@ complex.c:
 #  137|         getRValue(): [VariableAccess] jd
 #  137|             Type = [ArithmeticType] _Imaginary double
 #  137|             ValueCategory = prvalue(load)
-#  137|         : [CStyleCast] (float)...
+#  137|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #  137|             Conversion = [FloatingPointConversion] floating point conversion
 #  137|             Type = [FloatType] float
 #  137|             ValueCategory = prvalue
@@ -1626,7 +1626,7 @@ complex.c:
 #  138|         getRValue(): [VariableAccess] jld
 #  138|             Type = [ArithmeticType] _Imaginary long double
 #  138|             ValueCategory = prvalue(load)
-#  138|         : [CStyleCast] (float)...
+#  138|         getRValue().getFullyConverted(): [CStyleCast] (float)...
 #  138|             Conversion = [FloatingPointConversion] floating point conversion
 #  138|             Type = [FloatType] float
 #  138|             ValueCategory = prvalue
@@ -1640,7 +1640,7 @@ complex.c:
 #  139|         getRValue(): [VariableAccess] jf
 #  139|             Type = [ArithmeticType] _Imaginary float
 #  139|             ValueCategory = prvalue(load)
-#  139|         : [CStyleCast] (double)...
+#  139|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #  139|             Conversion = [FloatingPointConversion] floating point conversion
 #  139|             Type = [DoubleType] double
 #  139|             ValueCategory = prvalue
@@ -1654,7 +1654,7 @@ complex.c:
 #  140|         getRValue(): [VariableAccess] jd
 #  140|             Type = [ArithmeticType] _Imaginary double
 #  140|             ValueCategory = prvalue(load)
-#  140|         : [CStyleCast] (double)...
+#  140|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #  140|             Conversion = [FloatingPointConversion] floating point conversion
 #  140|             Type = [DoubleType] double
 #  140|             ValueCategory = prvalue
@@ -1668,7 +1668,7 @@ complex.c:
 #  141|         getRValue(): [VariableAccess] jld
 #  141|             Type = [ArithmeticType] _Imaginary long double
 #  141|             ValueCategory = prvalue(load)
-#  141|         : [CStyleCast] (double)...
+#  141|         getRValue().getFullyConverted(): [CStyleCast] (double)...
 #  141|             Conversion = [FloatingPointConversion] floating point conversion
 #  141|             Type = [DoubleType] double
 #  141|             ValueCategory = prvalue
@@ -1682,7 +1682,7 @@ complex.c:
 #  142|         getRValue(): [VariableAccess] jf
 #  142|             Type = [ArithmeticType] _Imaginary float
 #  142|             ValueCategory = prvalue(load)
-#  142|         : [CStyleCast] (long double)...
+#  142|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #  142|             Conversion = [FloatingPointConversion] floating point conversion
 #  142|             Type = [LongDoubleType] long double
 #  142|             ValueCategory = prvalue
@@ -1696,7 +1696,7 @@ complex.c:
 #  143|         getRValue(): [VariableAccess] jd
 #  143|             Type = [ArithmeticType] _Imaginary double
 #  143|             ValueCategory = prvalue(load)
-#  143|         : [CStyleCast] (long double)...
+#  143|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #  143|             Conversion = [FloatingPointConversion] floating point conversion
 #  143|             Type = [LongDoubleType] long double
 #  143|             ValueCategory = prvalue
@@ -1710,14 +1710,14 @@ complex.c:
 #  144|         getRValue(): [VariableAccess] jld
 #  144|             Type = [ArithmeticType] _Imaginary long double
 #  144|             ValueCategory = prvalue(load)
-#  144|         : [CStyleCast] (long double)...
+#  144|         getRValue().getFullyConverted(): [CStyleCast] (long double)...
 #  144|             Conversion = [FloatingPointConversion] floating point conversion
 #  144|             Type = [LongDoubleType] long double
 #  144|             ValueCategory = prvalue
 #  145|     getStmt(72): [ReturnStmt] return ...
 ir.cpp:
 #    1| [TopLevelFunction] void Constants()
-#    1|   : 
+#    1|   <params>: 
 #    1|   getEntryPoint(): [BlockStmt] { ... }
 #    2|     getStmt(0): [DeclStmt] declaration
 #    2|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of c_i
@@ -1727,7 +1727,7 @@ ir.cpp:
 #    2|               Type = [IntType] int
 #    2|               Value = [Literal] 1
 #    2|               ValueCategory = prvalue
-#    2|           : [CStyleCast] (char)...
+#    2|           getExpr().getFullyConverted(): [CStyleCast] (char)...
 #    2|               Conversion = [IntegralConversion] integral conversion
 #    2|               Type = [PlainCharType] char
 #    2|               Value = [CStyleCast] 1
@@ -1752,7 +1752,7 @@ ir.cpp:
 #    5|                 Type = [IntType] int
 #    5|                 Value = [Literal] 1
 #    5|                 ValueCategory = prvalue
-#    5|           : [CStyleCast] (signed char)...
+#    5|           getExpr().getFullyConverted(): [CStyleCast] (signed char)...
 #    5|               Conversion = [IntegralConversion] integral conversion
 #    5|               Type = [SignedCharType] signed char
 #    5|               Value = [CStyleCast] -1
@@ -1765,7 +1765,7 @@ ir.cpp:
 #    6|               Type = [PlainCharType] char
 #    6|               Value = [CharLiteral] 65
 #    6|               ValueCategory = prvalue
-#    6|           : [CStyleCast] (signed char)...
+#    6|           getExpr().getFullyConverted(): [CStyleCast] (signed char)...
 #    6|               Conversion = [IntegralConversion] integral conversion
 #    6|               Type = [SignedCharType] signed char
 #    6|               Value = [CStyleCast] 65
@@ -1778,7 +1778,7 @@ ir.cpp:
 #    8|               Type = [IntType] int
 #    8|               Value = [Literal] 5
 #    8|               ValueCategory = prvalue
-#    8|           : [CStyleCast] (unsigned char)...
+#    8|           getExpr().getFullyConverted(): [CStyleCast] (unsigned char)...
 #    8|               Conversion = [IntegralConversion] integral conversion
 #    8|               Type = [UnsignedCharType] unsigned char
 #    8|               Value = [CStyleCast] 5
@@ -1791,7 +1791,7 @@ ir.cpp:
 #    9|               Type = [PlainCharType] char
 #    9|               Value = [CharLiteral] 65
 #    9|               ValueCategory = prvalue
-#    9|           : [CStyleCast] (unsigned char)...
+#    9|           getExpr().getFullyConverted(): [CStyleCast] (unsigned char)...
 #    9|               Conversion = [IntegralConversion] integral conversion
 #    9|               Type = [UnsignedCharType] unsigned char
 #    9|               Value = [CStyleCast] 65
@@ -1804,7 +1804,7 @@ ir.cpp:
 #   11|               Type = [IntType] int
 #   11|               Value = [Literal] 5
 #   11|               ValueCategory = prvalue
-#   11|           : [CStyleCast] (short)...
+#   11|           getExpr().getFullyConverted(): [CStyleCast] (short)...
 #   11|               Conversion = [IntegralConversion] integral conversion
 #   11|               Type = [ShortType] short
 #   11|               Value = [CStyleCast] 5
@@ -1817,7 +1817,7 @@ ir.cpp:
 #   12|               Type = [IntType] int
 #   12|               Value = [Literal] 5
 #   12|               ValueCategory = prvalue
-#   12|           : [CStyleCast] (unsigned short)...
+#   12|           getExpr().getFullyConverted(): [CStyleCast] (unsigned short)...
 #   12|               Conversion = [IntegralConversion] integral conversion
 #   12|               Type = [ShortType] unsigned short
 #   12|               Value = [CStyleCast] 5
@@ -1838,7 +1838,7 @@ ir.cpp:
 #   15|               Type = [IntType] int
 #   15|               Value = [Literal] 5
 #   15|               ValueCategory = prvalue
-#   15|           : [CStyleCast] (unsigned int)...
+#   15|           getExpr().getFullyConverted(): [CStyleCast] (unsigned int)...
 #   15|               Conversion = [IntegralConversion] integral conversion
 #   15|               Type = [IntType] unsigned int
 #   15|               Value = [CStyleCast] 5
@@ -1851,7 +1851,7 @@ ir.cpp:
 #   17|               Type = [IntType] int
 #   17|               Value = [Literal] 5
 #   17|               ValueCategory = prvalue
-#   17|           : [CStyleCast] (long)...
+#   17|           getExpr().getFullyConverted(): [CStyleCast] (long)...
 #   17|               Conversion = [IntegralConversion] integral conversion
 #   17|               Type = [LongType] long
 #   17|               Value = [CStyleCast] 5
@@ -1864,7 +1864,7 @@ ir.cpp:
 #   18|               Type = [IntType] int
 #   18|               Value = [Literal] 5
 #   18|               ValueCategory = prvalue
-#   18|           : [CStyleCast] (unsigned long)...
+#   18|           getExpr().getFullyConverted(): [CStyleCast] (unsigned long)...
 #   18|               Conversion = [IntegralConversion] integral conversion
 #   18|               Type = [LongType] unsigned long
 #   18|               Value = [CStyleCast] 5
@@ -1877,7 +1877,7 @@ ir.cpp:
 #   20|               Type = [IntType] int
 #   20|               Value = [Literal] 5
 #   20|               ValueCategory = prvalue
-#   20|           : [CStyleCast] (long long)...
+#   20|           getExpr().getFullyConverted(): [CStyleCast] (long long)...
 #   20|               Conversion = [IntegralConversion] integral conversion
 #   20|               Type = [LongLongType] long long
 #   20|               Value = [CStyleCast] 5
@@ -1898,7 +1898,7 @@ ir.cpp:
 #   22|               Type = [IntType] int
 #   22|               Value = [Literal] 5
 #   22|               ValueCategory = prvalue
-#   22|           : [CStyleCast] (unsigned long long)...
+#   22|           getExpr().getFullyConverted(): [CStyleCast] (unsigned long long)...
 #   22|               Conversion = [IntegralConversion] integral conversion
 #   22|               Type = [LongLongType] unsigned long long
 #   22|               Value = [CStyleCast] 5
@@ -1935,7 +1935,7 @@ ir.cpp:
 #   28|               Type = [IntType] int
 #   28|               Value = [Literal] 5
 #   28|               ValueCategory = prvalue
-#   28|           : [CStyleCast] (wchar_t)...
+#   28|           getExpr().getFullyConverted(): [CStyleCast] (wchar_t)...
 #   28|               Conversion = [IntegralConversion] integral conversion
 #   28|               Type = [Wchar_t,WideCharType] wchar_t
 #   28|               Value = [CStyleCast] 5
@@ -1972,7 +1972,7 @@ ir.cpp:
 #   34|               Type = [IntType] int
 #   34|               Value = [Literal] 1
 #   34|               ValueCategory = prvalue
-#   34|           : [CStyleCast] (float)...
+#   34|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #   34|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   34|               Type = [FloatType] float
 #   34|               Value = [CStyleCast] 1.0
@@ -1993,7 +1993,7 @@ ir.cpp:
 #   36|               Type = [DoubleType] double
 #   36|               Value = [Literal] 1.0
 #   36|               ValueCategory = prvalue
-#   36|           : [CStyleCast] (float)...
+#   36|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #   36|               Conversion = [FloatingPointConversion] floating point conversion
 #   36|               Type = [FloatType] float
 #   36|               Value = [CStyleCast] 1.0
@@ -2006,7 +2006,7 @@ ir.cpp:
 #   38|               Type = [IntType] int
 #   38|               Value = [Literal] 1
 #   38|               ValueCategory = prvalue
-#   38|           : [CStyleCast] (double)...
+#   38|           getExpr().getFullyConverted(): [CStyleCast] (double)...
 #   38|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #   38|               Type = [DoubleType] double
 #   38|               Value = [CStyleCast] 1.0
@@ -2019,7 +2019,7 @@ ir.cpp:
 #   39|               Type = [FloatType] float
 #   39|               Value = [Literal] 1.0
 #   39|               ValueCategory = prvalue
-#   39|           : [CStyleCast] (double)...
+#   39|           getExpr().getFullyConverted(): [CStyleCast] (double)...
 #   39|               Conversion = [FloatingPointConversion] floating point conversion
 #   39|               Type = [DoubleType] double
 #   39|               Value = [CStyleCast] 1.0
@@ -2034,7 +2034,7 @@ ir.cpp:
 #   40|               ValueCategory = prvalue
 #   41|     getStmt(28): [ReturnStmt] return ...
 #   43| [TopLevelFunction] void Foo()
-#   43|   : 
+#   43|   <params>: 
 #   43|   getEntryPoint(): [BlockStmt] { ... }
 #   44|     getStmt(0): [DeclStmt] declaration
 #   44|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -2060,7 +2060,7 @@ ir.cpp:
 #   45|               Type = [IntType] int
 #   45|               Value = [Literal] 7
 #   45|               ValueCategory = prvalue
-#   45|           : [CStyleCast] (short)...
+#   45|           getExpr().getFullyConverted(): [CStyleCast] (short)...
 #   45|               Conversion = [IntegralConversion] integral conversion
 #   45|               Type = [ShortType] short
 #   45|               Value = [CStyleCast] 7
@@ -2081,11 +2081,11 @@ ir.cpp:
 #   46|           getRightOperand(): [VariableAccess] y
 #   46|               Type = [ShortType] short
 #   46|               ValueCategory = prvalue(load)
-#   46|           : [CStyleCast] (int)...
+#   46|           getRightOperand().getFullyConverted(): [CStyleCast] (int)...
 #   46|               Conversion = [IntegralConversion] integral conversion
 #   46|               Type = [IntType] int
 #   46|               ValueCategory = prvalue
-#   46|         : [CStyleCast] (short)...
+#   46|         getRValue().getFullyConverted(): [CStyleCast] (short)...
 #   46|             Conversion = [IntegralConversion] integral conversion
 #   46|             Type = [ShortType] short
 #   46|             ValueCategory = prvalue
@@ -2105,13 +2105,13 @@ ir.cpp:
 #   47|           getRightOperand(): [VariableAccess] y
 #   47|               Type = [ShortType] short
 #   47|               ValueCategory = prvalue(load)
-#   47|           : [CStyleCast] (int)...
+#   47|           getRightOperand().getFullyConverted(): [CStyleCast] (int)...
 #   47|               Conversion = [IntegralConversion] integral conversion
 #   47|               Type = [IntType] int
 #   47|               ValueCategory = prvalue
 #   48|     getStmt(4): [ReturnStmt] return ...
 #   50| [TopLevelFunction] void IntegerOps(int, int)
-#   50|   : 
+#   50|   <params>: 
 #   50|     getParameter(0): [Parameter] x
 #   50|         Type = [IntType] int
 #   50|     getParameter(1): [Parameter] y
@@ -2442,17 +2442,17 @@ ir.cpp:
 #   84|           getOperand(): [VariableAccess] x
 #   84|               Type = [IntType] int
 #   84|               ValueCategory = prvalue(load)
-#   84|           : [CStyleCast] (bool)...
+#   84|           getOperand().getFullyConverted(): [CStyleCast] (bool)...
 #   84|               Conversion = [BoolConversion] conversion to bool
 #   84|               Type = [BoolType] bool
 #   84|               ValueCategory = prvalue
-#   84|         : [CStyleCast] (int)...
+#   84|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 #   84|             Conversion = [IntegralConversion] integral conversion
 #   84|             Type = [IntType] int
 #   84|             ValueCategory = prvalue
 #   85|     getStmt(26): [ReturnStmt] return ...
 #   87| [TopLevelFunction] void IntegerCompare(int, int)
-#   87|   : 
+#   87|   <params>: 
 #   87|     getParameter(0): [Parameter] x
 #   87|         Type = [IntType] int
 #   87|     getParameter(1): [Parameter] y
@@ -2559,7 +2559,7 @@ ir.cpp:
 #   95|               ValueCategory = prvalue(load)
 #   96|     getStmt(7): [ReturnStmt] return ...
 #   98| [TopLevelFunction] void IntegerCrement(int)
-#   98|   : 
+#   98|   <params>: 
 #   98|     getParameter(0): [Parameter] x
 #   98|         Type = [IntType] int
 #   98|   getEntryPoint(): [BlockStmt] { ... }
@@ -2620,7 +2620,7 @@ ir.cpp:
 #  104|               ValueCategory = lvalue
 #  105|     getStmt(5): [ReturnStmt] return ...
 #  107| [TopLevelFunction] void IntegerCrement_LValue(int)
-#  107|   : 
+#  107|   <params>: 
 #  107|     getParameter(0): [Parameter] x
 #  107|         Type = [IntType] int
 #  107|   getEntryPoint(): [BlockStmt] { ... }
@@ -2643,7 +2643,7 @@ ir.cpp:
 #  110|             getOperand(): [VariableAccess] x
 #  110|                 Type = [IntType] int
 #  110|                 ValueCategory = lvalue
-#  110|           : [ParenthesisExpr] (...)
+#  110|           getOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #  110|               Type = [IntType] int
 #  110|               ValueCategory = lvalue
 #  111|     getStmt(2): [ExprStmt] ExprStmt
@@ -2662,12 +2662,12 @@ ir.cpp:
 #  111|             getOperand(): [VariableAccess] x
 #  111|                 Type = [IntType] int
 #  111|                 ValueCategory = lvalue
-#  111|           : [ParenthesisExpr] (...)
+#  111|           getOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #  111|               Type = [IntType] int
 #  111|               ValueCategory = lvalue
 #  112|     getStmt(3): [ReturnStmt] return ...
 #  114| [TopLevelFunction] void FloatOps(double, double)
-#  114|   : 
+#  114|   <params>: 
 #  114|     getParameter(0): [Parameter] x
 #  114|         Type = [DoubleType] double
 #  114|     getParameter(1): [Parameter] y
@@ -2818,7 +2818,7 @@ ir.cpp:
 #  130|               ValueCategory = prvalue(load)
 #  131|     getStmt(12): [ReturnStmt] return ...
 #  133| [TopLevelFunction] void FloatCompare(double, double)
-#  133|   : 
+#  133|   <params>: 
 #  133|     getParameter(0): [Parameter] x
 #  133|         Type = [DoubleType] double
 #  133|     getParameter(1): [Parameter] y
@@ -2925,7 +2925,7 @@ ir.cpp:
 #  141|               ValueCategory = prvalue(load)
 #  142|     getStmt(7): [ReturnStmt] return ...
 #  144| [TopLevelFunction] void FloatCrement(float)
-#  144|   : 
+#  144|   <params>: 
 #  144|     getParameter(0): [Parameter] x
 #  144|         Type = [FloatType] float
 #  144|   getEntryPoint(): [BlockStmt] { ... }
@@ -2986,7 +2986,7 @@ ir.cpp:
 #  150|               ValueCategory = lvalue
 #  151|     getStmt(5): [ReturnStmt] return ...
 #  153| [TopLevelFunction] void PointerOps(int*, int)
-#  153|   : 
+#  153|   <params>: 
 #  153|     getParameter(0): [Parameter] p
 #  153|         Type = [IntPointerType] int *
 #  153|     getParameter(1): [Parameter] i
@@ -3062,7 +3062,7 @@ ir.cpp:
 #  160|           getRightOperand(): [VariableAccess] q
 #  160|               Type = [IntPointerType] int *
 #  160|               ValueCategory = prvalue(load)
-#  160|         : [CStyleCast] (int)...
+#  160|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 #  160|             Conversion = [IntegralConversion] integral conversion
 #  160|             Type = [IntType] int
 #  160|             ValueCategory = prvalue
@@ -3106,7 +3106,7 @@ ir.cpp:
 #  167|         getRValue(): [VariableAccess] p
 #  167|             Type = [IntPointerType] int *
 #  167|             ValueCategory = prvalue(load)
-#  167|         : [CStyleCast] (bool)...
+#  167|         getRValue().getFullyConverted(): [CStyleCast] (bool)...
 #  167|             Conversion = [BoolConversion] conversion to bool
 #  167|             Type = [BoolType] bool
 #  167|             ValueCategory = prvalue
@@ -3123,13 +3123,13 @@ ir.cpp:
 #  168|           getOperand(): [VariableAccess] p
 #  168|               Type = [IntPointerType] int *
 #  168|               ValueCategory = prvalue(load)
-#  168|           : [CStyleCast] (bool)...
+#  168|           getOperand().getFullyConverted(): [CStyleCast] (bool)...
 #  168|               Conversion = [BoolConversion] conversion to bool
 #  168|               Type = [BoolType] bool
 #  168|               ValueCategory = prvalue
 #  169|     getStmt(11): [ReturnStmt] return ...
 #  171| [TopLevelFunction] void ArrayAccess(int*, int)
-#  171|   : 
+#  171|   <params>: 
 #  171|     getParameter(0): [Parameter] p
 #  171|         Type = [IntPointerType] int *
 #  171|     getParameter(1): [Parameter] i
@@ -3221,7 +3221,7 @@ ir.cpp:
 #  181|           getArrayOffset(): [VariableAccess] i
 #  181|               Type = [IntType] int
 #  181|               ValueCategory = prvalue(load)
-#  181|           : [ArrayToPointerConversion] array to pointer conversion
+#  181|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  181|               Type = [IntPointerType] int *
 #  181|               ValueCategory = prvalue
 #  182|     getStmt(7): [ExprStmt] ExprStmt
@@ -3240,7 +3240,7 @@ ir.cpp:
 #  182|           getArrayOffset(): [VariableAccess] i
 #  182|               Type = [IntType] int
 #  182|               ValueCategory = prvalue(load)
-#  182|           : [ArrayToPointerConversion] array to pointer conversion
+#  182|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  182|               Type = [IntPointerType] int *
 #  182|               ValueCategory = prvalue
 #  183|     getStmt(8): [ExprStmt] ExprStmt
@@ -3256,7 +3256,7 @@ ir.cpp:
 #  183|           getArrayOffset(): [VariableAccess] i
 #  183|               Type = [IntType] int
 #  183|               ValueCategory = prvalue(load)
-#  183|           : [ArrayToPointerConversion] array to pointer conversion
+#  183|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  183|               Type = [IntPointerType] int *
 #  183|               ValueCategory = prvalue
 #  183|         getRValue(): [VariableAccess] x
@@ -3275,7 +3275,7 @@ ir.cpp:
 #  184|           getArrayOffset(): [VariableAccess] i
 #  184|               Type = [IntType] int
 #  184|               ValueCategory = prvalue(load)
-#  184|           : [ArrayToPointerConversion] array to pointer conversion
+#  184|           getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  184|               Type = [IntPointerType] int *
 #  184|               ValueCategory = prvalue
 #  184|         getRValue(): [VariableAccess] x
@@ -3283,7 +3283,7 @@ ir.cpp:
 #  184|             ValueCategory = prvalue(load)
 #  185|     getStmt(10): [ReturnStmt] return ...
 #  187| [TopLevelFunction] void StringLiteral(int)
-#  187|   : 
+#  187|   <params>: 
 #  187|     getParameter(0): [Parameter] i
 #  187|         Type = [IntType] int
 #  187|   getEntryPoint(): [BlockStmt] { ... }
@@ -3301,7 +3301,7 @@ ir.cpp:
 #  188|             getArrayOffset(): [VariableAccess] i
 #  188|                 Type = [IntType] int
 #  188|                 ValueCategory = prvalue(load)
-#  188|             : [ArrayToPointerConversion] array to pointer conversion
+#  188|             getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  188|                 Type = [PointerType] const char *
 #  188|                 ValueCategory = prvalue
 #  189|     getStmt(1): [DeclStmt] declaration
@@ -3312,7 +3312,7 @@ ir.cpp:
 #  189|               Type = [ArrayType] const wchar_t[4]
 #  189|               Value = [StringLiteral] "Bar"
 #  189|               ValueCategory = lvalue
-#  189|           : [CStyleCast] (wchar_t *)...
+#  189|           getExpr().getFullyConverted(): [CStyleCast] (wchar_t *)...
 #  189|               Conversion = [PointerConversion] pointer conversion
 #  189|               Type = [PointerType] wchar_t *
 #  189|               ValueCategory = prvalue
@@ -3334,7 +3334,7 @@ ir.cpp:
 #  190|                 ValueCategory = prvalue(load)
 #  191|     getStmt(3): [ReturnStmt] return ...
 #  193| [TopLevelFunction] void PointerCompare(int*, int*)
-#  193|   : 
+#  193|   <params>: 
 #  193|     getParameter(0): [Parameter] p
 #  193|         Type = [IntPointerType] int *
 #  193|     getParameter(1): [Parameter] q
@@ -3441,7 +3441,7 @@ ir.cpp:
 #  201|               ValueCategory = prvalue(load)
 #  202|     getStmt(7): [ReturnStmt] return ...
 #  204| [TopLevelFunction] void PointerCrement(int*)
-#  204|   : 
+#  204|   <params>: 
 #  204|     getParameter(0): [Parameter] p
 #  204|         Type = [IntPointerType] int *
 #  204|   getEntryPoint(): [BlockStmt] { ... }
@@ -3502,7 +3502,7 @@ ir.cpp:
 #  210|               ValueCategory = lvalue
 #  211|     getStmt(5): [ReturnStmt] return ...
 #  213| [TopLevelFunction] void CompoundAssignment()
-#  213|   : 
+#  213|   <params>: 
 #  213|   getEntryPoint(): [BlockStmt] { ... }
 #  215|     getStmt(0): [DeclStmt] declaration
 #  215|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -3531,7 +3531,7 @@ ir.cpp:
 #  219|               Type = [IntType] int
 #  219|               Value = [Literal] 5
 #  219|               ValueCategory = prvalue
-#  219|           : [CStyleCast] (short)...
+#  219|           getExpr().getFullyConverted(): [CStyleCast] (short)...
 #  219|               Conversion = [IntegralConversion] integral conversion
 #  219|               Type = [ShortType] short
 #  219|               Value = [CStyleCast] 5
@@ -3565,7 +3565,7 @@ ir.cpp:
 #  226|               Type = [IntType] int
 #  226|               Value = [Literal] 7
 #  226|               ValueCategory = prvalue
-#  226|           : [CStyleCast] (long)...
+#  226|           getExpr().getFullyConverted(): [CStyleCast] (long)...
 #  226|               Conversion = [IntegralConversion] integral conversion
 #  226|               Type = [LongType] long
 #  226|               Value = [CStyleCast] 7
@@ -3583,7 +3583,7 @@ ir.cpp:
 #  227|             ValueCategory = prvalue
 #  228|     getStmt(7): [ReturnStmt] return ...
 #  230| [TopLevelFunction] void UninitializedVariables()
-#  230|   : 
+#  230|   <params>: 
 #  230|   getEntryPoint(): [BlockStmt] { ... }
 #  231|     getStmt(0): [DeclStmt] declaration
 #  231|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of x
@@ -3597,7 +3597,7 @@ ir.cpp:
 #  232|               ValueCategory = prvalue(load)
 #  233|     getStmt(2): [ReturnStmt] return ...
 #  235| [TopLevelFunction] int Parameters(int, int)
-#  235|   : 
+#  235|   <params>: 
 #  235|     getParameter(0): [Parameter] x
 #  235|         Type = [IntType] int
 #  235|     getParameter(1): [Parameter] y
@@ -3614,7 +3614,7 @@ ir.cpp:
 #  236|             Type = [IntType] int
 #  236|             ValueCategory = prvalue(load)
 #  239| [TopLevelFunction] void IfStatements(bool, int, int)
-#  239|   : 
+#  239|   <params>: 
 #  239|     getParameter(0): [Parameter] b
 #  239|         Type = [BoolType] bool
 #  239|     getParameter(1): [Parameter] x
@@ -3677,7 +3677,7 @@ ir.cpp:
 #  250|               ValueCategory = prvalue
 #  251|     getStmt(3): [ReturnStmt] return ...
 #  253| [TopLevelFunction] void WhileStatements(int)
-#  253|   : 
+#  253|   <params>: 
 #  253|     getParameter(0): [Parameter] n
 #  253|         Type = [IntType] int
 #  253|   getEntryPoint(): [BlockStmt] { ... }
@@ -3706,7 +3706,7 @@ ir.cpp:
 #  255|                 ValueCategory = prvalue
 #  257|     getStmt(1): [ReturnStmt] return ...
 #  259| [TopLevelFunction] void DoStatements(int)
-#  259|   : 
+#  259|   <params>: 
 #  259|     getParameter(0): [Parameter] n
 #  259|         Type = [IntType] int
 #  259|   getEntryPoint(): [BlockStmt] { ... }
@@ -3735,7 +3735,7 @@ ir.cpp:
 #  261|                 ValueCategory = prvalue
 #  263|     getStmt(1): [ReturnStmt] return ...
 #  265| [TopLevelFunction] void For_Empty()
-#  265|   : 
+#  265|   <params>: 
 #  265|   getEntryPoint(): [BlockStmt] { ... }
 #  266|     getStmt(0): [DeclStmt] declaration
 #  266|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of j
@@ -3744,7 +3744,7 @@ ir.cpp:
 #  267|       getStmt(): [BlockStmt] { ... }
 #  268|         getStmt(0): [EmptyStmt] ;
 #  272| [TopLevelFunction] void For_Init()
-#  272|   : 
+#  272|   <params>: 
 #  272|   getEntryPoint(): [BlockStmt] { ... }
 #  273|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  273|       getInitialization(): [DeclStmt] declaration
@@ -3758,7 +3758,7 @@ ir.cpp:
 #  273|       getStmt(): [BlockStmt] { ... }
 #  274|         getStmt(0): [EmptyStmt] ;
 #  278| [TopLevelFunction] void For_Condition()
-#  278|   : 
+#  278|   <params>: 
 #  278|   getEntryPoint(): [BlockStmt] { ... }
 #  279|     getStmt(0): [DeclStmt] declaration
 #  279|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3783,7 +3783,7 @@ ir.cpp:
 #  281|         getStmt(0): [EmptyStmt] ;
 #  283|     getStmt(2): [ReturnStmt] return ...
 #  285| [TopLevelFunction] void For_Update()
-#  285|   : 
+#  285|   <params>: 
 #  285|   getEntryPoint(): [BlockStmt] { ... }
 #  286|     getStmt(0): [DeclStmt] declaration
 #  286|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3807,7 +3807,7 @@ ir.cpp:
 #  287|       getStmt(): [BlockStmt] { ... }
 #  288|         getStmt(0): [EmptyStmt] ;
 #  292| [TopLevelFunction] void For_InitCondition()
-#  292|   : 
+#  292|   <params>: 
 #  292|   getEntryPoint(): [BlockStmt] { ... }
 #  293|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  293|       getInitialization(): [DeclStmt] declaration
@@ -3832,7 +3832,7 @@ ir.cpp:
 #  294|         getStmt(0): [EmptyStmt] ;
 #  296|     getStmt(1): [ReturnStmt] return ...
 #  298| [TopLevelFunction] void For_InitUpdate()
-#  298|   : 
+#  298|   <params>: 
 #  298|   getEntryPoint(): [BlockStmt] { ... }
 #  299|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  299|       getInitialization(): [DeclStmt] declaration
@@ -3856,7 +3856,7 @@ ir.cpp:
 #  299|       getStmt(): [BlockStmt] { ... }
 #  300|         getStmt(0): [EmptyStmt] ;
 #  304| [TopLevelFunction] void For_ConditionUpdate()
-#  304|   : 
+#  304|   <params>: 
 #  304|   getEntryPoint(): [BlockStmt] { ... }
 #  305|     getStmt(0): [DeclStmt] declaration
 #  305|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of i
@@ -3891,7 +3891,7 @@ ir.cpp:
 #  307|         getStmt(0): [EmptyStmt] ;
 #  309|     getStmt(2): [ReturnStmt] return ...
 #  311| [TopLevelFunction] void For_InitConditionUpdate()
-#  311|   : 
+#  311|   <params>: 
 #  311|   getEntryPoint(): [BlockStmt] { ... }
 #  312|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  312|       getInitialization(): [DeclStmt] declaration
@@ -3926,7 +3926,7 @@ ir.cpp:
 #  313|         getStmt(0): [EmptyStmt] ;
 #  315|     getStmt(1): [ReturnStmt] return ...
 #  317| [TopLevelFunction] void For_Break()
-#  317|   : 
+#  317|   <params>: 
 #  317|   getEntryPoint(): [BlockStmt] { ... }
 #  318|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  318|       getInitialization(): [DeclStmt] declaration
@@ -3974,7 +3974,7 @@ ir.cpp:
 #  322|     getStmt(1): [LabelStmt] label ...:
 #  323|     getStmt(2): [ReturnStmt] return ...
 #  325| [TopLevelFunction] void For_Continue_Update()
-#  325|   : 
+#  325|   <params>: 
 #  325|   getEntryPoint(): [BlockStmt] { ... }
 #  326|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  326|       getInitialization(): [DeclStmt] declaration
@@ -4022,7 +4022,7 @@ ir.cpp:
 #  326|         getStmt(1): [LabelStmt] label ...:
 #  331|     getStmt(1): [ReturnStmt] return ...
 #  333| [TopLevelFunction] void For_Continue_NoUpdate()
-#  333|   : 
+#  333|   <params>: 
 #  333|   getEntryPoint(): [BlockStmt] { ... }
 #  334|     getStmt(0): [ForStmt] for(...;...;...) ...
 #  334|       getInitialization(): [DeclStmt] declaration
@@ -4060,7 +4060,7 @@ ir.cpp:
 #  334|         getStmt(1): [LabelStmt] label ...:
 #  339|     getStmt(1): [ReturnStmt] return ...
 #  341| [TopLevelFunction] int Dereference(int*)
-#  341|   : 
+#  341|   <params>: 
 #  341|     getParameter(0): [Parameter] p
 #  341|         Type = [IntPointerType] int *
 #  341|   getEntryPoint(): [BlockStmt] { ... }
@@ -4086,7 +4086,7 @@ ir.cpp:
 #  343|             Type = [IntPointerType] int *
 #  343|             ValueCategory = prvalue(load)
 #  348| [TopLevelFunction] int* AddressOf()
-#  348|   : 
+#  348|   <params>: 
 #  348|   getEntryPoint(): [BlockStmt] { ... }
 #  349|     getStmt(0): [ReturnStmt] return ...
 #  349|       getExpr(): [AddressOfExpr] & ...
@@ -4096,7 +4096,7 @@ ir.cpp:
 #  349|             Type = [IntType] int
 #  349|             ValueCategory = lvalue
 #  352| [TopLevelFunction] void Break(int)
-#  352|   : 
+#  352|   <params>: 
 #  352|     getParameter(0): [Parameter] n
 #  352|         Type = [IntType] int
 #  352|   getEntryPoint(): [BlockStmt] { ... }
@@ -4138,7 +4138,7 @@ ir.cpp:
 #  357|     getStmt(1): [LabelStmt] label ...:
 #  358|     getStmt(2): [ReturnStmt] return ...
 #  360| [TopLevelFunction] void Continue(int)
-#  360|   : 
+#  360|   <params>: 
 #  360|     getParameter(0): [Parameter] n
 #  360|         Type = [IntType] int
 #  360|   getEntryPoint(): [BlockStmt] { ... }
@@ -4181,15 +4181,15 @@ ir.cpp:
 #  361|         getStmt(2): [LabelStmt] label ...:
 #  367|     getStmt(1): [ReturnStmt] return ...
 #  369| [TopLevelFunction] void VoidFunc()
-#  369|   : 
+#  369|   <params>: 
 #  370| [TopLevelFunction] int Add(int, int)
-#  370|   : 
+#  370|   <params>: 
 #  370|     getParameter(0): [Parameter] x
 #  370|         Type = [IntType] int
 #  370|     getParameter(1): [Parameter] y
 #  370|         Type = [IntType] int
 #  372| [TopLevelFunction] void Call()
-#  372|   : 
+#  372|   <params>: 
 #  372|   getEntryPoint(): [BlockStmt] { ... }
 #  373|     getStmt(0): [ExprStmt] ExprStmt
 #  373|       getExpr(): [FunctionCall] call to VoidFunc
@@ -4197,7 +4197,7 @@ ir.cpp:
 #  373|           ValueCategory = prvalue
 #  374|     getStmt(1): [ReturnStmt] return ...
 #  376| [TopLevelFunction] int CallAdd(int, int)
-#  376|   : 
+#  376|   <params>: 
 #  376|     getParameter(0): [Parameter] x
 #  376|         Type = [IntType] int
 #  376|     getParameter(1): [Parameter] y
@@ -4214,7 +4214,7 @@ ir.cpp:
 #  377|             Type = [IntType] int
 #  377|             ValueCategory = prvalue(load)
 #  380| [TopLevelFunction] int Comma(int, int)
-#  380|   : 
+#  380|   <params>: 
 #  380|     getParameter(0): [Parameter] x
 #  380|         Type = [IntType] int
 #  380|     getParameter(1): [Parameter] y
@@ -4237,7 +4237,7 @@ ir.cpp:
 #  381|               Type = [IntType] int
 #  381|               ValueCategory = prvalue(load)
 #  384| [TopLevelFunction] void Switch(int)
-#  384|   : 
+#  384|   <params>: 
 #  384|     getParameter(0): [Parameter] x
 #  384|         Type = [IntType] int
 #  384|   getEntryPoint(): [BlockStmt] { ... }
@@ -4367,23 +4367,23 @@ ir.cpp:
 #  409|     getStmt(2): [LabelStmt] label ...:
 #  410|     getStmt(3): [ReturnStmt] return ...
 #  412| [CopyAssignmentOperator] Point& Point::operator=(Point const&)
-#  412|   : 
+#  412|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Point &
 #  412| [MoveAssignmentOperator] Point& Point::operator=(Point&&)
-#  412|   : 
+#  412|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Point &&
 #  417| [CopyAssignmentOperator] Rect& Rect::operator=(Rect const&)
-#  417|   : 
+#  417|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Rect &
 #  417| [MoveAssignmentOperator] Rect& Rect::operator=(Rect&&)
-#  417|   : 
+#  417|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Rect &&
 #  422| [TopLevelFunction] Point ReturnStruct(Point)
-#  422|   : 
+#  422|   <params>: 
 #  422|     getParameter(0): [Parameter] pt
 #  422|         Type = [Struct] Point
 #  422|   getEntryPoint(): [BlockStmt] { ... }
@@ -4392,7 +4392,7 @@ ir.cpp:
 #  423|           Type = [Struct] Point
 #  423|           ValueCategory = prvalue(load)
 #  426| [TopLevelFunction] void FieldAccess()
-#  426|   : 
+#  426|   <params>: 
 #  426|   getEntryPoint(): [BlockStmt] { ... }
 #  427|     getStmt(0): [DeclStmt] declaration
 #  427|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pt
@@ -4442,7 +4442,7 @@ ir.cpp:
 #  430|                   ValueCategory = lvalue
 #  431|     getStmt(4): [ReturnStmt] return ...
 #  433| [TopLevelFunction] void LogicalOr(bool, bool)
-#  433|   : 
+#  433|   <params>: 
 #  433|     getParameter(0): [Parameter] a
 #  433|         Type = [BoolType] bool
 #  433|     getParameter(1): [Parameter] b
@@ -4509,7 +4509,7 @@ ir.cpp:
 #  443|                 ValueCategory = prvalue
 #  445|     getStmt(3): [ReturnStmt] return ...
 #  447| [TopLevelFunction] void LogicalAnd(bool, bool)
-#  447|   : 
+#  447|   <params>: 
 #  447|     getParameter(0): [Parameter] a
 #  447|         Type = [BoolType] bool
 #  447|     getParameter(1): [Parameter] b
@@ -4576,7 +4576,7 @@ ir.cpp:
 #  457|                 ValueCategory = prvalue
 #  459|     getStmt(3): [ReturnStmt] return ...
 #  461| [TopLevelFunction] void LogicalNot(bool, bool)
-#  461|   : 
+#  461|   <params>: 
 #  461|     getParameter(0): [Parameter] a
 #  461|         Type = [BoolType] bool
 #  461|     getParameter(1): [Parameter] b
@@ -4617,7 +4617,7 @@ ir.cpp:
 #  467|           getRightOperand(): [VariableAccess] b
 #  467|               Type = [BoolType] bool
 #  467|               ValueCategory = prvalue(load)
-#  467|         : [ParenthesisExpr] (...)
+#  467|         getOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #  467|             Type = [BoolType] bool
 #  467|             ValueCategory = prvalue
 #  467|       getThen(): [BlockStmt] { ... }
@@ -4646,7 +4646,7 @@ ir.cpp:
 #  471|                 ValueCategory = prvalue
 #  473|     getStmt(3): [ReturnStmt] return ...
 #  475| [TopLevelFunction] void ConditionValues(bool, bool)
-#  475|   : 
+#  475|   <params>: 
 #  475|     getParameter(0): [Parameter] a
 #  475|         Type = [BoolType] bool
 #  475|     getParameter(1): [Parameter] b
@@ -4706,12 +4706,12 @@ ir.cpp:
 #  479|             getRightOperand(): [VariableAccess] b
 #  479|                 Type = [BoolType] bool
 #  479|                 ValueCategory = prvalue(load)
-#  479|           : [ParenthesisExpr] (...)
+#  479|           getOperand().getFullyConverted(): [ParenthesisExpr] (...)
 #  479|               Type = [BoolType] bool
 #  479|               ValueCategory = prvalue
 #  480|     getStmt(4): [ReturnStmt] return ...
 #  482| [TopLevelFunction] void Conditional(bool, int, int)
-#  482|   : 
+#  482|   <params>: 
 #  482|     getParameter(0): [Parameter] a
 #  482|         Type = [BoolType] bool
 #  482|     getParameter(1): [Parameter] x
@@ -4737,7 +4737,7 @@ ir.cpp:
 #  483|                 ValueCategory = prvalue(load)
 #  484|     getStmt(1): [ReturnStmt] return ...
 #  486| [TopLevelFunction] void Conditional_LValue(bool)
-#  486|   : 
+#  486|   <params>: 
 #  486|     getParameter(0): [Parameter] a
 #  486|         Type = [BoolType] bool
 #  486|   getEntryPoint(): [BlockStmt] { ... }
@@ -4767,12 +4767,12 @@ ir.cpp:
 #  489|             Type = [IntType] int
 #  489|             Value = [Literal] 5
 #  489|             ValueCategory = prvalue
-#  489|         : [ParenthesisExpr] (...)
+#  489|         getLValue().getFullyConverted(): [ParenthesisExpr] (...)
 #  489|             Type = [IntType] int
 #  489|             ValueCategory = lvalue
 #  490|     getStmt(3): [ReturnStmt] return ...
 #  492| [TopLevelFunction] void Conditional_Void(bool)
-#  492|   : 
+#  492|   <params>: 
 #  492|     getParameter(0): [Parameter] a
 #  492|         Type = [BoolType] bool
 #  492|   getEntryPoint(): [BlockStmt] { ... }
@@ -4791,7 +4791,7 @@ ir.cpp:
 #  493|             ValueCategory = prvalue
 #  494|     getStmt(1): [ReturnStmt] return ...
 #  496| [TopLevelFunction] void Nullptr()
-#  496|   : 
+#  496|   <params>: 
 #  496|   getEntryPoint(): [BlockStmt] { ... }
 #  497|     getStmt(0): [DeclStmt] declaration
 #  497|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of p
@@ -4801,7 +4801,7 @@ ir.cpp:
 #  497|               Type = [NullPointerType] decltype(nullptr)
 #  497|               Value = [Literal] 0
 #  497|               ValueCategory = prvalue
-#  497|           : [CStyleCast] (int *)...
+#  497|           getExpr().getFullyConverted(): [CStyleCast] (int *)...
 #  497|               Conversion = [PointerConversion] pointer conversion
 #  497|               Type = [IntPointerType] int *
 #  497|               Value = [CStyleCast] 0
@@ -4814,7 +4814,7 @@ ir.cpp:
 #  498|               Type = [IntType] int
 #  498|               Value = [Literal] 0
 #  498|               ValueCategory = prvalue
-#  498|           : [CStyleCast] (int *)...
+#  498|           getExpr().getFullyConverted(): [CStyleCast] (int *)...
 #  498|               Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  498|               Type = [IntPointerType] int *
 #  498|               Value = [CStyleCast] 0
@@ -4830,7 +4830,7 @@ ir.cpp:
 #  499|             Type = [NullPointerType] decltype(nullptr)
 #  499|             Value = [Literal] 0
 #  499|             ValueCategory = prvalue
-#  499|         : [CStyleCast] (int *)...
+#  499|         getRValue().getFullyConverted(): [CStyleCast] (int *)...
 #  499|             Conversion = [PointerConversion] pointer conversion
 #  499|             Type = [IntPointerType] int *
 #  499|             Value = [CStyleCast] 0
@@ -4846,14 +4846,14 @@ ir.cpp:
 #  500|             Type = [IntType] int
 #  500|             Value = [Literal] 0
 #  500|             ValueCategory = prvalue
-#  500|         : [CStyleCast] (int *)...
+#  500|         getRValue().getFullyConverted(): [CStyleCast] (int *)...
 #  500|             Conversion = [IntegralToPointerConversion] integral to pointer conversion
 #  500|             Type = [IntPointerType] int *
 #  500|             Value = [CStyleCast] 0
 #  500|             ValueCategory = prvalue
 #  501|     getStmt(4): [ReturnStmt] return ...
 #  503| [TopLevelFunction] void InitList(int, float)
-#  503|   : 
+#  503|   <params>: 
 #  503|     getParameter(0): [Parameter] x
 #  503|         Type = [IntType] int
 #  503|     getParameter(1): [Parameter] f
@@ -4872,7 +4872,7 @@ ir.cpp:
 #  504|             getFieldExpr(y): [VariableAccess] f
 #  504|                 Type = [FloatType] float
 #  504|                 ValueCategory = prvalue(load)
-#  504|             : [CStyleCast] (int)...
+#  504|             getFieldExpr(y).getFullyConverted(): [CStyleCast] (int)...
 #  504|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  504|                 Type = [IntType] int
 #  504|                 ValueCategory = prvalue
@@ -4911,7 +4911,7 @@ ir.cpp:
 #  509|               ValueCategory = prvalue
 #  510|     getStmt(5): [ReturnStmt] return ...
 #  512| [TopLevelFunction] void NestedInitList(int, float)
-#  512|   : 
+#  512|   <params>: 
 #  512|     getParameter(0): [Parameter] x
 #  512|         Type = [IntType] int
 #  512|     getParameter(1): [Parameter] f
@@ -4940,7 +4940,7 @@ ir.cpp:
 #  514|               getFieldExpr(y): [VariableAccess] f
 #  514|                   Type = [FloatType] float
 #  514|                   ValueCategory = prvalue(load)
-#  514|               : [CStyleCast] (int)...
+#  514|               getFieldExpr(y).getFullyConverted(): [CStyleCast] (int)...
 #  514|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  514|                   Type = [IntType] int
 #  514|                   ValueCategory = prvalue
@@ -4960,7 +4960,7 @@ ir.cpp:
 #  515|               getFieldExpr(y): [VariableAccess] f
 #  515|                   Type = [FloatType] float
 #  515|                   ValueCategory = prvalue(load)
-#  515|               : [CStyleCast] (int)...
+#  515|               getFieldExpr(y).getFullyConverted(): [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
@@ -4973,7 +4973,7 @@ ir.cpp:
 #  515|               getFieldExpr(y): [VariableAccess] f
 #  515|                   Type = [FloatType] float
 #  515|                   ValueCategory = prvalue(load)
-#  515|               : [CStyleCast] (int)...
+#  515|               getFieldExpr(y).getFullyConverted(): [CStyleCast] (int)...
 #  515|                   Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  515|                   Type = [IntType] int
 #  515|                   ValueCategory = prvalue
@@ -4998,7 +4998,7 @@ ir.cpp:
 #  516|                   ValueCategory = prvalue(load)
 #  517|     getStmt(4): [ReturnStmt] return ...
 #  519| [TopLevelFunction] void ArrayInit(int, float)
-#  519|   : 
+#  519|   <params>: 
 #  519|     getParameter(0): [Parameter] x
 #  519|         Type = [IntType] int
 #  519|     getParameter(1): [Parameter] f
@@ -5028,7 +5028,7 @@ ir.cpp:
 #  521|                 Type = [IntType] int
 #  521|                 Value = [Literal] 0
 #  521|                 ValueCategory = prvalue
-#  521|             : [CStyleCast] (int)...
+#  521|             getElementExpr(1).getFullyConverted(): [CStyleCast] (int)...
 #  521|                 Conversion = [FloatingPointToIntegralConversion] floating point to integral conversion
 #  521|                 Type = [IntType] int
 #  521|                 ValueCategory = prvalue
@@ -5044,15 +5044,15 @@ ir.cpp:
 #  522|                 ValueCategory = prvalue(load)
 #  523|     getStmt(3): [ReturnStmt] return ...
 #  525| [CopyAssignmentOperator] U& U::operator=(U const&)
-#  525|   : 
+#  525|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const U &
 #  525| [MoveAssignmentOperator] U& U::operator=(U&&)
-#  525|   : 
+#  525|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] U &&
 #  530| [TopLevelFunction] void UnionInit(int, float)
-#  530|   : 
+#  530|   <params>: 
 #  530|     getParameter(0): [Parameter] x
 #  530|         Type = [IntType] int
 #  530|     getParameter(1): [Parameter] f
@@ -5068,13 +5068,13 @@ ir.cpp:
 #  531|             getFieldExpr(d): [VariableAccess] f
 #  531|                 Type = [FloatType] float
 #  531|                 ValueCategory = prvalue(load)
-#  531|             : [CStyleCast] (double)...
+#  531|             getFieldExpr(d).getFullyConverted(): [CStyleCast] (double)...
 #  531|                 Conversion = [FloatingPointConversion] floating point conversion
 #  531|                 Type = [DoubleType] double
 #  531|                 ValueCategory = prvalue
 #  533|     getStmt(1): [ReturnStmt] return ...
 #  535| [TopLevelFunction] void EarlyReturn(int, int)
-#  535|   : 
+#  535|   <params>: 
 #  535|     getParameter(0): [Parameter] x
 #  535|         Type = [IntType] int
 #  535|     getParameter(1): [Parameter] y
@@ -5104,7 +5104,7 @@ ir.cpp:
 #  540|             ValueCategory = prvalue(load)
 #  541|     getStmt(2): [ReturnStmt] return ...
 #  543| [TopLevelFunction] int EarlyReturnValue(int, int)
-#  543|   : 
+#  543|   <params>: 
 #  543|     getParameter(0): [Parameter] x
 #  543|         Type = [IntType] int
 #  543|     getParameter(1): [Parameter] y
@@ -5136,7 +5136,7 @@ ir.cpp:
 #  548|             Type = [IntType] int
 #  548|             ValueCategory = prvalue(load)
 #  551| [TopLevelFunction] int CallViaFuncPtr(int(*)(int))
-#  551|   : 
+#  551|   <params>: 
 #  551|     getParameter(0): [Parameter] pfn
 #  551|         Type = [FunctionPointerType] ..(*)(..)
 #  551|   getEntryPoint(): [BlockStmt] { ... }
@@ -5152,7 +5152,7 @@ ir.cpp:
 #  552|             Value = [Literal] 5
 #  552|             ValueCategory = prvalue
 #  560| [TopLevelFunction] int EnumSwitch(E)
-#  560|   : 
+#  560|   <params>: 
 #  560|     getParameter(0): [Parameter] e
 #  560|         Type = [CTypedefType] E
 #  560|   getEntryPoint(): [BlockStmt] { ... }
@@ -5166,7 +5166,7 @@ ir.cpp:
 #  562|               Type = [Enum] E
 #  562|               Value = [EnumConstantAccess] 0
 #  562|               ValueCategory = prvalue
-#  562|           : [CStyleCast] (int)...
+#  562|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 #  562|               Conversion = [IntegralConversion] integral conversion
 #  562|               Type = [IntType] int
 #  562|               Value = [CStyleCast] 0
@@ -5181,7 +5181,7 @@ ir.cpp:
 #  564|               Type = [Enum] E
 #  564|               Value = [EnumConstantAccess] 1
 #  564|               ValueCategory = prvalue
-#  564|           : [CStyleCast] (int)...
+#  564|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 #  564|               Conversion = [IntegralConversion] integral conversion
 #  564|               Type = [IntType] int
 #  564|               Value = [CStyleCast] 1
@@ -5201,12 +5201,12 @@ ir.cpp:
 #  567|                 Type = [IntType] int
 #  567|                 Value = [Literal] 1
 #  567|                 ValueCategory = prvalue
-#  561|       : [CStyleCast] (int)...
+#  561|       getExpr().getFullyConverted(): [CStyleCast] (int)...
 #  561|           Conversion = [IntegralConversion] integral conversion
 #  561|           Type = [IntType] int
 #  561|           ValueCategory = prvalue
 #  571| [TopLevelFunction] void InitArray()
-#  571|   : 
+#  571|   <params>: 
 #  571|   getEntryPoint(): [BlockStmt] { ... }
 #  572|     getStmt(0): [DeclStmt] declaration
 #  572|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a_pad
@@ -5253,7 +5253,7 @@ ir.cpp:
 #  577|                 Type = [IntType] int
 #  577|                 Value = [Literal] 0
 #  577|                 ValueCategory = prvalue
-#  577|             : [CStyleCast] (char)...
+#  577|             getElementExpr(0).getFullyConverted(): [CStyleCast] (char)...
 #  577|                 Conversion = [IntegralConversion] integral conversion
 #  577|                 Type = [PlainCharType] char
 #  577|                 Value = [CStyleCast] 0
@@ -5273,12 +5273,12 @@ ir.cpp:
 #  578|                 Type = [IntType] int
 #  578|                 Value = [Literal] 1
 #  578|                 ValueCategory = prvalue
-#  578|             : [CStyleCast] (char)...
+#  578|             getElementExpr(0).getFullyConverted(): [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 0
 #  578|                 ValueCategory = prvalue
-#  578|             : [CStyleCast] (char)...
+#  578|             getElementExpr(1).getFullyConverted(): [CStyleCast] (char)...
 #  578|                 Conversion = [IntegralConversion] integral conversion
 #  578|                 Type = [PlainCharType] char
 #  578|                 Value = [CStyleCast] 1
@@ -5294,18 +5294,18 @@ ir.cpp:
 #  579|                 Type = [IntType] int
 #  579|                 Value = [Literal] 0
 #  579|                 ValueCategory = prvalue
-#  579|             : [CStyleCast] (char)...
+#  579|             getElementExpr(0).getFullyConverted(): [CStyleCast] (char)...
 #  579|                 Conversion = [IntegralConversion] integral conversion
 #  579|                 Type = [PlainCharType] char
 #  579|                 Value = [CStyleCast] 0
 #  579|                 ValueCategory = prvalue
 #  580|     getStmt(8): [ReturnStmt] return ...
 #  582| [TopLevelFunction] void VarArgFunction(char const*)
-#  582|   : 
+#  582|   <params>: 
 #  582|     getParameter(0): [Parameter] s
 #  582|         Type = [PointerType] const char *
 #  584| [TopLevelFunction] void VarArgs()
-#  584|   : 
+#  584|   <params>: 
 #  584|   getEntryPoint(): [BlockStmt] { ... }
 #  585|     getStmt(0): [ExprStmt] ExprStmt
 #  585|       getExpr(): [FunctionCall] call to VarArgFunction
@@ -5323,19 +5323,19 @@ ir.cpp:
 #  585|             Type = [ArrayType] const char[7]
 #  585|             Value = [StringLiteral] "string"
 #  585|             ValueCategory = lvalue
-#  585|         : [ArrayToPointerConversion] array to pointer conversion
+#  585|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  585|             Type = [PointerType] const char *
 #  585|             ValueCategory = prvalue
-#  585|         : [ArrayToPointerConversion] array to pointer conversion
+#  585|         getArgument(2).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  585|             Type = [PointerType] const char *
 #  585|             ValueCategory = prvalue
 #  586|     getStmt(1): [ReturnStmt] return ...
 #  588| [TopLevelFunction] int FuncPtrTarget(int)
-#  588|   : 
+#  588|   <params>: 
 #  588|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  588|         Type = [IntType] int
 #  590| [TopLevelFunction] void SetFuncPtr()
-#  590|   : 
+#  590|   <params>: 
 #  590|   getEntryPoint(): [BlockStmt] { ... }
 #  591|     getStmt(0): [DeclStmt] declaration
 #  591|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of pfn
@@ -5394,33 +5394,33 @@ ir.cpp:
 #  594|                     ValueCategory = lvalue
 #  595|     getStmt(4): [ReturnStmt] return ...
 #  599| [CopyConstructor] void String::String(String const&)
-#  599|   : 
+#  599|   <params>: 
 #  599|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  599|         Type = [LValueReferenceType] const String &
 #  600| [MoveConstructor] void String::String(String&&)
-#  600|   : 
+#  600|   <params>: 
 #  600|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  600|         Type = [RValueReferenceType] String &&
 #  601| [ConversionConstructor] void String::String(char const*)
-#  601|   : 
+#  601|   <params>: 
 #  601|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  601|         Type = [PointerType] const char *
 #  602| [Destructor] void String::~String()
-#  602|   : 
+#  602|   <params>: 
 #  604| [CopyAssignmentOperator] String& String::operator=(String const&)
-#  604|   : 
+#  604|   <params>: 
 #  604|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  604|         Type = [LValueReferenceType] const String &
 #  605| [MoveAssignmentOperator] String& String::operator=(String&&)
-#  605|   : 
+#  605|   <params>: 
 #  605|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  605|         Type = [RValueReferenceType] String &&
 #  607| [ConstMemberFunction] char const* String::c_str() const
-#  607|   : 
+#  607|   <params>: 
 #  613| [TopLevelFunction] String ReturnObject()
-#  613|   : 
+#  613|   <params>: 
 #  615| [TopLevelFunction] void DeclareObject()
-#  615|   : 
+#  615|   <params>: 
 #  615|   getEntryPoint(): [BlockStmt] { ... }
 #  616|     getStmt(0): [DeclStmt] declaration
 #  616|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s1
@@ -5440,7 +5440,7 @@ ir.cpp:
 #  617|                 Type = [ArrayType] const char[6]
 #  617|                 Value = [StringLiteral] "hello"
 #  617|                 ValueCategory = lvalue
-#  617|             : [ArrayToPointerConversion] array to pointer conversion
+#  617|             getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  617|                 Type = [PointerType] const char *
 #  617|                 ValueCategory = prvalue
 #  618|     getStmt(2): [DeclStmt] declaration
@@ -5461,12 +5461,12 @@ ir.cpp:
 #  619|                 Type = [ArrayType] const char[5]
 #  619|                 Value = [StringLiteral] "test"
 #  619|                 ValueCategory = lvalue
-#  619|             : [ArrayToPointerConversion] array to pointer conversion
+#  619|             getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  619|                 Type = [PointerType] const char *
 #  619|                 ValueCategory = prvalue
 #  620|     getStmt(4): [ReturnStmt] return ...
 #  622| [TopLevelFunction] void CallMethods(String&, String*, String)
-#  622|   : 
+#  622|   <params>: 
 #  622|     getParameter(0): [Parameter] r
 #  622|         Type = [LValueReferenceType] String &
 #  622|     getParameter(1): [Parameter] p
@@ -5481,7 +5481,7 @@ ir.cpp:
 #  623|         getQualifier(): [VariableAccess] r
 #  623|             Type = [LValueReferenceType] String &
 #  623|             ValueCategory = prvalue(load)
-#  623|         getQualifier(): [CStyleCast] (const String)...
+#  623|         getQualifier().getFullyConverted(): [CStyleCast] (const String)...
 #  623|             Conversion = [GlvalueConversion] glvalue conversion
 #  623|             Type = [SpecifiedType] const String
 #  623|             ValueCategory = lvalue
@@ -5495,7 +5495,7 @@ ir.cpp:
 #  624|         getQualifier(): [VariableAccess] p
 #  624|             Type = [PointerType] String *
 #  624|             ValueCategory = prvalue(load)
-#  624|         getQualifier(): [CStyleCast] (const String *)...
+#  624|         getQualifier().getFullyConverted(): [CStyleCast] (const String *)...
 #  624|             Conversion = [PointerConversion] pointer conversion
 #  624|             Type = [PointerType] const String *
 #  624|             ValueCategory = prvalue
@@ -5506,32 +5506,32 @@ ir.cpp:
 #  625|         getQualifier(): [VariableAccess] s
 #  625|             Type = [Struct] String
 #  625|             ValueCategory = lvalue
-#  625|         getQualifier(): [CStyleCast] (const String)...
+#  625|         getQualifier().getFullyConverted(): [CStyleCast] (const String)...
 #  625|             Conversion = [GlvalueConversion] glvalue conversion
 #  625|             Type = [SpecifiedType] const String
 #  625|             ValueCategory = lvalue
 #  626|     getStmt(3): [ReturnStmt] return ...
 #  628| [CopyAssignmentOperator] C& C::operator=(C const&)
-#  628|   : 
+#  628|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveAssignmentOperator] C& C::operator=(C&&)
-#  628|   : 
+#  628|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [CopyConstructor] void C::C(C const&)
-#  628|   : 
+#  628|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const C &
 #  628| [MoveConstructor] void C::C(C&&)
-#  628|   : 
+#  628|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] C &&
 #  628| [Destructor] void C::~C()
-#  628|   : 
+#  628|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-#  628|   : 
+#  628|   <destructions>: 
 #  628|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of m_f
 #  628|         Type = [Struct] String
 #  628|         ValueCategory = prvalue
@@ -5551,7 +5551,7 @@ ir.cpp:
 #  628|             Type = [Struct] String
 #  628|             ValueCategory = lvalue
 #  630| [MemberFunction] int C::StaticMemberFunction(int)
-#  630|   : 
+#  630|   <params>: 
 #  630|     getParameter(0): [Parameter] x
 #  630|         Type = [IntType] int
 #  630|   getEntryPoint(): [BlockStmt] { ... }
@@ -5560,7 +5560,7 @@ ir.cpp:
 #  631|           Type = [IntType] int
 #  631|           ValueCategory = prvalue(load)
 #  634| [MemberFunction] int C::InstanceMemberFunction(int)
-#  634|   : 
+#  634|   <params>: 
 #  634|     getParameter(0): [Parameter] x
 #  634|         Type = [IntType] int
 #  634|   getEntryPoint(): [BlockStmt] { ... }
@@ -5569,7 +5569,7 @@ ir.cpp:
 #  635|           Type = [IntType] int
 #  635|           ValueCategory = prvalue(load)
 #  638| [VirtualFunction] int C::VirtualMemberFunction(int)
-#  638|   : 
+#  638|   <params>: 
 #  638|     getParameter(0): [Parameter] x
 #  638|         Type = [IntType] int
 #  638|   getEntryPoint(): [BlockStmt] { ... }
@@ -5578,7 +5578,7 @@ ir.cpp:
 #  639|           Type = [IntType] int
 #  639|           ValueCategory = prvalue(load)
 #  642| [MemberFunction] void C::FieldAccess()
-#  642|   : 
+#  642|   <params>: 
 #  642|   getEntryPoint(): [BlockStmt] { ... }
 #  643|     getStmt(0): [ExprStmt] ExprStmt
 #  643|       getExpr(): [AssignExpr] ... = ...
@@ -5607,7 +5607,7 @@ ir.cpp:
 #  644|             getOperand(): [ThisExpr] this
 #  644|                 Type = [PointerType] C *
 #  644|                 ValueCategory = prvalue(load)
-#  644|           getQualifier(): [ParenthesisExpr] (...)
+#  644|           getQualifier().getFullyConverted(): [ParenthesisExpr] (...)
 #  644|               Type = [Class] C
 #  644|               ValueCategory = lvalue
 #  644|         getRValue(): [Literal] 1
@@ -5660,7 +5660,7 @@ ir.cpp:
 #  648|             getOperand(): [ThisExpr] this
 #  648|                 Type = [PointerType] C *
 #  648|                 ValueCategory = prvalue(load)
-#  648|           getQualifier(): [ParenthesisExpr] (...)
+#  648|           getQualifier().getFullyConverted(): [ParenthesisExpr] (...)
 #  648|               Type = [Class] C
 #  648|               ValueCategory = lvalue
 #  649|     getStmt(6): [ExprStmt] ExprStmt
@@ -5678,7 +5678,7 @@ ir.cpp:
 #  649|               ValueCategory = prvalue(load)
 #  650|     getStmt(7): [ReturnStmt] return ...
 #  652| [MemberFunction] void C::MethodCalls()
-#  652|   : 
+#  652|   <params>: 
 #  652|   getEntryPoint(): [BlockStmt] { ... }
 #  653|     getStmt(0): [ExprStmt] ExprStmt
 #  653|       getExpr(): [FunctionCall] call to InstanceMemberFunction
@@ -5701,13 +5701,13 @@ ir.cpp:
 #  654|           getOperand(): [ThisExpr] this
 #  654|               Type = [PointerType] C *
 #  654|               ValueCategory = prvalue(load)
-#  654|         getArgument(0): [ParenthesisExpr] (...)
-#  654|             Type = [Class] C
-#  654|             ValueCategory = lvalue
 #  654|         getArgument(0): [Literal] 1
 #  654|             Type = [IntType] int
 #  654|             Value = [Literal] 1
 #  654|             ValueCategory = prvalue
+#  654|         getQualifier().getFullyConverted(): [ParenthesisExpr] (...)
+#  654|             Type = [Class] C
+#  654|             ValueCategory = lvalue
 #  655|     getStmt(2): [ExprStmt] ExprStmt
 #  655|       getExpr(): [FunctionCall] call to InstanceMemberFunction
 #  655|           Type = [IntType] int
@@ -5721,8 +5721,8 @@ ir.cpp:
 #  655|             ValueCategory = prvalue
 #  656|     getStmt(3): [ReturnStmt] return ...
 #  658| [Constructor] void C::C()
-#  658|   : 
-#  658|   : 
+#  658|   <params>: 
+#  658|   <initializations>: 
 #  659|     getInitializer(0): [ConstructorFieldInit] constructor init of field m_a
 #  659|         Type = [IntType] int
 #  659|         ValueCategory = prvalue
@@ -5743,7 +5743,7 @@ ir.cpp:
 #  660|           Type = [IntType] int
 #  660|           Value = [Literal] 3
 #  660|           ValueCategory = prvalue
-#  660|       : [CStyleCast] (char)...
+#  660|       getExpr().getFullyConverted(): [CStyleCast] (char)...
 #  660|           Conversion = [IntegralConversion] integral conversion
 #  660|           Type = [PlainCharType] char
 #  660|           Value = [CStyleCast] 3
@@ -5765,13 +5765,13 @@ ir.cpp:
 #  662|             Type = [ArrayType] const char[5]
 #  662|             Value = [StringLiteral] "test"
 #  662|             ValueCategory = lvalue
-#  662|         : [ArrayToPointerConversion] array to pointer conversion
+#  662|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  662|             Type = [PointerType] const char *
 #  662|             ValueCategory = prvalue
 #  663|   getEntryPoint(): [BlockStmt] { ... }
 #  664|     getStmt(0): [ReturnStmt] return ...
 #  675| [TopLevelFunction] int DerefReference(int&)
-#  675|   : 
+#  675|   <params>: 
 #  675|     getParameter(0): [Parameter] r
 #  675|         Type = [LValueReferenceType] int &
 #  675|   getEntryPoint(): [BlockStmt] { ... }
@@ -5779,23 +5779,23 @@ ir.cpp:
 #  676|       getExpr(): [VariableAccess] r
 #  676|           Type = [LValueReferenceType] int &
 #  676|           ValueCategory = prvalue(load)
-#  676|       : [ReferenceDereferenceExpr] (reference dereference)
+#  676|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  676|           Type = [IntType] int
 #  676|           ValueCategory = prvalue(load)
 #  679| [TopLevelFunction] int& TakeReference()
-#  679|   : 
+#  679|   <params>: 
 #  679|   getEntryPoint(): [BlockStmt] { ... }
 #  680|     getStmt(0): [ReturnStmt] return ...
 #  680|       getExpr(): [VariableAccess] g
 #  680|           Type = [IntType] int
 #  680|           ValueCategory = lvalue
-#  680|       : [ReferenceToExpr] (reference to)
+#  680|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  680|           Type = [LValueReferenceType] int &
 #  680|           ValueCategory = prvalue
 #  683| [TopLevelFunction] String& ReturnReference()
-#  683|   : 
+#  683|   <params>: 
 #  685| [TopLevelFunction] void InitReference(int)
-#  685|   : 
+#  685|   <params>: 
 #  685|     getParameter(0): [Parameter] x
 #  685|         Type = [IntType] int
 #  685|   getEntryPoint(): [BlockStmt] { ... }
@@ -5806,7 +5806,7 @@ ir.cpp:
 #  686|           getExpr(): [VariableAccess] x
 #  686|               Type = [IntType] int
 #  686|               ValueCategory = lvalue
-#  686|           : [ReferenceToExpr] (reference to)
+#  686|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  686|               Type = [LValueReferenceType] int &
 #  686|               ValueCategory = prvalue
 #  687|     getStmt(1): [DeclStmt] declaration
@@ -5816,7 +5816,7 @@ ir.cpp:
 #  687|           getExpr(): [VariableAccess] r
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue(load)
-#  687|           : [ReferenceToExpr] (reference to)
+#  687|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  687|               Type = [LValueReferenceType] int &
 #  687|               ValueCategory = prvalue
 #  687|             getExpr(): [ReferenceDereferenceExpr] (reference dereference)
@@ -5829,7 +5829,7 @@ ir.cpp:
 #  688|           getExpr(): [FunctionCall] call to ReturnReference
 #  688|               Type = [LValueReferenceType] String &
 #  688|               ValueCategory = prvalue
-#  688|           : [ReferenceToExpr] (reference to)
+#  688|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  688|               Type = [LValueReferenceType] const String &
 #  688|               ValueCategory = prvalue
 #  688|             getExpr(): [CStyleCast] (const String)...
@@ -5841,7 +5841,7 @@ ir.cpp:
 #  688|                   ValueCategory = lvalue
 #  689|     getStmt(3): [ReturnStmt] return ...
 #  691| [TopLevelFunction] void ArrayReferences()
-#  691|   : 
+#  691|   <params>: 
 #  691|   getEntryPoint(): [BlockStmt] { ... }
 #  692|     getStmt(0): [DeclStmt] declaration
 #  692|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
@@ -5853,7 +5853,7 @@ ir.cpp:
 #  693|           getExpr(): [VariableAccess] a
 #  693|               Type = [ArrayType] int[10]
 #  693|               ValueCategory = lvalue
-#  693|           : [ReferenceToExpr] (reference to)
+#  693|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  693|               Type = [LValueReferenceType] int(&)[10]
 #  693|               ValueCategory = prvalue
 #  694|     getStmt(2): [DeclStmt] declaration
@@ -5870,7 +5870,7 @@ ir.cpp:
 #  694|                 Type = [IntType] int
 #  694|                 Value = [Literal] 5
 #  694|                 ValueCategory = prvalue
-#  694|             : [ArrayToPointerConversion] array to pointer conversion
+#  694|             getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  694|                 Type = [IntPointerType] int *
 #  694|                 ValueCategory = prvalue
 #  694|               getExpr(): [ReferenceDereferenceExpr] (reference dereference)
@@ -5878,7 +5878,7 @@ ir.cpp:
 #  694|                   ValueCategory = lvalue
 #  695|     getStmt(3): [ReturnStmt] return ...
 #  697| [TopLevelFunction] void FunctionReferences()
-#  697|   : 
+#  697|   <params>: 
 #  697|   getEntryPoint(): [BlockStmt] { ... }
 #  698|     getStmt(0): [DeclStmt] declaration
 #  698|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of rfn
@@ -5887,7 +5887,7 @@ ir.cpp:
 #  698|           getExpr(): [FunctionAccess] FuncPtrTarget
 #  698|               Type = [RoutineType] ..()(..)
 #  698|               ValueCategory = lvalue
-#  698|           : [ReferenceToExpr] (reference to)
+#  698|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  698|               Type = [FunctionReferenceType] ..(&)(..)
 #  698|               ValueCategory = prvalue
 #  699|     getStmt(1): [DeclStmt] declaration
@@ -5897,7 +5897,7 @@ ir.cpp:
 #  699|           getExpr(): [VariableAccess] rfn
 #  699|               Type = [FunctionReferenceType] ..(&)(..)
 #  699|               ValueCategory = prvalue(load)
-#  699|           : [ReferenceDereferenceExpr] (reference dereference)
+#  699|           getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  699|               Type = [FunctionPointerType] ..(*)(..)
 #  699|               ValueCategory = prvalue(load)
 #  700|     getStmt(2): [ExprStmt] ExprStmt
@@ -5911,12 +5911,12 @@ ir.cpp:
 #  700|             Type = [IntType] int
 #  700|             Value = [Literal] 5
 #  700|             ValueCategory = prvalue
-#  700|         : [ReferenceDereferenceExpr] (reference dereference)
+#  700|         getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  700|             Type = [FunctionPointerType] ..(*)(..)
 #  700|             ValueCategory = prvalue(load)
 #  701|     getStmt(3): [ReturnStmt] return ...
 #  704| [TemplateFunction,TopLevelFunction] T min<T>(T, T)
-#  704|   : 
+#  704|   <params>: 
 #  704|     getParameter(0): [Parameter] x
 #  704|         Type = [TemplateParameter] T
 #  704|     getParameter(1): [Parameter] y
@@ -5941,7 +5941,7 @@ ir.cpp:
 #  705|         getElse(): [VariableAccess] y
 #  705|             Type = [TemplateParameter] T
 #  705|             ValueCategory = lvalue
-#  705|         : [CStyleCast] (bool)...
+#  705|         getCondition().getFullyConverted(): [CStyleCast] (bool)...
 #  705|             Conversion = [BoolConversion] conversion to bool
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
@@ -5949,7 +5949,7 @@ ir.cpp:
 #  705|               Type = [UnknownType] unknown
 #  705|               ValueCategory = prvalue
 #  704| [FunctionTemplateInstantiation,TopLevelFunction] int min<int>(int, int)
-#  704|   : 
+#  704|   <params>: 
 #  704|     getParameter(0): [Parameter] x
 #  704|         Type = [IntType] int
 #  704|     getParameter(1): [Parameter] y
@@ -5974,11 +5974,11 @@ ir.cpp:
 #  705|         getElse(): [VariableAccess] y
 #  705|             Type = [IntType] int
 #  705|             ValueCategory = prvalue(load)
-#  705|         : [ParenthesisExpr] (...)
+#  705|         getCondition().getFullyConverted(): [ParenthesisExpr] (...)
 #  705|             Type = [BoolType] bool
 #  705|             ValueCategory = prvalue
 #  708| [TopLevelFunction] int CallMin(int, int)
-#  708|   : 
+#  708|   <params>: 
 #  708|     getParameter(0): [Parameter] x
 #  708|         Type = [IntType] int
 #  708|     getParameter(1): [Parameter] y
@@ -5995,15 +5995,15 @@ ir.cpp:
 #  709|             Type = [IntType] int
 #  709|             ValueCategory = prvalue(load)
 #  713| [CopyAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long> const&)
-#  713|   : 
+#  713|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Outer<long> &
 #  713| [MoveAssignmentOperator] Outer<long>& Outer<long>::operator=(Outer<long>&&)
-#  713|   : 
+#  713|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Outer<long> &&
 #  715| [MemberFunction,TemplateFunction] T Outer<T>::Func<U, V>(U, V)
-#  715|   : 
+#  715|   <params>: 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
 #  715|     getParameter(1): [Parameter] y
@@ -6015,13 +6015,13 @@ ir.cpp:
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  715| [MemberFunction,TemplateFunction] long Outer<long>::Func<U, V>(U, V)
-#  715|   : 
+#  715|   <params>: 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [TemplateParameter] U
 #  715|     getParameter(1): [Parameter] y
 #  715|         Type = [TemplateParameter] V
 #  715| [FunctionTemplateInstantiation,MemberFunction] long Outer<long>::Func<void*, char>(void*, char)
-#  715|   : 
+#  715|   <params>: 
 #  715|     getParameter(0): [Parameter] x
 #  715|         Type = [VoidPointerType] void *
 #  715|     getParameter(1): [Parameter] y
@@ -6033,7 +6033,7 @@ ir.cpp:
 #  716|           Value = [Literal] 0
 #  716|           ValueCategory = prvalue
 #  720| [TopLevelFunction] double CallNestedTemplateFunc()
-#  720|   : 
+#  720|   <params>: 
 #  720|   getEntryPoint(): [BlockStmt] { ... }
 #  721|     getStmt(0): [ReturnStmt] return ...
 #  721|       getExpr(): [FunctionCall] call to Func
@@ -6047,17 +6047,17 @@ ir.cpp:
 #  721|             Type = [PlainCharType] char
 #  721|             Value = [CharLiteral] 111
 #  721|             ValueCategory = prvalue
-#  721|         : [CStyleCast] (void *)...
+#  721|         getArgument(0).getFullyConverted(): [CStyleCast] (void *)...
 #  721|             Conversion = [PointerConversion] pointer conversion
 #  721|             Type = [VoidPointerType] void *
 #  721|             Value = [CStyleCast] 0
 #  721|             ValueCategory = prvalue
-#  721|       : [CStyleCast] (double)...
+#  721|       getExpr().getFullyConverted(): [CStyleCast] (double)...
 #  721|           Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  721|           Type = [DoubleType] double
 #  721|           ValueCategory = prvalue
 #  724| [TopLevelFunction] void TryCatch(bool)
-#  724|   : 
+#  724|   <params>: 
 #  724|     getParameter(0): [Parameter] b
 #  724|         Type = [BoolType] bool
 #  724|   getEntryPoint(): [BlockStmt] { ... }
@@ -6084,7 +6084,7 @@ ir.cpp:
 #  728|                     Type = [ArrayType] const char[15]
 #  728|                     Value = [StringLiteral] "string literal"
 #  728|                     ValueCategory = lvalue
-#  728|                 : [ArrayToPointerConversion] array to pointer conversion
+#  728|                 getExpr().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  728|                     Type = [PointerType] const char *
 #  728|                     ValueCategory = prvalue
 #  730|           getElse(): [IfStmt] if (...) ... 
@@ -6126,7 +6126,7 @@ ir.cpp:
 #  731|                             Type = [ArrayType] const char[14]
 #  731|                             Value = [StringLiteral] "String object"
 #  731|                             ValueCategory = lvalue
-#  731|                         : [ArrayToPointerConversion] array to pointer conversion
+#  731|                         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  731|                             Type = [PointerType] const char *
 #  731|                             ValueCategory = prvalue
 #  733|         getStmt(2): [ExprStmt] ExprStmt
@@ -6162,7 +6162,7 @@ ir.cpp:
 #  741|                 ValueCategory = prvalue
 #  743|     getStmt(1): [ReturnStmt] return ...
 #  745| [CopyAssignmentOperator] Base& Base::operator=(Base const&)
-#  745|   : 
+#  745|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6185,13 +6185,13 @@ ir.cpp:
 #  745|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  745|               Type = [LValueReferenceType] const Base &
 #  745|               ValueCategory = prvalue(load)
-#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Base
 #-----|               ValueCategory = lvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(1): [ReturnStmt] return ...
@@ -6201,14 +6201,14 @@ ir.cpp:
 #-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Base *
 #-----|             ValueCategory = prvalue(load)
-#-----|       : [ReferenceToExpr] (reference to)
+#-----|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Base &
 #-----|           ValueCategory = prvalue
 #  745| [CopyConstructor] void Base::Base(Base const&)
-#  745|   : 
+#  745|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Base &
-#  745|   : 
+#  745|   <initializations>: 
 #  745|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  745|         Type = [Struct] String
 #  745|         ValueCategory = prvalue
@@ -6218,8 +6218,8 @@ ir.cpp:
 #  745|   getEntryPoint(): [BlockStmt] { ... }
 #  745|     getStmt(0): [ReturnStmt] return ...
 #  748| [Constructor] void Base::Base()
-#  748|   : 
-#  748|   : 
+#  748|   <params>: 
+#  748|   <initializations>: 
 #  748|     getInitializer(0): [ConstructorFieldInit] constructor init of field base_s
 #  748|         Type = [Struct] String
 #  748|         ValueCategory = prvalue
@@ -6229,10 +6229,10 @@ ir.cpp:
 #  748|   getEntryPoint(): [BlockStmt] { ... }
 #  749|     getStmt(0): [ReturnStmt] return ...
 #  750| [Destructor] void Base::~Base()
-#  750|   : 
+#  750|   <params>: 
 #  750|   getEntryPoint(): [BlockStmt] { ... }
 #  751|     getStmt(0): [ReturnStmt] return ...
-#  750|   : 
+#  750|   <destructions>: 
 #  751|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of base_s
 #  751|         Type = [Struct] String
 #  751|         ValueCategory = prvalue
@@ -6243,7 +6243,7 @@ ir.cpp:
 #  751|             Type = [Struct] String
 #  751|             ValueCategory = lvalue
 #  754| [CopyAssignmentOperator] Middle& Middle::operator=(Middle const&)
-#  754|   : 
+#  754|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6254,10 +6254,6 @@ ir.cpp:
 #  754|         getQualifier(): [ThisExpr] this
 #  754|             Type = [PointerType] Middle *
 #  754|             ValueCategory = prvalue(load)
-#-----|         getArgument(0): [CStyleCast] (Base *)...
-#-----|             Conversion = [BaseClassConversion] base class conversion
-#-----|             Type = [PointerType] Base *
-#-----|             ValueCategory = prvalue
 #  754|         getArgument(0): [PointerDereferenceExpr] * ...
 #  754|             Type = [SpecifiedType] const Base
 #  754|             ValueCategory = lvalue
@@ -6267,17 +6263,21 @@ ir.cpp:
 #  754|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #  754|                 Type = [LValueReferenceType] const Middle &
 #  754|                 ValueCategory = prvalue(load)
-#-----|             : [ReferenceDereferenceExpr] (reference dereference)
+#-----|             getOperand().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Middle
 #-----|                 ValueCategory = lvalue
-#-----|           : [CStyleCast] (const Base *)...
+#-----|           getOperand().getFullyConverted(): [CStyleCast] (const Base *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Base *
 #-----|               ValueCategory = prvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getQualifier().getFullyConverted(): [CStyleCast] (Base *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Base *
+#-----|             ValueCategory = prvalue
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Base &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct,VirtualBaseClass] Base
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(1): [ExprStmt] ExprStmt
@@ -6299,13 +6299,13 @@ ir.cpp:
 #  754|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  754|               Type = [LValueReferenceType] const Middle &
 #  754|               ValueCategory = prvalue(load)
-#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Middle
 #-----|               ValueCategory = lvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(2): [ReturnStmt] return ...
@@ -6315,16 +6315,16 @@ ir.cpp:
 #-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Middle *
 #-----|             ValueCategory = prvalue(load)
-#-----|       : [ReferenceToExpr] (reference to)
+#-----|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Middle &
 #-----|           ValueCategory = prvalue
 #  754| [CopyConstructor] void Middle::Middle(Middle const&)
-#  754|   : 
+#  754|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Middle &
 #  757| [Constructor] void Middle::Middle()
-#  757|   : 
-#  757|   : 
+#  757|   <params>: 
+#  757|   <initializations>: 
 #  757|     getInitializer(0): [ConstructorDirectInit] call to Base
 #  757|         Type = [VoidType] void
 #  757|         ValueCategory = prvalue
@@ -6337,10 +6337,10 @@ ir.cpp:
 #  757|   getEntryPoint(): [BlockStmt] { ... }
 #  758|     getStmt(0): [ReturnStmt] return ...
 #  759| [Destructor] void Middle::~Middle()
-#  759|   : 
+#  759|   <params>: 
 #  759|   getEntryPoint(): [BlockStmt] { ... }
 #  760|     getStmt(0): [ReturnStmt] return ...
-#  759|   : 
+#  759|   <destructions>: 
 #  760|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middle_s
 #  760|         Type = [Struct] String
 #  760|         ValueCategory = prvalue
@@ -6354,7 +6354,7 @@ ir.cpp:
 #  760|         Type = [VoidType] void
 #  760|         ValueCategory = prvalue
 #  763| [CopyAssignmentOperator] Derived& Derived::operator=(Derived const&)
-#  763|   : 
+#  763|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #-----|   getEntryPoint(): [BlockStmt] { ... }
@@ -6365,10 +6365,6 @@ ir.cpp:
 #  763|         getQualifier(): [ThisExpr] this
 #  763|             Type = [PointerType] Derived *
 #  763|             ValueCategory = prvalue(load)
-#-----|         getArgument(0): [CStyleCast] (Middle *)...
-#-----|             Conversion = [BaseClassConversion] base class conversion
-#-----|             Type = [PointerType] Middle *
-#-----|             ValueCategory = prvalue
 #  763|         getArgument(0): [PointerDereferenceExpr] * ...
 #  763|             Type = [SpecifiedType] const Middle
 #  763|             ValueCategory = lvalue
@@ -6378,17 +6374,21 @@ ir.cpp:
 #  763|             getOperand(): [VariableAccess] (unnamed parameter 0)
 #  763|                 Type = [LValueReferenceType] const Derived &
 #  763|                 ValueCategory = prvalue(load)
-#-----|             : [ReferenceDereferenceExpr] (reference dereference)
+#-----|             getOperand().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|                 Type = [SpecifiedType] const Derived
 #-----|                 ValueCategory = lvalue
-#-----|           : [CStyleCast] (const Middle *)...
+#-----|           getOperand().getFullyConverted(): [CStyleCast] (const Middle *)...
 #-----|               Conversion = [BaseClassConversion] base class conversion
 #-----|               Type = [PointerType] const Middle *
 #-----|               ValueCategory = prvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getQualifier().getFullyConverted(): [CStyleCast] (Middle *)...
+#-----|             Conversion = [BaseClassConversion] base class conversion
+#-----|             Type = [PointerType] Middle *
+#-----|             ValueCategory = prvalue
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const Middle &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] Middle
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(1): [ExprStmt] ExprStmt
@@ -6410,13 +6410,13 @@ ir.cpp:
 #  763|           getQualifier(): [VariableAccess] (unnamed parameter 0)
 #  763|               Type = [LValueReferenceType] const Derived &
 #  763|               ValueCategory = prvalue(load)
-#-----|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+#-----|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|               Type = [SpecifiedType] const Derived
 #-----|               ValueCategory = lvalue
-#-----|         : [ReferenceToExpr] (reference to)
+#-----|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|             Type = [LValueReferenceType] const String &
 #-----|             ValueCategory = prvalue
-#-----|       : [ReferenceDereferenceExpr] (reference dereference)
+#-----|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #-----|           Type = [Struct] String
 #-----|           ValueCategory = lvalue
 #-----|     getStmt(2): [ReturnStmt] return ...
@@ -6426,16 +6426,16 @@ ir.cpp:
 #-----|         getOperand(): [ThisExpr] this
 #-----|             Type = [PointerType] Derived *
 #-----|             ValueCategory = prvalue(load)
-#-----|       : [ReferenceToExpr] (reference to)
+#-----|       getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|           Type = [LValueReferenceType] Derived &
 #-----|           ValueCategory = prvalue
 #  763| [CopyConstructor] void Derived::Derived(Derived const&)
-#  763|   : 
+#  763|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Derived &
 #  766| [Constructor] void Derived::Derived()
-#  766|   : 
-#  766|   : 
+#  766|   <params>: 
+#  766|   <initializations>: 
 #  766|     getInitializer(0): [ConstructorDirectInit] call to Middle
 #  766|         Type = [VoidType] void
 #  766|         ValueCategory = prvalue
@@ -6448,10 +6448,10 @@ ir.cpp:
 #  766|   getEntryPoint(): [BlockStmt] { ... }
 #  767|     getStmt(0): [ReturnStmt] return ...
 #  768| [Destructor] void Derived::~Derived()
-#  768|   : 
+#  768|   <params>: 
 #  768|   getEntryPoint(): [BlockStmt] { ... }
 #  769|     getStmt(0): [ReturnStmt] return ...
-#  768|   : 
+#  768|   <destructions>: 
 #  769|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derived_s
 #  769|         Type = [Struct] String
 #  769|         ValueCategory = prvalue
@@ -6465,16 +6465,16 @@ ir.cpp:
 #  769|         Type = [VoidType] void
 #  769|         ValueCategory = prvalue
 #  772| [CopyAssignmentOperator] MiddleVB1& MiddleVB1::operator=(MiddleVB1 const&)
-#  772|   : 
+#  772|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  772| [CopyConstructor] void MiddleVB1::MiddleVB1(MiddleVB1 const&)
-#  772|   : 
+#  772|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB1 &
 #  775| [Constructor] void MiddleVB1::MiddleVB1()
-#  775|   : 
-#  775|   : 
+#  775|   <params>: 
+#  775|   <initializations>: 
 #  775|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  775|         Type = [VoidType] void
 #  775|         ValueCategory = prvalue
@@ -6487,10 +6487,10 @@ ir.cpp:
 #  775|   getEntryPoint(): [BlockStmt] { ... }
 #  776|     getStmt(0): [ReturnStmt] return ...
 #  777| [Destructor] void MiddleVB1::~MiddleVB1()
-#  777|   : 
+#  777|   <params>: 
 #  777|   getEntryPoint(): [BlockStmt] { ... }
 #  778|     getStmt(0): [ReturnStmt] return ...
-#  777|   : 
+#  777|   <destructions>: 
 #  778|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb1_s
 #  778|         Type = [Struct] String
 #  778|         ValueCategory = prvalue
@@ -6504,16 +6504,16 @@ ir.cpp:
 #  778|         Type = [VoidType] void
 #  778|         ValueCategory = prvalue
 #  781| [CopyAssignmentOperator] MiddleVB2& MiddleVB2::operator=(MiddleVB2 const&)
-#  781|   : 
+#  781|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  781| [CopyConstructor] void MiddleVB2::MiddleVB2(MiddleVB2 const&)
-#  781|   : 
+#  781|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const MiddleVB2 &
 #  784| [Constructor] void MiddleVB2::MiddleVB2()
-#  784|   : 
-#  784|   : 
+#  784|   <params>: 
+#  784|   <initializations>: 
 #  784|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  784|         Type = [VoidType] void
 #  784|         ValueCategory = prvalue
@@ -6526,10 +6526,10 @@ ir.cpp:
 #  784|   getEntryPoint(): [BlockStmt] { ... }
 #  785|     getStmt(0): [ReturnStmt] return ...
 #  786| [Destructor] void MiddleVB2::~MiddleVB2()
-#  786|   : 
+#  786|   <params>: 
 #  786|   getEntryPoint(): [BlockStmt] { ... }
 #  787|     getStmt(0): [ReturnStmt] return ...
-#  786|   : 
+#  786|   <destructions>: 
 #  787|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of middlevb2_s
 #  787|         Type = [Struct] String
 #  787|         ValueCategory = prvalue
@@ -6543,16 +6543,16 @@ ir.cpp:
 #  787|         Type = [VoidType] void
 #  787|         ValueCategory = prvalue
 #  790| [CopyAssignmentOperator] DerivedVB& DerivedVB::operator=(DerivedVB const&)
-#  790|   : 
+#  790|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  790| [CopyConstructor] void DerivedVB::DerivedVB(DerivedVB const&)
-#  790|   : 
+#  790|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DerivedVB &
 #  793| [Constructor] void DerivedVB::DerivedVB()
-#  793|   : 
-#  793|   : 
+#  793|   <params>: 
+#  793|   <initializations>: 
 #  793|     getInitializer(0): [ConstructorVirtualInit] call to Base
 #  793|         Type = [VoidType] void
 #  793|         ValueCategory = prvalue
@@ -6571,10 +6571,10 @@ ir.cpp:
 #  793|   getEntryPoint(): [BlockStmt] { ... }
 #  794|     getStmt(0): [ReturnStmt] return ...
 #  795| [Destructor] void DerivedVB::~DerivedVB()
-#  795|   : 
+#  795|   <params>: 
 #  795|   getEntryPoint(): [BlockStmt] { ... }
 #  796|     getStmt(0): [ReturnStmt] return ...
-#  795|   : 
+#  795|   <destructions>: 
 #  796|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of derivedvb_s
 #  796|         Type = [Struct] String
 #  796|         ValueCategory = prvalue
@@ -6594,7 +6594,7 @@ ir.cpp:
 #  796|         Type = [VoidType] void
 #  796|         ValueCategory = prvalue
 #  799| [TopLevelFunction] void HierarchyConversions()
-#  799|   : 
+#  799|   <params>: 
 #  799|   getEntryPoint(): [BlockStmt] { ... }
 #  800|     getStmt(0): [DeclStmt] declaration
 #  800|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
@@ -6657,14 +6657,14 @@ ir.cpp:
 #  808|         getArgument(0): [VariableAccess] m
 #  808|             Type = [Struct] Middle
 #  808|             ValueCategory = lvalue
-#  808|         : [ReferenceToExpr] (reference to)
+#  808|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  808|             Type = [LValueReferenceType] const Base &
 #  808|             ValueCategory = prvalue
 #  808|           getExpr(): [CStyleCast] (const Base)...
 #  808|               Conversion = [BaseClassConversion] base class conversion
 #  808|               Type = [SpecifiedType] const Base
 #  808|               ValueCategory = lvalue
-#  808|       : [ReferenceDereferenceExpr] (reference dereference)
+#  808|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  808|           Type = [Struct,VirtualBaseClass] Base
 #  808|           ValueCategory = lvalue
 #  809|     getStmt(7): [ExprStmt] ExprStmt
@@ -6680,21 +6680,21 @@ ir.cpp:
 #  809|           getArgument(0): [VariableAccess] m
 #  809|               Type = [Struct] Middle
 #  809|               ValueCategory = lvalue
-#  809|           : [ReferenceToExpr] (reference to)
+#  809|           getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  809|               Type = [LValueReferenceType] const Base &
 #  809|               ValueCategory = prvalue
 #  809|             getExpr(): [CStyleCast] (const Base)...
 #  809|                 Conversion = [BaseClassConversion] base class conversion
 #  809|                 Type = [SpecifiedType] const Base
 #  809|                 ValueCategory = lvalue
-#  809|         : [ReferenceToExpr] (reference to)
+#  809|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  809|             Type = [LValueReferenceType] const Base &
 #  809|             ValueCategory = prvalue
 #  809|           getExpr(): [CStyleCast] (const Base)...
 #  809|               Conversion = [GlvalueConversion] glvalue conversion
 #  809|               Type = [SpecifiedType] const Base
 #  809|               ValueCategory = lvalue
-#  809|       : [ReferenceDereferenceExpr] (reference dereference)
+#  809|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  809|           Type = [Struct,VirtualBaseClass] Base
 #  809|           ValueCategory = lvalue
 #  810|     getStmt(8): [ExprStmt] ExprStmt
@@ -6710,21 +6710,21 @@ ir.cpp:
 #  810|           getArgument(0): [VariableAccess] m
 #  810|               Type = [Struct] Middle
 #  810|               ValueCategory = lvalue
-#  810|           : [ReferenceToExpr] (reference to)
+#  810|           getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  810|               Type = [LValueReferenceType] const Base &
 #  810|               ValueCategory = prvalue
 #  810|             getExpr(): [CStyleCast] (const Base)...
 #  810|                 Conversion = [BaseClassConversion] base class conversion
 #  810|                 Type = [SpecifiedType] const Base
 #  810|                 ValueCategory = lvalue
-#  810|         : [ReferenceToExpr] (reference to)
+#  810|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  810|             Type = [LValueReferenceType] const Base &
 #  810|             ValueCategory = prvalue
 #  810|           getExpr(): [CStyleCast] (const Base)...
 #  810|               Conversion = [GlvalueConversion] glvalue conversion
 #  810|               Type = [SpecifiedType] const Base
 #  810|               ValueCategory = lvalue
-#  810|       : [ReferenceDereferenceExpr] (reference dereference)
+#  810|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  810|           Type = [Struct,VirtualBaseClass] Base
 #  810|           ValueCategory = lvalue
 #  811|     getStmt(9): [ExprStmt] ExprStmt
@@ -6737,7 +6737,7 @@ ir.cpp:
 #  811|         getRValue(): [VariableAccess] pm
 #  811|             Type = [PointerType] Middle *
 #  811|             ValueCategory = prvalue(load)
-#  811|         : [CStyleCast] (Base *)...
+#  811|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  811|             Conversion = [BaseClassConversion] base class conversion
 #  811|             Type = [PointerType] Base *
 #  811|             ValueCategory = prvalue
@@ -6751,7 +6751,7 @@ ir.cpp:
 #  812|         getRValue(): [VariableAccess] pm
 #  812|             Type = [PointerType] Middle *
 #  812|             ValueCategory = prvalue(load)
-#  812|         : [CStyleCast] (Base *)...
+#  812|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  812|             Conversion = [BaseClassConversion] base class conversion
 #  812|             Type = [PointerType] Base *
 #  812|             ValueCategory = prvalue
@@ -6765,7 +6765,7 @@ ir.cpp:
 #  813|         getRValue(): [VariableAccess] pm
 #  813|             Type = [PointerType] Middle *
 #  813|             ValueCategory = prvalue(load)
-#  813|         : [StaticCast] static_cast<Base *>...
+#  813|         getRValue().getFullyConverted(): [StaticCast] static_cast<Base *>...
 #  813|             Conversion = [BaseClassConversion] base class conversion
 #  813|             Type = [PointerType] Base *
 #  813|             ValueCategory = prvalue
@@ -6779,7 +6779,7 @@ ir.cpp:
 #  814|         getRValue(): [VariableAccess] pm
 #  814|             Type = [PointerType] Middle *
 #  814|             ValueCategory = prvalue(load)
-#  814|         : [ReinterpretCast] reinterpret_cast<Base *>...
+#  814|         getRValue().getFullyConverted(): [ReinterpretCast] reinterpret_cast<Base *>...
 #  814|             Conversion = [PointerConversion] pointer conversion
 #  814|             Type = [PointerType] Base *
 #  814|             ValueCategory = prvalue
@@ -6793,7 +6793,7 @@ ir.cpp:
 #  816|         getArgument(0): [VariableAccess] b
 #  816|             Type = [Struct,VirtualBaseClass] Base
 #  816|             ValueCategory = lvalue
-#  816|         : [ReferenceToExpr] (reference to)
+#  816|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  816|             Type = [LValueReferenceType] const Middle &
 #  816|             ValueCategory = prvalue
 #  816|           getExpr(): [CStyleCast] (const Middle)...
@@ -6804,7 +6804,7 @@ ir.cpp:
 #  816|                 Conversion = [DerivedClassConversion] derived class conversion
 #  816|                 Type = [Struct] Middle
 #  816|                 ValueCategory = lvalue
-#  816|       : [ReferenceDereferenceExpr] (reference dereference)
+#  816|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  816|           Type = [Struct] Middle
 #  816|           ValueCategory = lvalue
 #  817|     getStmt(14): [ExprStmt] ExprStmt
@@ -6817,7 +6817,7 @@ ir.cpp:
 #  817|         getArgument(0): [VariableAccess] b
 #  817|             Type = [Struct,VirtualBaseClass] Base
 #  817|             ValueCategory = lvalue
-#  817|         : [ReferenceToExpr] (reference to)
+#  817|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  817|             Type = [LValueReferenceType] const Middle &
 #  817|             ValueCategory = prvalue
 #  817|           getExpr(): [CStyleCast] (const Middle)...
@@ -6828,7 +6828,7 @@ ir.cpp:
 #  817|                 Conversion = [DerivedClassConversion] derived class conversion
 #  817|                 Type = [Struct] Middle
 #  817|                 ValueCategory = lvalue
-#  817|       : [ReferenceDereferenceExpr] (reference dereference)
+#  817|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  817|           Type = [Struct] Middle
 #  817|           ValueCategory = lvalue
 #  818|     getStmt(15): [ExprStmt] ExprStmt
@@ -6841,7 +6841,7 @@ ir.cpp:
 #  818|         getRValue(): [VariableAccess] pb
 #  818|             Type = [PointerType] Base *
 #  818|             ValueCategory = prvalue(load)
-#  818|         : [CStyleCast] (Middle *)...
+#  818|         getRValue().getFullyConverted(): [CStyleCast] (Middle *)...
 #  818|             Conversion = [DerivedClassConversion] derived class conversion
 #  818|             Type = [PointerType] Middle *
 #  818|             ValueCategory = prvalue
@@ -6855,7 +6855,7 @@ ir.cpp:
 #  819|         getRValue(): [VariableAccess] pb
 #  819|             Type = [PointerType] Base *
 #  819|             ValueCategory = prvalue(load)
-#  819|         : [StaticCast] static_cast<Middle *>...
+#  819|         getRValue().getFullyConverted(): [StaticCast] static_cast<Middle *>...
 #  819|             Conversion = [DerivedClassConversion] derived class conversion
 #  819|             Type = [PointerType] Middle *
 #  819|             ValueCategory = prvalue
@@ -6869,7 +6869,7 @@ ir.cpp:
 #  820|         getRValue(): [VariableAccess] pb
 #  820|             Type = [PointerType] Base *
 #  820|             ValueCategory = prvalue(load)
-#  820|         : [ReinterpretCast] reinterpret_cast<Middle *>...
+#  820|         getRValue().getFullyConverted(): [ReinterpretCast] reinterpret_cast<Middle *>...
 #  820|             Conversion = [PointerConversion] pointer conversion
 #  820|             Type = [PointerType] Middle *
 #  820|             ValueCategory = prvalue
@@ -6883,7 +6883,7 @@ ir.cpp:
 #  822|         getArgument(0): [VariableAccess] d
 #  822|             Type = [Struct] Derived
 #  822|             ValueCategory = lvalue
-#  822|         : [ReferenceToExpr] (reference to)
+#  822|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  822|             Type = [LValueReferenceType] const Base &
 #  822|             ValueCategory = prvalue
 #  822|           getExpr(): [CStyleCast] (const Base)...
@@ -6894,7 +6894,7 @@ ir.cpp:
 #  822|                 Conversion = [BaseClassConversion] base class conversion
 #  822|                 Type = [SpecifiedType] const Middle
 #  822|                 ValueCategory = lvalue
-#  822|       : [ReferenceDereferenceExpr] (reference dereference)
+#  822|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  822|           Type = [Struct,VirtualBaseClass] Base
 #  822|           ValueCategory = lvalue
 #  823|     getStmt(19): [ExprStmt] ExprStmt
@@ -6910,7 +6910,7 @@ ir.cpp:
 #  823|           getArgument(0): [VariableAccess] d
 #  823|               Type = [Struct] Derived
 #  823|               ValueCategory = lvalue
-#  823|           : [ReferenceToExpr] (reference to)
+#  823|           getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  823|               Type = [LValueReferenceType] const Base &
 #  823|               ValueCategory = prvalue
 #  823|             getExpr(): [CStyleCast] (const Base)...
@@ -6921,14 +6921,14 @@ ir.cpp:
 #  823|                   Conversion = [BaseClassConversion] base class conversion
 #  823|                   Type = [SpecifiedType] const Middle
 #  823|                   ValueCategory = lvalue
-#  823|         : [ReferenceToExpr] (reference to)
+#  823|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  823|             Type = [LValueReferenceType] const Base &
 #  823|             ValueCategory = prvalue
 #  823|           getExpr(): [CStyleCast] (const Base)...
 #  823|               Conversion = [GlvalueConversion] glvalue conversion
 #  823|               Type = [SpecifiedType] const Base
 #  823|               ValueCategory = lvalue
-#  823|       : [ReferenceDereferenceExpr] (reference dereference)
+#  823|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  823|           Type = [Struct,VirtualBaseClass] Base
 #  823|           ValueCategory = lvalue
 #  824|     getStmt(20): [ExprStmt] ExprStmt
@@ -6944,7 +6944,7 @@ ir.cpp:
 #  824|           getArgument(0): [VariableAccess] d
 #  824|               Type = [Struct] Derived
 #  824|               ValueCategory = lvalue
-#  824|           : [ReferenceToExpr] (reference to)
+#  824|           getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  824|               Type = [LValueReferenceType] const Base &
 #  824|               ValueCategory = prvalue
 #  824|             getExpr(): [CStyleCast] (const Base)...
@@ -6955,14 +6955,14 @@ ir.cpp:
 #  824|                   Conversion = [BaseClassConversion] base class conversion
 #  824|                   Type = [SpecifiedType] const Middle
 #  824|                   ValueCategory = lvalue
-#  824|         : [ReferenceToExpr] (reference to)
+#  824|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  824|             Type = [LValueReferenceType] const Base &
 #  824|             ValueCategory = prvalue
 #  824|           getExpr(): [CStyleCast] (const Base)...
 #  824|               Conversion = [GlvalueConversion] glvalue conversion
 #  824|               Type = [SpecifiedType] const Base
 #  824|               ValueCategory = lvalue
-#  824|       : [ReferenceDereferenceExpr] (reference dereference)
+#  824|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  824|           Type = [Struct,VirtualBaseClass] Base
 #  824|           ValueCategory = lvalue
 #  825|     getStmt(21): [ExprStmt] ExprStmt
@@ -6975,7 +6975,7 @@ ir.cpp:
 #  825|         getRValue(): [VariableAccess] pd
 #  825|             Type = [PointerType] Derived *
 #  825|             ValueCategory = prvalue(load)
-#  825|         : [CStyleCast] (Base *)...
+#  825|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  825|             Conversion = [BaseClassConversion] base class conversion
 #  825|             Type = [PointerType] Base *
 #  825|             ValueCategory = prvalue
@@ -6993,7 +6993,7 @@ ir.cpp:
 #  826|         getRValue(): [VariableAccess] pd
 #  826|             Type = [PointerType] Derived *
 #  826|             ValueCategory = prvalue(load)
-#  826|         : [CStyleCast] (Base *)...
+#  826|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  826|             Conversion = [BaseClassConversion] base class conversion
 #  826|             Type = [PointerType] Base *
 #  826|             ValueCategory = prvalue
@@ -7011,7 +7011,7 @@ ir.cpp:
 #  827|         getRValue(): [VariableAccess] pd
 #  827|             Type = [PointerType] Derived *
 #  827|             ValueCategory = prvalue(load)
-#  827|         : [StaticCast] static_cast<Base *>...
+#  827|         getRValue().getFullyConverted(): [StaticCast] static_cast<Base *>...
 #  827|             Conversion = [BaseClassConversion] base class conversion
 #  827|             Type = [PointerType] Base *
 #  827|             ValueCategory = prvalue
@@ -7029,7 +7029,7 @@ ir.cpp:
 #  828|         getRValue(): [VariableAccess] pd
 #  828|             Type = [PointerType] Derived *
 #  828|             ValueCategory = prvalue(load)
-#  828|         : [ReinterpretCast] reinterpret_cast<Base *>...
+#  828|         getRValue().getFullyConverted(): [ReinterpretCast] reinterpret_cast<Base *>...
 #  828|             Conversion = [PointerConversion] pointer conversion
 #  828|             Type = [PointerType] Base *
 #  828|             ValueCategory = prvalue
@@ -7043,7 +7043,7 @@ ir.cpp:
 #  830|         getArgument(0): [VariableAccess] b
 #  830|             Type = [Struct,VirtualBaseClass] Base
 #  830|             ValueCategory = lvalue
-#  830|         : [ReferenceToExpr] (reference to)
+#  830|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  830|             Type = [LValueReferenceType] const Derived &
 #  830|             ValueCategory = prvalue
 #  830|           getExpr(): [CStyleCast] (const Derived)...
@@ -7058,7 +7058,7 @@ ir.cpp:
 #  830|                   Conversion = [DerivedClassConversion] derived class conversion
 #  830|                   Type = [Struct] Middle
 #  830|                   ValueCategory = lvalue
-#  830|       : [ReferenceDereferenceExpr] (reference dereference)
+#  830|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  830|           Type = [Struct] Derived
 #  830|           ValueCategory = lvalue
 #  831|     getStmt(26): [ExprStmt] ExprStmt
@@ -7071,7 +7071,7 @@ ir.cpp:
 #  831|         getArgument(0): [VariableAccess] b
 #  831|             Type = [Struct,VirtualBaseClass] Base
 #  831|             ValueCategory = lvalue
-#  831|         : [ReferenceToExpr] (reference to)
+#  831|         getArgument(0).getFullyConverted(): [ReferenceToExpr] (reference to)
 #  831|             Type = [LValueReferenceType] const Derived &
 #  831|             ValueCategory = prvalue
 #  831|           getExpr(): [CStyleCast] (const Derived)...
@@ -7086,7 +7086,7 @@ ir.cpp:
 #  831|                   Conversion = [DerivedClassConversion] derived class conversion
 #  831|                   Type = [Struct] Middle
 #  831|                   ValueCategory = lvalue
-#  831|       : [ReferenceDereferenceExpr] (reference dereference)
+#  831|       getExpr().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 #  831|           Type = [Struct] Derived
 #  831|           ValueCategory = lvalue
 #  832|     getStmt(27): [ExprStmt] ExprStmt
@@ -7099,7 +7099,7 @@ ir.cpp:
 #  832|         getRValue(): [VariableAccess] pb
 #  832|             Type = [PointerType] Base *
 #  832|             ValueCategory = prvalue(load)
-#  832|         : [CStyleCast] (Derived *)...
+#  832|         getRValue().getFullyConverted(): [CStyleCast] (Derived *)...
 #  832|             Conversion = [DerivedClassConversion] derived class conversion
 #  832|             Type = [PointerType] Derived *
 #  832|             ValueCategory = prvalue
@@ -7117,7 +7117,7 @@ ir.cpp:
 #  833|         getRValue(): [VariableAccess] pb
 #  833|             Type = [PointerType] Base *
 #  833|             ValueCategory = prvalue(load)
-#  833|         : [StaticCast] static_cast<Derived *>...
+#  833|         getRValue().getFullyConverted(): [StaticCast] static_cast<Derived *>...
 #  833|             Conversion = [DerivedClassConversion] derived class conversion
 #  833|             Type = [PointerType] Derived *
 #  833|             ValueCategory = prvalue
@@ -7135,7 +7135,7 @@ ir.cpp:
 #  834|         getRValue(): [VariableAccess] pb
 #  834|             Type = [PointerType] Base *
 #  834|             ValueCategory = prvalue(load)
-#  834|         : [ReinterpretCast] reinterpret_cast<Derived *>...
+#  834|         getRValue().getFullyConverted(): [ReinterpretCast] reinterpret_cast<Derived *>...
 #  834|             Conversion = [PointerConversion] pointer conversion
 #  834|             Type = [PointerType] Derived *
 #  834|             ValueCategory = prvalue
@@ -7147,7 +7147,7 @@ ir.cpp:
 #  836|               Type = [NullPointerType] decltype(nullptr)
 #  836|               Value = [Literal] 0
 #  836|               ValueCategory = prvalue
-#  836|           : [CStyleCast] (MiddleVB1 *)...
+#  836|           getExpr().getFullyConverted(): [CStyleCast] (MiddleVB1 *)...
 #  836|               Conversion = [PointerConversion] pointer conversion
 #  836|               Type = [PointerType] MiddleVB1 *
 #  836|               Value = [CStyleCast] 0
@@ -7160,7 +7160,7 @@ ir.cpp:
 #  837|               Type = [NullPointerType] decltype(nullptr)
 #  837|               Value = [Literal] 0
 #  837|               ValueCategory = prvalue
-#  837|           : [CStyleCast] (DerivedVB *)...
+#  837|           getExpr().getFullyConverted(): [CStyleCast] (DerivedVB *)...
 #  837|               Conversion = [PointerConversion] pointer conversion
 #  837|               Type = [PointerType] DerivedVB *
 #  837|               Value = [CStyleCast] 0
@@ -7175,7 +7175,7 @@ ir.cpp:
 #  838|         getRValue(): [VariableAccess] pmv
 #  838|             Type = [PointerType] MiddleVB1 *
 #  838|             ValueCategory = prvalue(load)
-#  838|         : [CStyleCast] (Base *)...
+#  838|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  838|             Conversion = [BaseClassConversion] base class conversion
 #  838|             Type = [PointerType] Base *
 #  838|             ValueCategory = prvalue
@@ -7189,60 +7189,60 @@ ir.cpp:
 #  839|         getRValue(): [VariableAccess] pdv
 #  839|             Type = [PointerType] DerivedVB *
 #  839|             ValueCategory = prvalue(load)
-#  839|         : [CStyleCast] (Base *)...
+#  839|         getRValue().getFullyConverted(): [CStyleCast] (Base *)...
 #  839|             Conversion = [BaseClassConversion] base class conversion
 #  839|             Type = [PointerType] Base *
 #  839|             ValueCategory = prvalue
 #  840|     getStmt(34): [ReturnStmt] return ...
 #  842| [CopyAssignmentOperator] PolymorphicBase& PolymorphicBase::operator=(PolymorphicBase const&)
-#  842|   : 
+#  842|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  842| [Constructor] void PolymorphicBase::PolymorphicBase()
-#  842|   : 
-#  842|   : 
+#  842|   <params>: 
+#  842|   <initializations>: 
 #  842|   getEntryPoint(): [BlockStmt] { ... }
 #  842|     getStmt(0): [ReturnStmt] return ...
 #  842| [CopyConstructor] void PolymorphicBase::PolymorphicBase(PolymorphicBase const&)
-#  842|   : 
+#  842|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicBase &
 #  843| [Destructor,VirtualFunction] void PolymorphicBase::~PolymorphicBase()
-#  843|   : 
+#  843|   <params>: 
 #  846| [CopyAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived const&)
-#  846|   : 
+#  846|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveAssignmentOperator] PolymorphicDerived& PolymorphicDerived::operator=(PolymorphicDerived&&)
-#  846|   : 
+#  846|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Constructor] void PolymorphicDerived::PolymorphicDerived()
-#  846|   : 
-#  846|   : 
+#  846|   <params>: 
+#  846|   <initializations>: 
 #  846|     getInitializer(0): [ConstructorDirectInit] call to PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
 #  846|   getEntryPoint(): [BlockStmt] { ... }
 #  846|     getStmt(0): [ReturnStmt] return ...
 #  846| [CopyConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived const&)
-#  846|   : 
+#  846|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const PolymorphicDerived &
 #  846| [MoveConstructor] void PolymorphicDerived::PolymorphicDerived(PolymorphicDerived&&)
-#  846|   : 
+#  846|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] PolymorphicDerived &&
 #  846| [Destructor,VirtualFunction] void PolymorphicDerived::~PolymorphicDerived()
-#  846|   : 
+#  846|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-#  846|   : 
+#  846|   <destructions>: 
 #  846|     getDestruction(0): [DestructorDirectDestruction] call to ~PolymorphicBase
 #  846|         Type = [VoidType] void
 #  846|         ValueCategory = prvalue
 #  849| [TopLevelFunction] void DynamicCast()
-#  849|   : 
+#  849|   <params>: 
 #  849|   getEntryPoint(): [BlockStmt] { ... }
 #  850|     getStmt(0): [DeclStmt] declaration
 #  850|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of b
@@ -7288,7 +7288,7 @@ ir.cpp:
 #  857|         getRValue(): [VariableAccess] pd
 #  857|             Type = [PointerType] PolymorphicDerived *
 #  857|             ValueCategory = prvalue(load)
-#  857|         : [DynamicCast] dynamic_cast<PolymorphicBase *>...
+#  857|         getRValue().getFullyConverted(): [DynamicCast] dynamic_cast<PolymorphicBase *>...
 #  857|             Conversion = [DynamicCast] dynamic_cast
 #  857|             Type = [PointerType] PolymorphicBase *
 #  857|             ValueCategory = prvalue
@@ -7299,7 +7299,7 @@ ir.cpp:
 #  858|           getExpr(): [VariableAccess] d
 #  858|               Type = [Struct] PolymorphicDerived
 #  858|               ValueCategory = lvalue
-#  858|           : [ReferenceToExpr] (reference to)
+#  858|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  858|               Type = [LValueReferenceType] PolymorphicBase &
 #  858|               ValueCategory = prvalue
 #  858|             getExpr(): [DynamicCast] dynamic_cast<PolymorphicBase>...
@@ -7316,7 +7316,7 @@ ir.cpp:
 #  860|         getRValue(): [VariableAccess] pb
 #  860|             Type = [PointerType] PolymorphicBase *
 #  860|             ValueCategory = prvalue(load)
-#  860|         : [DynamicCast] dynamic_cast<PolymorphicDerived *>...
+#  860|         getRValue().getFullyConverted(): [DynamicCast] dynamic_cast<PolymorphicDerived *>...
 #  860|             Conversion = [DynamicCast] dynamic_cast
 #  860|             Type = [PointerType] PolymorphicDerived *
 #  860|             ValueCategory = prvalue
@@ -7327,7 +7327,7 @@ ir.cpp:
 #  861|           getExpr(): [VariableAccess] b
 #  861|               Type = [Struct] PolymorphicBase
 #  861|               ValueCategory = lvalue
-#  861|           : [ReferenceToExpr] (reference to)
+#  861|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  861|               Type = [LValueReferenceType] PolymorphicDerived &
 #  861|               ValueCategory = prvalue
 #  861|             getExpr(): [DynamicCast] dynamic_cast<PolymorphicDerived>...
@@ -7341,7 +7341,7 @@ ir.cpp:
 #  863|           getExpr(): [VariableAccess] pb
 #  863|               Type = [PointerType] PolymorphicBase *
 #  863|               ValueCategory = prvalue(load)
-#  863|           : [DynamicCast] dynamic_cast<void *>...
+#  863|           getExpr().getFullyConverted(): [DynamicCast] dynamic_cast<void *>...
 #  863|               Conversion = [DynamicCast] dynamic_cast
 #  863|               Type = [VoidPointerType] void *
 #  863|               ValueCategory = prvalue
@@ -7352,14 +7352,14 @@ ir.cpp:
 #  864|           getExpr(): [VariableAccess] pd
 #  864|               Type = [PointerType] PolymorphicDerived *
 #  864|               ValueCategory = prvalue(load)
-#  864|           : [DynamicCast] dynamic_cast<const void *>...
+#  864|           getExpr().getFullyConverted(): [DynamicCast] dynamic_cast<const void *>...
 #  864|               Conversion = [DynamicCast] dynamic_cast
 #  864|               Type = [PointerType] const void *
 #  864|               ValueCategory = prvalue
 #  865|     getStmt(10): [ReturnStmt] return ...
 #  867| [Constructor] void String::String()
-#  867|   : 
-#  867|   : 
+#  867|   <params>: 
+#  867|   <initializations>: 
 #  868|     getInitializer(0): [ConstructorDelegationInit] call to String
 #  868|         Type = [VoidType] void
 #  868|         ValueCategory = prvalue
@@ -7367,13 +7367,13 @@ ir.cpp:
 #  868|           Type = [ArrayType] const char[1]
 #  868|           Value = [StringLiteral] ""
 #  868|           ValueCategory = lvalue
-#  868|       : [ArrayToPointerConversion] array to pointer conversion
+#  868|       getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  868|           Type = [PointerType] const char *
 #  868|           ValueCategory = prvalue
 #  868|   getEntryPoint(): [BlockStmt] { ... }
 #  869|     getStmt(0): [ReturnStmt] return ...
 #  871| [TopLevelFunction] void ArrayConversions()
-#  871|   : 
+#  871|   <params>: 
 #  871|   getEntryPoint(): [BlockStmt] { ... }
 #  872|     getStmt(0): [DeclStmt] declaration
 #  872|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a
@@ -7385,7 +7385,7 @@ ir.cpp:
 #  873|           getExpr(): [VariableAccess] a
 #  873|               Type = [ArrayType] char[5]
 #  873|               ValueCategory = lvalue
-#  873|           : [CStyleCast] (const char *)...
+#  873|           getExpr().getFullyConverted(): [CStyleCast] (const char *)...
 #  873|               Conversion = [PointerConversion] pointer conversion
 #  873|               Type = [PointerType] const char *
 #  873|               ValueCategory = prvalue
@@ -7403,7 +7403,7 @@ ir.cpp:
 #  874|             Type = [ArrayType] const char[5]
 #  874|             Value = [StringLiteral] "test"
 #  874|             ValueCategory = lvalue
-#  874|         : [ArrayToPointerConversion] array to pointer conversion
+#  874|         getRValue().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  874|             Type = [PointerType] const char *
 #  874|             ValueCategory = prvalue
 #  875|     getStmt(3): [ExprStmt] ExprStmt
@@ -7426,10 +7426,10 @@ ir.cpp:
 #  875|                 Type = [IntType] int
 #  875|                 Value = [Literal] 0
 #  875|                 ValueCategory = prvalue
-#  875|             : [ArrayToPointerConversion] array to pointer conversion
+#  875|             getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  875|                 Type = [CharPointerType] char *
 #  875|                 ValueCategory = prvalue
-#  875|         : [CStyleCast] (const char *)...
+#  875|         getRValue().getFullyConverted(): [CStyleCast] (const char *)...
 #  875|             Conversion = [PointerConversion] pointer conversion
 #  875|             Type = [PointerType] const char *
 #  875|             ValueCategory = prvalue
@@ -7454,7 +7454,7 @@ ir.cpp:
 #  876|                 Type = [IntType] int
 #  876|                 Value = [Literal] 0
 #  876|                 ValueCategory = prvalue
-#  876|             : [ArrayToPointerConversion] array to pointer conversion
+#  876|             getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  876|                 Type = [PointerType] const char *
 #  876|                 ValueCategory = prvalue
 #  877|     getStmt(5): [DeclStmt] declaration
@@ -7464,7 +7464,7 @@ ir.cpp:
 #  877|           getExpr(): [VariableAccess] a
 #  877|               Type = [ArrayType] char[5]
 #  877|               ValueCategory = lvalue
-#  877|           : [ReferenceToExpr] (reference to)
+#  877|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  877|               Type = [LValueReferenceType] char(&)[5]
 #  877|               ValueCategory = prvalue
 #  878|     getStmt(6): [DeclStmt] declaration
@@ -7475,7 +7475,7 @@ ir.cpp:
 #  878|               Type = [ArrayType] const char[5]
 #  878|               Value = [StringLiteral] "test"
 #  878|               ValueCategory = lvalue
-#  878|           : [ReferenceToExpr] (reference to)
+#  878|           getExpr().getFullyConverted(): [ReferenceToExpr] (reference to)
 #  878|               Type = [LValueReferenceType] const char(&)[5]
 #  878|               ValueCategory = prvalue
 #  879|     getStmt(7): [DeclStmt] declaration
@@ -7488,7 +7488,7 @@ ir.cpp:
 #  879|             getOperand(): [VariableAccess] a
 #  879|                 Type = [ArrayType] char[5]
 #  879|                 ValueCategory = lvalue
-#  879|           : [CStyleCast] (const char(*)[5])...
+#  879|           getExpr().getFullyConverted(): [CStyleCast] (const char(*)[5])...
 #  879|               Conversion = [PointerConversion] pointer conversion
 #  879|               Type = [PointerType] const char(*)[5]
 #  879|               ValueCategory = prvalue
@@ -7508,7 +7508,7 @@ ir.cpp:
 #  880|               ValueCategory = lvalue
 #  881|     getStmt(9): [ReturnStmt] return ...
 #  883| [TopLevelFunction] void FuncPtrConversions(int(*)(int), void*)
-#  883|   : 
+#  883|   <params>: 
 #  883|     getParameter(0): [Parameter] pfn
 #  883|         Type = [FunctionPointerType] ..(*)(..)
 #  883|     getParameter(1): [Parameter] p
@@ -7524,7 +7524,7 @@ ir.cpp:
 #  884|         getRValue(): [VariableAccess] pfn
 #  884|             Type = [FunctionPointerType] ..(*)(..)
 #  884|             ValueCategory = prvalue(load)
-#  884|         : [CStyleCast] (void *)...
+#  884|         getRValue().getFullyConverted(): [CStyleCast] (void *)...
 #  884|             Conversion = [PointerConversion] pointer conversion
 #  884|             Type = [VoidPointerType] void *
 #  884|             ValueCategory = prvalue
@@ -7538,13 +7538,13 @@ ir.cpp:
 #  885|         getRValue(): [VariableAccess] p
 #  885|             Type = [VoidPointerType] void *
 #  885|             ValueCategory = prvalue(load)
-#  885|         : [CStyleCast] (..(*)(..))...
+#  885|         getRValue().getFullyConverted(): [CStyleCast] (..(*)(..))...
 #  885|             Conversion = [PointerConversion] pointer conversion
 #  885|             Type = [FunctionPointerType] ..(*)(..)
 #  885|             ValueCategory = prvalue
 #  886|     getStmt(2): [ReturnStmt] return ...
 #  888| [TopLevelFunction] void VAListUsage(int, __va_list_tag[1])
-#  888|   : 
+#  888|   <params>: 
 #  888|     getParameter(0): [Parameter] x
 #  888|         Type = [IntType] int
 #  888|     getParameter(1): [Parameter] args
@@ -7563,7 +7563,7 @@ ir.cpp:
 #  890|         getSourceVAList(): [VariableAccess] args
 #  890|             Type = [PointerType] __va_list_tag *
 #  890|             ValueCategory = prvalue(load)
-#  890|         : [ArrayToPointerConversion] array to pointer conversion
+#  890|         getDestinationVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  890|             Type = [PointerType] __va_list_tag *
 #  890|             ValueCategory = prvalue
 #  891|     getStmt(2): [DeclStmt] declaration
@@ -7586,7 +7586,7 @@ ir.cpp:
 #  892|             getVAList(): [VariableAccess] args
 #  892|                 Type = [PointerType] __va_list_tag *
 #  892|                 ValueCategory = prvalue(load)
-#  892|           : [CStyleCast] (float)...
+#  892|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #  892|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  892|               Type = [FloatType] float
 #  892|               ValueCategory = prvalue
@@ -7597,12 +7597,12 @@ ir.cpp:
 #  893|         getVAList(): [VariableAccess] args2
 #  893|             Type = [ArrayType] __va_list_tag[1]
 #  893|             ValueCategory = lvalue
-#  893|         : [ArrayToPointerConversion] array to pointer conversion
+#  893|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  893|             Type = [PointerType] __va_list_tag *
 #  893|             ValueCategory = prvalue
 #  894|     getStmt(5): [ReturnStmt] return ...
 #  896| [TopLevelFunction] void VarArgUsage(int)
-#  896|   : 
+#  896|   <params>: 
 #  896|     getParameter(0): [Parameter] x
 #  896|         Type = [IntType] int
 #  896|   getEntryPoint(): [BlockStmt] { ... }
@@ -7619,7 +7619,7 @@ ir.cpp:
 #  899|         getLastNamedParameter(): [VariableAccess] x
 #  899|             Type = [IntType] int
 #  899|             ValueCategory = lvalue
-#  899|         : [ArrayToPointerConversion] array to pointer conversion
+#  899|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  899|             Type = [PointerType] __va_list_tag *
 #  899|             ValueCategory = prvalue
 #  900|     getStmt(2): [DeclStmt] declaration
@@ -7635,10 +7635,10 @@ ir.cpp:
 #  901|         getSourceVAList(): [VariableAccess] args
 #  901|             Type = [ArrayType] __va_list_tag[1]
 #  901|             ValueCategory = lvalue
-#  901|         : [ArrayToPointerConversion] array to pointer conversion
+#  901|         getDestinationVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
-#  901|         : [ArrayToPointerConversion] array to pointer conversion
+#  901|         getSourceVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  901|             Type = [PointerType] __va_list_tag *
 #  901|             ValueCategory = prvalue
 #  902|     getStmt(4): [DeclStmt] declaration
@@ -7651,7 +7651,7 @@ ir.cpp:
 #  902|             getVAList(): [VariableAccess] args
 #  902|                 Type = [ArrayType] __va_list_tag[1]
 #  902|                 ValueCategory = lvalue
-#  902|             : [ArrayToPointerConversion] array to pointer conversion
+#  902|             getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  902|                 Type = [PointerType] __va_list_tag *
 #  902|                 ValueCategory = prvalue
 #  903|     getStmt(5): [DeclStmt] declaration
@@ -7664,10 +7664,10 @@ ir.cpp:
 #  903|             getVAList(): [VariableAccess] args
 #  903|                 Type = [ArrayType] __va_list_tag[1]
 #  903|                 ValueCategory = lvalue
-#  903|             : [ArrayToPointerConversion] array to pointer conversion
+#  903|             getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  903|                 Type = [PointerType] __va_list_tag *
 #  903|                 ValueCategory = prvalue
-#  903|           : [CStyleCast] (float)...
+#  903|           getExpr().getFullyConverted(): [CStyleCast] (float)...
 #  903|               Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 #  903|               Type = [FloatType] float
 #  903|               ValueCategory = prvalue
@@ -7678,7 +7678,7 @@ ir.cpp:
 #  904|         getVAList(): [VariableAccess] args
 #  904|             Type = [ArrayType] __va_list_tag[1]
 #  904|             ValueCategory = lvalue
-#  904|         : [ArrayToPointerConversion] array to pointer conversion
+#  904|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  904|             Type = [PointerType] __va_list_tag *
 #  904|             ValueCategory = prvalue
 #  905|     getStmt(7): [ExprStmt] ExprStmt
@@ -7691,7 +7691,7 @@ ir.cpp:
 #  905|         getArgument(1): [VariableAccess] args2
 #  905|             Type = [ArrayType] __va_list_tag[1]
 #  905|             ValueCategory = lvalue
-#  905|         : [ArrayToPointerConversion] array to pointer conversion
+#  905|         getArgument(1).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  905|             Type = [PointerType] __va_list_tag *
 #  905|             ValueCategory = prvalue
 #  906|     getStmt(8): [ExprStmt] ExprStmt
@@ -7701,12 +7701,12 @@ ir.cpp:
 #  906|         getVAList(): [VariableAccess] args2
 #  906|             Type = [ArrayType] __va_list_tag[1]
 #  906|             ValueCategory = lvalue
-#  906|         : [ArrayToPointerConversion] array to pointer conversion
+#  906|         getVAList().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  906|             Type = [PointerType] __va_list_tag *
 #  906|             ValueCategory = prvalue
 #  907|     getStmt(9): [ReturnStmt] return ...
 #  909| [TopLevelFunction] void CastToVoid(int)
-#  909|   : 
+#  909|   <params>: 
 #  909|     getParameter(0): [Parameter] x
 #  909|         Type = [IntType] int
 #  909|   getEntryPoint(): [BlockStmt] { ... }
@@ -7714,13 +7714,13 @@ ir.cpp:
 #  910|       getExpr(): [VariableAccess] x
 #  910|           Type = [IntType] int
 #  910|           ValueCategory = lvalue
-#  910|       : [CStyleCast] (void)...
+#  910|       getExpr().getFullyConverted(): [CStyleCast] (void)...
 #  910|           Conversion = [VoidConversion] conversion to void
 #  910|           Type = [VoidType] void
 #  910|           ValueCategory = prvalue
 #  911|     getStmt(1): [ReturnStmt] return ...
 #  913| [TopLevelFunction] void ConstantConditions(int)
-#  913|   : 
+#  913|   <params>: 
 #  913|     getParameter(0): [Parameter] x
 #  913|         Type = [IntType] int
 #  913|   getEntryPoint(): [BlockStmt] { ... }
@@ -7757,25 +7757,25 @@ ir.cpp:
 #  915|             getElse(): [VariableAccess] x
 #  915|                 Type = [IntType] int
 #  915|                 ValueCategory = prvalue(load)
-#  915|             : [ParenthesisExpr] (...)
+#  915|             getCondition().getFullyConverted(): [ParenthesisExpr] (...)
 #  915|                 Type = [BoolType] bool
 #  915|                 Value = [ParenthesisExpr] 1
 #  915|                 ValueCategory = prvalue
 #  916|     getStmt(2): [ReturnStmt] return ...
 #  924| [Operator,TopLevelFunction] void* operator new(size_t, float)
-#  924|   : 
+#  924|   <params>: 
 #  924|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  924|         Type = [CTypedefType,Size_t] size_t
 #  924|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  924|         Type = [FloatType] float
 #  925| [Operator,TopLevelFunction] void* operator new[](size_t, float)
-#  925|   : 
+#  925|   <params>: 
 #  925|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  925|         Type = [CTypedefType,Size_t] size_t
 #  925|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  925|         Type = [FloatType] float
 #  926| [Operator,TopLevelFunction] void* operator new(size_t, std::align_val_t, float)
-#  926|   : 
+#  926|   <params>: 
 #  926|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  926|         Type = [CTypedefType,Size_t] size_t
 #  926|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7783,7 +7783,7 @@ ir.cpp:
 #  926|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  926|         Type = [FloatType] float
 #  927| [Operator,TopLevelFunction] void* operator new[](size_t, std::align_val_t, float)
-#  927|   : 
+#  927|   <params>: 
 #  927|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  927|         Type = [CTypedefType,Size_t] size_t
 #  927|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7791,19 +7791,19 @@ ir.cpp:
 #  927|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  927|         Type = [FloatType] float
 #  928| [Operator,TopLevelFunction] void operator delete(void*, float)
-#  928|   : 
+#  928|   <params>: 
 #  928|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  928|         Type = [VoidPointerType] void *
 #  928|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  928|         Type = [FloatType] float
 #  929| [Operator,TopLevelFunction] void operator delete[](void*, float)
-#  929|   : 
+#  929|   <params>: 
 #  929|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  929|         Type = [VoidPointerType] void *
 #  929|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  929|         Type = [FloatType] float
 #  930| [Operator,TopLevelFunction] void operator delete(void*, std::align_val_t, float)
-#  930|   : 
+#  930|   <params>: 
 #  930|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  930|         Type = [VoidPointerType] void *
 #  930|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7811,7 +7811,7 @@ ir.cpp:
 #  930|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  930|         Type = [FloatType] float
 #  931| [Operator,TopLevelFunction] void operator delete[](void*, std::align_val_t, float)
-#  931|   : 
+#  931|   <params>: 
 #  931|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  931|         Type = [VoidPointerType] void *
 #  931|     getParameter(1): [Parameter] (unnamed parameter 1)
@@ -7819,63 +7819,63 @@ ir.cpp:
 #  931|     getParameter(2): [Parameter] (unnamed parameter 2)
 #  931|         Type = [FloatType] float
 #  933| [CopyAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc const&)
-#  933|   : 
+#  933|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const SizedDealloc &
 #  933| [MoveAssignmentOperator] SizedDealloc& SizedDealloc::operator=(SizedDealloc&&)
-#  933|   : 
+#  933|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] SizedDealloc &&
 #  935| [MemberFunction] void* SizedDealloc::operator new(size_t)
-#  935|   : 
+#  935|   <params>: 
 #  935|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  935|         Type = [CTypedefType,Size_t] size_t
 #  936| [MemberFunction] void* SizedDealloc::operator new[](size_t)
-#  936|   : 
+#  936|   <params>: 
 #  936|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  936|         Type = [CTypedefType,Size_t] size_t
 #  937| [MemberFunction] void SizedDealloc::operator delete(void*, size_t)
-#  937|   : 
+#  937|   <params>: 
 #  937|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  937|         Type = [VoidPointerType] void *
 #  937|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  937|         Type = [CTypedefType,Size_t] size_t
 #  938| [MemberFunction] void SizedDealloc::operator delete[](void*, size_t)
-#  938|   : 
+#  938|   <params>: 
 #  938|     getParameter(0): [Parameter] (unnamed parameter 0)
 #  938|         Type = [VoidPointerType] void *
 #  938|     getParameter(1): [Parameter] (unnamed parameter 1)
 #  938|         Type = [CTypedefType,Size_t] size_t
 #  941| [CopyAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned const&)
-#  941|   : 
+#  941|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Overaligned &
 #  941| [MoveAssignmentOperator] Overaligned& Overaligned::operator=(Overaligned&&)
-#  941|   : 
+#  941|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Overaligned &&
 #  945| [CopyAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam const&)
-#  945|   : 
+#  945|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveAssignmentOperator] DefaultCtorWithDefaultParam& DefaultCtorWithDefaultParam::operator=(DefaultCtorWithDefaultParam&&)
-#  945|   : 
+#  945|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  945| [CopyConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam const&)
-#  945|   : 
+#  945|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const DefaultCtorWithDefaultParam &
 #  945| [MoveConstructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(DefaultCtorWithDefaultParam&&)
-#  945|   : 
+#  945|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] DefaultCtorWithDefaultParam &&
 #  946| [Constructor] void DefaultCtorWithDefaultParam::DefaultCtorWithDefaultParam(double)
-#  946|   : 
+#  946|   <params>: 
 #  946|     getParameter(0): [Parameter] d
 #  946|         Type = [DoubleType] double
 #  949| [TopLevelFunction] void OperatorNew()
-#  949|   : 
+#  949|   <params>: 
 #  949|   getEntryPoint(): [BlockStmt] { ... }
 #  950|     getStmt(0): [ExprStmt] ExprStmt
 #  950|       getExpr(): [NewExpr] new
@@ -7931,7 +7931,7 @@ ir.cpp:
 #  954|               Type = [ArrayType] const char[6]
 #  954|               Value = [StringLiteral] "hello"
 #  954|               ValueCategory = lvalue
-#  954|           : [ArrayToPointerConversion] array to pointer conversion
+#  954|           getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  954|               Type = [PointerType] const char *
 #  954|               ValueCategory = prvalue
 #  955|     getStmt(5): [ExprStmt] ExprStmt
@@ -7966,7 +7966,7 @@ ir.cpp:
 #  956|             ValueCategory = prvalue
 #  957|     getStmt(7): [ReturnStmt] return ...
 #  959| [TopLevelFunction] void OperatorNewArray(int)
-#  959|   : 
+#  959|   <params>: 
 #  959|     getParameter(0): [Parameter] n
 #  959|         Type = [IntType] int
 #  959|   getEntryPoint(): [BlockStmt] { ... }
@@ -8077,7 +8077,7 @@ ir.cpp:
 #  967|             ValueCategory = prvalue(load)
 #  968|     getStmt(8): [ReturnStmt] return ...
 #  970| [TopLevelFunction] int designatedInit()
-#  970|   : 
+#  970|   <params>: 
 #  970|   getEntryPoint(): [BlockStmt] { ... }
 #  971|     getStmt(0): [DeclStmt] declaration
 #  971|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of a1
@@ -8105,11 +8105,11 @@ ir.cpp:
 #  972|             Type = [IntType] int
 #  972|             Value = [Literal] 900
 #  972|             ValueCategory = prvalue
-#  972|         : [ArrayToPointerConversion] array to pointer conversion
+#  972|         getArrayBase().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #  972|             Type = [IntPointerType] int *
 #  972|             ValueCategory = prvalue
 #  975| [TopLevelFunction] void IfStmtWithDeclaration(int, int)
-#  975|   : 
+#  975|   <params>: 
 #  975|     getParameter(0): [Parameter] x
 #  975|         Type = [IntType] int
 #  975|     getParameter(1): [Parameter] y
@@ -8141,7 +8141,7 @@ ir.cpp:
 #  979|           getVariableAccess(): [VariableAccess] z
 #  979|               Type = [IntType] int
 #  979|               ValueCategory = prvalue(load)
-#  979|           : [CStyleCast] (bool)...
+#  979|           getVariableAccess().getFullyConverted(): [CStyleCast] (bool)...
 #  979|               Conversion = [BoolConversion] conversion to bool
 #  979|               Type = [BoolType] bool
 #  979|               ValueCategory = prvalue
@@ -8164,7 +8164,7 @@ ir.cpp:
 #  982|             getVariableAccess(): [VariableAccess] p
 #  982|                 Type = [IntPointerType] int *
 #  982|                 ValueCategory = prvalue(load)
-#  982|             : [CStyleCast] (bool)...
+#  982|             getVariableAccess().getFullyConverted(): [CStyleCast] (bool)...
 #  982|                 Conversion = [BoolConversion] conversion to bool
 #  982|                 Type = [BoolType] bool
 #  982|                 ValueCategory = prvalue
@@ -8185,7 +8185,7 @@ ir.cpp:
 #  983|                     ValueCategory = prvalue
 #  985|     getStmt(1): [ReturnStmt] return ...
 #  987| [TopLevelFunction] void WhileStmtWithDeclaration(int, int)
-#  987|   : 
+#  987|   <params>: 
 #  987|     getParameter(0): [Parameter] x
 #  987|         Type = [IntType] int
 #  987|     getParameter(1): [Parameter] y
@@ -8206,7 +8206,7 @@ ir.cpp:
 #  990|         getVariableAccess(): [VariableAccess] z
 #  990|             Type = [IntType] int
 #  990|             ValueCategory = prvalue(load)
-#  990|         : [CStyleCast] (bool)...
+#  990|         getVariableAccess().getFullyConverted(): [CStyleCast] (bool)...
 #  990|             Conversion = [BoolConversion] conversion to bool
 #  990|             Type = [BoolType] bool
 #  990|             ValueCategory = prvalue
@@ -8218,14 +8218,14 @@ ir.cpp:
 #  992|         getVariableAccess(): [VariableAccess] p
 #  992|             Type = [IntPointerType] int *
 #  992|             ValueCategory = prvalue(load)
-#  992|         : [CStyleCast] (bool)...
+#  992|         getVariableAccess().getFullyConverted(): [CStyleCast] (bool)...
 #  992|             Conversion = [BoolConversion] conversion to bool
 #  992|             Type = [BoolType] bool
 #  992|             ValueCategory = prvalue
 #  992|       getStmt(): [BlockStmt] { ... }
 #  994|     getStmt(3): [ReturnStmt] return ...
 #  996| [TopLevelFunction] int PointerDecay(int[], int(float))
-#  996|   : 
+#  996|   <params>: 
 #  996|     getParameter(0): [Parameter] a
 #  996|         Type = [ArrayType] int[]
 #  996|     getParameter(1): [Parameter] fn
@@ -8255,13 +8255,13 @@ ir.cpp:
 #  997|               Type = [DoubleType] double
 #  997|               Value = [Literal] 1.0
 #  997|               ValueCategory = prvalue
-#  997|           : [CStyleCast] (float)...
+#  997|           getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 #  997|               Conversion = [FloatingPointConversion] floating point conversion
 #  997|               Type = [FloatType] float
 #  997|               Value = [CStyleCast] 1.0
 #  997|               ValueCategory = prvalue
 # 1000| [TopLevelFunction] int ExprStmt(int, int, int)
-# 1000|   : 
+# 1000|   <params>: 
 # 1000|     getParameter(0): [Parameter] b
 # 1000|         Type = [IntType] int
 # 1000|     getParameter(1): [Parameter] y
@@ -8281,7 +8281,7 @@ ir.cpp:
 # 1011|           Type = [IntType] int
 # 1011|           ValueCategory = prvalue
 # 1015| [TopLevelFunction] void OperatorDelete()
-# 1015|   : 
+# 1015|   <params>: 
 # 1015|   getEntryPoint(): [BlockStmt] { ... }
 # 1016|     getStmt(0): [ExprStmt] ExprStmt
 # 1016|       getExpr(): [DeleteExpr] delete
@@ -8291,7 +8291,7 @@ ir.cpp:
 # 1016|             Type = [NullPointerType] decltype(nullptr)
 # 1016|             Value = [Literal] 0
 # 1016|             ValueCategory = prvalue
-# 1016|         : [StaticCast] static_cast<int *>...
+# 1016|         getExpr().getFullyConverted(): [StaticCast] static_cast<int *>...
 # 1016|             Conversion = [PointerConversion] pointer conversion
 # 1016|             Type = [IntPointerType] int *
 # 1016|             Value = [StaticCast] 0
@@ -8307,7 +8307,7 @@ ir.cpp:
 # 1017|               Type = [NullPointerType] decltype(nullptr)
 # 1017|               Value = [Literal] 0
 # 1017|               ValueCategory = prvalue
-# 1017|           getQualifier(): [StaticCast] static_cast<String *>...
+# 1017|           getQualifier().getFullyConverted(): [StaticCast] static_cast<String *>...
 # 1017|               Conversion = [PointerConversion] pointer conversion
 # 1017|               Type = [PointerType] String *
 # 1017|               Value = [StaticCast] 0
@@ -8323,7 +8323,7 @@ ir.cpp:
 # 1018|             Type = [NullPointerType] decltype(nullptr)
 # 1018|             Value = [Literal] 0
 # 1018|             ValueCategory = prvalue
-# 1018|         : [StaticCast] static_cast<SizedDealloc *>...
+# 1018|         getExpr().getFullyConverted(): [StaticCast] static_cast<SizedDealloc *>...
 # 1018|             Conversion = [PointerConversion] pointer conversion
 # 1018|             Type = [PointerType] SizedDealloc *
 # 1018|             Value = [StaticCast] 0
@@ -8336,7 +8336,7 @@ ir.cpp:
 # 1019|             Type = [NullPointerType] decltype(nullptr)
 # 1019|             Value = [Literal] 0
 # 1019|             ValueCategory = prvalue
-# 1019|         : [StaticCast] static_cast<Overaligned *>...
+# 1019|         getExpr().getFullyConverted(): [StaticCast] static_cast<Overaligned *>...
 # 1019|             Conversion = [PointerConversion] pointer conversion
 # 1019|             Type = [PointerType] Overaligned *
 # 1019|             Value = [StaticCast] 0
@@ -8352,14 +8352,14 @@ ir.cpp:
 # 1020|               Type = [NullPointerType] decltype(nullptr)
 # 1020|               Value = [Literal] 0
 # 1020|               ValueCategory = prvalue
-# 1020|           getQualifier(): [StaticCast] static_cast<PolymorphicBase *>...
+# 1020|           getQualifier().getFullyConverted(): [StaticCast] static_cast<PolymorphicBase *>...
 # 1020|               Conversion = [PointerConversion] pointer conversion
 # 1020|               Type = [PointerType] PolymorphicBase *
 # 1020|               Value = [StaticCast] 0
 # 1020|               ValueCategory = prvalue
 # 1021|     getStmt(5): [ReturnStmt] return ...
 # 1024| [TopLevelFunction] void OperatorDeleteArray()
-# 1024|   : 
+# 1024|   <params>: 
 # 1024|   getEntryPoint(): [BlockStmt] { ... }
 # 1025|     getStmt(0): [ExprStmt] ExprStmt
 # 1025|       getExpr(): [DeleteArrayExpr] delete[]
@@ -8369,7 +8369,7 @@ ir.cpp:
 # 1025|             Type = [NullPointerType] decltype(nullptr)
 # 1025|             Value = [Literal] 0
 # 1025|             ValueCategory = prvalue
-# 1025|         : [StaticCast] static_cast<int *>...
+# 1025|         getExpr().getFullyConverted(): [StaticCast] static_cast<int *>...
 # 1025|             Conversion = [PointerConversion] pointer conversion
 # 1025|             Type = [IntPointerType] int *
 # 1025|             Value = [StaticCast] 0
@@ -8385,7 +8385,7 @@ ir.cpp:
 # 1026|               Type = [NullPointerType] decltype(nullptr)
 # 1026|               Value = [Literal] 0
 # 1026|               ValueCategory = prvalue
-# 1026|           getQualifier(): [StaticCast] static_cast<String *>...
+# 1026|           getQualifier().getFullyConverted(): [StaticCast] static_cast<String *>...
 # 1026|               Conversion = [PointerConversion] pointer conversion
 # 1026|               Type = [PointerType] String *
 # 1026|               Value = [StaticCast] 0
@@ -8401,7 +8401,7 @@ ir.cpp:
 # 1027|             Type = [NullPointerType] decltype(nullptr)
 # 1027|             Value = [Literal] 0
 # 1027|             ValueCategory = prvalue
-# 1027|         : [StaticCast] static_cast<SizedDealloc *>...
+# 1027|         getExpr().getFullyConverted(): [StaticCast] static_cast<SizedDealloc *>...
 # 1027|             Conversion = [PointerConversion] pointer conversion
 # 1027|             Type = [PointerType] SizedDealloc *
 # 1027|             Value = [StaticCast] 0
@@ -8414,7 +8414,7 @@ ir.cpp:
 # 1028|             Type = [NullPointerType] decltype(nullptr)
 # 1028|             Value = [Literal] 0
 # 1028|             ValueCategory = prvalue
-# 1028|         : [StaticCast] static_cast<Overaligned *>...
+# 1028|         getExpr().getFullyConverted(): [StaticCast] static_cast<Overaligned *>...
 # 1028|             Conversion = [PointerConversion] pointer conversion
 # 1028|             Type = [PointerType] Overaligned *
 # 1028|             Value = [StaticCast] 0
@@ -8430,22 +8430,22 @@ ir.cpp:
 # 1029|               Type = [NullPointerType] decltype(nullptr)
 # 1029|               Value = [Literal] 0
 # 1029|               ValueCategory = prvalue
-# 1029|           getQualifier(): [StaticCast] static_cast<PolymorphicBase *>...
+# 1029|           getQualifier().getFullyConverted(): [StaticCast] static_cast<PolymorphicBase *>...
 # 1029|               Conversion = [PointerConversion] pointer conversion
 # 1029|               Type = [PointerType] PolymorphicBase *
 # 1029|               Value = [StaticCast] 0
 # 1029|               ValueCategory = prvalue
 # 1030|     getStmt(5): [ReturnStmt] return ...
 # 1032| [CopyAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct const&)
-# 1032|   : 
+# 1032|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const EmptyStruct &
 # 1032| [MoveAssignmentOperator] EmptyStruct& EmptyStruct::operator=(EmptyStruct&&)
-# 1032|   : 
+# 1032|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] EmptyStruct &&
 # 1034| [TopLevelFunction] void EmptyStructInit()
-# 1034|   : 
+# 1034|   <params>: 
 # 1034|   getEntryPoint(): [BlockStmt] { ... }
 # 1035|     getStmt(0): [DeclStmt] declaration
 # 1035|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of s
@@ -8456,34 +8456,34 @@ ir.cpp:
 # 1035|               ValueCategory = prvalue
 # 1036|     getStmt(1): [ReturnStmt] return ...
 # 1038| [CopyAssignmentOperator] (lambda [] type at line 1038, col. 12)& (lambda [] type at line 1038, col. 12)::operator=((lambda [] type at line 1038, col. 12) const&)
-# 1038|   : 
+# 1038|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [CopyConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12) const&)
-# 1038|   : 
+# 1038|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1038, col. 12 &
 # 1038| [MoveConstructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)((lambda [] type at line 1038, col. 12)&&)
-# 1038|   : 
+# 1038|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1038, col. 12 &&
 # 1038| [Constructor] void (lambda [] type at line 1038, col. 12)::(unnamed constructor)()
-# 1038|   : 
+# 1038|   <params>: 
 # 1038| [MemberFunction] void (lambda [] type at line 1038, col. 12)::_FUN()
-# 1038|   : 
+# 1038|   <params>: 
 # 1038| [ConstMemberFunction] void (lambda [] type at line 1038, col. 12)::operator()() const
-# 1038|   : 
+# 1038|   <params>: 
 # 1038|   getEntryPoint(): [BlockStmt] { ... }
 # 1038|     getStmt(0): [ReturnStmt] return ...
 # 1038| [ConstMemberFunction,ConversionOperator] void(* (lambda [] type at line 1038, col. 12)::operator void (*)()() const)()
-# 1038|   : 
+# 1038|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 # 1038|     getStmt(0): [ReturnStmt] return ...
 # 1038|       getExpr(): [FunctionAccess] _FUN
 # 1038|           Type = [FunctionPointerType] ..(*)(..)
 # 1038|           ValueCategory = prvalue(load)
 # 1040| [TopLevelFunction] void Lambda(int, String const&)
-# 1040|   : 
+# 1040|   <params>: 
 # 1040|     getParameter(0): [Parameter] x
 # 1040|         Type = [IntType] int
 # 1040|     getParameter(1): [Parameter] s
@@ -8504,15 +8504,15 @@ ir.cpp:
 # 1042|         getQualifier(): [VariableAccess] lambda_empty
 # 1042|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1042|             ValueCategory = lvalue
-# 1042|         getArgument(0): [CStyleCast] (const lambda [] type at line 1041, col. 23)...
-# 1042|             Conversion = [GlvalueConversion] glvalue conversion
-# 1042|             Type = [SpecifiedType] const lambda [] type at line 1041, col. 23
-# 1042|             ValueCategory = lvalue
 # 1042|         getArgument(0): [Literal] 0
 # 1042|             Type = [IntType] int
 # 1042|             Value = [Literal] 0
 # 1042|             ValueCategory = prvalue
-# 1042|         : [CStyleCast] (float)...
+# 1042|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1041, col. 23)...
+# 1042|             Conversion = [GlvalueConversion] glvalue conversion
+# 1042|             Type = [SpecifiedType] const lambda [] type at line 1041, col. 23
+# 1042|             ValueCategory = lvalue
+# 1042|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1042|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1042|             Type = [FloatType] float
 # 1042|             Value = [CStyleCast] 0.0
@@ -8533,13 +8533,13 @@ ir.cpp:
 # 1043|               getFieldExpr(x): [VariableAccess] x
 # 1043|                   Type = [IntType] int
 # 1043|                   ValueCategory = lvalue
-# 1043|               : [ReferenceToExpr] (reference to)
+# 1043|               getFieldExpr(s).getFullyConverted(): [ReferenceToExpr] (reference to)
 # 1043|                   Type = [LValueReferenceType] const String &
 # 1043|                   ValueCategory = prvalue
 # 1043|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|                     Type = [SpecifiedType] const String
 # 1043|                     ValueCategory = lvalue
-#-----|               : [ReferenceToExpr] (reference to)
+#-----|               getFieldExpr(x).getFullyConverted(): [ReferenceToExpr] (reference to)
 #-----|                   Type = [LValueReferenceType] int &
 #-----|                   ValueCategory = prvalue
 # 1044|     getStmt(3): [ExprStmt] ExprStmt
@@ -8549,15 +8549,15 @@ ir.cpp:
 # 1044|         getQualifier(): [VariableAccess] lambda_ref
 # 1044|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1044|             ValueCategory = lvalue
-# 1044|         getArgument(0): [CStyleCast] (const lambda [] type at line 1043, col. 21)...
-# 1044|             Conversion = [GlvalueConversion] glvalue conversion
-# 1044|             Type = [SpecifiedType] const lambda [] type at line 1043, col. 21
-# 1044|             ValueCategory = lvalue
 # 1044|         getArgument(0): [Literal] 1
 # 1044|             Type = [IntType] int
 # 1044|             Value = [Literal] 1
 # 1044|             ValueCategory = prvalue
-# 1044|         : [CStyleCast] (float)...
+# 1044|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1043, col. 21)...
+# 1044|             Conversion = [GlvalueConversion] glvalue conversion
+# 1044|             Type = [SpecifiedType] const lambda [] type at line 1043, col. 21
+# 1044|             ValueCategory = lvalue
+# 1044|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1044|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1044|             Type = [FloatType] float
 # 1044|             Value = [CStyleCast] 1.0
@@ -8585,15 +8585,15 @@ ir.cpp:
 # 1046|         getQualifier(): [VariableAccess] lambda_val
 # 1046|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1046|             ValueCategory = lvalue
-# 1046|         getArgument(0): [CStyleCast] (const lambda [] type at line 1045, col. 21)...
-# 1046|             Conversion = [GlvalueConversion] glvalue conversion
-# 1046|             Type = [SpecifiedType] const lambda [] type at line 1045, col. 21
-# 1046|             ValueCategory = lvalue
 # 1046|         getArgument(0): [Literal] 2
 # 1046|             Type = [IntType] int
 # 1046|             Value = [Literal] 2
 # 1046|             ValueCategory = prvalue
-# 1046|         : [CStyleCast] (float)...
+# 1046|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1045, col. 21)...
+# 1046|             Conversion = [GlvalueConversion] glvalue conversion
+# 1046|             Type = [SpecifiedType] const lambda [] type at line 1045, col. 21
+# 1046|             ValueCategory = lvalue
+# 1046|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1046|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1046|             Type = [FloatType] float
 # 1046|             Value = [CStyleCast] 2.0
@@ -8611,7 +8611,7 @@ ir.cpp:
 # 1047|               getFieldExpr(s): [VariableAccess] s
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue(load)
-# 1047|               : [ReferenceToExpr] (reference to)
+# 1047|               getFieldExpr(s).getFullyConverted(): [ReferenceToExpr] (reference to)
 # 1047|                   Type = [LValueReferenceType] const String &
 # 1047|                   ValueCategory = prvalue
 # 1047|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
@@ -8624,15 +8624,15 @@ ir.cpp:
 # 1048|         getQualifier(): [VariableAccess] lambda_ref_explicit
 # 1048|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1048|             ValueCategory = lvalue
-# 1048|         getArgument(0): [CStyleCast] (const lambda [] type at line 1047, col. 30)...
-# 1048|             Conversion = [GlvalueConversion] glvalue conversion
-# 1048|             Type = [SpecifiedType] const lambda [] type at line 1047, col. 30
-# 1048|             ValueCategory = lvalue
 # 1048|         getArgument(0): [Literal] 3
 # 1048|             Type = [IntType] int
 # 1048|             Value = [Literal] 3
 # 1048|             ValueCategory = prvalue
-# 1048|         : [CStyleCast] (float)...
+# 1048|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1047, col. 30)...
+# 1048|             Conversion = [GlvalueConversion] glvalue conversion
+# 1048|             Type = [SpecifiedType] const lambda [] type at line 1047, col. 30
+# 1048|             ValueCategory = lvalue
+# 1048|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1048|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1048|             Type = [FloatType] float
 # 1048|             Value = [CStyleCast] 3.0
@@ -8657,15 +8657,15 @@ ir.cpp:
 # 1050|         getQualifier(): [VariableAccess] lambda_val_explicit
 # 1050|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1050|             ValueCategory = lvalue
-# 1050|         getArgument(0): [CStyleCast] (const lambda [] type at line 1049, col. 30)...
-# 1050|             Conversion = [GlvalueConversion] glvalue conversion
-# 1050|             Type = [SpecifiedType] const lambda [] type at line 1049, col. 30
-# 1050|             ValueCategory = lvalue
 # 1050|         getArgument(0): [Literal] 4
 # 1050|             Type = [IntType] int
 # 1050|             Value = [Literal] 4
 # 1050|             ValueCategory = prvalue
-# 1050|         : [CStyleCast] (float)...
+# 1050|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1049, col. 30)...
+# 1050|             Conversion = [GlvalueConversion] glvalue conversion
+# 1050|             Type = [SpecifiedType] const lambda [] type at line 1049, col. 30
+# 1050|             ValueCategory = lvalue
+# 1050|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1050|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1050|             Type = [FloatType] float
 # 1050|             Value = [CStyleCast] 4.0
@@ -8686,7 +8686,7 @@ ir.cpp:
 # 1051|               getFieldExpr(x): [VariableAccess] x
 # 1051|                   Type = [IntType] int
 # 1051|                   ValueCategory = prvalue(load)
-# 1051|               : [ReferenceToExpr] (reference to)
+# 1051|               getFieldExpr(s).getFullyConverted(): [ReferenceToExpr] (reference to)
 # 1051|                   Type = [LValueReferenceType] const String &
 # 1051|                   ValueCategory = prvalue
 # 1051|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
@@ -8699,15 +8699,15 @@ ir.cpp:
 # 1052|         getQualifier(): [VariableAccess] lambda_mixed_explicit
 # 1052|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1052|             ValueCategory = lvalue
-# 1052|         getArgument(0): [CStyleCast] (const lambda [] type at line 1051, col. 32)...
-# 1052|             Conversion = [GlvalueConversion] glvalue conversion
-# 1052|             Type = [SpecifiedType] const lambda [] type at line 1051, col. 32
-# 1052|             ValueCategory = lvalue
 # 1052|         getArgument(0): [Literal] 5
 # 1052|             Type = [IntType] int
 # 1052|             Value = [Literal] 5
 # 1052|             ValueCategory = prvalue
-# 1052|         : [CStyleCast] (float)...
+# 1052|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1051, col. 32)...
+# 1052|             Conversion = [GlvalueConversion] glvalue conversion
+# 1052|             Type = [SpecifiedType] const lambda [] type at line 1051, col. 32
+# 1052|             ValueCategory = lvalue
+# 1052|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1052|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1052|             Type = [FloatType] float
 # 1052|             Value = [CStyleCast] 5.0
@@ -8755,13 +8755,13 @@ ir.cpp:
 # 1054|               getFieldExpr(j): [VariableAccess] r
 # 1054|                   Type = [IntType] int
 # 1054|                   ValueCategory = lvalue
-# 1054|               : [ReferenceToExpr] (reference to)
+# 1054|               getFieldExpr(s).getFullyConverted(): [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] const String &
 # 1054|                   ValueCategory = prvalue
 # 1054|                 getExpr(): [ReferenceDereferenceExpr] (reference dereference)
 # 1054|                     Type = [SpecifiedType] const String
 # 1054|                     ValueCategory = lvalue
-# 1054|               : [ReferenceToExpr] (reference to)
+# 1054|               getFieldExpr(j).getFullyConverted(): [ReferenceToExpr] (reference to)
 # 1054|                   Type = [LValueReferenceType] int &
 # 1054|                   ValueCategory = prvalue
 # 1055|     getStmt(14): [ExprStmt] ExprStmt
@@ -8771,40 +8771,40 @@ ir.cpp:
 # 1055|         getQualifier(): [VariableAccess] lambda_inits
 # 1055|             Type = [Closure,LocalClass] decltype([...](...){...})
 # 1055|             ValueCategory = lvalue
-# 1055|         getArgument(0): [CStyleCast] (const lambda [] type at line 1054, col. 23)...
-# 1055|             Conversion = [GlvalueConversion] glvalue conversion
-# 1055|             Type = [SpecifiedType] const lambda [] type at line 1054, col. 23
-# 1055|             ValueCategory = lvalue
 # 1055|         getArgument(0): [Literal] 6
 # 1055|             Type = [IntType] int
 # 1055|             Value = [Literal] 6
 # 1055|             ValueCategory = prvalue
-# 1055|         : [CStyleCast] (float)...
+# 1055|         getQualifier().getFullyConverted(): [CStyleCast] (const lambda [] type at line 1054, col. 23)...
+# 1055|             Conversion = [GlvalueConversion] glvalue conversion
+# 1055|             Type = [SpecifiedType] const lambda [] type at line 1054, col. 23
+# 1055|             ValueCategory = lvalue
+# 1055|         getArgument(0).getFullyConverted(): [CStyleCast] (float)...
 # 1055|             Conversion = [IntegralToFloatingPointConversion] integral to floating point conversion
 # 1055|             Type = [FloatType] float
 # 1055|             Value = [CStyleCast] 6.0
 # 1055|             ValueCategory = prvalue
 # 1056|     getStmt(15): [ReturnStmt] return ...
 # 1041| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   : 
+# 1041|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23) const&)
-# 1041|   : 
+# 1041|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1041, col. 23 &
 # 1041| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)&&)
-# 1041|   : 
+# 1041|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1041, col. 23 &&
 # 1041| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::(unnamed constructor)()
-# 1041|   : 
+# 1041|   <params>: 
 # 1041| [MemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::_FUN(float)
-# 1041|   : 
+# 1041|   <params>: 
 # 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
 # 1041| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator()(float) const
-# 1041|   : 
+# 1041|   <params>: 
 # 1041|     getParameter(0): [Parameter] f
 # 1041|         Type = [FloatType] float
 # 1041|   getEntryPoint(): [BlockStmt] { ... }
@@ -8814,28 +8814,28 @@ ir.cpp:
 # 1041|           Value = [CharLiteral] 65
 # 1041|           ValueCategory = prvalue
 # 1041| [ConstMemberFunction,ConversionOperator] char(* (void Lambda(int, String const&))::(lambda [] type at line 1041, col. 23)::operator char (*)(float)() const)(float)
-# 1041|   : 
+# 1041|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 # 1041|     getStmt(0): [ReturnStmt] return ...
 # 1041|       getExpr(): [FunctionAccess] _FUN
 # 1041|           Type = [FunctionPointerType] ..(*)(..)
 # 1041|           ValueCategory = prvalue(load)
 # 1043| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   : 
+# 1043|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21) const&)
-# 1043|   : 
+# 1043|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1043, col. 21 &
 # 1043| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)&&)
-# 1043|   : 
+# 1043|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1043, col. 21 &&
 # 1043| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::(unnamed constructor)()
-# 1043|   : 
+# 1043|   <params>: 
 # 1043| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1043, col. 21)::operator()(float) const
-# 1043|   : 
+# 1043|   <params>: 
 # 1043|     getParameter(0): [Parameter] f
 # 1043|         Type = [FloatType] float
 # 1043|   getEntryPoint(): [BlockStmt] { ... }
@@ -8852,7 +8852,7 @@ ir.cpp:
 # 1043|             getQualifier(): [ThisExpr] this
 # 1043|                 Type = [PointerType] const lambda [] type at line 1043, col. 21 *
 # 1043|                 ValueCategory = prvalue(load)
-# 1043|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+# 1043|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|               Type = [SpecifiedType] const String
 # 1043|               ValueCategory = lvalue
 # 1043|         getArrayOffset(): [PointerFieldAccess] x
@@ -8861,28 +8861,28 @@ ir.cpp:
 # 1043|           getQualifier(): [ThisExpr] this
 # 1043|               Type = [PointerType] const lambda [] type at line 1043, col. 21 *
 # 1043|               ValueCategory = prvalue(load)
-# 1043|         : [ReferenceDereferenceExpr] (reference dereference)
+# 1043|         getArrayOffset().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1043|             Type = [IntType] int
 # 1043|             ValueCategory = prvalue(load)
 # 1045| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)& (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   : 
+# 1045|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21) const&)
-# 1045|   : 
+# 1045|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1045, col. 21 &
 # 1045| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)&&)
-# 1045|   : 
+# 1045|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1045, col. 21 &&
 # 1045| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::(unnamed constructor)()
-# 1045|   : 
+# 1045|   <params>: 
 # 1045| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::~<unnamed>()
-# 1045|   : 
+# 1045|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-# 1045|   : 
+# 1045|   <destructions>: 
 # 1045|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1045|         Type = [SpecifiedType] const String
 # 1045|         ValueCategory = prvalue
@@ -8893,7 +8893,7 @@ ir.cpp:
 # 1045|             Type = [SpecifiedType] const String
 # 1045|             ValueCategory = lvalue
 # 1045| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1045, col. 21)::operator()(float) const
-# 1045|   : 
+# 1045|   <params>: 
 # 1045|     getParameter(0): [Parameter] f
 # 1045|         Type = [FloatType] float
 # 1045|   getEntryPoint(): [BlockStmt] { ... }
@@ -8917,21 +8917,21 @@ ir.cpp:
 # 1045|               Type = [PointerType] const lambda [] type at line 1045, col. 21 *
 # 1045|               ValueCategory = prvalue(load)
 # 1047| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   : 
+# 1047|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30) const&)
-# 1047|   : 
+# 1047|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1047, col. 30 &
 # 1047| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)&&)
-# 1047|   : 
+# 1047|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1047, col. 30 &&
 # 1047| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::(unnamed constructor)()
-# 1047|   : 
+# 1047|   <params>: 
 # 1047| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1047, col. 30)::operator()(float) const
-# 1047|   : 
+# 1047|   <params>: 
 # 1047|     getParameter(0): [Parameter] f
 # 1047|         Type = [FloatType] float
 # 1047|   getEntryPoint(): [BlockStmt] { ... }
@@ -8948,7 +8948,7 @@ ir.cpp:
 # 1047|             getQualifier(): [ThisExpr] this
 # 1047|                 Type = [PointerType] const lambda [] type at line 1047, col. 30 *
 # 1047|                 ValueCategory = prvalue(load)
-# 1047|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+# 1047|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1047|               Type = [SpecifiedType] const String
 # 1047|               ValueCategory = lvalue
 # 1047|         getArrayOffset(): [Literal] 0
@@ -8956,24 +8956,24 @@ ir.cpp:
 # 1047|             Value = [Literal] 0
 # 1047|             ValueCategory = prvalue
 # 1049| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)& (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   : 
+# 1049|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30) const&)
-# 1049|   : 
+# 1049|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1049, col. 30 &
 # 1049| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)&&)
-# 1049|   : 
+# 1049|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1049, col. 30 &&
 # 1049| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::(unnamed constructor)()
-# 1049|   : 
+# 1049|   <params>: 
 # 1049| [Destructor] void (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::~<unnamed>()
-# 1049|   : 
+# 1049|   <params>: 
 #-----|   getEntryPoint(): [BlockStmt] { ... }
 #-----|     getStmt(0): [ReturnStmt] return ...
-# 1049|   : 
+# 1049|   <destructions>: 
 # 1049|     getDestruction(0): [DestructorFieldDestruction] destructor field destruction of s
 # 1049|         Type = [SpecifiedType] const String
 # 1049|         ValueCategory = prvalue
@@ -8984,7 +8984,7 @@ ir.cpp:
 # 1049|             Type = [SpecifiedType] const String
 # 1049|             ValueCategory = lvalue
 # 1049| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1049, col. 30)::operator()(float) const
-# 1049|   : 
+# 1049|   <params>: 
 # 1049|     getParameter(0): [Parameter] f
 # 1049|         Type = [FloatType] float
 # 1049|   getEntryPoint(): [BlockStmt] { ... }
@@ -9006,21 +9006,21 @@ ir.cpp:
 # 1049|             Value = [Literal] 0
 # 1049|             ValueCategory = prvalue
 # 1051| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)& (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   : 
+# 1051|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32) const&)
-# 1051|   : 
+# 1051|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1051, col. 32 &
 # 1051| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)&&)
-# 1051|   : 
+# 1051|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1051, col. 32 &&
 # 1051| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::(unnamed constructor)()
-# 1051|   : 
+# 1051|   <params>: 
 # 1051| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1051, col. 32)::operator()(float) const
-# 1051|   : 
+# 1051|   <params>: 
 # 1051|     getParameter(0): [Parameter] f
 # 1051|         Type = [FloatType] float
 # 1051|   getEntryPoint(): [BlockStmt] { ... }
@@ -9037,7 +9037,7 @@ ir.cpp:
 # 1051|             getQualifier(): [ThisExpr] this
 # 1051|                 Type = [PointerType] const lambda [] type at line 1051, col. 32 *
 # 1051|                 ValueCategory = prvalue(load)
-# 1051|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+# 1051|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1051|               Type = [SpecifiedType] const String
 # 1051|               ValueCategory = lvalue
 # 1051|         getArrayOffset(): [PointerFieldAccess] x
@@ -9047,21 +9047,21 @@ ir.cpp:
 # 1051|               Type = [PointerType] const lambda [] type at line 1051, col. 32 *
 # 1051|               ValueCategory = prvalue(load)
 # 1054| [CopyAssignmentOperator] (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)& (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator=((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   : 
+# 1054|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [CopyConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23) const&)
-# 1054|   : 
+# 1054|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const lambda [] type at line 1054, col. 23 &
 # 1054| [MoveConstructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)((void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)&&)
-# 1054|   : 
+# 1054|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] lambda [] type at line 1054, col. 23 &&
 # 1054| [Constructor] void (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::(unnamed constructor)()
-# 1054|   : 
+# 1054|   <params>: 
 # 1054| [ConstMemberFunction] char (void Lambda(int, String const&))::(lambda [] type at line 1054, col. 23)::operator()(float) const
-# 1054|   : 
+# 1054|   <params>: 
 # 1054|     getParameter(0): [Parameter] f
 # 1054|         Type = [FloatType] float
 # 1054|   getEntryPoint(): [BlockStmt] { ... }
@@ -9078,7 +9078,7 @@ ir.cpp:
 # 1054|             getQualifier(): [ThisExpr] this
 # 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|           getQualifier(): [ReferenceDereferenceExpr] (reference dereference)
+# 1054|           getQualifier().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [SpecifiedType] const String
 # 1054|               ValueCategory = lvalue
 # 1054|         getArrayOffset(): [SubExpr] ... - ...
@@ -9105,63 +9105,63 @@ ir.cpp:
 # 1054|             getQualifier(): [ThisExpr] this
 # 1054|                 Type = [PointerType] const lambda [] type at line 1054, col. 23 *
 # 1054|                 ValueCategory = prvalue(load)
-# 1054|           : [ReferenceDereferenceExpr] (reference dereference)
+# 1054|           getRightOperand().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1054|               Type = [IntType] int
 # 1054|               ValueCategory = prvalue(load)
 # 1059| [CopyAssignmentOperator] vector<int>& vector<int>::operator=(vector<int> const&)
-# 1059|   : 
+# 1059|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const vector<int> &
 # 1059| [MoveAssignmentOperator] vector<int>& vector<int>::operator=(vector<int>&&)
-# 1059|   : 
+# 1059|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] vector<int> &&
 # 1060| [CopyAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator const public&)
-# 1060|   : 
+# 1060|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const iterator &
 # 1060| [MoveAssignmentOperator] vector<int>::iterator& vector<int>::iterator::operator=(vector<int>::iterator&&)
-# 1060|   : 
+# 1060|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] iterator &&
 # 1062| [MemberFunction] vector<T>::iterator& vector<T>::iterator::operator++()
-# 1062|   : 
+# 1062|   <params>: 
 # 1062| [MemberFunction] vector<int>::iterator& vector<int>::iterator::operator++()
-# 1062|   : 
+# 1062|   <params>: 
 # 1063| [ConstMemberFunction] T& vector<T>::iterator::operator*() const
-# 1063|   : 
+# 1063|   <params>: 
 # 1063| [ConstMemberFunction] int& vector<int>::iterator::operator*() const
-# 1063|   : 
+# 1063|   <params>: 
 # 1065| [ConstMemberFunction] bool vector<T>::iterator::operator!=(vector<T>::iterator) const
-# 1065|   : 
+# 1065|   <params>: 
 # 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedClass,TemplateClass] iterator
 # 1065| [ConstMemberFunction] bool vector<int>::iterator::operator!=(vector<int>::iterator) const
-# 1065|   : 
+# 1065|   <params>: 
 # 1065|     getParameter(0): [Parameter] right
 # 1065|         Type = [NestedStruct] iterator
 # 1068| [ConstMemberFunction] vector<T>::iterator vector<T>::begin() const
-# 1068|   : 
+# 1068|   <params>: 
 # 1068| [ConstMemberFunction] vector<int>::iterator vector<int>::begin() const
-# 1068|   : 
+# 1068|   <params>: 
 # 1069| [ConstMemberFunction] vector<T>::iterator vector<T>::end() const
-# 1069|   : 
+# 1069|   <params>: 
 # 1069| [ConstMemberFunction] vector<int>::iterator vector<int>::end() const
-# 1069|   : 
+# 1069|   <params>: 
 # 1073| [Operator,TemplateFunction,TopLevelFunction] bool operator==<T>(iterator, iterator)
-# 1073|   : 
+# 1073|   <params>: 
 # 1073|     getParameter(0): [Parameter] left
 # 1073|         Type = [TemplateParameter] iterator
 # 1073|     getParameter(1): [Parameter] right
 # 1073|         Type = [TemplateParameter] iterator
 # 1075| [Operator,TemplateFunction,TopLevelFunction] bool operator!=<T>(iterator, iterator)
-# 1075|   : 
+# 1075|   <params>: 
 # 1075|     getParameter(0): [Parameter] left
 # 1075|         Type = [TemplateParameter] iterator
 # 1075|     getParameter(1): [Parameter] right
 # 1075|         Type = [TemplateParameter] iterator
 # 1077| [TopLevelFunction] void RangeBasedFor(vector<int> const&)
-# 1077|   : 
+# 1077|   <params>: 
 # 1077|     getParameter(0): [Parameter] v
 # 1077|         Type = [LValueReferenceType] const vector<int> &
 # 1077|   getEntryPoint(): [BlockStmt] { ... }
@@ -9174,13 +9174,13 @@ ir.cpp:
 # 1078|         getQualifier(): [VariableAccess] (__begin)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = lvalue
-#-----|         getArgument(0): [CStyleCast] (const iterator)...
-#-----|             Conversion = [GlvalueConversion] glvalue conversion
-#-----|             Type = [SpecifiedType] const iterator
-#-----|             ValueCategory = lvalue
 # 1078|         getArgument(0): [VariableAccess] (__end)
 # 1078|             Type = [NestedStruct] iterator
 # 1078|             ValueCategory = prvalue(load)
+#-----|         getQualifier().getFullyConverted(): [CStyleCast] (const iterator)...
+#-----|             Conversion = [GlvalueConversion] glvalue conversion
+#-----|             Type = [SpecifiedType] const iterator
+#-----|             ValueCategory = lvalue
 # 1078|       getUpdate(): [FunctionCall] call to operator++
 # 1078|           Type = [LValueReferenceType] iterator &
 # 1078|           ValueCategory = prvalue
@@ -9203,7 +9203,7 @@ ir.cpp:
 # 1079|           getThen(): [BlockStmt] { ... }
 # 1080|             getStmt(0): [ContinueStmt] continue;
 # 1078|         getStmt(1): [LabelStmt] label ...:
-# 1078|       : [ReferenceDereferenceExpr] (reference dereference)
+# 1078|       getUpdate().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1078|           Type = [NestedStruct] iterator
 # 1078|           ValueCategory = lvalue
 # 1084|     getStmt(1): [RangeBasedForStmt] for(...:...) ...
@@ -9215,13 +9215,13 @@ ir.cpp:
 # 1084|         getQualifier(): [VariableAccess] (__begin)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = lvalue
-#-----|         getArgument(0): [CStyleCast] (const iterator)...
-#-----|             Conversion = [GlvalueConversion] glvalue conversion
-#-----|             Type = [SpecifiedType] const iterator
-#-----|             ValueCategory = lvalue
 # 1084|         getArgument(0): [VariableAccess] (__end)
 # 1084|             Type = [NestedStruct] iterator
 # 1084|             ValueCategory = prvalue(load)
+#-----|         getQualifier().getFullyConverted(): [CStyleCast] (const iterator)...
+#-----|             Conversion = [GlvalueConversion] glvalue conversion
+#-----|             Type = [SpecifiedType] const iterator
+#-----|             ValueCategory = lvalue
 # 1084|       getUpdate(): [FunctionCall] call to operator++
 # 1084|           Type = [LValueReferenceType] iterator &
 # 1084|           ValueCategory = prvalue
@@ -9241,18 +9241,18 @@ ir.cpp:
 # 1085|                 Type = [IntType] int
 # 1085|                 Value = [Literal] 5
 # 1085|                 ValueCategory = prvalue
-# 1085|             : [ReferenceDereferenceExpr] (reference dereference)
+# 1085|             getLesserOperand().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1085|                 Type = [IntType] int
 # 1085|                 ValueCategory = prvalue(load)
 # 1085|           getThen(): [BlockStmt] { ... }
 # 1086|             getStmt(0): [BreakStmt] break;
-# 1084|       : [ReferenceDereferenceExpr] (reference dereference)
+# 1084|       getUpdate().getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1084|           Type = [NestedStruct] iterator
 # 1084|           ValueCategory = lvalue
 # 1088|     getStmt(2): [LabelStmt] label ...:
 # 1089|     getStmt(3): [ReturnStmt] return ...
 # 1108| [TopLevelFunction] int AsmStmt(int)
-# 1108|   : 
+# 1108|   <params>: 
 # 1108|     getParameter(0): [Parameter] x
 # 1108|         Type = [IntType] int
 # 1108|   getEntryPoint(): [BlockStmt] { ... }
@@ -9262,7 +9262,7 @@ ir.cpp:
 # 1110|           Type = [IntType] int
 # 1110|           ValueCategory = prvalue(load)
 # 1113| [TopLevelFunction] void AsmStmtWithOutputs(unsigned int&, unsigned int, unsigned int&, unsigned int)
-# 1113|   : 
+# 1113|   <params>: 
 # 1113|     getParameter(0): [Parameter] a
 # 1113|         Type = [LValueReferenceType] unsigned int &
 # 1113|     getParameter(1): [Parameter] b
@@ -9285,15 +9285,15 @@ ir.cpp:
 # 1118|       getChild(3): [VariableAccess] d
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
-# 1118|       : [ReferenceDereferenceExpr] (reference dereference)
+# 1118|       getChild(0).getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = lvalue
-# 1118|       : [ReferenceDereferenceExpr] (reference dereference)
+# 1118|       getChild(2).getFullyConverted(): [ReferenceDereferenceExpr] (reference dereference)
 # 1118|           Type = [IntType] unsigned int
 # 1118|           ValueCategory = prvalue(load)
 # 1120|     getStmt(1): [ReturnStmt] return ...
 # 1122| [TopLevelFunction] void ExternDeclarations()
-# 1122|   : 
+# 1122|   <params>: 
 # 1123|   getEntryPoint(): [BlockStmt] { ... }
 # 1124|     getStmt(0): [DeclStmt] declaration
 # 1124|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
@@ -9318,19 +9318,19 @@ ir.cpp:
 # 1128|           Type = [CTypedefType,LocalTypedefType] d
 # 1129|     getStmt(5): [ReturnStmt] return ...
 # 1126| [TopLevelFunction] int f(float)
-# 1126|   : 
+# 1126|   <params>: 
 # 1126|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1126|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int z(float)
-# 1127|   : 
+# 1127|   <params>: 
 # 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1127| [TopLevelFunction] int w(float)
-# 1127|   : 
+# 1127|   <params>: 
 # 1127|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1127|         Type = [FloatType] float
 # 1137| [TopLevelFunction] void ExternDeclarationsInMacro()
-# 1137|   : 
+# 1137|   <params>: 
 # 1138|   getEntryPoint(): [BlockStmt] { ... }
 # 1139|     getStmt(0): [DeclStmt] declaration
 # 1139|       getDeclarationEntry(0): [VariableDeclarationEntry] declaration of g
@@ -9367,7 +9367,7 @@ ir.cpp:
 # 1139|     getStmt(2): [EmptyStmt] ;
 # 1140|     getStmt(3): [ReturnStmt] return ...
 # 1142| [TopLevelFunction] void TryCatchNoCatchAny(bool)
-# 1142|   : 
+# 1142|   <params>: 
 # 1142|     getParameter(0): [Parameter] b
 # 1142|         Type = [BoolType] bool
 # 1142|   getEntryPoint(): [BlockStmt] { ... }
@@ -9394,7 +9394,7 @@ ir.cpp:
 # 1146|                     Type = [ArrayType] const char[15]
 # 1146|                     Value = [StringLiteral] "string literal"
 # 1146|                     ValueCategory = lvalue
-# 1146|                 : [ArrayToPointerConversion] array to pointer conversion
+# 1146|                 getExpr().getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1146|                     Type = [PointerType] const char *
 # 1146|                     ValueCategory = prvalue
 # 1148|           getElse(): [IfStmt] if (...) ... 
@@ -9436,7 +9436,7 @@ ir.cpp:
 # 1149|                             Type = [ArrayType] const char[14]
 # 1149|                             Value = [StringLiteral] "String object"
 # 1149|                             ValueCategory = lvalue
-# 1149|                         : [ArrayToPointerConversion] array to pointer conversion
+# 1149|                         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1149|                             Type = [PointerType] const char *
 # 1149|                             ValueCategory = prvalue
 # 1151|         getStmt(2): [ExprStmt] ExprStmt
@@ -9466,7 +9466,7 @@ ir.cpp:
 # 1156|         getBlock(): [CatchBlock] { ... }
 # 1158|     getStmt(1): [ReturnStmt] return ...
 # 1162| [TopLevelFunction] void VectorTypes(int)
-# 1162|   : 
+# 1162|   <params>: 
 # 1162|     getParameter(0): [Parameter] i
 # 1162|         Type = [IntType] int
 # 1162|   getEntryPoint(): [BlockStmt] { ... }
@@ -9577,7 +9577,7 @@ ir.cpp:
 # 1167|               ValueCategory = prvalue(load)
 # 1168|     getStmt(5): [ReturnStmt] return ...
 # 1170| [TopLevelFunction] void* memcpy(void*, void*, int)
-# 1170|   : 
+# 1170|   <params>: 
 # 1170|     getParameter(0): [Parameter] dst
 # 1170|         Type = [VoidPointerType] void *
 # 1170|     getParameter(1): [Parameter] src
@@ -9585,7 +9585,7 @@ ir.cpp:
 # 1170|     getParameter(2): [Parameter] size
 # 1170|         Type = [IntType] int
 # 1172| [TopLevelFunction] int ModeledCallTarget(int)
-# 1172|   : 
+# 1172|   <params>: 
 # 1172|     getParameter(0): [Parameter] x
 # 1172|         Type = [IntType] int
 # 1172|   getEntryPoint(): [BlockStmt] { ... }
@@ -9612,15 +9612,15 @@ ir.cpp:
 # 1174|             Type = [LongType] unsigned long
 # 1174|             Value = [SizeofTypeOperator] 4
 # 1174|             ValueCategory = prvalue
-# 1174|         : [CStyleCast] (void *)...
+# 1174|         getArgument(0).getFullyConverted(): [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|         : [CStyleCast] (void *)...
+# 1174|         getArgument(1).getFullyConverted(): [CStyleCast] (void *)...
 # 1174|             Conversion = [PointerConversion] pointer conversion
 # 1174|             Type = [VoidPointerType] void *
 # 1174|             ValueCategory = prvalue
-# 1174|         : [CStyleCast] (int)...
+# 1174|         getArgument(2).getFullyConverted(): [CStyleCast] (int)...
 # 1174|             Conversion = [IntegralConversion] integral conversion
 # 1174|             Type = [IntType] int
 # 1174|             Value = [CStyleCast] 4
@@ -9630,7 +9630,7 @@ ir.cpp:
 # 1175|           Type = [IntType] int
 # 1175|           ValueCategory = prvalue(load)
 # 1178| [TopLevelFunction] String ReturnObjectImpl()
-# 1178|   : 
+# 1178|   <params>: 
 # 1178|   getEntryPoint(): [BlockStmt] { ... }
 # 1179|     getStmt(0): [ReturnStmt] return ...
 # 1179|       getExpr(): [ConstructorCall] call to String
@@ -9640,11 +9640,11 @@ ir.cpp:
 # 1179|             Type = [ArrayType] const char[4]
 # 1179|             Value = [StringLiteral] "foo"
 # 1179|             ValueCategory = lvalue
-# 1179|         : [ArrayToPointerConversion] array to pointer conversion
+# 1179|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1179|             Type = [PointerType] const char *
 # 1179|             ValueCategory = prvalue
 # 1182| [TopLevelFunction] void switch1Case(int)
-# 1182|   : 
+# 1182|   <params>: 
 # 1182|     getParameter(0): [Parameter] x
 # 1182|         Type = [IntType] int
 # 1182|   getEntryPoint(): [BlockStmt] { ... }
@@ -9686,7 +9686,7 @@ ir.cpp:
 # 1188|               ValueCategory = prvalue(load)
 # 1189|     getStmt(3): [ReturnStmt] return ...
 # 1191| [TopLevelFunction] void switch2Case_fallthrough(int)
-# 1191|   : 
+# 1191|   <params>: 
 # 1191|     getParameter(0): [Parameter] x
 # 1191|         Type = [IntType] int
 # 1191|   getEntryPoint(): [BlockStmt] { ... }
@@ -9744,7 +9744,7 @@ ir.cpp:
 # 1199|               ValueCategory = prvalue(load)
 # 1200|     getStmt(3): [ReturnStmt] return ...
 # 1202| [TopLevelFunction] void switch2Case(int)
-# 1202|   : 
+# 1202|   <params>: 
 # 1202|     getParameter(0): [Parameter] x
 # 1202|         Type = [IntType] int
 # 1202|   getEntryPoint(): [BlockStmt] { ... }
@@ -9804,7 +9804,7 @@ ir.cpp:
 # 1211|               ValueCategory = prvalue(load)
 # 1212|     getStmt(4): [ReturnStmt] return ...
 # 1214| [TopLevelFunction] void switch2Case_default(int)
-# 1214|   : 
+# 1214|   <params>: 
 # 1214|     getParameter(0): [Parameter] x
 # 1214|         Type = [IntType] int
 # 1214|   getEntryPoint(): [BlockStmt] { ... }
@@ -9877,7 +9877,7 @@ ir.cpp:
 # 1228|               ValueCategory = prvalue(load)
 # 1229|     getStmt(4): [ReturnStmt] return ...
 # 1231| [TopLevelFunction] int staticLocalInit(int)
-# 1231|   : 
+# 1231|   <params>: 
 # 1231|     getParameter(0): [Parameter] x
 # 1231|         Type = [IntType] int
 # 1231|   getEntryPoint(): [BlockStmt] { ... }
@@ -9900,10 +9900,10 @@ ir.cpp:
 # 1233|             getExprOperand(): [VariableAccess] x
 # 1233|                 Type = [IntType] int
 # 1233|                 ValueCategory = lvalue
-# 1233|             : [ParenthesisExpr] (...)
+# 1233|             getExprOperand().getFullyConverted(): [ParenthesisExpr] (...)
 # 1233|                 Type = [IntType] int
 # 1233|                 ValueCategory = lvalue
-# 1233|           : [CStyleCast] (int)...
+# 1233|           getExpr().getFullyConverted(): [CStyleCast] (int)...
 # 1233|               Conversion = [IntegralConversion] integral conversion
 # 1233|               Type = [IntType] int
 # 1233|               Value = [CStyleCast] 4
@@ -9941,7 +9941,7 @@ ir.cpp:
 # 1237|             Type = [IntType] int
 # 1237|             ValueCategory = prvalue(load)
 # 1240| [TopLevelFunction] void staticLocalWithConstructor(char const*)
-# 1240|   : 
+# 1240|   <params>: 
 # 1240|     getParameter(0): [Parameter] dynamic
 # 1240|         Type = [PointerType] const char *
 # 1240|   getEntryPoint(): [BlockStmt] { ... }
@@ -9963,7 +9963,7 @@ ir.cpp:
 # 1242|                 Type = [ArrayType] const char[7]
 # 1242|                 Value = [StringLiteral] "static"
 # 1242|                 ValueCategory = lvalue
-# 1242|             : [ArrayToPointerConversion] array to pointer conversion
+# 1242|             getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1242|                 Type = [PointerType] const char *
 # 1242|                 ValueCategory = prvalue
 # 1243|     getStmt(2): [DeclStmt] declaration
@@ -9978,19 +9978,19 @@ ir.cpp:
 # 1243|                 ValueCategory = prvalue(load)
 # 1244|     getStmt(3): [ReturnStmt] return ...
 # 1248| [TopLevelFunction] char* strcpy(char*, char const*)
-# 1248|   : 
+# 1248|   <params>: 
 # 1248|     getParameter(0): [Parameter] destination
 # 1248|         Type = [CharPointerType] char *
 # 1248|     getParameter(1): [Parameter] source
 # 1248|         Type = [PointerType] const char *
 # 1249| [TopLevelFunction] char* strcat(char*, char const*)
-# 1249|   : 
+# 1249|   <params>: 
 # 1249|     getParameter(0): [Parameter] destination
 # 1249|         Type = [CharPointerType] char *
 # 1249|     getParameter(1): [Parameter] source
 # 1249|         Type = [PointerType] const char *
 # 1251| [TopLevelFunction] void test_strings(char*, char*)
-# 1251|   : 
+# 1251|   <params>: 
 # 1251|     getParameter(0): [Parameter] s1
 # 1251|         Type = [CharPointerType] char *
 # 1251|     getParameter(1): [Parameter] s2
@@ -10007,7 +10007,7 @@ ir.cpp:
 # 1252|                 Type = [IntType] int
 # 1252|                 Value = [Literal] 0
 # 1252|                 ValueCategory = prvalue
-# 1252|             : [CStyleCast] (char)...
+# 1252|             getElementExpr(0).getFullyConverted(): [CStyleCast] (char)...
 # 1252|                 Conversion = [IntegralConversion] integral conversion
 # 1252|                 Type = [PlainCharType] char
 # 1252|                 Value = [CStyleCast] 0
@@ -10022,10 +10022,10 @@ ir.cpp:
 # 1254|         getArgument(1): [VariableAccess] s1
 # 1254|             Type = [CharPointerType] char *
 # 1254|             ValueCategory = prvalue(load)
-# 1254|         : [ArrayToPointerConversion] array to pointer conversion
+# 1254|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1254|             Type = [CharPointerType] char *
 # 1254|             ValueCategory = prvalue
-# 1254|         : [CStyleCast] (const char *)...
+# 1254|         getArgument(1).getFullyConverted(): [CStyleCast] (const char *)...
 # 1254|             Conversion = [PointerConversion] pointer conversion
 # 1254|             Type = [PointerType] const char *
 # 1254|             ValueCategory = prvalue
@@ -10039,24 +10039,24 @@ ir.cpp:
 # 1255|         getArgument(1): [VariableAccess] s2
 # 1255|             Type = [CharPointerType] char *
 # 1255|             ValueCategory = prvalue(load)
-# 1255|         : [ArrayToPointerConversion] array to pointer conversion
+# 1255|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 # 1255|             Type = [CharPointerType] char *
 # 1255|             ValueCategory = prvalue
-# 1255|         : [CStyleCast] (const char *)...
+# 1255|         getArgument(1).getFullyConverted(): [CStyleCast] (const char *)...
 # 1255|             Conversion = [PointerConversion] pointer conversion
 # 1255|             Type = [PointerType] const char *
 # 1255|             ValueCategory = prvalue
 # 1256|     getStmt(3): [ReturnStmt] return ...
 # 1258| [CopyAssignmentOperator] A& A::operator=(A const&)
-# 1258|   : 
+# 1258|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const A &
 # 1258| [MoveAssignmentOperator] A& A::operator=(A&&)
-# 1258|   : 
+# 1258|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] A &&
 # 1261| [MemberFunction] void A::static_member(A*, int)
-# 1261|   : 
+# 1261|   <params>: 
 # 1261|     getParameter(0): [Parameter] a
 # 1261|         Type = [PointerType] A *
 # 1261|     getParameter(1): [Parameter] x
@@ -10077,11 +10077,11 @@ ir.cpp:
 # 1262|             ValueCategory = prvalue(load)
 # 1263|     getStmt(1): [ReturnStmt] return ...
 # 1265| [MemberFunction] void A::static_member_without_def()
-# 1265|   : 
+# 1265|   <params>: 
 # 1268| [TopLevelFunction] A* getAnInstanceOfA()
-# 1268|   : 
+# 1268|   <params>: 
 # 1270| [TopLevelFunction] void test_static_member_functions(int, A*)
-# 1270|   : 
+# 1270|   <params>: 
 # 1270|     getParameter(0): [Parameter] int_arg
 # 1270|         Type = [IntType] int
 # 1270|     getParameter(1): [Parameter] a_arg
@@ -10158,9 +10158,6 @@ ir.cpp:
 # 1279|         getArgument(0): [VariableAccess] a_arg
 # 1279|             Type = [PointerType] A *
 # 1279|             ValueCategory = prvalue(load)
-# 1279|         getArgument(1): [ParenthesisExpr] (...)
-# 1279|             Type = [PointerType] A *
-# 1279|             ValueCategory = prvalue
 # 1279|         getArgument(1): [AddExpr] ... + ...
 # 1279|             Type = [IntType] int
 # 1279|             ValueCategory = prvalue
@@ -10171,6 +10168,9 @@ ir.cpp:
 # 1279|               Type = [IntType] int
 # 1279|               Value = [Literal] 2
 # 1279|               ValueCategory = prvalue
+# 1279|         getQualifier().getFullyConverted(): [ParenthesisExpr] (...)
+# 1279|             Type = [PointerType] A *
+# 1279|             ValueCategory = prvalue
 # 1280|     getStmt(7): [ExprStmt] ExprStmt
 # 1280|       getExpr(): [FunctionCall] call to static_member
 # 1280|           Type = [VoidType] void
@@ -10187,13 +10187,13 @@ ir.cpp:
 # 1280|           getOperand(): [VariableAccess] a
 # 1280|               Type = [Struct] A
 # 1280|               ValueCategory = lvalue
-# 1280|         getArgument(1): [ParenthesisExpr] (...)
-# 1280|             Type = [Struct] A
-# 1280|             ValueCategory = lvalue
 # 1280|         getArgument(1): [Literal] 99
 # 1280|             Type = [IntType] int
 # 1280|             Value = [Literal] 99
 # 1280|             ValueCategory = prvalue
+# 1280|         getQualifier().getFullyConverted(): [ParenthesisExpr] (...)
+# 1280|             Type = [Struct] A
+# 1280|             ValueCategory = lvalue
 # 1281|     getStmt(8): [ExprStmt] ExprStmt
 # 1281|       getExpr(): [FunctionCall] call to static_member
 # 1281|           Type = [VoidType] void
@@ -10232,7 +10232,7 @@ ir.cpp:
 # 1286|             ValueCategory = prvalue
 # 1287|     getStmt(12): [ReturnStmt] return ...
 # 1289| [TopLevelFunction] int missingReturnValue(bool, int)
-# 1289|   : 
+# 1289|   <params>: 
 # 1289|     getParameter(0): [Parameter] b
 # 1289|         Type = [BoolType] bool
 # 1289|     getParameter(1): [Parameter] x
@@ -10249,7 +10249,7 @@ ir.cpp:
 # 1291|               ValueCategory = prvalue(load)
 # 1293|     getStmt(1): [ReturnStmt] return ...
 # 1295| [TopLevelFunction] void returnVoid(int, int)
-# 1295|   : 
+# 1295|   <params>: 
 # 1295|     getParameter(0): [Parameter] x
 # 1295|         Type = [IntType] int
 # 1295|     getParameter(1): [Parameter] y
@@ -10266,7 +10266,7 @@ ir.cpp:
 # 1296|             Type = [IntType] int
 # 1296|             ValueCategory = prvalue(load)
 # 1299| [TopLevelFunction] void gccBinaryConditional(bool, int, long)
-# 1299|   : 
+# 1299|   <params>: 
 # 1299|     getParameter(0): [Parameter] b
 # 1299|         Type = [BoolType] bool
 # 1299|     getParameter(1): [Parameter] x
@@ -10313,7 +10313,7 @@ ir.cpp:
 # 1302|           getElse(): [VariableAccess] y
 # 1302|               Type = [LongType] long
 # 1302|               ValueCategory = prvalue(load)
-# 1302|         : [CStyleCast] (int)...
+# 1302|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 # 1302|             Conversion = [IntegralConversion] integral conversion
 # 1302|             Type = [IntType] int
 # 1302|             ValueCategory = prvalue
@@ -10333,7 +10333,7 @@ ir.cpp:
 # 1303|           getElse(): [VariableAccess] x
 # 1303|               Type = [IntType] int
 # 1303|               ValueCategory = prvalue(load)
-# 1303|           : [CStyleCast] (bool)...
+# 1303|           getCondition().getFullyConverted(): [CStyleCast] (bool)...
 # 1303|               Conversion = [BoolConversion] conversion to bool
 # 1303|               Type = [BoolType] bool
 # 1303|               ValueCategory = prvalue
@@ -10353,11 +10353,11 @@ ir.cpp:
 # 1304|           getElse(): [VariableAccess] y
 # 1304|               Type = [LongType] long
 # 1304|               ValueCategory = prvalue(load)
-# 1304|           : [CStyleCast] (bool)...
+# 1304|           getCondition().getFullyConverted(): [CStyleCast] (bool)...
 # 1304|               Conversion = [BoolConversion] conversion to bool
 # 1304|               Type = [BoolType] bool
 # 1304|               ValueCategory = prvalue
-# 1304|         : [CStyleCast] (int)...
+# 1304|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 # 1304|             Conversion = [IntegralConversion] integral conversion
 # 1304|             Type = [IntType] int
 # 1304|             ValueCategory = prvalue
@@ -10377,15 +10377,15 @@ ir.cpp:
 # 1305|           getElse(): [VariableAccess] x
 # 1305|               Type = [IntType] int
 # 1305|               ValueCategory = prvalue(load)
-# 1305|           : [CStyleCast] (bool)...
+# 1305|           getCondition().getFullyConverted(): [CStyleCast] (bool)...
 # 1305|               Conversion = [BoolConversion] conversion to bool
 # 1305|               Type = [BoolType] bool
 # 1305|               ValueCategory = prvalue
-# 1305|           : [CStyleCast] (long)...
+# 1305|           getElse().getFullyConverted(): [CStyleCast] (long)...
 # 1305|               Conversion = [IntegralConversion] integral conversion
 # 1305|               Type = [LongType] long
 # 1305|               ValueCategory = prvalue
-# 1305|         : [CStyleCast] (int)...
+# 1305|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 # 1305|             Conversion = [IntegralConversion] integral conversion
 # 1305|             Type = [IntType] int
 # 1305|             ValueCategory = prvalue
@@ -10405,11 +10405,11 @@ ir.cpp:
 # 1306|           getElse(): [VariableAccess] y
 # 1306|               Type = [LongType] long
 # 1306|               ValueCategory = prvalue(load)
-# 1306|           : [CStyleCast] (bool)...
+# 1306|           getCondition().getFullyConverted(): [CStyleCast] (bool)...
 # 1306|               Conversion = [BoolConversion] conversion to bool
 # 1306|               Type = [BoolType] bool
 # 1306|               ValueCategory = prvalue
-# 1306|         : [CStyleCast] (int)...
+# 1306|         getRValue().getFullyConverted(): [CStyleCast] (int)...
 # 1306|             Conversion = [IntegralConversion] integral conversion
 # 1306|             Type = [IntType] int
 # 1306|             ValueCategory = prvalue
@@ -10435,30 +10435,30 @@ ir.cpp:
 # 1308|               getRightOperand(): [VariableAccess] b
 # 1308|                   Type = [BoolType] bool
 # 1308|                   ValueCategory = prvalue(load)
-# 1308|               : [CStyleCast] (bool)...
+# 1308|               getLeftOperand().getFullyConverted(): [CStyleCast] (bool)...
 # 1308|                   Conversion = [BoolConversion] conversion to bool
 # 1308|                   Type = [BoolType] bool
 # 1308|                   ValueCategory = prvalue
 # 1308|             getRightOperand(): [VariableAccess] y
 # 1308|                 Type = [LongType] long
 # 1308|                 ValueCategory = prvalue(load)
-# 1308|             : [CStyleCast] (bool)...
+# 1308|             getRightOperand().getFullyConverted(): [CStyleCast] (bool)...
 # 1308|                 Conversion = [BoolConversion] conversion to bool
 # 1308|                 Type = [BoolType] bool
 # 1308|                 ValueCategory = prvalue
 # 1308|           getElse(): [VariableAccess] x
 # 1308|               Type = [IntType] int
 # 1308|               ValueCategory = prvalue(load)
-# 1308|           : [ParenthesisExpr] (...)
+# 1308|           getCondition().getFullyConverted(): [ParenthesisExpr] (...)
 # 1308|               Type = [BoolType] bool
 # 1308|               ValueCategory = prvalue
 # 1309|     getStmt(8): [ReturnStmt] return ...
 # 1311| [TopLevelFunction] bool predicateA()
-# 1311|   : 
+# 1311|   <params>: 
 # 1312| [TopLevelFunction] bool predicateB()
-# 1312|   : 
+# 1312|   <params>: 
 # 1314| [TopLevelFunction] int shortCircuitConditional(int, int)
-# 1314|   : 
+# 1314|   <params>: 
 # 1314|     getParameter(0): [Parameter] x
 # 1314|         Type = [IntType] int
 # 1314|     getParameter(1): [Parameter] y
@@ -10484,13 +10484,13 @@ ir.cpp:
 # 1315|             Type = [IntType] int
 # 1315|             ValueCategory = prvalue(load)
 # 1318| [Operator,TopLevelFunction] void* operator new(size_t, void*)
-# 1318|   : 
+# 1318|   <params>: 
 # 1318|     getParameter(0): [Parameter] (unnamed parameter 0)
 # 1318|         Type = [CTypedefType,Size_t] size_t
 # 1318|     getParameter(1): [Parameter] (unnamed parameter 1)
 # 1318|         Type = [VoidPointerType] void *
 # 1320| [TopLevelFunction] void f(int*)
-# 1320|   : 
+# 1320|   <params>: 
 # 1320|     getParameter(0): [Parameter] p
 # 1320|         Type = [IntPointerType] int *
 # 1321|   getEntryPoint(): [BlockStmt] { ... }
@@ -10507,31 +10507,31 @@ ir.cpp:
 # 1322|           getArgument(1): [VariableAccess] p
 # 1322|               Type = [IntPointerType] int *
 # 1322|               ValueCategory = prvalue(load)
-# 1322|           : [CStyleCast] (void *)...
+# 1322|           getArgument(1).getFullyConverted(): [CStyleCast] (void *)...
 # 1322|               Conversion = [PointerConversion] pointer conversion
 # 1322|               Type = [VoidPointerType] void *
 # 1322|               ValueCategory = prvalue
 # 1323|     getStmt(1): [ReturnStmt] return ...
 perf-regression.cpp:
 #    4| [CopyAssignmentOperator] Big& Big::operator=(Big const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveAssignmentOperator] Big& Big::operator=(Big&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    4| [CopyConstructor] void Big::Big(Big const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Big &
 #    4| [MoveConstructor] void Big::Big(Big&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Big &&
 #    6| [Constructor] void Big::Big()
-#    6|   : 
-#    6|   : 
+#    6|   <params>: 
+#    6|   <initializations>: 
 #    6|     getInitializer(0): [ConstructorFieldInit] constructor init of field buffer
 #    6|         Type = [ArrayType] char[1073741824]
 #    6|         ValueCategory = prvalue
@@ -10541,7 +10541,7 @@ perf-regression.cpp:
 #    6|   getEntryPoint(): [BlockStmt] { ... }
 #    6|     getStmt(0): [ReturnStmt] return ...
 #    9| [TopLevelFunction] int main()
-#    9|   : 
+#    9|   <params>: 
 #    9|   getEntryPoint(): [BlockStmt] { ... }
 #   10|     getStmt(0): [DeclStmt] declaration
 #   10|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of big
@@ -10560,23 +10560,23 @@ perf-regression.cpp:
 #   12|           ValueCategory = prvalue
 struct_init.cpp:
 #    1| [TopLevelFunction] int handler1(void*)
-#    1|   : 
+#    1|   <params>: 
 #    1|     getParameter(0): [Parameter] p
 #    1|         Type = [VoidPointerType] void *
 #    2| [TopLevelFunction] int handler2(void*)
-#    2|   : 
+#    2|   <params>: 
 #    2|     getParameter(0): [Parameter] p
 #    2|         Type = [VoidPointerType] void *
 #    4| [CopyAssignmentOperator] Info& Info::operator=(Info const&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [LValueReferenceType] const Info &
 #    4| [MoveAssignmentOperator] Info& Info::operator=(Info&&)
-#    4|   : 
+#    4|   <params>: 
 #-----|     getParameter(0): [Parameter] (unnamed parameter 0)
 #-----|         Type = [RValueReferenceType] Info &&
 #   16| [TopLevelFunction] void let_info_escape(Info*)
-#   16|   : 
+#   16|   <params>: 
 #   16|     getParameter(0): [Parameter] info
 #   16|         Type = [PointerType] Info *
 #   16|   getEntryPoint(): [BlockStmt] { ... }
@@ -10592,7 +10592,7 @@ struct_init.cpp:
 #   17|             ValueCategory = prvalue(load)
 #   18|     getStmt(1): [ReturnStmt] return ...
 #   20| [TopLevelFunction] void declare_static_infos()
-#   20|   : 
+#   20|   <params>: 
 #   20|   getEntryPoint(): [BlockStmt] { ... }
 #   21|     getStmt(0): [DeclStmt] declaration
 #   21|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of static_infos
@@ -10611,7 +10611,7 @@ struct_init.cpp:
 #   22|               getFieldExpr(handler): [FunctionAccess] handler1
 #   22|                   Type = [FunctionPointerType] ..(*)(..)
 #   22|                   ValueCategory = prvalue(load)
-#   22|               : [ArrayToPointerConversion] array to pointer conversion
+#   22|               getFieldExpr(name).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   22|                   Type = [PointerType] const char *
 #   22|                   ValueCategory = prvalue
 #   23|             getElementExpr(1): [ClassAggregateLiteral] {...}
@@ -10627,7 +10627,7 @@ struct_init.cpp:
 #   23|                 getOperand(): [FunctionAccess] handler2
 #   23|                     Type = [RoutineType] ..()(..)
 #   23|                     ValueCategory = lvalue
-#   23|               : [ArrayToPointerConversion] array to pointer conversion
+#   23|               getFieldExpr(name).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   23|                   Type = [PointerType] const char *
 #   23|                   ValueCategory = prvalue
 #   25|     getStmt(1): [ExprStmt] ExprStmt
@@ -10637,12 +10637,12 @@ struct_init.cpp:
 #   25|         getArgument(0): [VariableAccess] static_infos
 #   25|             Type = [ArrayType] Info[2]
 #   25|             ValueCategory = lvalue
-#   25|         : [ArrayToPointerConversion] array to pointer conversion
+#   25|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   25|             Type = [PointerType] Info *
 #   25|             ValueCategory = prvalue
 #   26|     getStmt(2): [ReturnStmt] return ...
 #   28| [TopLevelFunction] void declare_local_infos()
-#   28|   : 
+#   28|   <params>: 
 #   28|   getEntryPoint(): [BlockStmt] { ... }
 #   29|     getStmt(0): [DeclStmt] declaration
 #   29|       getDeclarationEntry(0): [VariableDeclarationEntry] definition of local_infos
@@ -10661,7 +10661,7 @@ struct_init.cpp:
 #   30|               getFieldExpr(handler): [FunctionAccess] handler1
 #   30|                   Type = [FunctionPointerType] ..(*)(..)
 #   30|                   ValueCategory = prvalue(load)
-#   30|               : [ArrayToPointerConversion] array to pointer conversion
+#   30|               getFieldExpr(name).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   30|                   Type = [PointerType] const char *
 #   30|                   ValueCategory = prvalue
 #   31|             getElementExpr(1): [ClassAggregateLiteral] {...}
@@ -10677,7 +10677,7 @@ struct_init.cpp:
 #   31|                 getOperand(): [FunctionAccess] handler2
 #   31|                     Type = [RoutineType] ..()(..)
 #   31|                     ValueCategory = lvalue
-#   31|               : [ArrayToPointerConversion] array to pointer conversion
+#   31|               getFieldExpr(name).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   31|                   Type = [PointerType] const char *
 #   31|                   ValueCategory = prvalue
 #   33|     getStmt(1): [ExprStmt] ExprStmt
@@ -10687,12 +10687,12 @@ struct_init.cpp:
 #   33|         getArgument(0): [VariableAccess] local_infos
 #   33|             Type = [ArrayType] Info[2]
 #   33|             ValueCategory = lvalue
-#   33|         : [ArrayToPointerConversion] array to pointer conversion
+#   33|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   33|             Type = [PointerType] Info *
 #   33|             ValueCategory = prvalue
 #   34|     getStmt(2): [ReturnStmt] return ...
 #   36| [TopLevelFunction] void declare_static_runtime_infos(char const*)
-#   36|   : 
+#   36|   <params>: 
 #   36|     getParameter(0): [Parameter] name1
 #   36|         Type = [PointerType] const char *
 #   36|   getEntryPoint(): [BlockStmt] { ... }
@@ -10725,7 +10725,7 @@ struct_init.cpp:
 #   39|                 getOperand(): [FunctionAccess] handler2
 #   39|                     Type = [RoutineType] ..()(..)
 #   39|                     ValueCategory = lvalue
-#   39|               : [ArrayToPointerConversion] array to pointer conversion
+#   39|               getFieldExpr(name).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   39|                   Type = [PointerType] const char *
 #   39|                   ValueCategory = prvalue
 #   41|     getStmt(1): [ExprStmt] ExprStmt
@@ -10735,7 +10735,7 @@ struct_init.cpp:
 #   41|         getArgument(0): [VariableAccess] static_infos
 #   41|             Type = [ArrayType] Info[2]
 #   41|             ValueCategory = lvalue
-#   41|         : [ArrayToPointerConversion] array to pointer conversion
+#   41|         getArgument(0).getFullyConverted(): [ArrayToPointerConversion] array to pointer conversion
 #   41|             Type = [PointerType] Info *
 #   41|             ValueCategory = prvalue
 #   42|     getStmt(2): [ReturnStmt] return ...


### PR DESCRIPTION
This PR demonstrates how we can include predicate names in the PrintAST output.
This addresses a part of 

For now, this is only a draft PR to collect feedback on the implementation.
There are two main things missing:
- short names together with the full predicate names
- the PR should be based on #4493 because our textual output right now is not fully accurate (we don't report the need to call `getFullyConverted()`

To show the contents of the new metadata, I switched `PrintAST` over to the predicate names.
This is only temporary!

There are some limitations:
- Sometimes, we call multiple predicates on a class instead of just one.
This will pose a problem if we want to navigate to the predicate in the extension.
- For function calls, there are no predicates that go from a `Function` to its children in the `PrintAST` output

CC: @github/codeql-c-analysis 